### PR TITLE
refactor: update dashboard URL logic

### DIFF
--- a/src/components/layout/navbar-items.tsx
+++ b/src/components/layout/navbar-items.tsx
@@ -10,14 +10,16 @@ import styles from './navbar-items.module.css'
 import { OrgAdminDashboardLink } from './org-admin-dashboard-link'
 import { OrgSwitcher } from '../org/org-switcher'
 import { RefWrapper } from './nav-ref-wrapper'
+import { useAuth } from '@clerk/nextjs'
 
 export const NavbarItems: FC = () => {
     const { isLoaded, isReviewer, isResearcher, isAdmin, preferredOrgSlug } = useAuthInfo()
+    const { orgRole } = useAuth()
     const pathname = usePathname()
 
     const dashboardURL = () => {
+        if (isResearcher && !orgRole) return '/researcher/dashboard'
         if (isReviewer && preferredOrgSlug) return `/reviewer/${preferredOrgSlug}/dashboard`
-        if (isResearcher) return '/researcher/dashboard'
         if (isAdmin) return `/admin/safeinsights`
         return '/'
     }


### PR DESCRIPTION
bug fix: Exiting Manage Team page redirects users to Reviewer view

As an administrator with multiple roles, the auth object’s orgRole property is set to ‘null’ for the researcher view and ‘org:admin’ for the reviewer view. Now conditionally checking for this in to ensure that the dashboard view is correctly redirected.