### PR TITLE
OTTER-219 - add confirmation modal

### DIFF
--- a/src/app/reviewer/[orgSlug]/study/[studyId]/review/study-review-buttons.tsx
+++ b/src/app/reviewer/[orgSlug]/study/[studyId]/review/study-review-buttons.tsx
@@ -2,7 +2,7 @@
 
 import React, { FC } from 'react'
 import { useMutation } from '@tanstack/react-query'
-import { Button, Group } from '@mantine/core'
+import { Button, Group, Stack, Text } from '@mantine/core'
 import { useParams, useRouter } from 'next/navigation'
 import type { StudyStatus } from '@/database/types'
 import {
@@ -12,6 +12,8 @@ import {
 } from '@/server/actions/study.actions'
 import { reportMutationError } from '@/components/errors'
 import StudyStatusDisplay from '@/components/study/study-status-display'
+import { AppModal } from '@/components/modal'
+import { useDisclosure } from '@mantine/hooks'
 
 export const StudyReviewButtons: FC<{ study: SelectedStudy }> = ({ study }) => {
     const router = useRouter()
@@ -35,6 +37,8 @@ export const StudyReviewButtons: FC<{ study: SelectedStudy }> = ({ study }) => {
         onSuccess: () => router.push(backPath),
     })
 
+    const [isApproveModalOpen, { open: openApproveModal, close: closeApproveModal }] = useDisclosure(false)
+
     if (study.status === 'APPROVED' || study.status === 'REJECTED') {
         return <StudyStatusDisplay status={study.status} date={study.approvedAt ?? study.rejectedAt} />
     }
@@ -52,10 +56,54 @@ export const StudyReviewButtons: FC<{ study: SelectedStudy }> = ({ study }) => {
             <Button
                 disabled={isPending || isSuccess}
                 loading={isPending && pendingStatus == 'APPROVED'}
-                onClick={() => updateStudy('APPROVED')}
+                onClick={openApproveModal}
             >
                 Approve
             </Button>
+            <ConfirmStudyApprovalModal
+                isOpen={isApproveModalOpen}
+                onClose={closeApproveModal}
+                onApprove={() => {
+                    updateStudy('APPROVED')
+                    closeApproveModal()
+                }}
+                isPending={isPending}
+            />
         </Group>
+    )
+}
+
+const ConfirmStudyApprovalModal: FC<{
+    isOpen: boolean
+    onClose: () => void
+    onApprove: () => void
+    isPending: boolean
+}> = ({ isOpen, onClose, onApprove, isPending }) => {
+    const router = useRouter()
+    return (
+        <AppModal isOpen={isOpen} onClose={onClose} title="Confirm decision" size="xl">
+            <Stack>
+                <Text size="md">
+                    Once the code is processed, you&apos;ll need your Reviewer Key to access the encrypted logs and
+                    results. Before proceeding, please make sure you have access to your unique Reviewer Key —{' '}
+                    <b>without it, you won&apos;t be able to decrypt this study&apos;s results</b>.
+                </Text>
+                <Text size="sm" c="grey.6" fw={500}>
+                    <span style={{ fontWeight: 'bolder' }}>Note: </span>
+                    You were prompted to generate a key and save it locally during account creation.
+                </Text>
+                <Text size="md" mb="md">
+                    Do you want to proceed?
+                </Text>
+                <Group justify="flex-start">
+                    <Button variant="outline" size="sm" onClick={() => router.push('/account/keys')}>
+                        Lost key? Generate new one
+                    </Button>
+                    <Button loading={isPending} onClick={onApprove}>
+                        Yes, approve code
+                    </Button>
+                </Group>
+            </Stack>
+        </AppModal>
     )
 }

--- a/src/components/modal.tsx
+++ b/src/components/modal.tsx
@@ -47,6 +47,10 @@ export function AppModal({
                     borderRadius: '32px',
                     padding: '4px',
                 },
+                title: {
+                    fontWeight: 600,
+                    fontSize: '18px',
+                },
             }}
         >
             {children}

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -74,8 +74,16 @@ test.describe('Studies', () => {
 
         await expect(page.getByRole('heading', { name: 'Study details' })).toBeVisible()
 
+        // Click approve – modal should appear
         await page.getByRole('button', { name: /approve/i }).click()
 
+        // Confirm within modal
+        await page.getByRole('button', { name: 'Yes, approve code' }).click()
+
+        // Wait for redirect back to dashboard
+        await page.waitForURL('/reviewer/openstax/dashboard')
+
+        // Re-open study details and verify approval timestamp is displayed
         await page.getByRole('row', { name: title }).getByRole('link', { name: 'View' }).click()
 
         await expect(page.getByText(/approved on/i)).toBeVisible()


### PR DESCRIPTION
### Feature: Study Approval Confirmation Modal
* Added a confirmation modal (`ConfirmStudyApprovalModal`) to the `StudyReviewButtons` component, requiring users to confirm their decision before approving a study. The modal includes options to approve or generate a new Reviewer Key if needed.
* Implemented logic to persist and check timestamps in `localStorage` to skip the confirmation modal if a modal action occurred within the last 48 hours. 

### UI Enhancements

* Updated the `AppModal` component to include a styled title with specific font weight and size.

### Testing Updates

* Modified the `study-flow.spec.ts` test to validate the new modal workflow, including opening the modal, confirming the approval, and verifying the approval timestamp.