### PR TITLE
OTTER-271 update status labels

### DIFF
--- a/src/app/researcher/dashboard/page.tsx
+++ b/src/app/researcher/dashboard/page.tsx
@@ -73,11 +73,7 @@ export default async function ResearcherDashboardPage(): Promise<React.ReactElem
             <TableTd>{dayjs(study.createdAt).format('MMM DD, YYYY')}</TableTd>
             <TableTd>{study.reviewerTeamName}</TableTd>
             <TableTd>
-                <DisplayStudyStatus
-                    studyStatus={study.status}
-                    jobStatus={study.latestJobStatus}
-                    jobId={study.latestStudyJobId}
-                />
+                <DisplayStudyStatus studyStatus={study.status} jobStatus={study.latestJobStatus} />
             </TableTd>
             <TableTd>
                 <Link href={`/researcher/study/${study.id}/review`}>View</Link>

--- a/src/app/researcher/study/[studyId]/review/page.tsx
+++ b/src/app/researcher/study/[studyId]/review/page.tsx
@@ -7,8 +7,8 @@ import { StudyDetails } from '@/components/study/study-details'
 import { getStudyAction } from '@/server/actions/study.actions'
 import { StudyCodeDetails } from '@/components/study/study-code-details'
 import React from 'react'
-import StudyStatusDisplay from '@/components/study/study-status-display'
-import { CodeApprovalStatus, FileApprovalStatus } from '@/components/study/job-status-display'
+import StudyApprovalStatus from '@/components/study/study-approval-status'
+import { CodeApprovalStatus, FileApprovalStatus } from '@/components/study/job-approval-status'
 import { JobResultsStatusMessage } from '@/app/researcher/study/[studyId]/review/job-results-status-message'
 
 export const dynamic = 'force-dynamic'
