### PR TITLE
Do not display ‘Results are not available.’ at bottom of reviewer screen

### DIFF
--- a/src/app/member/[memberSlug]/study/[studyIdentifier]/review/study-results.tsx
+++ b/src/app/member/[memberSlug]/study/[studyIdentifier]/review/study-results.tsx
@@ -172,10 +172,8 @@ export const StudyResults: FC<{
                         </form>
                     )}
                 </Stack>
-                {jobStatus === 'RESULTS-APPROVED' ? (
+                {jobStatus === 'RESULTS-APPROVED' && (
                     <ViewJobResultsCSV job={latestJob} />
-                ) : (
-                    <Text>Results are not available.</Text>
                 )}
             </Stack>
         </Paper>

--- a/src/app/member/[memberSlug]/study/[studyIdentifier]/review/study-results.tsx
+++ b/src/app/member/[memberSlug]/study/[studyIdentifier]/review/study-results.tsx
@@ -107,6 +107,16 @@ export const StudyResults: FC<{
         },
     })
 
+    const onSubmit = (values: StudyResultsFormValues) => {
+        decryptResults({ privateKey: values.privateKey })
+    }
+
+    const handleError = (errors: typeof form.errors) => {
+        if (errors.privateKey) {
+            notifications.show({ message: 'Invalid private key', color: 'red' })
+        }
+    }
+
     if (!latestJob) {
         return (
             <Paper bg="white" p="xl">
@@ -132,14 +142,8 @@ export const StudyResults: FC<{
         )
     }
 
-    const onSubmit = (values: StudyResultsFormValues) => {
-        decryptResults({ privateKey: values.privateKey })
-    }
-
-    const handleError = (errors: typeof form.errors) => {
-        if (errors.privateKey) {
-            notifications.show({ message: 'Invalid private key', color: 'red' })
-        }
+    if (!jobStatus || !['RESULTS-APPROVED', 'RUN-COMPLETE'].includes(jobStatus)) {
+        return null // nothing to display
     }
 
     return (
@@ -172,9 +176,7 @@ export const StudyResults: FC<{
                         </form>
                     )}
                 </Stack>
-                {jobStatus === 'RESULTS-APPROVED' && (
-                    <ViewJobResultsCSV job={latestJob} />
-                )}
+                {jobStatus === 'RESULTS-APPROVED' && <ViewJobResultsCSV job={latestJob} />}
             </Stack>
         </Paper>
     )


### PR DESCRIPTION
I added a fallback message in #138 that had incorrect logic and displayed more often than it should have.