### PR TITLE
OTTO-189 patch - session activity timeout

### DIFF
--- a/src/components/activity-context.tsx
+++ b/src/components/activity-context.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
-import { useSession, useClerk } from '@clerk/nextjs'
+import { useClerk, useSession } from '@clerk/clerk-react'
 import { notifications } from '@mantine/notifications'
 import { Button, Text, Space, Stack } from '@mantine/core'
 
@@ -12,21 +12,33 @@ export const ActivityContext = () => {
     useEffect(() => {
         if (!session) return
 
-        const getRemainingTime = () => {
-            if (!session.lastActiveAt || !session.expireAt) return null
-            const expireTime = new Date(session.expireAt).getTime()
-            const currentTime = new Date().getTime()
-            const remainingMs = expireTime - currentTime
+        const INACTIVITY_TIMEOUT_MS = 20 * 60 * 1000 // 20 minutes
+        const WARNING_THRESHOLD_MS = 2 * 60 * 1000 // 2 minutes
 
-            return Math.max(0, Math.floor(remainingMs / 1000)) // Convert to seconds
-        }
+        const checkInactivity = () => {
+            if (!session.lastActiveAt) return
 
-        // Set up interval to check remaining time
-        const intervalId = setInterval(() => {
-            const remaining = getRemainingTime()
+            const lastActiveTime = new Date(session.lastActiveAt).getTime()
+            const currentTime = Date.now()
+            const inactivityDuration = currentTime - lastActiveTime
 
-            if (remaining !== null && remaining <= 2 * 60) {
-                // 2 minute warning
+            if (inactivityDuration < WARNING_THRESHOLD_MS) {
+                // Hide the signout notification if the user is active again
+                notifications.hide('session-expired')
+            }
+
+            if (inactivityDuration >= INACTIVITY_TIMEOUT_MS) {
+                notifications.show({
+                    title: 'Session Expired',
+                    id: 'session-expired',
+                    message: 'You’ve been logged out due to inactivity. Log back in to resume your work.',
+                    withCloseButton: true,
+                    autoClose: false,
+                })
+                notifications.hide('inactivity-warning')
+                clearInterval(intervalId)
+                signOut()
+            } else if (INACTIVITY_TIMEOUT_MS - inactivityDuration <= WARNING_THRESHOLD_MS) {
                 notifications.show({
                     title: 'Session Expiration Warning',
                     id: 'inactivity-warning',
@@ -35,15 +47,19 @@ export const ActivityContext = () => {
                     message: (
                         <Stack>
                             <Text>
-                                {`To keep your account secure, you'll be logged out in ${Math.floor(remaining / 60)} minutes due to inactivity. Click 'Stay Signed In' to continue your session.`}
+                                {`To keep your account secure, you'll be logged out in ${Math.ceil(
+                                    (INACTIVITY_TIMEOUT_MS - inactivityDuration) / 60000,
+                                )} minutes due to inactivity. Click 'Stay Signed In' to continue your session.`}
                             </Text>
                             <Space h="xs" />
                             <Button
                                 variant="filled"
                                 size="sm"
-                                onClick={() => {
-                                    session.touch()
-                                    notifications.hide('inactivity-warning')
+                                onClick={async () => {
+                                    const updatedSession = await session.touch()
+                                    if (updatedSession) {
+                                        notifications.hide('inactivity-warning')
+                                    }
                                 }}
                             >
                                 Stay Signed In
@@ -52,17 +68,9 @@ export const ActivityContext = () => {
                     ),
                 })
             }
+        }
 
-            if (remaining !== null && remaining <= 0) {
-                notifications.show({
-                    title: 'Session Expired',
-                    message: "You've been logged out due to inactivity. Log back in to resume your work.",
-                    withCloseButton: true,
-                    autoClose: false,
-                })
-                signOut()
-            }
-        }, 10000) // Check every 10 seconds
+        const intervalId = setInterval(checkInactivity, 10000) // Check every 10 seconds
 
         return () => clearInterval(intervalId)
     }, [session, signOut])

--- a/src/components/activity-context.tsx
+++ b/src/components/activity-context.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 import { useClerk, useSession } from '@clerk/clerk-react'
 import { notifications } from '@mantine/notifications'
 import { Button, Text, Space, Stack } from '@mantine/core'
+import { INACTIVITY_TIMEOUT_MS, WARNING_THRESHOLD_MS } from '@/lib/types'
 
 export const ActivityContext = () => {
     const { session } = useSession()
@@ -11,9 +12,6 @@ export const ActivityContext = () => {
 
     useEffect(() => {
         if (!session) return
-
-        const INACTIVITY_TIMEOUT_MS = 20 * 60 * 1000 // 20 minutes
-        const WARNING_THRESHOLD_MS = 2 * 60 * 1000 // 2 minutes
 
         const checkInactivity = () => {
             if (!session.lastActiveAt) return

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -70,4 +70,8 @@ export function isMinimalStudyJobInfo(info: MinimalStudyInfo | MinimalJobResults
 
 export const CLERK_ADMIN_ORG_SLUG = 'safe-insights' as const
 
+// inactivity timeout and warning threshold for user sessions
+export const INACTIVITY_TIMEOUT_MS = 20 * 60 * 1000 // 20 minutes
+export const WARNING_THRESHOLD_MS = 2 * 60 * 1000 // 2 minutes
+
 export type UserOrgRoles = { isAdmin: boolean; isResearcher: boolean; isReviewer: boolean }


### PR DESCRIPTION
adjusted logic to only sign out according to lastactive value in the clerk session object.
removed maximum session life value in clerk dashboard since this will remove the session at the given value date no matter the user activity