### PR TITLE
OTTER-233 hide reviewer key option from non-reviewer context

### DIFF
--- a/src/components/auth.tsx
+++ b/src/components/auth.tsx
@@ -5,14 +5,14 @@ import { AuthRole } from '@/lib/types'
 
 export const useAuthInfo = () => {
     const { isLoaded: authLoaded, userId } = clerkUseAuth()
-    const { isLoaded: orgLoaded, org, preferredOrgSlug } = useOrgInfo()
+    const { isLoaded: orgLoaded, org, orgSlug, preferredOrgSlug } = useOrgInfo()
 
     return useMemo(
         () => ({
             isLoaded: Boolean(authLoaded && orgLoaded),
             userId,
             preferredOrgSlug,
-            orgSlug: org?.slug,
+            orgSlug,
             ...org,
             role: org.isAdmin
                 ? AuthRole.Admin
@@ -22,7 +22,7 @@ export const useAuthInfo = () => {
                     ? AuthRole.Researcher
                     : null,
         }),
-        [authLoaded, orgLoaded, userId, org, preferredOrgSlug],
+        [authLoaded, orgLoaded, userId, org, orgSlug, preferredOrgSlug],
     )
 }
 


### PR DESCRIPTION
Identifies when a user is in a researcher context (when no organization is actively selected) and adjusts their permissions accordingly, ensuring that users only have access to UI elements appropriate for their currently active role. This fixes a bug where users with multiple roles could see the Reviewer Key option from the user profile navbar.