### PR TITLE
allow totp codes starting with zero

### DIFF
--- a/src/app/account/mfa/app/page.tsx
+++ b/src/app/account/mfa/app/page.tsx
@@ -67,7 +67,10 @@ function VerifyTotpScreen({ setStep }: { setStep: React.Dispatch<React.SetStateA
             code: '',
         },
         validate: {
-            code: (c: string) => (String(Number(c)).length != 6 ? 'Code must be six digits' : null),
+            code: (c: string) => {
+                // Verify exactly 6 digits (0-9), nothing else
+                return /^\d{6}$/.test(c) ? null : 'Code must be six digits'
+            },
         },
     })
 


### PR DESCRIPTION
totp codes starting with zero gave an error message (bug)

<img width="514" alt="image" src="https://github.com/user-attachments/assets/58560b88-0560-4df9-8266-6da4776681c3" />
