### PR TITLE
Trigger code build when study is approved

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.1",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
+                "@aws-sdk/client-codebuild": "^3.775.0",
                 "@aws-sdk/client-ecr": "^3.758.0",
                 "@aws-sdk/client-s3": "^3.758.0",
                 "@aws-sdk/client-secrets-manager": "^3.758.0",
@@ -351,6 +352,473 @@
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-codebuild/-/client-codebuild-3.775.0.tgz",
+            "integrity": "sha512-mviCaw2wbB4c0FN55QMH7Eo+1FT/74fNQoa66HzfRb/X4OnQmCrASKfumvD8StKZUMOX36XqQc5/vNyZZ9/nGA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/credential-provider-node": "3.775.0",
+                "@aws-sdk/middleware-host-header": "3.775.0",
+                "@aws-sdk/middleware-logger": "3.775.0",
+                "@aws-sdk/middleware-recursion-detection": "3.775.0",
+                "@aws-sdk/middleware-user-agent": "3.775.0",
+                "@aws-sdk/region-config-resolver": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@aws-sdk/util-endpoints": "3.775.0",
+                "@aws-sdk/util-user-agent-browser": "3.775.0",
+                "@aws-sdk/util-user-agent-node": "3.775.0",
+                "@smithy/config-resolver": "^4.1.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/fetch-http-handler": "^5.0.2",
+                "@smithy/hash-node": "^4.0.2",
+                "@smithy/invalid-dependency": "^4.0.2",
+                "@smithy/middleware-content-length": "^4.0.2",
+                "@smithy/middleware-endpoint": "^4.1.0",
+                "@smithy/middleware-retry": "^4.1.0",
+                "@smithy/middleware-serde": "^4.0.3",
+                "@smithy/middleware-stack": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/node-http-handler": "^4.0.4",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/url-parser": "^4.0.2",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.8",
+                "@smithy/util-defaults-mode-node": "^4.0.8",
+                "@smithy/util-endpoints": "^3.0.2",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-retry": "^4.0.2",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/client-sso": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.775.0.tgz",
+            "integrity": "sha512-vqG1S2ap77WP4D5qt4bEPE0duQ4myN+cDr1NeP8QpSTajetbkDGVo7h1VViYMcUoFUVWBj6Qf1X1VfOq+uaxbA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/middleware-host-header": "3.775.0",
+                "@aws-sdk/middleware-logger": "3.775.0",
+                "@aws-sdk/middleware-recursion-detection": "3.775.0",
+                "@aws-sdk/middleware-user-agent": "3.775.0",
+                "@aws-sdk/region-config-resolver": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@aws-sdk/util-endpoints": "3.775.0",
+                "@aws-sdk/util-user-agent-browser": "3.775.0",
+                "@aws-sdk/util-user-agent-node": "3.775.0",
+                "@smithy/config-resolver": "^4.1.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/fetch-http-handler": "^5.0.2",
+                "@smithy/hash-node": "^4.0.2",
+                "@smithy/invalid-dependency": "^4.0.2",
+                "@smithy/middleware-content-length": "^4.0.2",
+                "@smithy/middleware-endpoint": "^4.1.0",
+                "@smithy/middleware-retry": "^4.1.0",
+                "@smithy/middleware-serde": "^4.0.3",
+                "@smithy/middleware-stack": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/node-http-handler": "^4.0.4",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/url-parser": "^4.0.2",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.8",
+                "@smithy/util-defaults-mode-node": "^4.0.8",
+                "@smithy/util-endpoints": "^3.0.2",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-retry": "^4.0.2",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/core": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.775.0.tgz",
+            "integrity": "sha512-8vpW4WihVfz0DX+7WnnLGm3GuQER++b0IwQG35JlQMlgqnc44M//KbJPsIHA0aJUJVwJAEShgfr5dUbY8WUzaA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/signature-v4": "^5.0.2",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.775.0.tgz",
+            "integrity": "sha512-6ESVxwCbGm7WZ17kY1fjmxQud43vzJFoLd4bmlR+idQSWdqlzGDYdcfzpjDKTcivdtNrVYmFvcH1JBUwCRAZhw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.775.0.tgz",
+            "integrity": "sha512-PjDQeDH/J1S0yWV32wCj2k5liRo0ssXMseCBEkCsD3SqsU8o5cU82b0hMX4sAib/RkglCSZqGO0xMiN0/7ndww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/fetch-http-handler": "^5.0.2",
+                "@smithy/node-http-handler": "^4.0.4",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-stream": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.775.0.tgz",
+            "integrity": "sha512-0gJc6cALsgrjeC5U3qDjbz4myIC/j49+gPz9nkvY+C0OYWt1KH1tyfiZUuCRGfuFHhQ+3KMMDSL229TkBP3E7g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/credential-provider-env": "3.775.0",
+                "@aws-sdk/credential-provider-http": "3.775.0",
+                "@aws-sdk/credential-provider-process": "3.775.0",
+                "@aws-sdk/credential-provider-sso": "3.775.0",
+                "@aws-sdk/credential-provider-web-identity": "3.775.0",
+                "@aws-sdk/nested-clients": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/credential-provider-imds": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.775.0.tgz",
+            "integrity": "sha512-D8Zre5W2sXC/ANPqCWPqwYpU1cKY9DF6ckFZyDrqlcBC0gANgpY6fLrBtYo2fwJsbj+1A24iIpBINV7erdprgA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.775.0",
+                "@aws-sdk/credential-provider-http": "3.775.0",
+                "@aws-sdk/credential-provider-ini": "3.775.0",
+                "@aws-sdk/credential-provider-process": "3.775.0",
+                "@aws-sdk/credential-provider-sso": "3.775.0",
+                "@aws-sdk/credential-provider-web-identity": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/credential-provider-imds": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.775.0.tgz",
+            "integrity": "sha512-A6k68H9rQp+2+7P7SGO90Csw6nrUEm0Qfjpn9Etc4EboZhhCLs9b66umUsTsSBHus4FDIe5JQxfCUyt1wgNogg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.775.0.tgz",
+            "integrity": "sha512-du06V7u9HDmRuwZnRjf85shO3dffeKOkQplV5/2vf3LgTPNEI9caNomi/cCGyxKGOeSUHAKrQ1HvpPfOaI6t5Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.775.0",
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/token-providers": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.775.0.tgz",
+            "integrity": "sha512-z4XLYui5aHsr78mbd5BtZfm55OM5V55qK/X17OPrEqjYDDk3GlI8Oe2ZjTmOVrKwMpmzXKhsakeFHKfDyOvv1A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/nested-clients": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.775.0.tgz",
+            "integrity": "sha512-tkSegM0Z6WMXpLB8oPys/d+umYIocvO298mGvcMCncpRl77L9XkvSLJIFzaHes+o7djAgIduYw8wKIMStFss2w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.775.0.tgz",
+            "integrity": "sha512-FaxO1xom4MAoUJsldmR92nT1G6uZxTdNYOFYtdHfd6N2wcNaTuxgjIvqzg5y7QIH9kn58XX/dzf1iTjgqUStZw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.775.0.tgz",
+            "integrity": "sha512-GLCzC8D0A0YDG5u3F5U03Vb9j5tcOEFhr8oc6PDk0k0vm5VwtZOE6LvK7hcCSoAB4HXyOUM0sQuXrbaAh9OwXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.775.0.tgz",
+            "integrity": "sha512-7Lffpr1ptOEDE1ZYH1T78pheEY1YmeXWBfFt/amZ6AGsKSLG+JPXvof3ltporTGR2bhH/eJPo7UHCglIuXfzYg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@aws-sdk/util-endpoints": "3.775.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/nested-clients": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.775.0.tgz",
+            "integrity": "sha512-f37jmAzkuIhKyhtA6s0LGpqQvm218vq+RNMUDkGm1Zz2fxJ5pBIUTDtygiI3vXTcmt9DTIB8S6JQhjrgtboktw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/middleware-host-header": "3.775.0",
+                "@aws-sdk/middleware-logger": "3.775.0",
+                "@aws-sdk/middleware-recursion-detection": "3.775.0",
+                "@aws-sdk/middleware-user-agent": "3.775.0",
+                "@aws-sdk/region-config-resolver": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@aws-sdk/util-endpoints": "3.775.0",
+                "@aws-sdk/util-user-agent-browser": "3.775.0",
+                "@aws-sdk/util-user-agent-node": "3.775.0",
+                "@smithy/config-resolver": "^4.1.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/fetch-http-handler": "^5.0.2",
+                "@smithy/hash-node": "^4.0.2",
+                "@smithy/invalid-dependency": "^4.0.2",
+                "@smithy/middleware-content-length": "^4.0.2",
+                "@smithy/middleware-endpoint": "^4.1.0",
+                "@smithy/middleware-retry": "^4.1.0",
+                "@smithy/middleware-serde": "^4.0.3",
+                "@smithy/middleware-stack": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/node-http-handler": "^4.0.4",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/url-parser": "^4.0.2",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.8",
+                "@smithy/util-defaults-mode-node": "^4.0.8",
+                "@smithy/util-endpoints": "^3.0.2",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-retry": "^4.0.2",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.775.0.tgz",
+            "integrity": "sha512-40iH3LJjrQS3LKUJAl7Wj0bln7RFPEvUYKFxtP8a+oKFDO0F65F52xZxIJbPn6sHkxWDAnZlGgdjZXM3p2g5wQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/token-providers": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.775.0.tgz",
+            "integrity": "sha512-Q6MtbEhkOggVSz/dN89rIY/ry80U3v89o0Lrrc+Rpvaiaaz8pEN0DsfEcg0IjpzBQ8Owoa6lNWyglHbzPhaJpA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/nested-clients": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/types": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.775.0.tgz",
+            "integrity": "sha512-ZoGKwa4C9fC9Av6bdfqcW6Ix5ot05F/S4VxWR2nHuMv7hzfmAjTOcUiWT7UR4hM/U0whf84VhDtXN/DWAk52KA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.775.0.tgz",
+            "integrity": "sha512-yjWmUgZC9tUxAo8Uaplqmq0eUh0zrbZJdwxGRKdYxfm4RG6fMw1tj52+KkatH7o+mNZvg1GDcVp/INktxonJLw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-endpoints": "^3.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.775.0.tgz",
+            "integrity": "sha512-txw2wkiJmZKVdDbscK7VBK+u+TJnRtlUjRTLei+elZg2ADhpQxfVAQl436FUeIv6AhB/oRHW6/K/EAGXUSWi0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/types": "^4.2.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-codebuild/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.775.0.tgz",
+            "integrity": "sha512-N9yhTevbizTOMo3drH7Eoy6OkJ3iVPxhV7dwb6CMAObbLneS36CSfA6xQXupmHWcRvZPTz8rd1JGG3HzFOau+g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@aws-sdk/client-ecr": {
@@ -5126,12 +5594,12 @@
             "license": "(Unlicense OR Apache-2.0)"
         },
         "node_modules/@smithy/abort-controller": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
