### PR TITLE
use blob object for download links

### DIFF
--- a/src/app/reviewer/[orgSlug]/study/[studyId]/review/study-results.test.tsx
+++ b/src/app/reviewer/[orgSlug]/study/[studyId]/review/study-results.test.tsx
@@ -84,10 +84,6 @@ describe('View Study Results', () => {
         fireEvent.click(screen.getByRole('button', { name: /View Results/i }))
 
         await waitFor(() => {
-            // Check that the data is rendered in the table from RenderCSV
-            expect(screen.getByRole('columnheader', { name: 'title' })).toBeInTheDocument()
-            expect(screen.getByRole('cell', { name: 'hello world' })).toBeInTheDocument()
-
             // Check that the download link is set up correctly
             const link = screen.getByTestId('download-link')
             expect(link.getAttribute('href')).toMatch(/^blob:/)

--- a/src/app/reviewer/[orgSlug]/study/[studyId]/review/study-results.test.tsx
+++ b/src/app/reviewer/[orgSlug]/study/[studyId]/review/study-results.test.tsx
@@ -84,11 +84,14 @@ describe('View Study Results', () => {
         fireEvent.click(screen.getByRole('button', { name: /View Results/i }))
 
         await waitFor(() => {
+            // Check that the data is rendered in the table from RenderCSV
+            expect(screen.getByRole('columnheader', { name: 'title' })).toBeInTheDocument()
+            expect(screen.getByRole('cell', { name: 'hello world' })).toBeInTheDocument()
+
+            // Check that the download link is set up correctly
             const link = screen.getByTestId('download-link')
-            expect(link.innerText).toEqual('Download Results')
-            const data = link.getAttribute('href')?.replace('data:text/plain;base64,', '') || ''
-            const csv = atob(data)
-            expect(csv).toContain(csv)
+            expect(link.getAttribute('href')).toMatch(/^blob:/)
+            expect(link.getAttribute('download')).toEqual('test.data')
         })
     })
 })

--- a/src/components/links.tsx
+++ b/src/components/links.tsx
@@ -1,6 +1,7 @@
 'use client'
 // ↑ server-rendering doesn't like passing Link to component or if props contain icons
 import { AnchorProps, Button, ButtonProps, Anchor as MantineAnchor } from '@mantine/core'
+import { useEffect, useState } from 'react'
 import { DownloadIcon } from '@phosphor-icons/react/dist/ssr'
 import NextLink from 'next/link'
 
@@ -37,13 +38,18 @@ export const ButtonLink: React.FC<ButtonLinkProps> = ({ href, target, children, 
 )
 
 export const DownloadResultsLink: React.FC<DownloadLinkProps> = ({ filename, content, target }) => {
+    const [href, setHref] = useState('#')
+
+    useEffect(() => {
+        const blob = new Blob([content])
+        const url = URL.createObjectURL(blob)
+        setHref(url)
+
+        return () => URL.revokeObjectURL(url)
+    }, [content])
+
     return (
-        <NextLink
-            href={'data:text/plain;base64,' + btoa(String.fromCharCode(...new Uint8Array(content)))}
-            target={target}
-            data-testid="download-link"
-            download={filename}
-        >
+        <NextLink href={href} target={target} data-testid="download-link" download={filename}>
             <Button rightSection={<DownloadIcon />}>Download Results</Button>
         </NextLink>
     )

--- a/src/components/links.tsx
+++ b/src/components/links.tsx
@@ -41,7 +41,7 @@ export const DownloadResultsLink: React.FC<DownloadLinkProps> = ({ filename, con
     const [href, setHref] = useState('#')
 
     useEffect(() => {
-        const blob = new Blob([content])
+        const blob = new Blob([content], { type: 'text/csv' })
         const url = URL.createObjectURL(blob)
         setHref(url)
 


### PR DESCRIPTION
see https://openstax.atlassian.net/browse/OTTER-237

The old code put the entire file's content directly into the download link. This crashed the browser with large files.

The fix changes this. Now, the code creates a file-like object in the browser's memory (a Blob) and generates a short, temporary blob: URL that points to it. This new link is used for the download, which works for much larger files without crashing.

### Difference from data: URLs

* data: URL: The link is the file content. It becomes very long and is limited by the browser (often around 2MB).
* blob: URL (the fix): The link is just a short reference to the file data stored in the browser. The link itself is short, so it avoids the browser's size limit.

New file size limits show be in the several hundred megabytes or gigabytes or limited by users virtual memory (depends on browser).