### PR TITLE
Fix admin invite and admin org view

### DIFF
--- a/src/app/admin/invite/admin-users.actions.test.ts
+++ b/src/app/admin/invite/admin-users.actions.test.ts
@@ -10,7 +10,7 @@ describe('invite user Actions', async () => {
     beforeEach(() => {
         mockClerkSession({
             clerkUserId: 'user-id',
-            org_slug: 'safeinsights',
+            org_slug: 'safe-insights',
         })
     })
     async function userRecordCount() {

--- a/src/app/admin/invite/admin-users.actions.test.ts
+++ b/src/app/admin/invite/admin-users.actions.test.ts
@@ -1,5 +1,6 @@
 import { db } from '@/database'
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest'
+import { CLERK_ADMIN_ORG_SLUG } from '@/server/config'
 import { mockClerkSession } from '@/tests/unit.helpers'
 import { adminInviteUserAction } from './admin-users.actions'
 import { faker } from '@faker-js/faker'

--- a/src/app/admin/invite/admin-users.actions.test.ts
+++ b/src/app/admin/invite/admin-users.actions.test.ts
@@ -10,7 +10,7 @@ describe('invite user Actions', async () => {
     beforeEach(() => {
         mockClerkSession({
             clerkUserId: 'user-id',
-            org_slug: 'safe-insights',
+            org_slug: CLERK_ADMIN_ORG_SLUG,
         })
     })
     async function userRecordCount() {

--- a/src/app/admin/organization/table.tsx
+++ b/src/app/admin/organization/table.tsx
@@ -2,7 +2,7 @@
 
 import { DataTable, type DataTableSortStatus } from 'mantine-datatable'
 import * as R from 'remeda'
-import { FC, useEffect, useState } from 'react'
+import { FC, useMemo, useState } from 'react'
 import { deleteMemberAction, fetchMembersAction } from '@/server/actions/member.actions'
 import { getNewMember, type Member } from '@/schema/member'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
@@ -23,12 +23,10 @@ export function MembersAdminTable() {
         direction: 'desc',
     })
 
-    const [members, setMembers] = useState<Member[]>([])
-
-    useEffect(() => {
+    const sortedMembers = useMemo(() => {
         const newMembers = R.sortBy(data, R.prop(sortStatus.columnAccessor as keyof Member))
-        setMembers(sortStatus.direction === 'desc' ? R.reverse(newMembers) : newMembers)
-    }, [sortStatus, data])
+        return sortStatus.direction === 'desc' ? R.reverse(newMembers) : newMembers
+    }, [data, sortStatus])
 
     return (
         <Flex direction={'column'}>
@@ -38,7 +36,7 @@ export function MembersAdminTable() {
                 idAccessor="identifier"
                 noRecordsText="No organisations yet, add some using button below"
                 noRecordsIcon={<Users />}
-                records={members}
+                records={sortedMembers}
                 sortStatus={sortStatus}
                 onSortStatusChange={setSortStatus}
                 columns={[

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -36,7 +36,7 @@ const middlewareDebug = debug('app:middleware')
 const isMemberRoute = createRouteMatcher(['/member(.*)'])
 const isResearcherRoute = createRouteMatcher(['/researcher(.*)'])
 const OPENSTAX_ORG_SLUG = 'openstax'
-const SAFEINSIGHTS_ORG_SLUG = 'safe-insights'
+const CLERK_ADMIN_ORG_SLUG = 'safe-insights'
 
 const MFA_ROUTE = '/account/mfa'
 
@@ -57,7 +57,7 @@ export default clerkMiddleware(async (auth, req) => {
 
     // Define user roles
     const userRoles = {
-        isAdmin: orgSlug === SAFEINSIGHTS_ORG_SLUG,
+        isAdmin: orgSlug === CLERK_ADMIN_ORG_SLUG,
         hasMFA: !!sessionClaims?.hasMFA,
         get isMember() {
             return orgSlug && !this.isAdmin

--- a/src/server/actions/member.actions.test.ts
+++ b/src/server/actions/member.actions.test.ts
@@ -13,7 +13,7 @@ describe('Member Actions', () => {
     beforeEach(() => {
         mockClerkSession({
             clerkUserId: 'user-id',
-            org_slug: 'safeinsights',
+            org_slug: 'safe-insights',
         })
     })
     const newMember = {

--- a/src/server/actions/member.actions.test.ts
+++ b/src/server/actions/member.actions.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, beforeEach } from 'vitest'
+import { CLERK_ADMIN_ORG_SLUG } from '@/server/config'
 import { db } from '@/database'
 import { mockClerkSession } from '@/tests/unit.helpers'
 import { Member } from '@/schema/member'
@@ -13,7 +14,7 @@ describe('Member Actions', () => {
     beforeEach(() => {
         mockClerkSession({
             clerkUserId: 'user-id',
-            org_slug: 'safe-insights',
+            org_slug: CLERK_ADMIN_ORG_SLUG,
         })
     })
     const newMember = {

--- a/src/server/actions/user.actions.test.ts
+++ b/src/server/actions/user.actions.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import { CLERK_ADMIN_ORG_SLUG } from '@/server/config'
 import { db } from '@/database'
 import { findOrCreateSiUserId } from '@/server/db/mutations'
 

--- a/src/server/actions/wrappers.ts
+++ b/src/server/actions/wrappers.ts
@@ -82,7 +82,7 @@ export function adminAction<S extends Schema, F extends WrappedFunc<S>>(func: F,
     const wrappedFunction = async (arg: z.infer<S>): Promise<any> => {
         const store = localStorageContext.getStore()
         if (store?.orgSlug !== 'safe-insights') {
-            logger.error("Current orgSlug in adminAction:", store?.orgSlug)
+            logger.error('Current orgSlug in adminAction:', store?.orgSlug)
             throw new AccessDeniedError('Only admins are allowed to perform this action')
         }
         return await func(arg)

--- a/src/server/actions/wrappers.ts
+++ b/src/server/actions/wrappers.ts
@@ -4,6 +4,7 @@ import { AccessDeniedError } from '@/lib/types'
 import { z, type Schema } from 'zod'
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { type SiUser, siUser } from '../db/queries'
+import { CLERK_ADMIN_ORG_SLUG } from '../config'
 
 export { z } from 'zod'
 
@@ -81,7 +82,7 @@ export function adminAction<S extends Schema, F extends WrappedFunc<S>>(func: F,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const wrappedFunction = async (arg: z.infer<S>): Promise<any> => {
         const store = localStorageContext.getStore()
-        if (store?.orgSlug !== 'safe-insights') {
+        if (store?.orgSlug !== CLERK_ADMIN_ORG_SLUG) {
             logger.error('Current orgSlug in adminAction:', store?.orgSlug)
             throw new AccessDeniedError('Only admins are allowed to perform this action')
         }

--- a/src/server/actions/wrappers.ts
+++ b/src/server/actions/wrappers.ts
@@ -1,3 +1,4 @@
+import logger from '@/lib/logger'
 import { auth as clerkAuth } from '@clerk/nextjs/server'
 import { AccessDeniedError } from '@/lib/types'
 import { z, type Schema } from 'zod'
@@ -80,8 +81,8 @@ export function adminAction<S extends Schema, F extends WrappedFunc<S>>(func: F,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const wrappedFunction = async (arg: z.infer<S>): Promise<any> => {
         const store = localStorageContext.getStore()
-
-        if (store?.orgSlug !== 'safeinsights') {
+        if (store?.orgSlug !== 'safe-insights') {
+            logger.error("Current orgSlug in adminAction:", store?.orgSlug)
             throw new AccessDeniedError('Only admins are allowed to perform this action')
         }
         return await func(arg)

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,5 +1,7 @@
 import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager'
 
+export const CLERK_ADMIN_ORG_SLUG = 'safe-insights'
+
 export const DEV_ENV = !!process && process.env.NODE_ENV === 'development'
 
 export const TEST_ENV = !!(process.env.CI || process.env.NODE_ENV === 'test')


### PR DESCRIPTION
Hot fix for pages https://openstax.atlassian.net/browse/OTTER-61

```
http://localhost:4000/admin/invite
http://localhost:4000/admin/organization
```

Errors:
* Next JS error on organisations list view
* no org visible
* org selector broken on invite

Now it works if user is in SafeInsights Clerk org (bottom):
<img width="417" alt="image" src="https://github.com/user-attachments/assets/996b0d24-0839-4161-996c-40a4a2c20aca" />