-            "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.2.tgz",
+            "integrity": "sha512-Sl/78VDtgqKxN2+1qduaVE140XF+Xg+TafkncspwM4jFP/LHr76ZHmIY/y3V1M0mMLNk+Je6IGbzxy23RSToMw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5164,15 +5632,15 @@
             }
         },
         "node_modules/@smithy/config-resolver": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
-            "integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.0.tgz",
+            "integrity": "sha512-8smPlwhga22pwl23fM5ew4T9vfLUCeFXlcqNOCD5M5h8VmNPNUE9j6bQSuRXpDSV11L/E/SwEBQuW8hr6+nS1A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "@smithy/util-config-provider": "^4.0.0",
-                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-middleware": "^4.0.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5180,17 +5648,17 @@
             }
         },
         "node_modules/@smithy/core": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.5.tgz",
-            "integrity": "sha512-HLclGWPkCsekQgsyzxLhCQLa8THWXtB5PxyYN+2O6nkyLt550KQKTlbV2D1/j5dNIQapAZM1+qFnpBFxZQkgCA==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.2.0.tgz",
+            "integrity": "sha512-k17bgQhVZ7YmUvA8at4af1TDpl0NDMBuBKJl8Yg0nrefwmValU+CnA5l/AriVdQNthU/33H3nK71HrLgqOPr1Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/middleware-serde": "^4.0.2",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/middleware-serde": "^4.0.3",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
                 "@smithy/util-body-length-browser": "^4.0.0",
