### PR TITLE
Otter 178 error fixes and api key placeholder section

### DIFF
--- a/src/app/admin/team/[orgSlug]/settings/api-key-settings-display.tsx
+++ b/src/app/admin/team/[orgSlug]/settings/api-key-settings-display.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { Stack, Title, Divider, Paper, Text } from '@mantine/core'
+
+export function ApiKeySettingsDisplay() {
+    return (
+        <Paper bg="white" p="xxl">
+            <Stack>
+                <Title order={4} size="xl">
+                    API key
+                </Title>
+                <Divider c="dimmed" />
+                <Text fz="sm" fw={600}>
+                    Section Under Design
+                </Text>
+            </Stack>
+        </Paper>
+    )
+}

--- a/src/app/admin/team/[orgSlug]/settings/organization-settings-edit.tsx
+++ b/src/app/admin/team/[orgSlug]/settings/organization-settings-edit.tsx
@@ -1,7 +1,20 @@
 'use client'
 
-import { Stack, TextInput, Textarea, Grid, Text, Flex, Title, Button, Group, Divider } from '@mantine/core'
+import {
+    Stack,
+    TextInput,
+    Textarea,
+    Grid,
+    Text,
+    Flex,
+    Title,
+    Button,
+    Group,
+    Divider,
+    useMantineTheme,
+} from '@mantine/core'
 import { useForm, type UseFormReturnType } from '@mantine/form'
+import { WarningCircle } from '@phosphor-icons/react/dist/ssr'
 import { zodResolver } from 'mantine-form-zod-resolver'
 import { useMutation } from '@tanstack/react-query'
 import { notifications } from '@mantine/notifications'
@@ -12,6 +25,7 @@ import { updateOrgSettingsAction } from '@/server/actions/org.actions'
 import { handleMutationErrorsWithForm } from '@/components/errors'
 
 export const settingsFormSchema = baseOrgSchema.pick({ name: true }).extend({
+    name: z.string().min(1, 'Name is required').max(50, 'Name cannot exceed 50 characters'),
     description: z.string().max(250, 'Word limit is 250 characters').default(''),
 })
 
