### PR TITLE
Otter 208 log in flow v.2 refactor

### DIFF
--- a/src/app/account/signin/sign-in-form.tsx
+++ b/src/app/account/signin/sign-in-form.tsx
@@ -53,25 +53,16 @@ export const SignInForm: FC<{
         } catch (err: unknown) {
             reportError(err, 'Failed Signin Attempt')
             if (isClerkApiError(err)) {
-                const emailError = err.errors?.find((error) => error.meta?.paramName === 'email_address')
-                if (emailError) {
-                    form.setFieldError('email', emailError.longMessage)
-                    return
-                }
-
-                const passwordError = err.errors?.find((error) => error.meta?.paramName === 'password')
-                if (passwordError) {
-                    form.setFieldError('password', passwordError.longMessage)
-                    return
-                }
-
                 const authError = err.errors?.find(
                     (error) =>
                         error.code === 'form_password_incorrect' ||
-                        error.code === 'session_invalid' ||
-                        error.code === 'form_identifier_not_found',
+                        error.code === 'form_param_format_invalid' ||
+                        error.code === 'form_identifier_not_found' ||
+                        error.meta?.paramName === 'email_address' ||
+                        error.meta?.paramName === 'password',
                 )
                 if (authError) {
+                    form.setFieldError('email', ' ')
                     form.setFieldError(
                         'password',
                         'Invalid login credentials. Please double-check your email and password.',
@@ -89,6 +80,7 @@ export const SignInForm: FC<{
             }
 
             // fallback for non-clerk errors
+            form.setFieldError('email', ' ')
             form.setFieldError('password', 'Invalid login credentials. Please double-check your email and password.')
         }
     })


### PR DESCRIPTION
Fix sign-in error handling to show consistent "Invalid login credentials" message for all auth failures instead of different messages for email vs password errors.