-                "@smithy/util-middleware": "^4.0.1",
-                "@smithy/util-stream": "^4.1.2",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-stream": "^4.2.0",
                 "@smithy/util-utf8": "^4.0.0",
                 "tslib": "^2.6.2"
             },
@@ -5199,15 +5667,15 @@
             }
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
-            "integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.2.tgz",
+            "integrity": "sha512-32lVig6jCaWBHnY+OEQ6e6Vnt5vDHaLiydGrwYMW9tPqO688hPGTYRamYJ1EptxEC2rAwJrHWmPoKRBl4iTa8w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/types": "^4.1.0",
-                "@smithy/url-parser": "^4.0.1",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "@smithy/url-parser": "^4.0.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5285,14 +5753,14 @@
             }
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
-            "integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.2.tgz",
+            "integrity": "sha512-+9Dz8sakS9pe7f2cBocpJXdeVjMopUDLgZs1yWeu7h++WqSbjUYv/JAJwKwXw1HV6gq1jyWjxuyn24E2GhoEcQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/querystring-builder": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/querystring-builder": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "@smithy/util-base64": "^4.0.0",
                 "tslib": "^2.6.2"
             },
@@ -5316,12 +5784,12 @@
             }
         },
         "node_modules/@smithy/hash-node": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
