### PR TITLE
OTTER-225 fix missing status labels

### DIFF
--- a/src/components/study/display-study-status.tsx
+++ b/src/components/study/display-study-status.tsx
@@ -29,27 +29,31 @@ const JobIdPopover: PopOverComponent = ({ jobId }) => {
     )
 }
 
-type StatusLabels = {
+type StatusLabel = {
     type: 'Code' | 'Results' | 'Proposal'
     label: string
     InfoComponent?: PopOverComponent
 }
 
-const StatusLabels: Partial<Record<AllStatus, StatusLabels>> = {
+const STATUS_LABELS: Partial<Record<AllStatus, StatusLabel>> = {
     APPROVED: { type: 'Proposal', label: 'Approved' },
     REJECTED: { type: 'Proposal', label: 'Rejected' },
+    'PENDING-REVIEW': { type: 'Proposal', label: 'Under Review' },
+    'CODE-APPROVED': { type: 'Code', label: 'Approved' },
+    'CODE-REJECTED': { type: 'Code', label: 'Rejected' },
+    'CODE-SUBMITTED': { type: 'Code', label: 'Submitted' },
     'JOB-PACKAGING': { type: 'Code', label: 'Processing' },
     'JOB-RUNNING': { type: 'Code', label: 'Running' },
+    'JOB-READY': { type: 'Code', label: 'Ready' },
     'JOB-ERRORED': { type: 'Code', label: 'Errored', InfoComponent: JobIdPopover },
     'RUN-COMPLETE': { type: 'Results', label: 'Under Review' },
     'RESULTS-REJECTED': { type: 'Results', label: 'Rejected' },
     'RESULTS-APPROVED': { type: 'Results', label: 'Approved' },
-    'PENDING-REVIEW': { type: 'Proposal', label: 'Under Review' },
 }
 
-const StatusBlock: React.FC<StatusLabels & { jobId?: string | null }> = ({ type, label, jobId, InfoComponent }) => {
+const StatusBlock: React.FC<StatusLabel & { jobId?: string | null }> = ({ type, label, jobId, InfoComponent }) => {
     const color =
-        [StatusLabels['RUN-COMPLETE']?.label, StatusLabels['PENDING-REVIEW']?.label].indexOf(label) > -1
+        [STATUS_LABELS['RUN-COMPLETE']?.label, STATUS_LABELS['PENDING-REVIEW']?.label].indexOf(label) > -1
             ? 'red.9'
             : 'dark.8'
     return (
@@ -74,8 +78,7 @@ export const DisplayStudyStatus: FC<{
     jobStatus: StudyJobStatus | null
     jobId?: string | null
 }> = ({ studyStatus, jobStatus, jobId }) => {
-    const statusToDisplay = jobStatus ?? studyStatus
-    const props = StatusLabels[statusToDisplay]
+    const props = jobStatus && STATUS_LABELS[jobStatus] ? STATUS_LABELS[jobStatus] : STATUS_LABELS[studyStatus]
 
     return props ? <StatusBlock {...props} jobId={jobId} /> : null
 }


### PR DESCRIPTION
### Bug Fix
* Resolved an issue where empty statuses appeared due to job statuses lacking corresponding entries in the status label mapping. Previously, the component did not fall back to the study status since the job status was defined but unmapped.

### Test Refactoring:
* Replaced the repetitive test case array with a reusable helper function to simplify and improve test readability in `display-study-status.test.tsx`. Added new test cases for edge scenarios, such as unmapped statuses.

### Status Label Improvements:
* Expanded the mappings for job statuses like `CODE-APPROVED`, `CODE-REJECTED`, `CODE-SUBMITTED`, and `JOB-READY`.

### Component Logic Refinement:
* Modified the `DisplayStudyStatus` component to first verify if `jobStatus` exists within the status label mapping, defaulting to `studyStatus` if no match is found.