### PR TITLE
make mailgun errors more verbose and detailed

### DIFF
--- a/src/server/mailgun.ts
+++ b/src/server/mailgun.ts
@@ -63,6 +63,6 @@ export async function deliver({
             'h:X-Mailgun-Variables': tmplVars,
         })
     } catch (error) {
-        logger.error.log(`mailgun send ${template} error: ${error}`)
+        logger.error(`mailgun send ${template} error:`, error)
     }
 }


### PR DESCRIPTION
Change
```
mailgun send welcome email error: Error: Forbidden
```

to this
```
2025-05-28T19:36:42.935Z app:error mailgun send welcome email error: [Error: Forbidden] {
  status: 403,
  details: 'Domain sandboxXYZ.mailgun.org is not allowed to send: Sandbox subdomains are for test purposes only. Please add your own domain or add the address to your authorized recipients.',
  type: 'MailgunAPIError'
}
```