-            "integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.2.tgz",
+            "integrity": "sha512-VnTpYPnRUE7yVhWozFdlxcYknv9UN7CeOqSrMH+V877v4oqtVYuoqhIhtSjmGPvYrYnAkaM61sLMKHvxL138yg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "@smithy/util-buffer-from": "^4.0.0",
                 "@smithy/util-utf8": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -5345,12 +5813,12 @@
             }
         },
         "node_modules/@smithy/invalid-dependency": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
-            "integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.2.tgz",
+            "integrity": "sha512-GatB4+2DTpgWPday+mnUkoumP54u/MDM/5u44KF9hIu8jF0uafZtQLcdfIKkIcUNuF/fBojpLEHZS/56JqPeXQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5384,13 +5852,13 @@
             }
         },
         "node_modules/@smithy/middleware-content-length": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
-            "integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.2.tgz",
+            "integrity": "sha512-hAfEXm1zU+ELvucxqQ7I8SszwQ4znWMbNv6PLMndN83JJN41EPuS93AIyh2N+gJ6x8QFhzSO6b7q2e6oClDI8A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5398,18 +5866,18 @@
             }
         },
         "node_modules/@smithy/middleware-endpoint": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
-            "integrity": "sha512-ftpmkTHIFqgaFugcjzLZv3kzPEFsBFSnq1JsIkr2mwFzCraZVhQk2gqN51OOeRxqhbPTkRFj39Qd2V91E/mQxg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.0.tgz",
+            "integrity": "sha512-xhLimgNCbCzsUppRTGXWkZywksuTThxaIB0HwbpsVLY5sceac4e1TZ/WKYqufQLaUy+gUSJGNdwD2jo3cXL0iA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.1.5",
-                "@smithy/middleware-serde": "^4.0.2",
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/shared-ini-file-loader": "^4.0.1",
-                "@smithy/types": "^4.1.0",
-                "@smithy/url-parser": "^4.0.1",
-                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/core": "^3.2.0",
+                "@smithy/middleware-serde": "^4.0.3",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "@smithy/url-parser": "^4.0.2",
+                "@smithy/util-middleware": "^4.0.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5417,18 +5885,18 @@
             }
         },
         "node_modules/@smithy/middleware-retry": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.7.tgz",
-            "integrity": "sha512-58j9XbUPLkqAcV1kHzVX/kAR16GT+j7DUZJqwzsxh1jtz7G82caZiGyyFgUvogVfNTg3TeAOIJepGc8TXF4AVQ==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.0.tgz",
+            "integrity": "sha512-2zAagd1s6hAaI/ap6SXi5T3dDwBOczOMCSkkYzktqN1+tzbk1GAsHNAdo/1uzxz3Ky02jvZQwbi/vmDA6z4Oyg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/service-error-classification": "^4.0.1",
-                "@smithy/smithy-client": "^4.1.6",
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-middleware": "^4.0.1",
-                "@smithy/util-retry": "^4.0.1",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/service-error-classification": "^4.0.2",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-retry": "^4.0.2",
                 "tslib": "^2.6.2",
                 "uuid": "^9.0.1"
             },
@@ -5450,12 +5918,12 @@
             }
         },
         "node_modules/@smithy/middleware-serde": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
-            "integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.3.tgz",
+            "integrity": "sha512-rfgDVrgLEVMmMn0BI8O+8OVr6vXzjV7HZj57l0QxslhzbvVfikZbVfBVthjLHqib4BW44QhcIgJpvebHlRaC9A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5463,12 +5931,12 @@
             }
         },
         "node_modules/@smithy/middleware-stack": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
-            "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.2.tgz",
+            "integrity": "sha512-eSPVcuJJGVYrFYu2hEq8g8WWdJav3sdrI4o2c6z/rjnYDd3xH9j9E7deZQCzFn4QvGPouLngH3dQ+QVTxv5bOQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5476,14 +5944,14 @@
             }
         },
         "node_modules/@smithy/node-config-provider": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
