### PR TITLE
output to Sentry on production environment for warnings and errors

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -48,7 +48,7 @@ function pretty(a: unknown): string {
     return String(a)
 }
 
-function _logAndReport(level: 'warn' | 'error', ...args: unknown[]): void {
+function logAndReport(level: 'warn' | 'error', ...args: unknown[]): void {
     const debugInstance = level === 'warn' ? debugWarn : debugError
     const consoleMethod = consoleMethodMap[level]
     const sentrySeverity = sentrySeverityMap[level]
@@ -73,13 +73,9 @@ const logger = {
     debug: debug('app:debug'),
     info: debug('app:info'),
 
-    warn: (...args: unknown[]) => {
-        _logAndReport('warn', ...args)
-    },
+    warn: (...args: unknown[]) => logAndReport('warn', ...args),
 
-    error: (...args: unknown[]) => {
-        _logAndReport('error', ...args)
-    },
+    error: (...args: unknown[]) => logAndReport('error', ...args),
 }
 
 // Enable debug output in development

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -3,6 +3,18 @@ import * as Sentry from '@sentry/nextjs'
 import type { SeverityLevel } from '@sentry/nextjs'
 import { inspect } from 'util'
 
+// map our log levels to the right console method
+const consoleMethodMap = {
+    warn: console.warn,
+    error: console.error,
+} as const
+
+// map our log levels to Sentry severities
+const sentrySeverityMap: Record<'warn' | 'error', SeverityLevel> = {
+    warn: 'warning',
+    error: 'error',
+}
+
 // keep namespace‐based debug for debug/info
 const debugWarn = debug('app:warn')
 const debugError = debug('app:error')
@@ -29,9 +41,10 @@ function pretty(a: unknown): string {
 
 function _logAndReport(level: 'warn' | 'error', ...args: unknown[]): void {
     const debugInstance = level === 'warn' ? debugWarn : debugError
-    const consoleMethod = level === 'warn' ? console.warn : console.error
-    const sentrySeverity: SeverityLevel = level === 'warn' ? 'warning' : 'error'
+    const consoleMethod = consoleMethodMap[level]
+    const sentrySeverity = sentrySeverityMap[level]
 
+    // print to console
     consoleMethod(...args)
 
     const realErr = args.find((a) => a instanceof Error) as Error | undefined

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -15,12 +15,10 @@ const logger = {
         const msg = args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ')
         debugWarn(msg)
         console.warn(...args)
-        if (process.env.NODE_ENV !== 'development') {
-            try {
-                Sentry.captureMessage(msg, 'warning')
-            } catch (e) {
-                console.warn('Failed to send warning to Sentry:', e)
-            }
+        try {
+            Sentry.captureMessage(msg, 'warning')
+        } catch (e) {
+            console.warn('Failed to send warning to Sentry:', e)
         }
     },
 
@@ -35,17 +33,14 @@ const logger = {
             debugError(msg)
         }
         console.error(...args)
-        if (process.env.NODE_ENV !== 'development') {
-            try {
-                if (realErr) {
-                    Sentry.captureException(realErr)
-                } else {
-                    const msg = args.map((a) => String(a)).join(' ')
-                    Sentry.captureException(new Error(msg))
-                }
-            } catch (e) {
-                console.error('Failed to send exception to Sentry:', e)
+        try {
+            if (realErr) {
+                Sentry.captureException(realErr)
+            } else {
+                Sentry.captureMessage(args.map((a) => String(a)).join(' '), 'error')
             }
+        } catch (e) {
+            console.error('Failed to send exception to Sentry:', e)
         }
     },
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,19 +1,53 @@
 import debug from 'debug'
+import * as Sentry from '@sentry/nextjs'
+
+// keep namespace‐based debug for debug/info
+const debugWarn = debug('app:warn')
+const debugError = debug('app:error')
 
 const logger = {
     debug: debug('app:debug'),
     info: debug('app:info'),
-    warn: debug('app:warn'),
-    error: debug('app:error'),
+
+    // always console.warn, then forward to Sentry only in prod
+    warn: (...args: unknown[]) => {
+        debugWarn(...args)
+        console.warn(...args)
+        if (process.env.NODE_ENV !== 'development') {
+            try {
+                const msg = args
+                    .map(a => typeof a === 'string' ? a : JSON.stringify(a))
+                    .join(' ')
+                Sentry.captureMessage(msg, 'warning')
+            } catch (e) {
+                console.warn('Failed to send warning to Sentry:', e)
+            }
+        }
+    },
+
+    // always console.error, then forward real Error or wrapped text in prod
+    error: (...args: unknown[]) => {
+        debugError(...args)
+        console.error(...args)
+        if (process.env.NODE_ENV !== 'development') {
+            try {
+                const real = args.find(a => a instanceof Error) as Error | undefined
+                if (real) {
+                    Sentry.captureException(real)
+                } else {
+                    const msg = args.map(String).join(' ')
+                    Sentry.captureException(new Error(msg))
+                }
+            } catch (e) {
+                console.error('Failed to send exception to Sentry:', e)
+            }
+        }
+    },
 }
 
 // Enable debug output in development
 if (process.env.NODE_ENV === 'development') {
     debug.enable('app:*')
 }
-
-// Forward warnings and errors to console
-logger.warn.log = console.warn.bind(console)
-logger.error.log = console.error.bind(console)
 
 export default logger

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -72,9 +72,7 @@ function logAndReport(level: 'warn' | 'error', ...args: unknown[]): void {
 const logger = {
     debug: debug('app:debug'),
     info: debug('app:info'),
-
     warn: (...args: unknown[]) => logAndReport('warn', ...args),
-
     error: (...args: unknown[]) => logAndReport('error', ...args),
 }
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -15,9 +15,7 @@ const logger = {
         console.warn(...args)
         if (process.env.NODE_ENV !== 'development') {
             try {
-                const msg = args
-                    .map(a => typeof a === 'string' ? a : JSON.stringify(a))
-                    .join(' ')
+                const msg = args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ')
                 Sentry.captureMessage(msg, 'warning')
             } catch (e) {
                 console.warn('Failed to send warning to Sentry:', e)
@@ -31,7 +29,7 @@ const logger = {
         console.error(...args)
         if (process.env.NODE_ENV !== 'development') {
             try {
-                const real = args.find(a => a instanceof Error) as Error | undefined
+                const real = args.find((a) => a instanceof Error) as Error | undefined
                 if (real) {
                     Sentry.captureException(real)
                 } else {

--- a/src/server/mailgun.ts
+++ b/src/server/mailgun.ts
@@ -63,6 +63,6 @@ export async function deliver({
             'h:X-Mailgun-Variables': tmplVars,
         })
     } catch (error) {
-        logger.error.log(`mailgun send ${template} error: ${error}`)
+        logger.error(`mailgun send ${template} error: ${error}`)
     }
 }


### PR DESCRIPTION
this is a refactor from an old local branch to add Sentry output to the logger. Related to [PR207 comment](https://github.com/safeinsights/management-app/pull/207#discussion_r2098971101).

I don't even know on how to test this. But maybe it's useful @nathanstitt for https://openstax.atlassian.net/browse/OTTER-175 ?