### PR TITLE
add IaM policy for enclave access when creating ECR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
                 "@types/uuid": "^10.0.0",
                 "@vanilla-extract/css": "^1.16",
                 "@vanilla-extract/next-plugin": "^2.4",
+                "aws-iam-policy-types": "^1.0.1",
                 "aws-sdk": "^2.1691.0",
                 "child_process": "^1.0.2",
                 "clsx": "^2.1.1",
@@ -7860,6 +7861,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/aws-iam-policy-types": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/aws-iam-policy-types/-/aws-iam-policy-types-1.0.1.tgz",
+            "integrity": "sha512-MH2dVighgbf0uZhxP+3tJoZZ1av47i2DaEug4LV97DksFjeSQrwUWIxQsNDd+oiLH9yVxFIWd7N7WyPVJdUVBA==",
+            "license": "MIT",
+            "bin": {
+                "aws-iam-policy-types": "dist/cjs/cli/index.js"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/aws-sdk": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
         "@types/uuid": "^10.0.0",
         "@vanilla-extract/css": "^1.16",
         "@vanilla-extract/next-plugin": "^2.4",
+        "aws-iam-policy-types": "^1.0.1",
         "aws-sdk": "^2.1691.0",
         "child_process": "^1.0.2",
         "clsx": "^2.1.1",

--- a/src/server/aws-ecr-policy.ts
+++ b/src/server/aws-ecr-policy.ts
@@ -1,0 +1,28 @@
+import { type AwsIAMPolicy, AwsEcrActions as Action } from 'aws-iam-policy-types'
+import { ENCLAVE_AWS_ACCOUNT_NUMBERS } from './config'
+
+export const EcrPolicy: AwsIAMPolicy = {
+    Version: '2012-10-17',
+    Statement: [
+        {
+            Condition: {
+                StringEquals: {
+                    'ecr:ResourceTag/Target': 'si:analysis',
+                },
+            },
+            Action: [
+                Action.BatchCheckLayerAvailability,
+                Action.BatchGetImage,
+                Action.DescribeImages,
+                Action.GetAuthorizationToken,
+                Action.ListTagsForResource,
+            ],
+            Principal: {
+                Service: ['ecs-tasks.amazonaws.com'],
+                AWS: ENCLAVE_AWS_ACCOUNT_NUMBERS.map((acct) => `arn:aws:iam::${acct}:root`),
+            },
+            Effect: 'Allow',
+            Sid: 'AllowEnclaveECSTaskToPullImages',
+        },
+    ],
+}

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -14,3 +14,10 @@ export const USING_S3_STORAGE = process.env.USE_S3_STORAGE === 't' || PROD_ENV
 
 export const SIMULATE_RESULTS_UPLOAD =
     process.env.SIMULATE_RESULTS_UPLOAD === 't' || (process.env.SIMULATE_RESULTS_UPLOAD != 'f' && DEV_ENV)
+
+export const ENCLAVE_AWS_ACCOUNT_NUMBERS = [
+    '337909745635', //prod
+    '536697261124', // staging
+    '084375557107', // dev
+    '354918363956', // sandbox
+]


### PR DESCRIPTION
Needed to allow os enclave to pull from repos.  In the future we'll need to figure out how to pass the account numbers in programically instead of hardcoding 