### PR TITLE
Display a popover with job id when job errors

### DIFF
--- a/src/app/member/[memberIdentifier]/dashboard/display-study-status.tsx
+++ b/src/app/member/[memberIdentifier]/dashboard/display-study-status.tsx
@@ -1,97 +1,79 @@
 import React, { FC } from 'react'
-import { StudyJobStatus, StudyStatus } from '@/database/types'
-import { Stack, Text } from '@mantine/core'
+import { StudyStatus, StudyJobStatus } from '@/database/types'
+import { AllStatus } from '@/lib/types'
+import { Stack, Text, Popover, PopoverTarget, PopoverDropdown, Flex } from '@mantine/core'
+import { Info } from '@phosphor-icons/react/dist/ssr'
+import { CopyingInput } from '@/components/copying-input'
 
-export const DisplayStudyStatus: FC<{ studyStatus: StudyStatus; jobStatus: StudyJobStatus | null }> = ({
-    studyStatus,
-    jobStatus,
-}) => {
-    if (jobStatus === 'JOB-PACKAGING') {
-        return (
-            <Stack gap="0">
-                <Text size="xs" c="#64707C">
-                    Code
+type PopOverComponent = React.FC<{ jobId?: string | null }>
+
+const JobIdPopover: PopOverComponent = ({ jobId }) => {
+    if (!jobId) return null
+
+    return (
+        <Popover width={200} position="bottom" withArrow shadow="md">
+            <PopoverTarget>
+                <Info color="blue" />
+            </PopoverTarget>
+            <PopoverDropdown miw={'350px'}>
+                <Text size="xs" fw="bold">
+                    Job ID to share with support
                 </Text>
-                <Text>Processing</Text>
-            </Stack>
-        )
+                <CopyingInput value={jobId} tooltipLabel="Copy JobId" />
+            </PopoverDropdown>
+        </Popover>
+    )
+}
+
+type StatusLabels = {
+    type: 'Code' | 'Results' | 'Proposal'
+    label: string
+    InfoComponent?: PopOverComponent
+}
+
+const StatusLabels: Partial<Record<AllStatus, StatusLabels>> = {
+    APPROVED: { type: 'Proposal', label: 'Approved' },
+    REJECTED: { type: 'Proposal', label: 'Rejected' },
+    'JOB-PACKAGING': { type: 'Code', label: 'Processing' },
+    'JOB-ERRORED': { type: 'Code', label: 'Errored', InfoComponent: JobIdPopover },
+    'RUN-COMPLETE': { type: 'Results', label: 'Under Review' },
+    'RESULTS-REJECTED': { type: 'Results', label: 'Rejected' },
+    'RESULTS-APPROVED': { type: 'Results', label: 'Approved' },
+    'PENDING-REVIEW': { type: 'Proposal', label: 'Under Review' },
+}
+
+const StatusBlock: React.FC<StatusLabels & { jobId?: string | null }> = ({ type, label, jobId, InfoComponent }) => {
+    return (
+        <Stack gap="0">
+            <Text size="xs" c="#64707C">
+                {type}
+            </Text>
+            {InfoComponent && jobId ? (
+                <Flex align="center" gap="xs">
+                    <Text>{label}</Text>
+                    <InfoComponent jobId={jobId} />
+                </Flex>
+            ) : (
+                <Text>{label}</Text>
+            )}
+        </Stack>
+    )
+}
+
+export const DisplayStudyStatus: FC<{
+    studyStatus: StudyStatus
+    jobStatus: StudyJobStatus | null
+    jobId?: string | null
+}> = ({ studyStatus, jobStatus, jobId }) => {
+    if (jobStatus) {
+        const props = StatusLabels[jobStatus] || null
+        if (props) {
+            return <StatusBlock {...props} jobId={jobId} />
+        }
     }
-
-    if (jobStatus === 'JOB-ERRORED') {
-        return (
-            <Stack gap="0">
-                <Text size="xs" c="#64707C">
-                    Code
-                </Text>
-                <Text>Errored</Text>
-            </Stack>
-        )
-    }
-
-    if (jobStatus === 'RUN-COMPLETE') {
-        return (
-            <Stack gap="0">
-                <Text size="xs" c="#64707C">
-                    Results
-                </Text>
-                <Text>Under Review</Text>
-            </Stack>
-        )
-    }
-
-    if (jobStatus === 'RESULTS-REJECTED') {
-        return (
-            <Stack gap="0">
-                <Text size="xs" c="#64707C">
-                    Results
-                </Text>
-                <Text>Rejected</Text>
-            </Stack>
-        )
-    }
-
-    if (jobStatus === 'RESULTS-APPROVED') {
-        return (
-            <Stack gap="0">
-                <Text size="xs" c="#64707C">
-                    Results
-                </Text>
-                <Text>Approved</Text>
-            </Stack>
-        )
-    }
-
-    if (studyStatus === 'PENDING-REVIEW') {
-        return (
-            <Stack gap="0">
-                <Text size="xs" c="#64707C">
-                    Proposal
-                </Text>
-                <Text>Under Review</Text>
-            </Stack>
-        )
-    }
-
-    if (studyStatus === 'APPROVED') {
-        return (
-            <Stack gap="0">
-                <Text size="xs" c="#64707C">
-                    Proposal
-                </Text>
-                <Text>Approved</Text>
-            </Stack>
-        )
-    }
-
-    if (studyStatus === 'REJECTED') {
-        return (
-            <Stack gap="0">
-                <Text size="xs" c="#64707C">
-                    Proposal
-                </Text>
-                <Text>Rejected</Text>
-            </Stack>
-        )
+    const props = StatusLabels[studyStatus] || null
+    if (props) {
+        return <StatusBlock {...props} jobId={jobId} />
     }
 
     return null

--- a/src/app/member/[memberIdentifier]/dashboard/page.test.tsx
+++ b/src/app/member/[memberIdentifier]/dashboard/page.test.tsx
@@ -48,6 +48,7 @@ const mockStudies = [
         title: 'Study Title 1',
         researcherName: 'Person A',
         latestJobStatus: 'JOB-PACKAGING' as StudyJobStatus,
+        latestStudyJobId: 'job-1',
         memberIdentifier: 'test-member',
     },
     {

--- a/src/app/member/[memberIdentifier]/dashboard/page.tsx
+++ b/src/app/member/[memberIdentifier]/dashboard/page.tsx
@@ -49,7 +49,11 @@ export default async function MemberDashboardPage(props: { params: Promise<{ mem
             <TableTd>{study.researcherName}</TableTd>
             <TableTd>{study.reviewerName}</TableTd>
             <TableTd>
-                <DisplayStudyStatus studyStatus={study.status} jobStatus={study.latestJobStatus} />
+                <DisplayStudyStatus
+                    studyStatus={study.status}
+                    jobStatus={study.latestJobStatus}
+                    jobId={study.latestStudyJobId}
+                />
             </TableTd>
             <TableTd>
                 <Anchor component={Link} href={`/member/${member.identifier}/study/${study.id}/review`}>

--- a/src/app/researcher/dashboard/page.tsx
+++ b/src/app/researcher/dashboard/page.tsx
@@ -72,7 +72,11 @@ export default async function ResearcherDashboardPage(): Promise<React.ReactElem
             <TableTd>{study.reviewerTeamName}</TableTd>
             <TableTd>
                 <Stack gap="xs">
-                    <DisplayStudyStatus studyStatus={study.status} jobStatus={study.latestJobStatus} />
+                    <DisplayStudyStatus
+                        studyStatus={study.status}
+                        jobStatus={study.latestJobStatus}
+                        jobId={study.latestStudyJobId}
+                    />
                 </Stack>
             </TableTd>
             <TableTd>

--- a/src/components/copying-input.tsx
+++ b/src/components/copying-input.tsx
@@ -5,27 +5,25 @@ import { Check, Copy } from '@phosphor-icons/react/dist/ssr'
 import { useClipboard } from '@mantine/hooks'
 import { FC } from 'react'
 
-export const CopyingInput: FC<{ value: string }> = ({ value }) => {
+export const CopyingInput: FC<{ value: string; tooltipLabel?: string }> = ({ value, tooltipLabel = 'Copy code' }) => {
     const clipboard = useClipboard({ timeout: 500 })
 
     return (
-        <>
-            <Input
-                value={value}
-                styles={{ input: { cursor: 'pointer', backgroundColor: '#eaedff' } }}
-                readOnly
-                rightSectionPointerEvents="all"
-                size="sm"
-                my="sm"
-                onFocus={(event) => event.target.select()}
-                rightSection={
-                    <Tooltip label={clipboard.copied ? 'Copied' : 'Copy code'} offset={10}>
-                        <UnstyledButton type="button" onClick={() => clipboard.copy(value)} display="flex">
-                            {clipboard.copied ? <Check color="green" /> : <Copy />}
-                        </UnstyledButton>
-                    </Tooltip>
-                }
-            />
-        </>
+        <Input
+            value={value}
+            styles={{ input: { cursor: 'pointer', backgroundColor: '#eaedff' } }}
+            readOnly
+            rightSectionPointerEvents="all"
+            size="sm"
+            my="sm"
+            onFocus={(event) => event.target.select()}
+            rightSection={
+                <Tooltip label={clipboard.copied ? 'Copied' : tooltipLabel} offset={10}>
+                    <UnstyledButton type="button" onClick={() => clipboard.copy(value)} display="flex">
+                        {clipboard.copied ? <Check color="green" /> : <Copy />}
+                    </UnstyledButton>
+                </Tooltip>
+            }
+        />
     )
 }

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -34,11 +34,7 @@ export const fetchStudiesForCurrentMemberAction = memberAction(async () => {
             (eb) =>
                 eb
                     .selectFrom('studyJob')
-                    .select([
-                        'studyJob.studyId',
-                        'studyJob.id as latestStudyJobId',
-                        'studyJob.createdAt as studyJobCreatedAt',
-                    ])
+                    .select(['studyJob.studyId', 'studyJob.id as jobId', 'studyJob.createdAt as studyJobCreatedAt'])
                     .distinctOn('studyId')
                     .orderBy('studyId')
                     .orderBy('createdAt', 'desc')
@@ -60,7 +56,7 @@ export const fetchStudiesForCurrentMemberAction = memberAction(async () => {
                     .orderBy('studyJobId')
                     .orderBy('createdAt', 'desc')
                     .as('latestJobStatus'),
-            (join) => join.onRef('latestJobStatus.studyJobId', '=', 'latestStudyJob.latestStudyJobId'),
+            (join) => join.onRef('latestJobStatus.studyJobId', '=', 'latestStudyJob.jobId'),
         )
 
         .select([
@@ -81,6 +77,7 @@ export const fetchStudiesForCurrentMemberAction = memberAction(async () => {
             'reviewerUser.fullName as reviewerName',
             'member.identifier as memberIdentifier',
             'latestJobStatus.status as latestJobStatus',
+            'latestStudyJob.jobId as latestStudyJobId',
         ])
         .orderBy('study.createdAt', 'desc')
         .execute()
@@ -98,11 +95,7 @@ export const fetchStudiesForCurrentResearcherAction = researcherAction(async (us
             (eb) =>
                 eb
                     .selectFrom('studyJob')
-                    .select([
-                        'studyJob.studyId',
-                        'studyJob.id as latestStudyJobId',
-                        'studyJob.createdAt as studyJobCreatedAt',
-                    ])
+                    .select(['studyJob.studyId', 'studyJob.id as jobId', 'studyJob.createdAt as studyJobCreatedAt'])
                     .distinctOn('studyId')
                     .orderBy('studyId')
                     .orderBy('createdAt', 'desc')
@@ -123,7 +116,7 @@ export const fetchStudiesForCurrentResearcherAction = researcherAction(async (us
                     .orderBy('studyJobId')
                     .orderBy('createdAt', 'desc')
                     .as('latestJobStatus'),
-            (join) => join.onRef('latestJobStatus.studyJobId', '=', 'latestStudyJob.latestStudyJobId'),
+            (join) => join.onRef('latestJobStatus.studyJobId', '=', 'latestStudyJob.jobId'),
         )
         .select([
             'study.id',
@@ -133,6 +126,7 @@ export const fetchStudiesForCurrentResearcherAction = researcherAction(async (us
             'study.createdAt',
             'member.name as reviewerTeamName',
             'latestJobStatus.status as latestJobStatus',
+            'latestStudyJob.jobId as latestStudyJobId',
         ])
         .orderBy('study.createdAt', 'desc')
         .execute()


### PR DESCRIPTION
I started to refactor in order to display other statuses like 'CODE-REJECTED' but then noticed that they're marked as POST-MVP

I held off implementing them but left the refactoring so it'll be easier to support them in the future


<img width="552" alt="image" src="https://github.com/user-attachments/assets/6ac1e07c-b6e2-4580-ad87-051d0717b538" />
