### PR TITLE
feat(researcher): Allow resubmission of errored study code

### DIFF
--- a/src/app/researcher/study/[studyId]/resubmit/page.tsx
+++ b/src/app/researcher/study/[studyId]/resubmit/page.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { FC } from 'react'
+import { Paper, Stack, Title } from '@mantine/core'
+import { StudyCodeSection } from '@/app/researcher/study/request/[orgSlug]/upload-study-job-code'
+import { Button, Group } from '@mantine/core'
+import Link from 'next/link'
+import { z } from 'zod'
+import { useForm } from '@mantine/form'
+import { zodResolver } from 'mantine-form-zod-resolver'
+import { StudyProposalFormValues } from '../../request/[orgSlug]/study-proposal-form-schema'
+
+const ResubmitStudyJobCodeSchema = z.object({
+    mainCodeFile: z.instanceof(File).nullable(),
+    additionalCodeFiles: z.array(z.instanceof(File)),
+})
+
+export type ResubmitStudyJobCodeValues = z.infer<typeof ResubmitStudyJobCodeSchema>
+
+const ResubmitPage: FC = () => {
+    const form = useForm<StudyProposalFormValues>({
+        validate: zodResolver(ResubmitStudyJobCodeSchema),
+    })
+
+    return (
+        <Paper p="xl">
+            <Stack>
+                <Title order={2}>Resubmit study code</Title>
+                <StudyCodeSection studyProposalForm={form} />
+                <Group justify="flex-end">
+                    <Button variant="default" component={Link} href="/researcher/dashboard">
+                        Cancel
+                    </Button>
+                    <Button>Resubmit study code</Button>
+                </Group>
+            </Stack>
+        </Paper>
+    )
+}
+
+export default ResubmitPage

--- a/src/app/researcher/study/[studyId]/resubmit/resubmit-code-btn.tsx
+++ b/src/app/researcher/study/[studyId]/resubmit/resubmit-code-btn.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { Button } from '@mantine/core'
+import Link from 'next/link'
+import { LatestJobForStudy } from '@/server/db/queries'
+import { FC } from 'react'
+
+interface ResubmitCodeButtonProps {
+    job: LatestJobForStudy
+}
+
+export const ResubmitCodeButton: FC<ResubmitCodeButtonProps> = ({ job }) => {
+    const studyId = job.studyId
+
+    return (
+        <Button component={Link} href={`/researcher/study/${studyId}/resubmit`}>
+            Resubmit study code
+        </Button>
+    )
+}

--- a/src/app/researcher/study/[studyId]/review/page.tsx
+++ b/src/app/researcher/study/[studyId]/review/page.tsx
@@ -1,7 +1,7 @@
 import { Divider, Group, Paper, Stack, Title } from '@mantine/core'
 import { AlertNotFound } from '@/components/errors'
 import { ResearcherBreadcrumbs } from '@/components/page-breadcrumbs'
-import { latestJobForStudy } from '@/server/db/queries'
+import { allJobsForStudy } from '@/server/db/queries'
 import { JobResults } from '@/components/job-results'
 import { StudyDetails } from '@/components/study/study-details'
 import { getStudyAction } from '@/server/actions/study.actions'
