### PR TITLE
enforce tab order on "Back to Login" link

### DIFF
--- a/src/app/account/reset-password/reset-form.tsx
+++ b/src/app/account/reset-password/reset-form.tsx
@@ -76,7 +76,7 @@ export function ResetForm({ onCompleteAction }: ResetFormProps) {
                         <Button type="submit" loading={isPending}>
                             Send Reset Code
                         </Button>
-                        <Anchor onClick={() => router.push('/')}>Back to Login</Anchor>
+                        <Anchor tabIndex={0} role="link" onClick={() => router.push('/')}>Back to Login</Anchor>
                     </Stack>
                 </Paper>
             </form>

--- a/src/app/account/reset-password/reset-form.tsx
+++ b/src/app/account/reset-password/reset-form.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Button, Group, Stack, Text, TextInput, Paper, CloseButton, Anchor } from '@mantine/core'
+import { Button, Group, Stack, Text, TextInput, Paper, CloseButton } from '@mantine/core'
 import { isEmail, useForm } from '@mantine/form'
 import { useRouter } from 'next/navigation'
 import { useSignIn } from '@clerk/nextjs'

--- a/src/app/account/reset-password/reset-form.tsx
+++ b/src/app/account/reset-password/reset-form.tsx
@@ -76,7 +76,9 @@ export function ResetForm({ onCompleteAction }: ResetFormProps) {
                         <Button type="submit" loading={isPending}>
                             Send Reset Code
                         </Button>
-                        <Anchor tabIndex={0} role="link" onClick={() => router.push('/')}>Back to Login</Anchor>
+                        <Anchor tabIndex={0} role="link" onClick={() => router.push('/')}>
+                            Back to Login
+                        </Anchor>
                     </Stack>
                 </Paper>
             </form>

--- a/src/app/account/reset-password/reset-form.tsx
+++ b/src/app/account/reset-password/reset-form.tsx
@@ -7,6 +7,7 @@ import { useSignIn } from '@clerk/nextjs'
 import type { SignInResource } from '@clerk/types'
 import { errorToString } from '@/lib/errors'
 import { useMutation } from '@tanstack/react-query'
+import { Link } from '@/components/links'
 
 interface ResetFormValues {
     email: string
@@ -76,9 +77,7 @@ export function ResetForm({ onCompleteAction }: ResetFormProps) {
                         <Button type="submit" loading={isPending}>
                             Send Reset Code
                         </Button>
-                        <Anchor tabIndex={0} role="link" onClick={() => router.push('/')}>
-                            Back to Login
-                        </Anchor>
+                        <Link href="/account/signin">Back to Login</Link>
                     </Stack>
                 </Paper>
             </form>


### PR DESCRIPTION
[OTTER-163](http://openstax.atlassian.net/browse/OTTER-163)

The component wasn't included in tab order because it's missing the `href` attribute (_we're using the `next/navigation `router instead_). I've added accessibility attributes to the`Anchor` component to resolve this. The component is now included in the tab order. (see video below).


https://github.com/user-attachments/assets/42eff4ec-1bf9-4604-acc4-baae2c36ee3c





[OTTER-163]: https://openstax.atlassian.net/browse/OTTER-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