### PR TITLE
Otter 223, allow org editing for SI/super admins even when another org is selected

### DIFF
--- a/tests/unit.helpers.tsx
+++ b/tests/unit.helpers.tsx
@@ -16,6 +16,7 @@ vi.mock('@clerk/nextjs/server', async (importOriginal) => {
             },
             users: {
                 createUser: vi.fn(),
+                getOrganizationMembershipList: vi.fn().mockResolvedValue({ data: [] }),
             },
         }),
         auth: vi.fn().mockResolvedValue({ sessionClaims: {}, orgSlug: null, userId: null }),
@@ -370,6 +371,7 @@ export const mockClerkSession = (values: MockSession) => {
         },
         users: {
             createUser: vi.fn(async () => ({ id: '1234' })),
+            getOrganizationMembershipList: vi.fn().mockResolvedValue({ data: [] }),
         },
     }
     const useUserReturn = {


### PR DESCRIPTION
see https://openstax.atlassian.net/browse/OTTER-223

## Problem

User is SI/super admin but not org admin.

The "Manage Team" page appeared empty for a super admin if their active organization in the Clerk UI was not the designated admin organization (CLERK_ADMIN_ORG_SLUG).

This occurred because the authorization logic only checked the user's active organization slug from their session to determine super admin status. When a super admin switched away from the admin organization, they lost their universal admin privileges, causing backend actions to fail with an "Access Denied" error and resulting in an empty user table.

## Fix

The authorization logic in the orgAction wrapper was updated to correctly identify super admins regardless of their active organization.

The fix modifies `src/server/actions/wrappers.ts` to:

1. Fetch the user's full list of organization memberships directly from Clerk using clerkClient.
2. Check if the user is a member of the admin organization (CLERK_ADMIN_ORG_SLUG) in any capacity.

If the user is a member of the admin organization, they are granted universal admin rights for the action, ensuring they can always view and manage any organization's team page.

## What is not modified

There is another wrapper, siAdminAction, which protects global, super-admin-only actions (like creating or deleting organizations). This wrapper was not modified and still relies on checking the user's active organization slug to be `SafeInsights (admin)` organization.