### PR TITLE
fix study status order and bug

### DIFF
--- a/src/components/study/display-study-status.tsx
+++ b/src/components/study/display-study-status.tsx
@@ -37,6 +37,7 @@ const StatusLabels: Partial<Record<AllStatus, StatusLabels>> = {
     APPROVED: { type: 'Proposal', label: 'Approved' },
     REJECTED: { type: 'Proposal', label: 'Rejected' },
     'JOB-PACKAGING': { type: 'Code', label: 'Processing' },
+    'JOB-RUNNING': { type: 'Code', label: 'Running' },
     'JOB-ERRORED': { type: 'Code', label: 'Errored', InfoComponent: JobIdPopover },
     'RUN-COMPLETE': { type: 'Results', label: 'Under Review' },
     'RESULTS-REJECTED': { type: 'Results', label: 'Rejected' },

--- a/src/server/actions/study-job.actions.ts
+++ b/src/server/actions/study-job.actions.ts
@@ -81,7 +81,7 @@ export const loadStudyJobAction = userAction(async (studyJobIdentifier) => {
         )
         .leftJoin('jobStatusChange', (join) =>
             join
-                .on('jobStatusChange.studyJobId', '=', 'studyJob.id')
+                .onRef('jobStatusChange.studyJobId', '=', 'studyJob.id')
                 .on('jobStatusChange.status', 'in', ['RESULTS-APPROVED', 'RESULTS-REJECTED']),
         )
         .select([


### PR DESCRIPTION
Running was missing from status, and the approve button query wasn't fetching anything causing the buttons to always be shown