-            "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.2.tgz",
+            "integrity": "sha512-WgCkILRZfJwJ4Da92a6t3ozN/zcvYyJGUTmfGbgS/FkCcoCjl7G4FJaCDN1ySdvLvemnQeo25FdkyMSTSwulsw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/shared-ini-file-loader": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5491,15 +5959,15 @@
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
-            "integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.4.tgz",
+            "integrity": "sha512-/mdqabuAT3o/ihBGjL94PUbTSPSRJ0eeVTdgADzow0wRJ0rN4A27EOrtlK56MYiO1fDvlO3jVTCxQtQmK9dZ1g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/abort-controller": "^4.0.1",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/querystring-builder": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/abort-controller": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/querystring-builder": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5507,12 +5975,12 @@
             }
         },
         "node_modules/@smithy/property-provider": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
-            "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.2.tgz",
+            "integrity": "sha512-wNRoQC1uISOuNc2s4hkOYwYllmiyrvVXWMtq+TysNRVQaHm4yoafYQyjN/goYZS+QbYlPIbb/QRjaUZMuzwQ7A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5520,12 +5988,12 @@
             }
         },
         "node_modules/@smithy/protocol-http": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
-            "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.0.tgz",
+            "integrity": "sha512-KxAOL1nUNw2JTYrtviRRjEnykIDhxc84qMBzxvu1MUfQfHTuBlCG7PA6EdVwqpJjH7glw7FqQoFxUJSyBQgu7g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5533,12 +6001,12 @@
             }
         },
         "node_modules/@smithy/querystring-builder": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
-            "integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.2.tgz",
+            "integrity": "sha512-NTOs0FwHw1vimmQM4ebh+wFQvOwkEf/kQL6bSM1Lock+Bv4I89B3hGYoUEPkmvYPkDKyp5UdXJYu+PoTQ3T31Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "@smithy/util-uri-escape": "^4.0.0",
                 "tslib": "^2.6.2"
             },
@@ -5547,12 +6015,12 @@
             }
         },
         "node_modules/@smithy/querystring-parser": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
-            "integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.2.tgz",
+            "integrity": "sha512-v6w8wnmZcVXjfVLjxw8qF7OwESD9wnpjp0Dqry/Pod0/5vcEA3qxCr+BhbOHlxS8O+29eLpT3aagxXGwIoEk7Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5560,24 +6028,24 @@
             }
         },
         "node_modules/@smithy/service-error-classification": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
-            "integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.2.tgz",
+            "integrity": "sha512-LA86xeFpTKn270Hbkixqs5n73S+LVM0/VZco8dqd+JT75Dyx3Lcw/MraL7ybjmz786+160K8rPOmhsq0SocoJQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0"
+                "@smithy/types": "^4.2.0"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/shared-ini-file-loader": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
-            "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.2.tgz",
+            "integrity": "sha512-J9/gTWBGVuFZ01oVA6vdb4DAjf1XbDhK6sLsu3OS9qmLrS6KB5ygpeHiM3miIbj1qgSJ96GYszXFWv6ErJ8QEw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5585,16 +6053,16 @@
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
-            "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.2.tgz",
+            "integrity": "sha512-Mz+mc7okA73Lyz8zQKJNyr7lIcHLiPYp0+oiqiMNc/t7/Kf2BENs5d63pEj7oPqdjaum6g0Fc8wC78dY1TgtXw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
                 "@smithy/util-hex-encoding": "^4.0.0",
-                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-middleware": "^4.0.2",
                 "@smithy/util-uri-escape": "^4.0.0",
                 "@smithy/util-utf8": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -5604,17 +6072,17 @@
             }
         },
         "node_modules/@smithy/smithy-client": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
-            "integrity": "sha512-UYDolNg6h2O0L+cJjtgSyKKvEKCOa/8FHYJnBobyeoeWDmNpXjwOAtw16ezyeu1ETuuLEOZbrynK0ZY1Lx9Jbw==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.2.0.tgz",
+            "integrity": "sha512-Qs65/w30pWV7LSFAez9DKy0Koaoh3iHhpcpCCJ4waj/iqwsuSzJna2+vYwq46yBaqO5ZbP9TjUsATUNxrKeBdw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.1.5",
-                "@smithy/middleware-endpoint": "^4.0.6",
-                "@smithy/middleware-stack": "^4.0.1",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-stream": "^4.1.2",
+                "@smithy/core": "^3.2.0",
+                "@smithy/middleware-endpoint": "^4.1.0",
+                "@smithy/middleware-stack": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-stream": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5622,9 +6090,9 @@
             }
         },
         "node_modules/@smithy/types": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
