### PR TITLE
OTTER-225 status labels

### DIFF
--- a/src/app/reviewer/[orgSlug]/dashboard/table.test.tsx
+++ b/src/app/reviewer/[orgSlug]/dashboard/table.test.tsx
@@ -7,6 +7,10 @@ import { StudyJobStatus, StudyStatus } from '@/database/types'
 import { useUser } from '@clerk/nextjs'
 import { UseUserReturn } from '@clerk/types'
 
+vi.mock('@/components/auth', () => ({
+    useAuthInfo: () => ({ isReviewer: true }),
+}))
+
 vi.mock('@/server/actions/org.actions', () => ({
     getOrgFromSlugAction: vi.fn(),
 }))

--- a/src/components/study/display-study-status.test.tsx
+++ b/src/components/study/display-study-status.test.tsx
@@ -1,8 +1,14 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { StudyJobStatus, StudyStatus } from '@/database/types'
 import { renderWithProviders } from '@/tests/unit.helpers'
 import { screen } from '@testing-library/react'
 import { DisplayStudyStatus } from './display-study-status'
+
+let mockedAuthInfo = { isReviewer: false }
+
+vi.mock('@/components/auth', () => ({
+    useAuthInfo: () => mockedAuthInfo,
+}))
 
 describe('DisplayStudyStatus', () => {
     const renderAndExpect = (
@@ -45,5 +51,11 @@ describe('DisplayStudyStatus', () => {
     it('renders a fallback status when the status is not in the STATUS_LABELS map', () => {
         // ARCHIVED and JOB-PROVISIONING are not in STATUS_LABELS, should display titleized status instead
         renderAndExpect('ARCHIVED', 'JOB-PROVISIONING', null, 'Job Provisioning')
+    })
+
+    it('shows "Needs Review" for reviewer users', () => {
+        // Simulate reviewer UI
+        mockedAuthInfo = { isReviewer: true }
+        renderAndExpect('PENDING-REVIEW', null, 'Proposal', 'Needs Review')
     })
 })


### PR DESCRIPTION
### Refinements to status label mappings:

* Modified the `STATUS_LABELS` mapping to adjust labels, matching the status mapping outlined [here](https://docs.google.com/document/d/1DUab0MVHWQ4LqhqjdlqX84W2Ao-jcnJDAkbcWP5nGiw/edit?tab=t.0#bookmark=id.enaim8fj2at7)

### Test suite updates:

* Updated the test to mock the `useAuthInfo` hook to simulate reviewer and non-reviewer roles. Added a new test case to validate that "Needs Review" is displayed for reviewer users when applicable.