### PR TITLE
Fix lint ignore patterns

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 src/database/types.ts
+.*

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,7 @@ const compat = new FlatCompat({
 /** @type {import('eslint').Linter.Config[]} */
 const eslintConfig = [
     {
-        ignores: ['src/styles/generated/'],
+        ignores: ['.*', 'src/styles/generated/'],
     },
     ...compat.extends('next/core-web-vitals'),
     ...compat.extends('next/typescript'),

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,7 @@ const compat = new FlatCompat({
 })
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
+const eslintConfig = [
     {
         ignores: ['src/styles/generated/'],
     },
@@ -24,3 +24,5 @@ export default [
         },
     },
 ]
+
+export default eslintConfig


### PR DESCRIPTION
ignore dot files for linting. Sometimes `npm run checks` complaining too much locally here and there should not be any main code in dot files.