@@ -24,6 +38,7 @@ interface OrganizationSettingsEditProps {
 }
 
 export function OrganizationSettingsEdit({ org, onSaveSuccess, onCancel }: OrganizationSettingsEditProps) {
+    const theme = useMantineTheme()
     const labelSpan = { base: 12, sm: 3, md: 2, lg: 2 }
     const inputSpan = { base: 12, sm: 9, md: 6, lg: 4 }
 
@@ -34,6 +49,7 @@ export function OrganizationSettingsEdit({ org, onSaveSuccess, onCancel }: Organ
         },
         validate: zodResolver(settingsFormSchema),
         validateInputOnBlur: true,
+        validateInputOnChange: true,
     })
 
     const { mutate: updateOrgSettings, isPending: isOrgUpdating } = useMutation({
@@ -90,10 +106,18 @@ export function OrganizationSettingsEdit({ org, onSaveSuccess, onCancel }: Organ
                                 aria-label="Name"
                                 required
                                 aria-required="true"
-                                maxLength={50}
                                 autoFocus
                                 key={form.key('name')}
                                 {...form.getInputProps('name')}
+                                error={
+                                    form.errors.name && (
+                                        <Group gap="xs">
+                                            <WarningCircle size={14} color={theme.colors.red[7]} weight="fill" />
+                                            {form.errors.name}
+                                            <span>{(form.values.name || '').length} /50 characters</span>
+                                        </Group>
+                                    )
+                                }
                             />
                         </Grid.Col>
                     </Grid>
@@ -105,15 +129,27 @@ export function OrganizationSettingsEdit({ org, onSaveSuccess, onCancel }: Organ
                             <Textarea
                                 id={form.key('description')}
                                 aria-label="Description"
-                                maxLength={250}
                                 key={form.key('description')}
                                 {...form.getInputProps('description')}
                                 autosize
                                 minRows={3}
+                                placeholder="Consider adding a sentence to publicly introduce your organization."
+                                error={
+                                    form.errors.description && (
+                                        <Group c="red.7" gap="xs">
+                                            <WarningCircle size={14} color={theme.colors.red[7]} weight="fill" />
+                                            {form.errors.description}
+                                            <span>{(form.values.description || '').length} /250 characters</span>
+                                        </Group>
+                                    )
+                                }
                             />
-                            <Text size="xs" c="dimmed" mt="xs">
-                                {(form.values.description || '').length}/250 characters
-                            </Text>
+                            {/* If there is no description error show the characters count */}
+                            {!form.errors.description && (
+                                <Text size="xs" c="dimmed" mt="xs">
+                                    {(form.values.description || '').length}/250 characters
+                                </Text>
+                            )}
                         </Grid.Col>
                     </Grid>
                 </Stack>

--- a/src/app/admin/team/[orgSlug]/settings/page.tsx
+++ b/src/app/admin/team/[orgSlug]/settings/page.tsx
@@ -3,6 +3,7 @@ import { Link } from '@/components/links'
 import { RequireOrgAdmin } from '@/components/require-org-admin'
 import { OrganizationSettingsManager } from './organization-settings-manager'
 import { getOrgFromSlugAction } from '@/server/actions/org.actions'
+import { ApiKeySettingsDisplay } from './api-key-settings-display'
 
 export const dynamic = 'force-dynamic'
 
@@ -30,6 +31,7 @@ export default async function AdminSettingsPage({ params }: { params: Promise<{ 
             </Title>
 
             <OrganizationSettingsManager org={org} />
+            <ApiKeySettingsDisplay />
         </Stack>
     )
 }

--- a/src/server/actions/org.actions.ts
+++ b/src/server/actions/org.actions.ts
@@ -87,6 +87,12 @@ export const updateOrgSettingsAction = orgAdminAction(async ({ orgSlug, name, de
     // TypeScript ensures orgFromContext.name is a string due to ActionContextOrgInfo type.
     const originalName = orgFromContext.name
 
+    // Check for duplicate name for existing organizations 
+    const existingOrg = await db.selectFrom('org').select('id').where('name', '=', name).executeTakeFirst()
+    if (existingOrg && existingOrg.id !== orgFromContext.id) {
+        throw new ActionFailure({name:'Team name is already in use. Enter a unique name.')
+    }
+
     // Update the database first, Clerk second
     await db.updateTable('org').set({ name, description }).where('slug', '=', orgSlug).executeTakeFirstOrThrow()
 

--- a/src/server/actions/org.actions.ts
+++ b/src/server/actions/org.actions.ts
@@ -90,7 +90,7 @@ export const updateOrgSettingsAction = orgAdminAction(async ({ orgSlug, name, de
     // Check for duplicate name for existing organizations 
     const existingOrg = await db.selectFrom('org').select('id').where('name', '=', name).executeTakeFirst()
     if (existingOrg && existingOrg.id !== orgFromContext.id) {
-        throw new ActionFailure({name:'Team name is already in use. Enter a unique name.')
+        throw new ActionFailure({name:'Team name is already in use. Enter a unique name.'})
     }
 
     // Update the database first, Clerk second


### PR DESCRIPTION
[OTTER-178](https://openstax.atlassian.net/browse/OTTER-178)

Updated error handling of Name and Description fields on the org setting page.

**1. IF it surpasses 50 characters THEN turn the field red AND highlight the character counter showing that the user surpassed character limit**

![Screenshot 2025-06-05 at 5 21 29 PM](https://github.com/user-attachments/assets/dcb5e092-1753-4ce4-bafb-a7a4e90d6317)

**2. If not unique THEN display validation error: "Team name is already in use. Enter a unique name."**
![Screenshot 2025-06-05 at 5 01 09 PM](https://github.com/user-attachments/assets/27daa980-1911-4140-a65f-44f82b6dcde5)

**3. A character counter must be displayed alongside this field for better UX (e.g., 0/250)
IF it surpasses 250 characters THEN turn the field red AND highlight the character counter showing that the user surpassed character limit**

https://github.com/user-attachments/assets/2c668f12-7722-485d-8b60-afbddb59e5a6

**4. Placeholder text must read: “Consider adding a sentence to publicly introduce your organization.”**
![Screenshot 2025-06-05 at 5 25 04 PM](https://github.com/user-attachments/assets/a89fe613-d281-4865-a1fb-f8ff47c6df93)

**5. API Key Placeholder section**
![Screenshot 2025-06-05 at 5 01 52 PM](https://github.com/user-attachments/assets/7ea2ca05-a4bd-4944-bf4f-44ecb8a3cfeb)