@@ -27,7 +27,7 @@ export default async function StudyReviewPage(props: { params: Promise<{ studyId
         return <AlertNotFound title="Study was not found" message="no such study exists" />
     }
 
-    const job = await latestJobForStudy(studyId)
+    const jobs = await allJobsForStudy(studyId)
 
     return (
         <Stack p="xl" gap="xl">
@@ -56,10 +56,10 @@ export default async function StudyReviewPage(props: { params: Promise<{ studyId
                         <Title order={4} size="xl">
                             Study Code
                         </Title>
-                        <CodeApprovalStatus job={job} />
+                        <CodeApprovalStatus job={jobs[0]} />
                     </Group>
                     <Divider c="dimmed" />
-                    <StudyCodeDetails job={job} />
+                    <StudyCodeDetails jobs={jobs} />
                 </Stack>
             </Paper>
 
@@ -69,11 +69,11 @@ export default async function StudyReviewPage(props: { params: Promise<{ studyId
                         <Title order={4} size="xl">
                             Study Status
                         </Title>
-                        <FileApprovalStatus job={job} />
+                        <FileApprovalStatus job={jobs[0]} />
                     </Group>
                     <Divider c="dimmed" />
-                    <JobResultsStatusMessage job={job} />
-                    <JobResults job={job} />
+                    <JobResultsStatusMessage job={jobs[0]} />
+                    <JobResults jobs={jobs} />
                 </Stack>
             </Paper>
         </Stack>

--- a/src/app/researcher/study/request/[orgSlug]/upload-study-job-code.tsx
+++ b/src/app/researcher/study/request/[orgSlug]/upload-study-job-code.tsx
@@ -37,9 +37,9 @@ export const handleDuplicateUpload = (mainFile: File | null, additionalFiles: Fi
     return duplicateFound
 }
 
-export const UploadStudyJobCode: FC<{ studyProposalForm: UseFormReturnType<StudyProposalFormValues> }> = ({
-    studyProposalForm,
-}) => {
+export const StudyCodeSection: FC<{
+    studyProposalForm: UseFormReturnType<StudyProposalFormValues>
+}> = ({ studyProposalForm }) => {
     const theme = useMantineTheme()
     const color = theme.colors.blue[7]
 
@@ -65,12 +65,8 @@ export const UploadStudyJobCode: FC<{ studyProposalForm: UseFormReturnType<Study
     }
 
     const mainFileUpload = getFileUploadIcon(color, studyProposalForm.values.mainCodeFile?.name ?? '')
-
     return (
-        <Paper p="xl">
-            <Text fz="sm" fw={700} c="gray.6" pb="sm">
-                Step 2 of 2
-            </Text>
+        <>
             <Title order={4}>Study Code</Title>
             <Divider my="sm" mt="sm" mb="md" />
             <Text mb="md">
@@ -208,6 +204,19 @@ export const UploadStudyJobCode: FC<{ studyProposalForm: UseFormReturnType<Study
                     </GridCol>
                 </Grid>
             </Group>
+        </>
+    )
+}
+
+export const UploadStudyJobCode: FC<{ studyProposalForm: UseFormReturnType<StudyProposalFormValues> }> = ({
+    studyProposalForm,
+}) => {
+    return (
+        <Paper p="xl">
+            <Text fz="sm" fw={700} c="gray.6" pb="sm">
+                Step 2 of 2
+            </Text>
+            <StudyCodeSection studyProposalForm={studyProposalForm} />
         </Paper>
     )
 }

--- a/src/app/reviewer/[orgSlug]/study/[studyId]/review/page.tsx
+++ b/src/app/reviewer/[orgSlug]/study/[studyId]/review/page.tsx
@@ -57,7 +57,7 @@ export default async function StudyReviewPage(props: {
                         Study Code
                     </Title>
                     <Divider c="dimmed" />
-                    <StudyCodeDetails job={latestJob} />
+                    <StudyCodeDetails jobs={[latestJob]} />
                 </Stack>
             </Paper>
 

--- a/src/app/reviewer/[orgSlug]/study/[studyId]/review/study-results.tsx
+++ b/src/app/reviewer/[orgSlug]/study/[studyId]/review/study-results.tsx
@@ -45,7 +45,7 @@ export const StudyResults: FC<{
                 <Divider c="dimmed" />
                 <JobStatusHelpText job={job} />
                 <DecryptResults job={job} onApproval={setDecryptedResults} />
-                <JobResults job={job} />
+                <JobResults jobs={[job]} />
             </Stack>
         </Paper>
     )

--- a/src/components/job-results-iteration.tsx
+++ b/src/components/job-results-iteration.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import React, { FC, useMemo } from 'react'
+import { Group, LoadingOverlay, Stack, Text, useMantineTheme } from '@mantine/core'
+import { useQuery } from '@tanstack/react-query'
+import { ErrorAlert } from '@/components/errors'
+import { fetchApprovedJobFilesAction } from '@/server/actions/study-job.actions'
+import { JobFile } from '@/lib/types'
+import { DownloadResultsLink, ViewResultsLink } from './links'
+import { LatestJobForStudy } from '@/server/db/queries'
+
+export const JobResultsIteration: FC<{ job: LatestJobForStudy }> = ({ job }) => {
+    const {
+        data: approvedFiles,
+        isLoading,
+        isError,
+        error,
+    } = useQuery({
+        queryKey: ['job-results', job.id],
+        queryFn: async () => await fetchApprovedJobFilesAction(job.id),
+    })
+
+    const { resultsFiles, logFiles } = useMemo(() => {
+        const res: JobFile[] = []
+        const logs: JobFile[] = []
+
+        approvedFiles?.forEach((f) => {
+            if (f.fileType === 'APPROVED-RESULT') res.push(f)
+            else if (f.fileType === 'APPROVED-LOG') logs.push(f)
+        })
+
+        return { resultsFiles: res, logFiles: logs }
+    }, [approvedFiles])
+
+    if (isError) {
+        return <ErrorAlert error={error} />
+    }
+
+    if (isLoading || !approvedFiles) {
+        return <LoadingOverlay />
+    }
+
+    return (
+        <Stack>
+            {resultsFiles.map((approvedFile) => (
+                <ViewFile file={approvedFile} key={approvedFile.path} />
+            ))}
+            {logFiles.map((approvedFile) => (
+                <ViewFile file={approvedFile} key={approvedFile.path} />
+            ))}
+        </Stack>
+    )
+}
+
+export const ViewFile: FC<{ file: JobFile }> = ({ file }) => {
+    const theme = useMantineTheme()
+    return (
+        <Group gap="xs">
+            <Text fz="sm" fw={600}>
+                {file.fileType === 'APPROVED-RESULT' ? 'Results:' : 'Logs:'}
+            </Text>
+            <ViewResultsLink content={file.contents} />
+            <span
+                style={{
+                    height: 16,
+                    borderLeft: `1px solid ${theme.colors.charcoal[4]}`,
+                }}
+            ></span>
+            <DownloadResultsLink target="_blank" filename={file.path} content={file.contents} />
+        </Group>
+    )
+}

--- a/src/components/job-results.tsx
+++ b/src/components/job-results.tsx
@@ -1,53 +1,27 @@
 'use client'
 
-import React, { FC, useMemo } from 'react'
-import { Group, LoadingOverlay, Stack, Text, useMantineTheme } from '@mantine/core'
-import { useQuery } from '@tanstack/react-query'
-import { ErrorAlert } from '@/components/errors'
-import { fetchApprovedJobFilesAction } from '@/server/actions/study-job.actions'
+import { FC } from 'react'
+import { Group, Stack, Text, useMantineTheme } from '@mantine/core'
 import { JobFile } from '@/lib/types'
 import { DownloadResultsLink, ViewResultsLink } from './links'
 import { LatestJobForStudy } from '@/server/db/queries'
+import { Title } from '@mantine/core'
+import { JobResultsIteration } from './job-results-iteration'
 
-export const JobResults: FC<{ job: LatestJobForStudy }> = ({ job }) => {
-    const {
-        data: approvedFiles,
-        isLoading,
-        isError,
-        error,
-    } = useQuery({
-        queryKey: ['job-results', job.id],
-        queryFn: async () => await fetchApprovedJobFilesAction(job.id),
-    })
-
-    const { resultsFiles, logFiles } = useMemo(() => {
-        const res: JobFile[] = []
-        const logs: JobFile[] = []
-
-        approvedFiles?.forEach((f) => {
-            if (f.fileType === 'APPROVED-RESULT') res.push(f)
-            else if (f.fileType === 'APPROVED-LOG') logs.push(f)
-        })
-
-        return { resultsFiles: res, logFiles: logs }
-    }, [approvedFiles])
-
-    if (isError) {
-        return <ErrorAlert error={error} />
-    }
-
-    if (isLoading || !approvedFiles) {
-        return <LoadingOverlay />
-    }
-
+export const JobResults: FC<{ jobs: LatestJobForStudy[] }> = ({ jobs }) => {
     return (
         <Stack>
-            {resultsFiles.map((approvedFile) => (
-                <ViewFile file={approvedFile} key={approvedFile.path} />
-            ))}
-            {logFiles.map((approvedFile) => (
-                <ViewFile file={approvedFile} key={approvedFile.path} />
-            ))}
+            {jobs.map((job, index) => {
+                const iteration = jobs.length - index
+                const isCurrent = index === 0
+
+                return (
+                    <Stack key={job.id}>
+                        <Title order={5}>{isCurrent ? null : `Logs - Iteration ${iteration}`}</Title>
+                        <JobResultsIteration job={job} />
+                    </Stack>
+                )
+            })}
         </Stack>
     )
 }

--- a/src/components/study/job-status-display.tsx
+++ b/src/components/study/job-status-display.tsx
@@ -4,6 +4,7 @@ import { Group, Text } from '@mantine/core'
 import { FC } from 'react'
 import { type AllStatus } from '@/lib/types'
 import { LatestJobForStudy } from '@/server/db/queries'
+import { ResubmitCodeButton } from '@/app/researcher/study/[studyId]/resubmit/resubmit-code-btn'
 
 const allowedStatuses: AllStatus[] = ['CODE-APPROVED', 'CODE-REJECTED', 'FILES-APPROVED', 'FILES-REJECTED']
 
@@ -48,6 +49,11 @@ export const FileApprovalStatus: FC<{ job: LatestJobForStudy }> = ({ job }) => {
 
     if (!filesStatusChange) {
         return null
+    }
+
+    console.warn('lol', filesStatusChange.status)
+    if (filesStatusChange.status === 'FILES-REJECTED') {
+        return <ResubmitCodeButton job={job} />
     }
 
     return <JobStatusDisplay statusChange={filesStatusChange} />

--- a/src/components/study/study-code-details.tsx
+++ b/src/components/study/study-code-details.tsx
@@ -1,80 +1,25 @@
 'use client'
 
 import React, { FC } from 'react'
-import { Badge, Stack, Text, Group } from '@mantine/core'
-import { loadStudyJobAction } from '@/server/actions/study-job.actions'
+import { Stack } from '@mantine/core'
+import { Title } from '@mantine/core'
+import { StudyCodeIteration } from './study-code-iteration'
 import { StudyJob } from '@/schema/study'
-import { useQuery } from '@tanstack/react-query'
-import { DownloadIcon } from '@phosphor-icons/react/dist/ssr'
-import { studyCodeURL } from '@/lib/paths'
 
-export const StudyCodeDetails: FC<{ job: StudyJob }> = ({ job }) => {
-    const { data, isLoading } = useQuery({
-        queryKey: ['studyJobFiles', job.id],
-        enabled: !!job.id,
-        queryFn: () => loadStudyJobAction(job.id),
-    })
-
-    if (isLoading || !data) return <Text>Loading files...</Text>
-
-    if (!data.files?.length) {
-        return (
-            <Stack>
-                <Text c="dimmed" size="sm">
-                    No code files have been uploaded for this job yet.
-                </Text>
-            </Stack>
-        )
-    }
-
-    const mainCodeFile = data.files.find((file) => file.fileType === 'MAIN-CODE')
-    const supplementalCodeFiles = data.files.filter((file) => file.fileType === 'SUPPLEMENTAL-CODE')
-
-    const mainCodeFileChip = mainCodeFile ? (
-        <Badge
-            color="#D4D1F3"
-            c="black"
-            component="a"
-            href={studyCodeURL(job.id, mainCodeFile.name)}
-            target="_blank"
-            rightSection={<DownloadIcon />}
-            style={{ cursor: 'pointer' }}
-            key={mainCodeFile.name}
-        >
-            {mainCodeFile.name}
-        </Badge>
-    ) : null
-
-    const supplementalCodeFileChips = supplementalCodeFiles.map((file) => (
-        <Badge
-            color="#D4D1F3"
-            c="black"
-            component="a"
-            href={studyCodeURL(job.id, file.name)}
-            target="_blank"
-            rightSection={<DownloadIcon />}
-            style={{ cursor: 'pointer' }}
-            key={file.name}
-        >
-            {file.name}
-        </Badge>
-    ))
-
+export const StudyCodeDetails: FC<{ jobs: StudyJob[] }> = ({ jobs }) => {
     return (
         <Stack>
-            <Text>View the code files that you uploaded to run against the dataset.</Text>
-            {mainCodeFileChip && (
-                <Group>
-                    <Text fw={650}>Main code file:</Text>
-                    {mainCodeFileChip}
-                </Group>
-            )}
-            {supplementalCodeFiles.length > 0 && (
-                <Group>
-                    <Text fw={650}>Additional file(s):</Text>
-                    <Group gap="md">{supplementalCodeFileChips}</Group>
-                </Group>
-            )}
+            {jobs.map((job, index) => {
+                const iteration = jobs.length - index
+                const isCurrent = index === 0
+
+                return (
+                    <Stack key={job.id}>
+                        <Title order={5}>{isCurrent ? 'Current Iteration' : `Iteration ${iteration}`}</Title>
+                        <StudyCodeIteration job={job} />
+                    </Stack>
+                )
+            })}
         </Stack>
     )
 }

--- a/src/components/study/study-code-iteration.tsx
+++ b/src/components/study/study-code-iteration.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import React, { FC } from 'react'
+import { Badge, Stack, Text, Group } from '@mantine/core'
+import { loadStudyJobAction } from '@/server/actions/study-job.actions'
+import { StudyJob } from '@/schema/study'
+import { useQuery } from '@tanstack/react-query'
+import { DownloadIcon } from '@phosphor-icons/react/dist/ssr'
+import { studyCodeURL } from '@/lib/paths'
+
+export const StudyCodeIteration: FC<{ job: StudyJob }> = ({ job }) => {
+    const { data, isLoading } = useQuery({
+        queryKey: ['studyJobFiles', job.id],
+        enabled: !!job.id,
+        queryFn: () => loadStudyJobAction(job.id),
+    })
+
+    if (isLoading || !data) return <Text>Loading files...</Text>
+
+    if (!data.files?.length) {
+        return (
+            <Stack>
+                <Text c="dimmed" size="sm">
+                    No code files have been uploaded for this job yet.
+                </Text>
+            </Stack>
+        )
+    }
+
+    const mainCodeFile = data.files.find((file) => file.fileType === 'MAIN-CODE')
+    const supplementalCodeFiles = data.files.filter((file) => file.fileType === 'SUPPLEMENTAL-CODE')
+
+    const mainCodeFileChip = mainCodeFile ? (
+        <Badge
+            color="#D4D1F3"
+            c="black"
+            component="a"
+            href={studyCodeURL(job.id, mainCodeFile.name)}
+            target="_blank"
+            rightSection={<DownloadIcon />}
+            style={{ cursor: 'pointer' }}
+            key={mainCodeFile.name}
+        >
+            {mainCodeFile.name}
+        </Badge>
+    ) : null
+
+    const supplementalCodeFileChips = supplementalCodeFiles.map((file) => (
+        <Badge
+            color="#D4D1F3"
+            c="black"
+            component="a"
+            href={studyCodeURL(job.id, file.name)}
+            target="_blank"
+            rightSection={<DownloadIcon />}
+            style={{ cursor: 'pointer' }}
+            key={file.name}
+        >
+            {file.name}
+        </Badge>
+    ))
+
+    return (
+        <Stack>
+            <Text>View the code files that you uploaded to run against the dataset.</Text>
+            {mainCodeFileChip && (
+                <Group>
+                    <Text fw={650}>Main code file:</Text>
+                    {mainCodeFileChip}
+                </Group>
+            )}
+            {supplementalCodeFiles.length > 0 && (
+                <Group>
+                    <Text fw={650}>Additional file(s):</Text>
+                    <Group gap="md">{supplementalCodeFileChips}</Group>
+                </Group>
+            )}
+        </Stack>
+    )
+}


### PR DESCRIPTION
Implements a new workflow for researchers to correct and resubmit study code that has previously errored, without needing to create a new study.

Key changes:
   - Adds a 'Resubmit study code' button to the Study Details page for studies with errored code.
   - Creates a new 'Resubmit study code' page with a file upload component.
   - Implements a confirmation modal for cancellation to prevent accidental loss of changes.
   - Updates the Study Details page to display all submitted code iterations and their corresponding logs. The most recent is labeled 'Current Iteration', and previous versions are numbered sequentially.

Addresses: Researchers - New - Correcting and Re-running code that previously errored