### PR TITLE
use term reviewer instead of member for user interactions

### DIFF
--- a/tests/e2e.helpers.ts
+++ b/tests/e2e.helpers.ts
@@ -132,17 +132,17 @@ const clerkSignInHelper = async (params: ClerkSignInParams) => {
     }
 }
 
-export type TestingRole = 'researcher' | 'member'
+export type TestingRole = 'researcher' | 'reviewer'
 export const TestingUsers: Record<TestingRole, ClerkSignInParams> = {
     researcher: {
         mfa: CLERK_MFA_CODE,
         identifier: process.env.E2E_CLERK_RESEARCHER_EMAIL!,
         password: process.env.E2E_CLERK_RESEARCHER_PASSWORD!,
     },
-    member: {
+    reviewer: {
         mfa: CLERK_MFA_CODE,
-        identifier: process.env.E2E_CLERK_MEMBER_EMAIL!,
-        password: process.env.E2E_CLERK_MEMBER_PASSWORD!,
+        identifier: process.env.E2E_CLERK_REVIEWER_EMAIL!,
+        password: process.env.E2E_CLERK_REVIEWER_PASSWORD!,
     },
 }
 

--- a/tests/member-review-study.spec.tsx
+++ b/tests/member-review-study.spec.tsx
@@ -2,12 +2,12 @@ import { visitClerkProtectedPage, test, expect } from './e2e.helpers'
 
 test.describe('BMA member review', () => {
     const studyTitle = `E2E Member review - ${[...Array(6)].map(() => Math.floor(Math.random() * 16).toString(16)).join('')}`
-    const investigator = 'Principal Investigator'
+    const investigator = 'Member Reviewer'
     const studyDescription = 'A more complete study description'
     const mainR = 'tests/assets/main.r'
     const codeLine = 'print("Hello, Tester")'
 
-    test.beforeEach(async ({ page }) => {
+    test.beforeEach('a researcher submits a study with a main.r', async ({ page }) => {
         await visitClerkProtectedPage({ page, role: 'researcher', url: '/' })
         await expect(page).toHaveTitle(/SafeInsights/)
         await page.getByRole('button', { name: /propose/i }).click()
@@ -28,8 +28,8 @@ test.describe('BMA member review', () => {
         await expect(page).toHaveTitle(/SafeInsights/)
     })
 
-    test('member reviews a study main code file', async ({ page }) => {
-        await visitClerkProtectedPage({ page, role: 'member', url: '/' })
+    test('member reviews a study main.r code file', async ({ page }) => {
+        await visitClerkProtectedPage({ page, role: 'reviewer', url: '/' })
         await page.getByRole('button', { name: /review studies/i }).click()
         await page.locator('li').filter({ hasText: studyTitle }).getByRole('link').click()
         await page.getByRole('button', { name: /researcher code/i }).click()

--- a/tests/mfa.spec.ts
+++ b/tests/mfa.spec.ts
@@ -1,14 +1,14 @@
-import { visitClerkProtectedPage, clerk, test, TestingUsers, CLERK_MFA_CODE } from './e2e.helpers'
+import { visitClerkProtectedPage, test, CLERK_MFA_CODE } from './e2e.helpers'
 
 test.describe('MFA authentication', async () => {
     test('adds using app', async ({ page }) => {
-        await visitClerkProtectedPage({ page, url: '/account/mfa?TESTING_FORCE_NO_MFA=1', role: 'member' })
+        await visitClerkProtectedPage({ page, role: 'reviewer', url: '/account/mfa?TESTING_FORCE_NO_MFA=1' })
 
         await page.getByRole('button', { name: 'authenticator' }).click()
 
         await page.getByRole('button', { name: 'verify' }).click()
 
-        await page.getByLabel('code').fill('123456')
+        await page.getByLabel('code').fill(CLERK_MFA_CODE)
 
         await page.getByRole('button', { name: 'verify' }).click()
 
@@ -18,7 +18,7 @@ test.describe('MFA authentication', async () => {
     })
 
     test('adds using sms', async ({ page }) => {
-        await visitClerkProtectedPage({ page, url: '/account/mfa?TESTING_FORCE_NO_MFA=1', role: 'member' })
+        await visitClerkProtectedPage({ page, role: 'reviewer', url: '/account/mfa?TESTING_FORCE_NO_MFA=1' })
         await page.getByRole('button', { name: 'sms' }).click()
 
         await page.getByRole('button', { name: 'user profile' }).click()

--- a/tests/playwright.setup.ts
+++ b/tests/playwright.setup.ts
@@ -4,7 +4,7 @@ import { test as setup } from '@playwright/test'
 setup('global setup', async ({}) => {
     await clerkSetup()
 
-    for (const role of ['RESEARCHER']) {
+    for (const role of ['RESEARCHER', 'REVIEWER']) {
         for (const part of ['EMAIL', 'PASSWORD']) {
             const env = `E2E_CLERK_${role}_${part}`
             if (!process.env[env]) {


### PR DESCRIPTION
split terms to reinforce the difference between a member organization and a code/results reviewer who is a part of the member org