### PR TITLE
fix study result approve/rejected labels not showing up.

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,7 @@ const nextConfig: NextConfig = async (phase: string) => {
 
     const nextConfig: NextConfig = {
         productionBrowserSourceMaps: true,
-        assetPrefix: process.env.ASSETS_PREFIX || isDev ? undefined : '/assets/',
+        assetPrefix: process.env.CI || isDev ? undefined : '/assets/',
         output: 'standalone',
         transpilePackages: ['si-encryption'],
         experimental: {

--- a/src/app/reviewer/[orgSlug]/study/[studyId]/review/job-review-buttons.tsx
+++ b/src/app/reviewer/[orgSlug]/study/[studyId]/review/job-review-buttons.tsx
@@ -14,6 +14,17 @@ type FileEntry = {
     contents: ArrayBuffer
 }
 
+const DownloadResults: React.FC<{ results?: FileEntry }> = ({ results }) => {
+    if (!results) return null
+    return (
+        <>
+            <Divider />
+            <DownloadLink target="_blank" filename={results.path} content={results.contents} />
+            <Divider />
+        </>
+    )
+}
+
 export const JobReviewButtons = ({
     job,
     decryptedResults,
@@ -53,8 +64,6 @@ export const JobReviewButtons = ({
         },
     })
 
-    const results = decryptedResults ?? []
-
     if (job.latestStatus === 'RESULTS-APPROVED') {
         return (
             <Group gap="2">
@@ -79,9 +88,7 @@ export const JobReviewButtons = ({
 
     return (
         <Group>
-            <Divider />
-            <DownloadLink target="_blank" filename={results[0].path} content={results[0].contents} />
-            <Divider />
+            <DownloadResults results={decryptedResults?.[0]} />
             <Button
                 disabled={isPending || isSuccess}
                 loading={isPending && pendingStatus == 'RESULTS-REJECTED'}

--- a/src/app/reviewer/[orgSlug]/study/[studyId]/review/job-review-buttons.tsx
+++ b/src/app/reviewer/[orgSlug]/study/[studyId]/review/job-review-buttons.tsx
@@ -81,7 +81,11 @@ export const JobReviewButtons = ({
     return (
         <Group>
             <Divider />
-            <DownloadLink target="_blank" filename={decryptedResults[0].path} content={decryptedResults[0].contents} />
+            <DownloadLink
+                target="_blank"
+                filename={decryptedResults?.[0]?.path}
+                content={decryptedResults?.[0]?.contents}
+            />
             <Divider />
             <Button
                 disabled={isPending || isSuccess}

--- a/src/app/reviewer/[orgSlug]/study/[studyId]/review/job-review-buttons.tsx
+++ b/src/app/reviewer/[orgSlug]/study/[studyId]/review/job-review-buttons.tsx
@@ -3,7 +3,7 @@ import { StudyJobStatus } from '@/database/types'
 import { MinimalJobInfo } from '@/lib/types'
 import { approveStudyJobResultsAction, rejectStudyJobResultsAction } from '@/server/actions/study-job.actions'
 import type { StudyJobWithLastStatus } from '@/server/db/queries'
-import { Button, Divider, Group, Text, Flex, useMantineTheme } from '@mantine/core'
+import { Button, Divider, Group, Text, useMantineTheme } from '@mantine/core'
 import { CheckCircle, XCircle } from '@phosphor-icons/react/dist/ssr'
 import { useMutation } from '@tanstack/react-query'
 import dayjs from 'dayjs'
@@ -53,31 +53,28 @@ export const JobReviewButtons = ({
         },
     })
 
-    if (!decryptedResults?.length) return null
+    //TODO: Revist the implementation of this null check
+    // if (!decryptedResults?.length) return null
 
     if (job.latestStatus === 'RESULTS-APPROVED') {
         return (
-            <Flex align="center">
-                <Group gap="2">
-                    <CheckCircle weight="fill" size={24} color={theme.colors.green[9]} />
-                    <Text fz="xs" fw={600} c="green.9">
-                        Approved on {dayjs(job.latestStatusChangeOccurredAt).format('MMM DD, YYYY')}
-                    </Text>
-                </Group>
-            </Flex>
+            <Group gap="2">
+                <CheckCircle weight="fill" size={24} color={theme.colors.green[9]} />
+                <Text fz="xs" fw={600} c="green.9">
+                    Approved on {dayjs(job.latestStatusChangeOccurredAt).format('MMM DD, YYYY')}
+                </Text>
+            </Group>
         )
     }
 
     if (job.latestStatus === 'RESULTS-REJECTED') {
         return (
-            <Flex align="center">
-                <Group gap="2">
-                    <XCircle weight="fill" size={24} color={theme.colors.red[9]} />
-                    <Text fz="xs" fw={600} c="red.9">
-                        Rejected on {dayjs(job.latestStatusChangeOccurredAt).format('MMM DD, YYYY')}
-                    </Text>
-                </Group>
-            </Flex>
+            <Group gap="2">
+                <XCircle weight="fill" size={24} color={theme.colors.red[9]} />
+                <Text fz="xs" fw={600} c="red.9">
+                    Rejected on {dayjs(job.latestStatusChangeOccurredAt).format('MMM DD, YYYY')}
+                </Text>
+            </Group>
         )
     }
 

--- a/src/app/reviewer/[orgSlug]/study/[studyId]/review/job-review-buttons.tsx
+++ b/src/app/reviewer/[orgSlug]/study/[studyId]/review/job-review-buttons.tsx
@@ -53,8 +53,7 @@ export const JobReviewButtons = ({
         },
     })
 
-    //TODO: Revist the implementation of this null check
-    // if (!decryptedResults?.length) return null
+    const results = decryptedResults ?? []
 
     if (job.latestStatus === 'RESULTS-APPROVED') {
         return (
@@ -83,8 +82,8 @@ export const JobReviewButtons = ({
             <Divider />
             <DownloadLink
                 target="_blank"
-                filename={decryptedResults?.[0]?.path}
-                content={decryptedResults?.[0]?.contents}
+                filename={results[0].path}
+                content={results[0].contents}
             />
             <Divider />
             <Button

--- a/src/app/reviewer/[orgSlug]/study/[studyId]/review/job-review-buttons.tsx
+++ b/src/app/reviewer/[orgSlug]/study/[studyId]/review/job-review-buttons.tsx
@@ -80,11 +80,7 @@ export const JobReviewButtons = ({
     return (
         <Group>
             <Divider />
-            <DownloadLink
-                target="_blank"
-                filename={results[0].path}
-                content={results[0].contents}
-            />
+            <DownloadLink target="_blank" filename={results[0].path} content={results[0].contents} />
             <Divider />
             <Button
                 disabled={isPending || isSuccess}

--- a/src/app/reviewer/[orgSlug]/study/[studyId]/review/study-review-buttons.tsx
+++ b/src/app/reviewer/[orgSlug]/study/[studyId]/review/study-review-buttons.tsx
@@ -2,7 +2,7 @@
 
 import React, { FC } from 'react'
 import { useMutation } from '@tanstack/react-query'
-import { Button, Group, Text, Flex, useMantineTheme } from '@mantine/core'
+import { Button, Group, Text, useMantineTheme } from '@mantine/core'
 import { useParams, useRouter } from 'next/navigation'
 import type { StudyStatus } from '@/database/types'
 import {
@@ -42,27 +42,23 @@ export const StudyReviewButtons: FC<{ study: SelectedStudy }> = ({ study }) => {
 
     if (study.status === 'APPROVED' && study.approvedAt) {
         return (
-            <Flex align="center">
-                <Group gap="2">
-                    <CheckCircle weight="fill" size={24} color={theme.colors.green[9]} />
-                    <Text fz="xs" fw={600} c="green.9">
-                        Approved on {dayjs(study.approvedAt).format('MMM DD, YYYY')}
-                    </Text>
-                </Group>
-            </Flex>
+            <Group c="#12B886" gap="0.5rem" align="center">
+                <CheckCircle weight="fill" size={24} color={theme.colors.green[9]} />
+                <Text fz="xs" fw="semibold" c="green.9">
+                    Approved on {dayjs(study.approvedAt).format('MMM DD, YYYY')}
+                </Text>
+            </Group>
         )
     }
 
     if (study.status === 'REJECTED' && study.rejectedAt) {
         return (
-            <Flex align="center">
-                <Group gap="2">
-                    <XCircle weight="fill" size={24} color={theme.colors.red[9]} />
-                    <Text fz="xs" fw={600} c="red.9">
-                        Rejected on {dayjs(study.rejectedAt).format('MMM DD, YYYY')}
-                    </Text>
-                </Group>
-            </Flex>
+            <Group c="#FA5252" gap="0.5rem">
+                <XCircle weight="fill" size={24} color={theme.colors.red[9]} />
+                <Text fz="xs" fw="semibold" c="red.9">
+                    Rejected on {dayjs(study.rejectedAt).format('MMM DD, YYYY')}
+                </Text>
+            </Group>
         )
     }
 


### PR DESCRIPTION
[OTTTER-134](https://openstax.atlassian.net/browse/OTTER-134)

**Issue**: Approve/Rejected labels and timestamps not appearing in the study results panel

**Work done:** 
- [x] Removed unnecessary `Flex` components
- [x] refactor decryptedResults check. Solution: set decryptedResult to an empty array if null/undefined

**Explanation:** 
Upon further investigation, I’ve realized that the issue with the labels not showing up stems from [this logic](https://github.com/safeinsights/management-app/blob/3f43e021a1d228e3c70a75fc3587626dad88075a/src/app/reviewer/%5BorgSlug%5D/study/%5BstudyId%5D/review/job-review-buttons.tsx#L56) and [this](https://github.com/safeinsights/management-app/blob/3f43e021a1d228e3c70a75fc3587626dad88075a/src/app/reviewer/%5BorgSlug%5D/study/%5BstudyId%5D/review/job-review-buttons.tsx#L87) The [previous PR](https://github.com/safeinsights/management-app/pull/195) checks to see I the results have been decrypted and then displays the link.  It appears that decryptedResults isn’t ever set to true at least in the dev env, which explains why the label for the Study Results Panel and labels were not appearing.