### PR TITLE
add tests for wrappers and simplify structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "update-db-types": "kysely-codegen --out-file src/database/types.ts",
         "checks": "run-p -c typecheck lint validate-actions",
         "test:e2e": "playwright test",
-        "test:unit": "vitest --coverage",
+        "test:unit": "vitest",
         "test": "run-p -c test:*",
         "test:coverage": "tsx tests/merged-coverage.ts",
         "pre:commit": "npx lint-staged",

--- a/src/app/admin/invite/admin-users.actions.test.ts
+++ b/src/app/admin/invite/admin-users.actions.test.ts
@@ -77,7 +77,7 @@ describe('invite user Actions', async () => {
         expect(sendWelcomeEmail).toHaveBeenCalledWith(user.email, `${user.firstName} ${user.lastName}`)
     })
 
-    it.only('throws an error when user insert fails', async () => {
+    it('throws an error when user insert fails', async () => {
         clerkMocks?.client.users.createUser.mockImplementation(() =>
             Promise.reject({ errors: [{ code: 'no-user', message: 'failed' }] }),
         )

--- a/src/app/admin/invite/admin-users.actions.test.ts
+++ b/src/app/admin/invite/admin-users.actions.test.ts
@@ -1,7 +1,6 @@
 import { db } from '@/database'
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest'
-import { CLERK_ADMIN_ORG_SLUG } from '@/lib/types'
-import { mockClerkSession, type ClerkMocks } from '@/tests/unit.helpers'
+import { mockSessionWithTestData, type ClerkMocks } from '@/tests/unit.helpers'
 import { adminInviteUserAction } from './admin-users.actions'
 import { faker } from '@faker-js/faker'
 import { randomString } from 'remeda'
@@ -15,11 +14,8 @@ vi.mock('@/server/mailgun', () => ({
 
 describe('invite user Actions', async () => {
     let clerkMocks: ClerkMocks | null = null
-    beforeEach(() => {
-        clerkMocks = mockClerkSession({
-            clerkUserId: 'user-id',
-            org_slug: CLERK_ADMIN_ORG_SLUG,
-        })
+    beforeEach(async () => {
+        clerkMocks = await mockSessionWithTestData({ isAdmin: true })
     })
 
     async function userRecordCount() {
@@ -81,7 +77,7 @@ describe('invite user Actions', async () => {
         expect(sendWelcomeEmail).toHaveBeenCalledWith(user.email, `${user.firstName} ${user.lastName}`)
     })
 
-    it('throws an error when user insert fails', async () => {
+    it.only('throws an error when user insert fails', async () => {
         clerkMocks?.client.users.createUser.mockImplementation(() =>
             Promise.reject({ errors: [{ code: 'no-user', message: 'failed' }] }),
         )
@@ -97,6 +93,6 @@ describe('invite user Actions', async () => {
             },
         }))
         await expect(adminInviteUserAction(userInvite)).rejects.toThrowError()
-        expect(beforeCount).toEqual((await userRecordCount()) - 1)
+        expect(beforeCount).toEqual(await userRecordCount())
     })
 })

--- a/src/app/reviewer/[orgSlug]/study/[studyId]/review/job-review-buttons.test.tsx
+++ b/src/app/reviewer/[orgSlug]/study/[studyId]/review/job-review-buttons.test.tsx
@@ -37,7 +37,6 @@ describe('Study Results Approve/Reject buttons', async () => {
             const latest = await latestJobForStudy(job.studyId, { orgSlug: org.slug })
             expect(latest?.latestStatus).toEqual(statusChange)
         })
-
     }
 
     it('renders the approve/reject buttons when there is an unreviewed job', async () => {
@@ -55,7 +54,6 @@ describe('Study Results Approve/Reject buttons', async () => {
         await insertAndRender('REJECTED')
         expect(screen.queryByText(/rejected on/i)).toBeDefined()
     })
-
 
     it('can approve results', async () => {
         await clickNTest('Approve', actions.approveStudyJobResultsAction as Mock, 'RESULTS-APPROVED')

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,12 +1,14 @@
 import * as Sentry from '@sentry/nextjs'
 
-type TimeOpts = { [key: number]: 'seconds' } | { [key: number]: 'minutes' }
+type TimeOpts = { [key: number]: 'ms' } | { [key: number]: 'seconds' } | { [key: number]: 'minutes' }
 
 export async function sleep(opts: TimeOpts): Promise<void> {
     let ms = 0
     for (const [key, unit] of Object.entries(opts)) {
         const duration = parseInt(key, 10)
-        if (unit === 'seconds') {
+        if (unit === 'ms') {
+            ms += duration
+        } else if (unit === 'seconds') {
             ms += duration * 1000
         } else if (unit === 'minutes') {
             ms += duration * 60 * 1000

--- a/src/server/actions/study-job.actions.ts
+++ b/src/server/actions/study-job.actions.ts
@@ -41,22 +41,20 @@ export const approveStudyJobResultsAction = orgAction(async ({ jobInfo: info, jo
     const resultsFile = new File([result.contents], result.path)
     await storeStudyResultsFile({ ...info, resultsType: 'APPROVED', resultsPath: resultsFile.name }, resultsFile)
 
-    const user = await siUser(false)
+    const user = await siUser()
     await db
         .updateTable('studyJob')
         .set({ resultsPath: resultsFile.name })
         .where('id', '=', info.studyJobId)
         .executeTakeFirstOrThrow()
-
     await db
         .insertInto('jobStatusChange')
         .values({
-            userId: user?.id,
+            userId: user.id,
             status: 'RESULTS-APPROVED',
             studyJobId: info.studyJobId,
         })
         .executeTakeFirstOrThrow()
-
     revalidatePath(`/reviewer/[orgSlug]/study/${info.studyId}`)
 }, approveStudyJobResultsActionSchema)
 

--- a/src/server/actions/study-job.actions.ts
+++ b/src/server/actions/study-job.actions.ts
@@ -130,7 +130,8 @@ export const loadStudyJobAction = userAction(async (studyJobId) => {
 }, z.string())
 
 export const latestJobForStudyAction = userAction(async (studyId) => {
-    const latestJob = await latestJobForStudy(studyId, await actionContext())
+    const ctx = await actionContext()
+    const latestJob = await latestJobForStudy(studyId, { orgSlug: ctx.org.slug, userId: ctx.user.id })
 
     // We should always have a job, something is wrong if we don't
     if (!latestJob) {

--- a/src/server/actions/study-job.actions.ts
+++ b/src/server/actions/study-job.actions.ts
@@ -48,7 +48,6 @@ export const approveStudyJobResultsAction = orgAction(async ({ jobInfo: info, jo
         .where('id', '=', info.studyJobId)
         .executeTakeFirstOrThrow()
 
-    return
     await db
         .insertInto('jobStatusChange')
         .values({

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -22,7 +22,7 @@ describe('Study Actions', () => {
     it('getStudyAction returns any study that belongs to an org that user is a org of', async () => {
         const { user, org } = await mockSessionWithTestData()
         const otherOrg = await insertTestOrg()
-        const otherUser = await insertTestUser({ org: otherOrg })
+        const { user: otherUser } = await insertTestUser({ org: otherOrg })
 
         const { studyId } = await insertTestStudyData({ org, researcherId: user.id })
 
@@ -38,7 +38,7 @@ describe('Study Actions', () => {
         const { user, org } = await mockSessionWithTestData()
 
         const otherOrg = await insertTestOrg()
-        const otherUser = await insertTestUser({ org: otherOrg })
+        const { user: otherUser } = await insertTestUser({ org: otherOrg })
 
         const { studyId } = await insertTestStudyData({ org, researcherId: user.id })
 

--- a/src/server/actions/user.actions.test.ts
+++ b/src/server/actions/user.actions.test.ts
@@ -8,7 +8,7 @@ describe('User Actions', () => {
     describe('findOrCreateSiUserId', () => {
         it('returns existing user id when user exists', async () => {
             const org = await insertTestOrg()
-            const user = await insertTestUser({ org })
+            const { user } = await insertTestUser({ org })
 
             const foundUserId = await findOrCreateSiUserId(user.clerkId)
             expect(foundUserId).toBe(user.id)

--- a/src/server/actions/wrappers.test.tsx
+++ b/src/server/actions/wrappers.test.tsx
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, Mock } from 'vitest'
+import { z } from 'zod'
+import { auth as clerkAuth } from '@clerk/nextjs/server'
+import {
+    actionContext,
+    getUserIdFromActionContext,
+    getOrgInfoFromActionContext,
+    anonAction,
+    userAction,
+    adminAction,
+    researcherAction,
+    orgAction,
+    orgAdminAction,
+    checkMemberOfOrgWithSlug,
+    localStorageContext,
+} from './wrappers'
+import { db } from '@/database'
+import { CLERK_ADMIN_ORG_SLUG } from '@/lib/types'
+import { AccessDeniedError } from '@/lib/errors'
+import { mockSessionWithTestData } from '@/tests/unit.helpers'
+
+const clerkAuthMock = clerkAuth as unknown as Mock
+
+describe('anonAction()', () => {
+    it('calls through when no schema is provided', async () => {
+        const func = vi.fn().mockResolvedValue('OK')
+        const wrapped = anonAction(func)
+        await expect(wrapped({ foo: 'bar' })).resolves.toBe('OK')
+        expect(func).toHaveBeenCalledWith({ foo: 'bar' })
+    })
+
+    it('validates args against schema and rejects invalid', async () => {
+        const schema = z.object({ x: z.number() })
+        const func = vi.fn().mockResolvedValue('OK')
+        const wrapped = anonAction(func, schema)
+        await expect(wrapped({ x: 123 })).resolves.toBe('OK')
+        await expect(wrapped({ x: 'nope' })).rejects.toThrow()
+    })
+})
+
+describe('actionContext & simple getters', () => {
+    it('returns a fresh ctx when none is set', async () => {
+        const { org, user } = await mockSessionWithTestData()
+        const ctx = await actionContext()
+        expect(ctx.user.id).toBe(user.id)
+        expect(ctx.org).toEqual({ slug: org.slug })
+    })
+
+    it('getUserIdFromActionContext() returns the same userId', async () => {
+        const { user } = await mockSessionWithTestData()
+        await expect(getUserIdFromActionContext()).resolves.toBe(user.id)
+    })
+
+    it('getOrgInfoFromActionContext() throws when no org', async () => {
+        const { user } = await mockSessionWithTestData()
+        await localStorageContext.run(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            { user: user as any, org: {} },
+            async () => {
+                await expect(getOrgInfoFromActionContext()).rejects.toThrow('user is not a member of organization?')
+            },
+        )
+    })
+
+    it('getOrgInfoFromActionContext(false) returns partial org', async () => {
+        const { user, orgUser } = await mockSessionWithTestData()
+        await localStorageContext.run(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            { user: user as any, org: orgUser as any },
+            async () => {
+                await expect(getOrgInfoFromActionContext(false)).resolves.toEqual(orgUser)
+            },
+        )
+    })
+})
+
+describe('userAction()', () => {
+    it('runs inner func with AsyncLocalStorage populated', async () => {
+        const { user } = await mockSessionWithTestData()
+        const fn = vi.fn().mockImplementation(async () => {
+            return localStorageContext.getStore()
+        })
+        const wrapped = userAction(fn)
+        const store = await wrapped({})
+        expect(store).toMatchObject({
+            user: expect.objectContaining({ id: user.id }),
+            org: {},
+        })
+    })
+})
+
+describe('adminAction()', () => {
+    it('allows when orgSlug === CLERK_ADMIN_ORG_SLUG', async () => {
+        await mockSessionWithTestData()
+        clerkAuthMock.mockResolvedValue({ orgSlug: CLERK_ADMIN_ORG_SLUG })
+        const fn = vi.fn().mockResolvedValue('ADM_OK')
+        const wrapped = adminAction(fn)
+        await expect(wrapped({})).resolves.toBe('ADM_OK')
+    })
+
+    it('throws AccessDeniedError when not admin org', async () => {
+        const wrapped = adminAction(vi.fn())
+        await expect(wrapped({})).rejects.toBeInstanceOf(AccessDeniedError)
+    })
+})
+
+describe('researcherAction()', () => {
+    it('allows when user.isResearcher === true', async () => {
+        const { orgUser } = await mockSessionWithTestData()
+        await db.updateTable('orgUser').set({ isResearcher: true }).where('id', '=', orgUser.id).execute()
+        const fn = vi.fn().mockResolvedValue('RES_OK')
+        const wrapped = researcherAction(fn)
+        await expect(wrapped({})).resolves.toBe('RES_OK')
+    })
+
+    it('throws when user.isResearcher === false', async () => {
+        const { orgUser } = await mockSessionWithTestData()
+        await db.updateTable('orgUser').set({ isResearcher: false }).where('id', '=', orgUser.id).execute()
+
+        const wrapped = researcherAction(vi.fn())
+        await expect(wrapped({})).rejects.toBeInstanceOf(AccessDeniedError)
+    })
+
+    it('checks orgSlug if given', async () => {
+        const { orgUser } = await mockSessionWithTestData()
+        await db.updateTable('orgUser').set({ isResearcher: true }).where('id', '=', orgUser.id).execute()
+
+        const wrapped = researcherAction(vi.fn())
+        await expect(wrapped({ orgSlug: 'not-valid' })).rejects.toBeInstanceOf(AccessDeniedError)
+    })
+})
+
+describe('orgAction()', () => {
+    const schema = z.object({ orgSlug: z.string() })
+
+    it('throws if arg.orgSlug is missing', async () => {
+        const wrapped = orgAction(vi.fn(), schema)
+        await expect(wrapped({})).rejects.toBeInstanceOf(AccessDeniedError)
+    })
+
+    it('throws if user is not a member', async () => {
+        const { orgUser } = await mockSessionWithTestData()
+        await db.deleteFrom('orgUser').where('id', '=', orgUser.id).execute()
+        const wrapped = orgAction(vi.fn(), schema)
+        await expect(wrapped({ orgSlug: 'nope' })).rejects.toBeInstanceOf(AccessDeniedError)
+    })
+
+    it('succeeds and injects ctx.org when member exists', async () => {
+        const { org, orgUser } = await mockSessionWithTestData()
+        await db
+            .updateTable('orgUser')
+            .set({ isResearcher: false, isReviewer: true, isAdmin: true })
+            .where('id', '=', orgUser.id)
+            .execute()
+
+        const fn = vi.fn().mockImplementation(async () => localStorageContext.getStore())
+        const wrapped = orgAction(fn, schema)
+        const store = await wrapped({ orgSlug: org.slug })
+        expect(store.org).toMatchObject({
+            id: org.id,
+            slug: org.slug,
+            isReviewer: true,
+            isResearcher: false,
+            isAdmin: true,
+        })
+    })
+})
+
+describe('orgAdminAction()', () => {
+    const schema = z.object({ orgSlug: z.string() })
+
+    it('throws if user is not org-admin after orgAction', async () => {
+        const { orgUser, org } = await mockSessionWithTestData()
+        await db.updateTable('orgUser').set({ isAdmin: false }).where('id', '=', orgUser.id).execute()
+
+        const wrapped = orgAdminAction(vi.fn(), schema)
+        await expect(wrapped({ orgSlug: org.slug })).rejects.toBeInstanceOf(AccessDeniedError)
+    })
+
+    it('allows when user is org-admin', async () => {
+        const { org, orgUser } = await mockSessionWithTestData()
+        await db.updateTable('orgUser').set({ isAdmin: true }).where('id', '=', orgUser.id).execute()
+
+        const fn = vi.fn().mockResolvedValue('OKAY')
+        const wrapped = orgAdminAction(fn, schema)
+        await expect(wrapped({ orgSlug: org.slug })).resolves.toBe('OKAY')
+    })
+})
+
+describe('checkMemberOfOrgWithSlug()', () => {
+    it('returns true if slug matches ctx.org.slug', async () => {
+        const { org, user } = await mockSessionWithTestData()
+        await localStorageContext.run(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            { user: user as any, org: { slug: org.slug } },
+            async () => {
+                await expect(checkMemberOfOrgWithSlug(org.slug)).resolves.toBe(true)
+            },
+        )
+    })
+
+    it('throws if slug does not match', async () => {
+        await mockSessionWithTestData()
+
+        localStorageContext.run(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            { user: { id: 'u11' } as any, org: { slug: 'aaa' } },
+            async () => {
+                await expect(checkMemberOfOrgWithSlug('bbb')).rejects.toBeInstanceOf(AccessDeniedError)
+            },
+        )
+    })
+})

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -78,7 +78,6 @@ export const checkUserAllowedStudyReview = async (studyId?: string) => {
 
 export type SiUser = ClerkUser & {
     id: string
-    isResearcher: boolean
 }
 
 export async function siUser(throwIfNotFound?: true): Promise<SiUser>
@@ -94,7 +93,6 @@ export async function siUser(throwIfNotFound = true): Promise<SiUser | null> {
     return {
         ...clerkUser,
         id: userId,
-        isResearcher: true, // FIXME: we'll ned to update this once we have orgs orgship
     } as SiUser
 }
 

--- a/src/server/mutations.ts
+++ b/src/server/mutations.ts
@@ -1,5 +1,5 @@
 import { db } from '@/database'
-import { getOrgSlugFromActionContext, getUserIdFromActionContext } from './actions/wrappers'
+import { getOrgInfoFromActionContext, getUserIdFromActionContext } from './actions/wrappers'
 import { getFirstOrganizationForUser } from './db/queries'
 import { currentUser, clerkClient } from '@clerk/nextjs/server'
 
@@ -70,8 +70,8 @@ export async function findOrCreateOrgMembership({
 
 export async function ensureUserIsMemberOfOrg() {
     const userId = await getUserIdFromActionContext()
-    const slug = await getOrgSlugFromActionContext(false)
-    if (!slug) {
+    const info = await getOrgInfoFromActionContext(false)
+    if (!info.slug) {
         let org = await getFirstOrganizationForUser(userId)
         if (!org) {
             const clerkUser = await currentUser()
@@ -91,5 +91,5 @@ export async function ensureUserIsMemberOfOrg() {
         }
         return org
     }
-    return await findOrCreateOrgMembership({ userId, slug })
+    return await findOrCreateOrgMembership({ userId, slug: info.slug })
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
         environment: 'happy-dom',
         setupFiles: ['tests/vitest.setup.ts'],
         include: ['src/**/*.(test).{js,jsx,ts,tsx}'],
-
+        allowOnly: !IS_CI,
         coverage: {
             enabled: Boolean(IS_CI || process.env.COVERAGE),
             reportsDirectory: 'test-results/unit',


### PR DESCRIPTION
This sets up the wrapper context to have only user and org properties and modifies researcher wrapper to check the DB with an optional slug