@@ -41,7 +41,7 @@ export default async function StudyReviewPage(props: { params: Promise<{ studyId
                         <Title order={4} size="xl">
                             Study Proposal
                         </Title>
-                        <StudyStatusDisplay status={study.status} date={study.approvedAt ?? study.rejectedAt} />
+                        <StudyApprovalStatus status={study.status} date={study.approvedAt ?? study.rejectedAt} />
                     </Group>
                     <StudyDetails studyId={studyId} />
                 </Stack>

--- a/src/app/reviewer/[orgSlug]/dashboard/table.tsx
+++ b/src/app/reviewer/[orgSlug]/dashboard/table.tsx
@@ -41,11 +41,7 @@ const Row: FC<{ study: Studies[number]; orgSlug: string }> = ({ study, orgSlug }
             <TableTd>{study.researcherName}</TableTd>
             <TableTd>{study.reviewerName}</TableTd>
             <TableTd>
-                <DisplayStudyStatus
-                    studyStatus={study.status}
-                    jobStatus={study.latestJobStatus}
-                    jobId={study.latestStudyJobId}
-                />
+                <DisplayStudyStatus studyStatus={study.status} jobStatus={study.latestJobStatus} />
             </TableTd>
             <TableTd>
                 <Link href={`/reviewer/${orgSlug}/study/${study.id}/review`} c="blue.7">

--- a/src/app/reviewer/[orgSlug]/study/[studyId]/review/study-review-buttons.tsx
+++ b/src/app/reviewer/[orgSlug]/study/[studyId]/review/study-review-buttons.tsx
@@ -11,7 +11,7 @@ import {
     type SelectedStudy,
 } from '@/server/actions/study.actions'
 import { reportMutationError } from '@/components/errors'
-import StudyStatusDisplay from '@/components/study/study-status-display'
+import StudyApprovalStatus from '@/components/study/study-approval-status'
 
 export const StudyReviewButtons: FC<{ study: SelectedStudy }> = ({ study }) => {
     const router = useRouter()
@@ -36,7 +36,7 @@ export const StudyReviewButtons: FC<{ study: SelectedStudy }> = ({ study }) => {
     })
 
     if (study.status === 'APPROVED' || study.status === 'REJECTED') {
-        return <StudyStatusDisplay status={study.status} date={study.approvedAt ?? study.rejectedAt} />
+        return <StudyApprovalStatus status={study.status} date={study.approvedAt ?? study.rejectedAt} />
     }
 
     return (

--- a/src/components/study/display-study-status.test.tsx
+++ b/src/components/study/display-study-status.test.tsx
@@ -1,8 +1,13 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { StudyJobStatus, StudyStatus } from '@/database/types'
 import { renderWithProviders } from '@/tests/unit.helpers'
 import { screen } from '@testing-library/react'
 import { DisplayStudyStatus } from './display-study-status'
+
+let mockPathname = '/'
+vi.mock('next/navigation', () => ({
+    usePathname: () => mockPathname,
+}))
 
 describe('DisplayStudyStatus', () => {
     const renderAndExpect = (
@@ -13,11 +18,15 @@ describe('DisplayStudyStatus', () => {
     ) => {
         renderWithProviders(<DisplayStudyStatus studyStatus={studyStatus} jobStatus={jobStatus} />)
 
-        if (expectedType && expectedLabel) {
+        if (expectedType) {
             expect(screen.getByText(expectedType)).toBeDefined()
-            expect(screen.getByText(expectedLabel)).toBeDefined()
         } else {
+            // Ensure that none of the type headers are rendered when not expected
             expect(screen.queryByText(/Proposal|Code|Results/)).toBeNull()
+        }
+
+        if (expectedLabel) {
+            expect(screen.getByText(expectedLabel)).toBeDefined()
         }
     }
 
@@ -25,13 +34,13 @@ describe('DisplayStudyStatus', () => {
         renderAndExpect('PENDING-REVIEW', null, 'Proposal', 'Under Review')
     })
 
-    it('falls back to study status when job status is unmapped', () => {
-        // JOB-PROVISIONING is not in STATUS_LABELS, should display study status instead
-        renderAndExpect('REJECTED', 'JOB-PROVISIONING', 'Proposal', 'Rejected')
+    it('falls back to job status when job status is unmapped', () => {
+        // JOB-PROVISIONING is not in STATUS_LABELS, should display a title-cased version of the job status
+        renderAndExpect('REJECTED', 'JOB-PROVISIONING', null, 'Job Provisioning')
     })
 
-    it('shows mapped code status when available', () => {
-        renderAndExpect('APPROVED', 'CODE-APPROVED', 'Code', 'Approved')
+    it('shows proposal status for CODE-APPROVED', () => {
+        renderAndExpect('APPROVED', 'CODE-APPROVED', 'Proposal', 'Approved')
     })
 
     it('shows mapped results status', () => {
@@ -43,7 +52,35 @@ describe('DisplayStudyStatus', () => {
     })
 
     it('renders a fallback status when the status is not in the STATUS_LABELS map', () => {
-        // ARCHIVED and JOB-PROVISIONING are not in STATUS_LABELS, should display titleized status instead
+        // ARCHIVED and JOB-PROVISIONING are not in STATUS_LABELS, should display titleized job status instead
         renderAndExpect('ARCHIVED', 'JOB-PROVISIONING', null, 'Job Provisioning')
+    })
+
+    // ------------------------------------------------------
+    // Reviewer-facing path (starts with /reviewer/) test cases
+    // ------------------------------------------------------
+
+    it('shows reviewer proposal awaiting review', () => {
+        mockPathname = '/reviewer/test-study'
+        renderAndExpect('PENDING-REVIEW', null, 'Proposal', 'Awaiting Review')
+    })
+
+    it('shows reviewer results awaiting review', () => {
+        mockPathname = '/reviewer/test-study'
+        renderAndExpect('APPROVED', 'RUN-COMPLETE', 'Results', 'Awaiting Review')
+    })
+
+    // ------------------------------------------------------
+    // Researcher-facing path (starts with /researcher/) test cases
+    // ------------------------------------------------------
+
+    it('shows researcher proposal under review', () => {
+        mockPathname = '/researcher/test-study'
+        renderAndExpect('PENDING-REVIEW', null, 'Proposal', 'Under Review')
+    })
+
+    it('shows researcher results under review', () => {
+        mockPathname = '/researcher/test-study'
+        renderAndExpect('APPROVED', 'RUN-COMPLETE', 'Results', 'Under Review')
     })
 })

--- a/src/components/study/display-study-status.test.tsx
+++ b/src/components/study/display-study-status.test.tsx
@@ -47,10 +47,6 @@ describe('DisplayStudyStatus', () => {
         renderAndExpect('APPROVED', 'RUN-COMPLETE', 'Results', 'Under Review')
     })
 
-    it('renders nothing for completely unmapped study status', () => {
-        renderAndExpect('INITIATED', null, null, null)
-    })
-
     it('renders a fallback status when the status is not in the STATUS_LABELS map', () => {
         // ARCHIVED and JOB-PROVISIONING are not in STATUS_LABELS, should display titleized job status instead
         renderAndExpect('ARCHIVED', 'JOB-PROVISIONING', null, 'Job Provisioning')

--- a/src/components/study/display-study-status.tsx
+++ b/src/components/study/display-study-status.tsx
@@ -1,18 +1,14 @@
 'use client'
 
-import { CopyingInput } from '@/components/copying-input'
 import { StudyJobStatus, StudyStatus } from '@/database/types'
-import { AllStatus } from '@/lib/types'
 import { titleize } from '@/lib/string'
 import { Flex, Popover, PopoverDropdown, PopoverTarget, Stack, Text } from '@mantine/core'
 import { InfoIcon } from '../icons'
 import React, { FC } from 'react'
+import { StatusLabel, REVIEWER_STATUS_LABELS, RESEARCHER_STATUS_LABELS } from '@/lib/status-labels'
+import { usePathname } from 'next/navigation'
 
-type PopOverComponent = React.FC<{ jobId?: string | null }>
-
-const JobIdPopover: PopOverComponent = ({ jobId }) => {
-    if (!jobId) return null
-
+const TooltipPopover: FC<{ tooltip: string }> = ({ tooltip }) => {
     return (
         <Popover width={200} position="bottom" withArrow shadow="md">
             <PopoverTarget>
@@ -22,41 +18,15 @@ const JobIdPopover: PopOverComponent = ({ jobId }) => {
             </PopoverTarget>
             <PopoverDropdown miw={'350px'}>
                 <Text size="xs" fw="bold">
-                    Job ID to share with support
+                    {tooltip}
                 </Text>
-                <CopyingInput value={jobId} tooltipLabel="Copy JobId" />
             </PopoverDropdown>
         </Popover>
     )
 }
 
-type StatusLabel = {
-    type?: 'Code' | 'Results' | 'Proposal' | null
-    label: string
-    InfoComponent?: PopOverComponent
-}
-
-const STATUS_LABELS: Partial<Record<AllStatus, StatusLabel>> = {
-    APPROVED: { type: 'Proposal', label: 'Approved' },
-    REJECTED: { type: 'Proposal', label: 'Rejected' },
-    'PENDING-REVIEW': { type: 'Proposal', label: 'Under Review' },
-    'CODE-APPROVED': { type: 'Code', label: 'Approved' },
-    'CODE-REJECTED': { type: 'Code', label: 'Rejected' },
-    'CODE-SUBMITTED': { type: 'Code', label: 'Submitted' },
-    'JOB-PACKAGING': { type: 'Code', label: 'Processing' },
-    'JOB-RUNNING': { type: 'Code', label: 'Running' },
-    'JOB-READY': { type: 'Code', label: 'Ready' },
-    'JOB-ERRORED': { type: 'Code', label: 'Errored', InfoComponent: JobIdPopover },
-    'RUN-COMPLETE': { type: 'Results', label: 'Under Review' },
-    'FILES-REJECTED': { type: 'Results', label: 'Rejected' },
-    'FILES-APPROVED': { type: 'Results', label: 'Approved' },
-}
-
-const StatusBlock: React.FC<StatusLabel & { jobId?: string | null }> = ({ type, label, jobId, InfoComponent }) => {
-    const color =
-        [STATUS_LABELS['RUN-COMPLETE']?.label, STATUS_LABELS['PENDING-REVIEW']?.label].indexOf(label) > -1
-            ? 'red.9'
-            : 'dark.8'
+const StatusBlock: React.FC<StatusLabel> = ({ type, label, tooltip }) => {
+    const color = label === 'Errored' || label === 'Awaiting Review' ? 'red.9' : 'dark.8'
     return (
         <Stack gap="0">
             {type && (
@@ -64,14 +34,10 @@ const StatusBlock: React.FC<StatusLabel & { jobId?: string | null }> = ({ type, 
                     {type}
                 </Text>
             )}
-            {InfoComponent && jobId ? (
-                <Flex align="center" gap="xs">
-                    <Text>{label}</Text>
-                    <InfoComponent jobId={jobId} />
-                </Flex>
-            ) : (
+            <Flex align="center" gap="xs">
                 <Text c={color}>{label}</Text>
-            )}
+                {tooltip && <TooltipPopover tooltip={tooltip} />}
+            </Flex>
         </Stack>
     )
 }
@@ -79,16 +45,22 @@ const StatusBlock: React.FC<StatusLabel & { jobId?: string | null }> = ({ type, 
 export const DisplayStudyStatus: FC<{
     studyStatus: StudyStatus
     jobStatus: StudyJobStatus | null
-    jobId?: string | null
-}> = ({ studyStatus, jobStatus, jobId }) => {
-    let props = jobStatus && STATUS_LABELS[jobStatus] ? STATUS_LABELS[jobStatus] : STATUS_LABELS[studyStatus]
+}> = ({ studyStatus, jobStatus }) => {
+    const pathname = usePathname()
+
+    // Determine which status labels to use based on URL path
+    const isReviewerPath = pathname.startsWith('/reviewer/')
+    const statusLabels = isReviewerPath ? REVIEWER_STATUS_LABELS : RESEARCHER_STATUS_LABELS
+
+    const status = jobStatus || studyStatus
+    let props = statusLabels[status]
 
     if (!props) {
-        const status = jobStatus || studyStatus
+        // Fallback for statuses not in the labels
         props = {
             label: titleize(status.replace(/-/g, ' ')),
         }
     }
 
-    return props ? <StatusBlock {...props} jobId={jobId} /> : null
+    return props ? <StatusBlock {...props} /> : null
 }

--- a/src/components/study/job-approval-status.test.tsx
+++ b/src/components/study/job-approval-status.test.tsx
@@ -4,9 +4,9 @@ import { screen } from '@testing-library/react'
 import dayjs from 'dayjs'
 import type { LatestJobForStudy } from '@/server/db/queries'
 import { StudyJobStatus } from '@/database/types'
-import { CodeApprovalStatus, FileApprovalStatus } from '@/components/study/job-status-display'
+import { CodeApprovalStatus, FileApprovalStatus } from '@/components/study/job-approval-status'
 
-describe('JobStatusDisplay', () => {
+describe('JobApprovalStatus', () => {
     const baseJob: LatestJobForStudy = {
         id: 'test-id',
         studyId: 'study-1',

--- a/src/components/study/job-approval-status.tsx
+++ b/src/components/study/job-approval-status.tsx
@@ -9,7 +9,7 @@ const allowedStatuses: AllStatus[] = ['CODE-APPROVED', 'CODE-REJECTED', 'FILES-A
 
 type Status = { status: AllStatus; createdAt: Date | string }
 
-const JobStatusDisplay: FC<{ statusChange: Status }> = ({ statusChange }) => {
+const JobApprovalStatus: FC<{ statusChange: Status }> = ({ statusChange }) => {
     if (!statusChange || !allowedStatuses.includes(statusChange.status)) {
         return null
     }
@@ -38,7 +38,7 @@ export const CodeApprovalStatus: FC<{ job: LatestJobForStudy }> = ({ job }) => {
         return null
     }
 
-    return <JobStatusDisplay statusChange={codeStatusChange} />
+    return <JobApprovalStatus statusChange={codeStatusChange} />
 }
 
 export const FileApprovalStatus: FC<{ job: LatestJobForStudy }> = ({ job }) => {
@@ -50,5 +50,5 @@ export const FileApprovalStatus: FC<{ job: LatestJobForStudy }> = ({ job }) => {
         return null
     }
 
-    return <JobStatusDisplay statusChange={filesStatusChange} />
+    return <JobApprovalStatus statusChange={filesStatusChange} />
 }

--- a/src/components/study/study-approval-status.test.tsx
+++ b/src/components/study/study-approval-status.test.tsx
@@ -1,13 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import { renderWithProviders } from '@/tests/unit.helpers'
 import { screen } from '@testing-library/react'
-import StudyStatusDisplay from './study-status-display'
+import StudyApprovalStatus from './study-approval-status'
 import dayjs from 'dayjs'
 
-describe('StudyStatusDisplay', () => {
+describe('StudyApprovalStatus', () => {
     it('shows approved date when status is APPROVED', () => {
         const date = new Date('2024-01-01T00:00:00Z')
-        renderWithProviders(<StudyStatusDisplay status="APPROVED" date={date} />)
+        renderWithProviders(<StudyApprovalStatus status="APPROVED" date={date} />)
 
         expect(screen.getByText(/Approved/)).toBeDefined()
         expect(screen.getByText(new RegExp(dayjs(date).format('MMM DD, YYYY')))).toBeDefined()
@@ -15,17 +15,17 @@ describe('StudyStatusDisplay', () => {
 
     it('shows rejected date when status is REJECTED', () => {
         const date = new Date('2024-02-02T00:00:00Z')
-        renderWithProviders(<StudyStatusDisplay status="REJECTED" date={date} />)
+        renderWithProviders(<StudyApprovalStatus status="REJECTED" date={date} />)
 
         expect(screen.getByText(/Rejected/)).toBeDefined()
         expect(screen.getByText(new RegExp(dayjs(date).format('MMM DD, YYYY')))).toBeDefined()
     })
 
     it('renders nothing for other statuses or missing date', () => {
-        renderWithProviders(<StudyStatusDisplay status="INITIATED" date={new Date()} />)
+        renderWithProviders(<StudyApprovalStatus status="INITIATED" date={new Date()} />)
         expect(screen.queryByText(/Approved|Rejected/)).toBeNull()
 
-        renderWithProviders(<StudyStatusDisplay status="APPROVED" date={null} />)
+        renderWithProviders(<StudyApprovalStatus status="APPROVED" date={null} />)
         expect(screen.queryByText(/Approved|Rejected/)).toBeNull()
     })
 })

--- a/src/components/study/study-approval-status.tsx
+++ b/src/components/study/study-approval-status.tsx
@@ -4,7 +4,7 @@ import dayjs from 'dayjs'
 import { Group, Text } from '@mantine/core'
 import { FC } from 'react'
 
-const StudyStatusDisplay: FC<{ status: StudyStatus; date?: Date | null }> = ({ status, date }) => {
+const StudyApprovalStatus: FC<{ status: StudyStatus; date?: Date | null }> = ({ status, date }) => {
     const allowedStatuses: StudyStatus[] = ['APPROVED', 'REJECTED']
     if (!date || !status || !allowedStatuses.includes(status)) return null
 
@@ -25,4 +25,4 @@ const StudyStatusDisplay: FC<{ status: StudyStatus; date?: Date | null }> = ({ s
     )
 }
 
-export default StudyStatusDisplay
+export default StudyApprovalStatus

--- a/src/lib/status-labels.ts
+++ b/src/lib/status-labels.ts
@@ -1,0 +1,150 @@
+import { AllStatus } from '@/lib/types'
+
+export type StatusLabel = {
+    type?: 'Proposal' | 'Code' | 'Results'
+    label: string
+    tooltip?: string
+}
+
+// Proposal -> Code -> Results
+export const REVIEWER_STATUS_LABELS: Partial<Record<AllStatus, StatusLabel>> = {
+    // Step 1 of 3: Proposal
+    'PENDING-REVIEW': {
+        type: 'Proposal',
+        label: 'Awaiting Review',
+        tooltip: 'Step 1 of 3:\n\nThis proposal is now ready for review. Open the study for more details.',
+    },
+    'CODE-SUBMITTED': {
+        type: 'Proposal',
+        label: 'Awaiting Review',
+        tooltip: 'Step 1 of 3:\n\nThis proposal is now ready for review. Open the study for more details.',
+    },
+    APPROVED: {
+        type: 'Proposal',
+        label: 'Approved',
+        tooltip:
+            'Step 1 of 3:\n\nApproved! The code is now being prepared to run in the enclave. No further action is needed at this time.',
+    },
+    'CODE-APPROVED': {
+        type: 'Proposal',
+        label: 'Approved',
+        tooltip:
+            'Step 1 of 3:\n\nApproved! The code is now being prepared to run in the enclave. No further action is needed at this time.',
+    },
+    REJECTED: {
+        type: 'Proposal',
+        label: 'Rejected',
+        tooltip: 'Step 1 of 3:\n\nRejected. The research lab now needs to revise and submit an updated version.',
+    },
+    'CODE-REJECTED': {
+        type: 'Proposal',
+        label: 'Rejected',
+        tooltip: 'Step 1 of 3:\n\nRejected. The research lab now needs to revise and submit an updated version.',
+    },
+
+    // Step 2 of 3: Code
+    'JOB-PACKAGING': {
+        type: 'Code',
+        label: 'Packaging',
+        tooltip:
+            'Step 2 of 3:\n\nPreparing code to run in enclave. If it stays in this status for over 1h, contact SI admins.',
+    },
+    'JOB-READY': {
+        type: 'Code',
+        label: 'Ready',
+        tooltip:
+            'Step 2 of 3:\n\nThe code is packaged and ready to be picked up by the enclave. If it stays in this status for over 1h, contact your Org Admin.',
+    },
+    'JOB-RUNNING': {
+        type: 'Code',
+        label: 'Processing',
+        tooltip:
+            "Step 2 of 3:\n\nThe code is now running against the enclave. You'll receive an email once results are ready for review.",
+    },
+    'JOB-ERRORED': {
+        type: 'Code',
+        label: 'Errored',
+        tooltip: 'Step 2 of 3:\n\nThe code ran into an error. Open the study for more details.',
+    },
+
+    // Step 3 of 3: Results
+    'RUN-COMPLETE': {
+        type: 'Results',
+        label: 'Awaiting Review',
+        tooltip: 'Step 3 of 3:\n\nStudy results are now ready for review. Open the study for more details.',
+    },
+    'FILES-APPROVED': {
+        type: 'Results',
+        label: 'Approved',
+        tooltip: 'Step 3 of 3:\n\nApproved! Study results have now been shared with the Researcher.',
+    },
+    'FILES-REJECTED': {
+        type: 'Results',
+        label: 'Rejected',
+        tooltip:
+            'Step 3 of 3:\n\nSharing of results was rejected. The research lab now needs to revise and submit an updated version.',
+    },
+}
+
+// Proposal -> Results
+export const RESEARCHER_STATUS_LABELS: Partial<Record<AllStatus, StatusLabel>> = {
+    // Step 1 of 2: Proposal
+    'PENDING-REVIEW': {
+        type: 'Proposal',
+        label: 'Under Review',
+        tooltip: "Step 1 of 2:\n\nYour proposal is being reviewed. You'll receive an email once a decision is made.",
+    },
+    'CODE-SUBMITTED': {
+        type: 'Proposal',
+        label: 'Under Review',
+        tooltip: "Step 1 of 2:\n\nYour proposal is being reviewed. You'll receive an email once a decision is made.",
+    },
+    APPROVED: {
+        type: 'Proposal',
+        label: 'Approved',
+        tooltip:
+            "Step 1 of 2:\n\nYour proposal has been approved, and its code is now running! You'll receive an email as soon as your results are ready.",
+    },
+    'CODE-APPROVED': {
+        type: 'Proposal',
+        label: 'Approved',
+        tooltip:
+            "Step 1 of 2:\n\nYour proposal has been approved, and its code is now running! You'll receive an email as soon as your results are ready.",
+    },
+    REJECTED: {
+        type: 'Proposal',
+        label: 'Rejected',
+        tooltip:
+            "Step 1 of 2:\n\nYour proposal has not been approved. Click 'Propose New Study' to submit a new proposal.",
+    },
+    'CODE-REJECTED': {
+        type: 'Proposal',
+        label: 'Rejected',
+        tooltip:
+            "Step 1 of 2:\n\nYour proposal has not been approved. Click 'Propose New Study' to submit a new proposal.",
+    },
+    'JOB-ERRORED': {
+        type: 'Code',
+        label: 'Errored',
+        tooltip: 'Step 1 of 2:\n\nYour study code needs revision. Open your study for more details.',
+    },
+
+    // Step 2 of 2: Results
+    'RUN-COMPLETE': {
+        type: 'Results',
+        label: 'Under Review',
+        tooltip:
+            "Step 2 of 2:\n\nYour code ran successfully! The results are now under review. You'll receive an email once a decision is made.",
+    },
+    'FILES-APPROVED': {
+        type: 'Results',
+        label: 'Approved',
+        tooltip: 'Step 2 of 2:\n\nThe results of your analysis have been approved! Open your study to access them.',
+    },
+    'FILES-REJECTED': {
+        type: 'Results',
+        label: 'Rejected',
+        tooltip:
+            'Step 2 of 2:\n\nThe results of your analysis have not been approved. Open your study for more details.',
+    },
+}


### PR DESCRIPTION
### Refactoring and Component Updates:
- **Renaming Components and Files to Discern from Dashboard Status Labels:**
  * Renamed `StudyStatusDisplay` to `StudyApprovalStatus` and updated all references accordingly (`src/components/study/study-status-display.tsx` → `src/components/study/study-approval-status.tsx`).
  * Renamed `JobStatusDisplay` to `JobApprovalStatus` and updated references (`src/components/study/job-status-display.tsx` → `src/components/study/job-approval-status.tsx`).

- **Role-Specific Status Labels:**
  * Updated `DisplayStudyStatus` to use separate status label mappings (`REVIEWER_STATUS_LABELS` and `RESEARCHER_STATUS_LABELS`) based on the URL path, enabling role-specific behavior. 
  
- **Simplified Props for `DisplayStudyStatus`:**
  * Removed the `jobId` prop and replaced the `JobIdPopover` with a generic `TooltipPopover` component. 

### Test Updates:
- **Updated Test Cases for Renamed Components:**
  * Reflected the component renaming in test files (`study-status-display.test.tsx` → `study-approval-status.test.tsx` and `job-status-display.test.tsx` → `job-approval-status.test.tsx`). 
  * Added new test cases to verify role-specific behavior in `DisplayStudyStatus` for both reviewer and researcher paths.

### Code Simplifications:
- **Removed Unused Code:**
  * Eliminated the `CopyingInput` component and unused `STATUS_LABELS` mapping in `DisplayStudyStatus`. (Copy Input being moved to Study Status section)