### PR TITLE
OTTER-147 - add timestamps for study code and results

### DIFF
--- a/src/app/researcher/study/[studyId]/review/page.tsx
+++ b/src/app/researcher/study/[studyId]/review/page.tsx
@@ -47,9 +47,21 @@ export default async function StudyReviewPage(props: { params: Promise<{ studyId
 
             <Paper bg="white" p="xxl">
                 <Stack>
-                    <Title order={4} size="xl">
-                        Study Code
-                    </Title>
+                    <Group justify="space-between" align="center">
+                        <Title order={4} size="xl">
+                            Study Code
+                        </Title>
+                        <StudyStatusDisplay
+                            status={
+                                job?.latestStatus === 'CODE-APPROVED'
+                                    ? 'APPROVED'
+                                    : job?.latestStatus === 'CODE-REJECTED'
+                                      ? 'REJECTED'
+                                      : null
+                            }
+                            date={job?.latestStatusChangeOccurredAt}
+                        />
+                    </Group>
                     <Divider c="dimmed" />
                     <StudyCodeDetails job={job} />
                 </Stack>
@@ -57,9 +69,21 @@ export default async function StudyReviewPage(props: { params: Promise<{ studyId
 
             <Paper bg="white" p="xxl">
                 <Stack>
-                    <Title order={4} size="xl">
-                        Study Results
-                    </Title>
+                    <Group justify="space-between" align="center">
+                        <Title order={4} size="xl">
+                            Study Results
+                        </Title>
+                        <StudyStatusDisplay
+                            status={
+                                job?.latestStatus === 'RESULTS-APPROVED'
+                                    ? 'APPROVED'
+                                    : job?.latestStatus === 'RESULTS-REJECTED'
+                                      ? 'REJECTED'
+                                      : null
+                            }
+                            date={job?.latestStatusChangeOccurredAt}
+                        />
+                    </Group>
                     <Divider c="dimmed" />
                     <ViewJobResultsCSV job={job} />
                 </Stack>

--- a/src/app/researcher/study/[studyId]/review/page.tsx
+++ b/src/app/researcher/study/[studyId]/review/page.tsx
@@ -8,6 +8,8 @@ import { getStudyAction } from '@/server/actions/study.actions'
 import { StudyCodeDetails } from '@/components/study/study-code-details'
 import React from 'react'
 import StudyStatusDisplay from '@/components/study/study-status-display'
+import JobStatusDisplay from '@/components/study/job-status-display'
+import type { StudyJobStatus } from '@/database/types'
 
 export const dynamic = 'force-dynamic'
 
@@ -51,15 +53,9 @@ export default async function StudyReviewPage(props: { params: Promise<{ studyId
                         <Title order={4} size="xl">
                             Study Code
                         </Title>
-                        <StudyStatusDisplay
-                            status={
-                                job?.latestStatus === 'CODE-APPROVED'
-                                    ? 'APPROVED'
-                                    : job?.latestStatus === 'CODE-REJECTED'
-                                      ? 'REJECTED'
-                                      : null
-                            }
-                            date={job?.latestStatusChangeOccurredAt}
+                        <JobStatusDisplay
+                            status={job?.codeStatus as StudyJobStatus | undefined}
+                            date={job?.codeStatusOccurredAt}
                         />
                     </Group>
                     <Divider c="dimmed" />
@@ -73,15 +69,9 @@ export default async function StudyReviewPage(props: { params: Promise<{ studyId
                         <Title order={4} size="xl">
                             Study Results
                         </Title>
-                        <StudyStatusDisplay
-                            status={
-                                job?.latestStatus === 'RESULTS-APPROVED'
-                                    ? 'APPROVED'
-                                    : job?.latestStatus === 'RESULTS-REJECTED'
-                                      ? 'REJECTED'
-                                      : null
-                            }
-                            date={job?.latestStatusChangeOccurredAt}
+                        <JobStatusDisplay
+                            status={job?.resultsStatus as StudyJobStatus | undefined}
+                            date={job?.resultsStatusOccurredAt}
                         />
                     </Group>
                     <Divider c="dimmed" />

--- a/src/components/study/job-status-display.test.tsx
+++ b/src/components/study/job-status-display.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { renderWithProviders } from '@/tests/unit.helpers'
+import { screen } from '@testing-library/react'
+import JobStatusDisplay from './job-status-display'
+import dayjs from 'dayjs'
+
+describe('JobStatusDisplay', () => {
+    it('shows approved status for CODE-APPROVED', () => {
+        const date = new Date('2024-03-03T00:00:00Z')
+        renderWithProviders(<JobStatusDisplay status="CODE-APPROVED" date={date} />)
+
+        expect(screen.getByText(/Approved/)).toBeDefined()
+        expect(screen.getByText(new RegExp(dayjs(date).format('MMM DD, YYYY')))).toBeDefined()
+    })
+
+    it('shows rejected status for RESULTS-REJECTED', () => {
+        const date = new Date('2024-04-04T00:00:00Z')
+        renderWithProviders(<JobStatusDisplay status="RESULTS-REJECTED" date={date} />)
+
+        expect(screen.getByText(/Rejected/)).toBeDefined()
+        expect(screen.getByText(new RegExp(dayjs(date).format('MMM DD, YYYY')))).toBeDefined()
+    })
+
+    it('renders nothing for disallowed status or missing date', () => {
+        renderWithProviders(<JobStatusDisplay status="JOB-RUNNING" date={new Date()} />)
+        expect(screen.queryByText(/Approved|Rejected/)).toBeNull()
+
+        renderWithProviders(<JobStatusDisplay status="CODE-APPROVED" date={null} />)
+        expect(screen.queryByText(/Approved|Rejected/)).toBeNull()
+    })
+})

--- a/src/components/study/job-status-display.tsx
+++ b/src/components/study/job-status-display.tsx
@@ -1,0 +1,26 @@
+import { StudyJobStatus } from '@/database/types'
+import { CheckCircle, XCircle } from '@phosphor-icons/react/dist/ssr'
+import dayjs from 'dayjs'
+import { Group, Text } from '@mantine/core'
+import { FC } from 'react'
+
+const JobStatusDisplay: FC<{ status?: StudyJobStatus; date?: Date | null }> = ({ status, date }) => {
+    const allowedStatuses: StudyJobStatus[] = ['CODE-APPROVED', 'CODE-REJECTED', 'RESULTS-APPROVED', 'RESULTS-REJECTED']
+    if (!date || !status || !allowedStatuses.includes(status)) return null
+
+    const isApproved = status === 'CODE-APPROVED' || status === 'RESULTS-APPROVED'
+
+    const color = isApproved ? 'green.9' : 'red.9'
+    const statusDisplay = isApproved ? 'Approved' : 'Rejected'
+
+    return (
+        <Group c={color} gap="xs" align="center">
+            {isApproved ? <CheckCircle weight="fill" size={24} /> : <XCircle weight="fill" size={24} />}
+            <Text fz="xs" fw={600} c={color}>
+                {statusDisplay} on {dayjs(date).format('MMM DD, YYYY')}
+            </Text>
+        </Group>
+    )
+}
+
+export default JobStatusDisplay

--- a/src/components/study/study-status-display.test.tsx
+++ b/src/components/study/study-status-display.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { renderWithProviders } from '@/tests/unit.helpers'
+import { screen } from '@testing-library/react'
+import StudyStatusDisplay from './study-status-display'
+import dayjs from 'dayjs'
+
+describe('StudyStatusDisplay', () => {
+    it('shows approved date when status is APPROVED', () => {
+        const date = new Date('2024-01-01T00:00:00Z')
+        renderWithProviders(<StudyStatusDisplay status="APPROVED" date={date} />)
+
+        expect(screen.getByText(/Approved/)).toBeDefined()
+        expect(screen.getByText(new RegExp(dayjs(date).format('MMM DD, YYYY')))).toBeDefined()
+    })
+
+    it('shows rejected date when status is REJECTED', () => {
+        const date = new Date('2024-02-02T00:00:00Z')
+        renderWithProviders(<StudyStatusDisplay status="REJECTED" date={date} />)
+
+        expect(screen.getByText(/Rejected/)).toBeDefined()
+        expect(screen.getByText(new RegExp(dayjs(date).format('MMM DD, YYYY')))).toBeDefined()
+    })
+
+    it('renders nothing for other statuses or missing date', () => {
+        renderWithProviders(<StudyStatusDisplay status="INITIATED" date={new Date()} />)
+        expect(screen.queryByText(/Approved|Rejected/)).toBeNull()
+
+        renderWithProviders(<StudyStatusDisplay status="APPROVED" date={null} />)
+        expect(screen.queryByText(/Approved|Rejected/)).toBeNull()
+    })
+})

--- a/src/components/study/study-status-display.tsx
+++ b/src/components/study/study-status-display.tsx
@@ -1,14 +1,12 @@
-import { StudyJobStatus, StudyStatus } from '@/database/types'
+import { StudyStatus } from '@/database/types'
 import { CheckCircle, XCircle } from '@phosphor-icons/react/dist/ssr'
 import dayjs from 'dayjs'
 import { Group, Text } from '@mantine/core'
 import { FC } from 'react'
 
-const StudyStatusDisplay: FC<{ status?: StudyStatus | StudyJobStatus | null; date?: Date | null }> = ({
-    status,
-    date,
-}) => {
-    if (!date || !status) return null
+const StudyStatusDisplay: FC<{ status: StudyStatus; date?: Date | null }> = ({ status, date }) => {
+    const allowedStatuses: StudyStatus[] = ['APPROVED', 'REJECTED']
+    if (!date || !status || !allowedStatuses.includes(status)) return null
 
     const color = status === 'APPROVED' ? 'green.9' : 'red.9'
     const statusDisplay = status === 'APPROVED' ? 'Approved' : 'Rejected'

--- a/src/components/study/study-status-display.tsx
+++ b/src/components/study/study-status-display.tsx
@@ -1,20 +1,23 @@
-import { StudyStatus } from '@/database/types'
+import { StudyJobStatus, StudyStatus } from '@/database/types'
 import { CheckCircle, XCircle } from '@phosphor-icons/react/dist/ssr'
 import dayjs from 'dayjs'
 import { Group, Text } from '@mantine/core'
 import { FC } from 'react'
-import { capitalize } from 'remeda'
 
-const StudyStatusDisplay: FC<{ status: StudyStatus; date?: Date | null }> = ({ status, date }) => {
-    if (!date) return null
+const StudyStatusDisplay: FC<{ status?: StudyStatus | StudyJobStatus | null; date?: Date | null }> = ({
+    status,
+    date,
+}) => {
+    if (!date || !status) return null
 
     const color = status === 'APPROVED' ? 'green.9' : 'red.9'
+    const statusDisplay = status === 'APPROVED' ? 'Approved' : 'Rejected'
 
     return (
         <Group c={color} gap="xs" align="center">
             {status === 'APPROVED' ? <CheckCircle weight="fill" size={24} /> : <XCircle weight="fill" size={24} />}
             <Text fz="xs" fw={600} c={color}>
-                {capitalize(status.toLowerCase())} on {dayjs(date).format('MMM DD, YYYY')}
+                {statusDisplay} on {dayjs(date).format('MMM DD, YYYY')}
             </Text>
         </Group>
     )


### PR DESCRIPTION
### UI Enhancements:
* Added the `JobStatusDisplay` component, which displays the code/results status (approved/rejected) and the date of the status change, with appropriate icons and colors. (`src/components/study/job-status-display.tsx`)
* Integrated `JobStatusDisplay` into the study review page to show the code and results statuses for each study, using the new `codeStatus` and `resultsStatus` fields. (`src/app/researcher/study/[studyId]/review/page.tsx`) ([src/app/researcher/study/[studyId]/review/page.tsxR52-R76](diffhunk://#diff-f8441026ffe5b92e36e000eb908e8de3d5b6ccb6d839a48c72e5f3a9d8d30134R52-R76))

### Database Query Updates:
* Updated the `latestJobForStudy` query to include two new fields: `codeStatus` and `resultsStatus`, along with their respective timestamps (`codeStatusOccurredAt` and `resultsStatusOccurredAt`). These fields fetch the latest "approved" or "rejected" statuses for both code and results. (`src/server/db/queries.ts`)

### Refactoring:
* Updated the `StudyStatusDisplay` component to remove the dependency on `remeda` for capitalization and align its logic with the newly added `JobStatusDisplay`. (`src/components/study/study-status-display.tsx`)