-            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.2.0.tgz",
+            "integrity": "sha512-7eMk09zQKCO+E/ivsjQv+fDlOupcFUCSC/L2YUPgwhvowVGWbPQHjEFcmjt7QQ4ra5lyowS92SV53Zc6XD4+fg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -5634,13 +6102,13 @@
             }
         },
         "node_modules/@smithy/url-parser": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
-            "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.2.tgz",
+            "integrity": "sha512-Bm8n3j2ScqnT+kJaClSVCMeiSenK6jVAzZCNewsYWuZtnBehEz4r2qP0riZySZVfzB+03XZHJeqfmJDkeeSLiQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/querystring-parser": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/querystring-parser": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5711,14 +6179,14 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.7.tgz",
-            "integrity": "sha512-CZgDDrYHLv0RUElOsmZtAnp1pIjwDVCSuZWOPhIOBvG36RDfX1Q9+6lS61xBf+qqvHoqRjHxgINeQz47cYFC2Q==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.8.tgz",
+            "integrity": "sha512-ZTypzBra+lI/LfTYZeop9UjoJhhGRTg3pxrNpfSTQLd3AJ37r2z4AXTKpq1rFXiiUIJsYyFgNJdjWRGP/cbBaQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/smithy-client": "^4.1.6",
-                "@smithy/types": "^4.1.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
             },
@@ -5727,17 +6195,17 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-node": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.7.tgz",
-            "integrity": "sha512-79fQW3hnfCdrfIi1soPbK3zmooRFnLpSx3Vxi6nUlqaaQeC5dm8plt4OTNDNqEEEDkvKghZSaoti684dQFVrGQ==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.8.tgz",
+            "integrity": "sha512-Rgk0Jc/UDfRTzVthye/k2dDsz5Xxs9LZaKCNPgJTRyoyBoeiNCnHsYGOyu1PKN+sDyPnJzMOz22JbwxzBp9NNA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/config-resolver": "^4.0.1",
-                "@smithy/credential-provider-imds": "^4.0.1",
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/smithy-client": "^4.1.6",
-                "@smithy/types": "^4.1.0",
+                "@smithy/config-resolver": "^4.1.0",
+                "@smithy/credential-provider-imds": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5745,13 +6213,13 @@
             }
         },
         "node_modules/@smithy/util-endpoints": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
-            "integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.2.tgz",
+            "integrity": "sha512-6QSutU5ZyrpNbnd51zRTL7goojlcnuOB55+F9VBD+j8JpRY50IGamsjlycrmpn8PQkmJucFW8A0LSfXj7jjtLQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5771,12 +6239,12 @@
             }
         },
         "node_modules/@smithy/util-middleware": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
-            "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.2.tgz",
+            "integrity": "sha512-6GDamTGLuBQVAEuQ4yDQ+ti/YINf/MEmIegrEeg7DdB/sld8BX1lqt9RRuIcABOhAGTA50bRbPzErez7SlDtDQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5784,13 +6252,13 @@
             }
         },
         "node_modules/@smithy/util-retry": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
-            "integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.2.tgz",
+            "integrity": "sha512-Qryc+QG+7BCpvjloFLQrmlSd0RsVRHejRXd78jNO3+oREueCjwG1CCEH1vduw/ZkM1U9TztwIKVIi3+8MJScGg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/service-error-classification": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/service-error-classification": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5798,14 +6266,14 @@
             }
         },
         "node_modules/@smithy/util-stream": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.1.2.tgz",
-            "integrity": "sha512-44PKEqQ303d3rlQuiDpcCcu//hV8sn+u2JBo84dWCE0rvgeiVl0IlLMagbU++o0jCWhYCsHaAt9wZuZqNe05Hw==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.0.tgz",
+            "integrity": "sha512-Vj1TtwWnuWqdgQI6YTUF5hQ/0jmFiOYsc51CSMgj7QfyO+RF4EnT2HNjoviNlOOmgzgvf3f5yno+EiC4vrnaWQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/fetch-http-handler": "^5.0.1",
-                "@smithy/node-http-handler": "^4.0.3",
-                "@smithy/types": "^4.1.0",
+                "@smithy/fetch-http-handler": "^5.0.2",
+                "@smithy/node-http-handler": "^4.0.4",
+                "@smithy/types": "^4.2.0",
                 "@smithy/util-base64": "^4.0.0",
                 "@smithy/util-buffer-from": "^4.0.0",
                 "@smithy/util-hex-encoding": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "update-all-packages": "npx npm-check-updates -u"
     },
     "dependencies": {
+        "@aws-sdk/client-codebuild": "^3.775.0",
         "@aws-sdk/client-ecr": "^3.758.0",
         "@aws-sdk/client-s3": "^3.758.0",
         "@aws-sdk/client-secrets-manager": "^3.758.0",

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,4 +1,4 @@
-import { Kysely, CamelCasePlugin, sql, type KyselyConfig } from 'kysely'
+import { Kysely, CamelCasePlugin, sql, type KyselyConfig, type Transaction as TransactionType } from 'kysely'
 import { DB } from './database/types'
 import { dialect } from './database/dialect'
 import { DEV_ENV } from './server/config'
@@ -14,3 +14,8 @@ export const db = new Kysely<DB>({
     ...kyselyOpts,
     plugins: [new CamelCasePlugin()],
 })
+
+export type Transaction = TransactionType<DB>
+export type DBConn = Kysely<DB>
+
+export type DBExecutor = Transaction | DBConn

--- a/src/server/actions/study-job.actions.ts
+++ b/src/server/actions/study-job.actions.ts
@@ -16,7 +16,7 @@ import { jsonArrayFrom } from 'kysely/helpers/postgres'
 
 export const approveStudyJobResultsAction = memberAction(
     async ({ jobInfo: info, jobResults }) => {
-        await checkMemberAllowedStudyReview(info.studyId, getUserIdFromActionContext())
+        await checkMemberAllowedStudyReview(info.studyId)
 
         const blob = new Blob(jobResults, { type: 'text/csv' })
         const resultsFile = new File([blob], 'job_results.csv')

--- a/src/server/actions/study-job.actions.ts
+++ b/src/server/actions/study-job.actions.ts
@@ -5,10 +5,8 @@ import { CodeManifest } from '@/lib/types'
 import { fetchCodeManifest, fetchStudyJobResults } from '@/server/aws'
 import { revalidatePath } from 'next/cache'
 import { minimalJobInfoShema } from '@/lib/types'
-import { USING_S3_STORAGE } from '@/server/config'
-
 import { attachResultsToStudyJob, storageForResultsFile } from '@/server/results'
-import { queryJobResult, siUser } from '@/server/db/queries'
+import { latestJobForStudy, queryJobResult, siUser } from '@/server/db/queries'
 import { promises as fs } from 'fs'
 import { getUserIdFromActionContext, getOrgSlugFromActionContext, memberAction, z } from './wrappers'
 import { checkMemberAllowedStudyReview } from '../db/queries'
@@ -89,21 +87,7 @@ export const dataForJobAction = memberAction(async (studyJobIdentifier) => {
 }, z.string())
 
 export const latestJobForStudyAction = memberAction(async (studyId) => {
-    const latestJob = await db
-        .selectFrom('studyJob')
-        .selectAll('studyJob')
-
-        // security, check user has access to record
-        .innerJoin('study', 'study.id', 'studyJob.studyId')
-        .innerJoin('member', (join) =>
-            join.on('member.identifier', '=', getOrgSlugFromActionContext()).onRef('member.id', '=', 'study.memberId'),
-        )
-
-        .where('studyJob.studyId', '=', studyId)
-        .orderBy('createdAt', 'desc')
-        .limit(1)
-        .executeTakeFirst()
-
+    const latestJob = await latestJobForStudy(studyId)
     // We should always have a job, something is wrong if we don't
     if (!latestJob) {
         throw new Error(`No job found for study id: ${studyId}`)
@@ -126,7 +110,7 @@ export const jobStatusForJobAction = memberAction(async (jobId) => {
 
         .select('jobStatusChange.status')
         .where('jobStatusChange.studyJobId', '=', jobId)
-        .orderBy('jobStatusChange.createdAt', 'desc')
+        .orderBy('jobStatusChange.id', 'desc')
         .limit(1)
         .executeTakeFirst()
 

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { insertTestStudyData, mockClerkSession, mockApiMember } from '@/tests/unit.helpers'
+
+import { approveStudyProposalAction } from './study.actions'
+
+import { jobStatusForJobAction } from './study-job.actions'
+import { triggerBuildImageForJob } from '@/server/aws'
+
+vi.mock('@/server/config', () => ({
+    USING_S3_STORAGE: true,
+}))
+vi.mock('@/server/aws', () => ({
+    triggerBuildImageForJob: vi.fn(),
+}))
+
+describe('Study Actions', () => {
+    beforeEach(() => {
+        mockClerkSession({
+            clerkUserId: 'user-id',
+            org_slug: 'testy-mctestface',
+        })
+    })
+
+    it('successfully approves a study proposal', async () => {
+        const member = await mockApiMember({ identifier: 'testy-mctestface' })
+        const {
+            studyId,
+            jobIds: [jobId],
+        } = await insertTestStudyData({ memberId: member.id })
+        await approveStudyProposalAction(studyId)
+        const status = await jobStatusForJobAction(jobId)
+        expect(status).toBe('CODE-APPROVED')
+        expect(triggerBuildImageForJob).toHaveBeenCalledWith(expect.objectContaining({ studyJobId: jobId }))
+    })
+})

--- a/src/server/aws.ts
+++ b/src/server/aws.ts
@@ -197,9 +197,12 @@ export async function fetchStudyJobResults(info: MinimalJobResultsInfo) {
 
 export async function triggerBuildImageForJob(info: MinimalJobInfo) {
     const codebuild = new CodeBuildClient({})
+    if (!process.env.ENVIRONMENT_ID) {
+        throw new Error('ENVIRONMENT_ID env var not set')
+    }
     await codebuild.send(
         new StartBuildCommand({
-            projectName: 'MgmntAppContainerizer-dev',
+            projectName: `MgmntAppContainerizer-${process.env.ENVIRONMENT_ID}`,
             environmentVariablesOverride: [
                 {
                     name: 'ON_START_PAYLOAD',

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -1,9 +1,9 @@
-import { db } from '@/database'
+import { db, type DBExecutor } from '@/database'
 import { currentUser as currentClerkUser, type User as ClerkUser } from '@clerk/nextjs/server'
 import { AccessDeniedError, MinimalJobResultsInfo } from '@/lib/types'
 import { wasCalledFromAPI } from '../context'
 import { findOrCreateSiUserId } from './mutations'
-import { getOrgSlugFromActionContext} from '../actions/wrappers'
+import { getOrgSlugFromActionContext } from '../actions/wrappers'
 
 export const queryJobResult = async (jobId: string) =>
     (await db
@@ -21,13 +21,11 @@ export const queryJobResult = async (jobId: string) =>
         .executeTakeFirst()) as MinimalJobResultsInfo | undefined
 
 export const checkMemberAllowedStudyReview = async (studyId: string, identifier = getOrgSlugFromActionContext()) => {
-
     const found = await db
         .selectFrom('study')
         .select('study.id')
         .innerJoin('member', (join) =>
-            join.on('member.identifier', '=', identifier)
-                .onRef('study.memberId', '=', 'member.id')
+            join.on('member.identifier', '=', identifier).onRef('study.memberId', '=', 'member.id'),
         )
         .where('study.id', '=', studyId)
         .executeTakeFirst()
@@ -41,8 +39,7 @@ export const checkMemberAllowedStudyRead = async (studyId: string, identifier = 
         .selectFrom('study')
         .select('study.id')
         .innerJoin('member', (join) =>
-            join.on('member.identifier', '=', identifier)
-                .onRef('study.memberId', '=', 'member.id')
+            join.on('member.identifier', '=', identifier).onRef('study.memberId', '=', 'member.id'),
         )
         .where('study.id', '=', studyId)
         .executeTakeFirst()
@@ -92,4 +89,21 @@ export const getMemberUserPublicKeyByClerkId = async (clerkId: string) => {
         .executeTakeFirst()
 
     return result?.publicKey
+}
+
+export const latestJobForStudy = async (studyId: string, conn: DBExecutor = db) => {
+    return await conn
+        .selectFrom('studyJob')
+        .selectAll('studyJob')
+
+        // security, check user has access to record
+        .innerJoin('study', 'study.id', 'studyJob.studyId')
+        .innerJoin('member', (join) =>
+            join.on('member.identifier', '=', getOrgSlugFromActionContext()).onRef('member.id', '=', 'study.memberId'),
+        )
+
+        .where('studyJob.studyId', '=', studyId)
+        .orderBy('createdAt', 'desc')
+        .limit(1)
+        .executeTakeFirst()
 }

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -34,7 +34,7 @@ beforeAll(async () => {
             },
         }
     })
-
+    vi.mock('next/cache')
     vi.mock('next/headers', async () => ({ headers: async () => Headers }))
 
     vi.mock('@clerk/nextjs')


### PR DESCRIPTION
Previously image builds were triggered when a `approved` file is uploaded but that stopped working because the code didn't find a manifest.json file it needed.

Rather than dig through that IaC code, it is simpler to call the codebuild itself with the info it needed