### PR TITLE
fix: manage team and settings items not activating

### DIFF
--- a/src/components/layout/nav-ref-wrapper.tsx
+++ b/src/components/layout/nav-ref-wrapper.tsx
@@ -1,27 +1,19 @@
 'use client'
 
-import { forwardRef } from 'react'
-
-interface RefWrapperProps {
-    children: React.ReactNode
-    className?: string
-}
+import { Box, BoxProps } from '@mantine/core'
+import { forwardRef, Ref } from 'react'
 
 //  wrapper that makes content focusable and handles Enter
-export const RefWrapper = forwardRef<HTMLDivElement, RefWrapperProps>(({ children, className }, ref) => (
-    <div
+export const RefWrapper = forwardRef((props: React.PropsWithChildren<BoxProps>, ref: Ref<HTMLDivElement>) => (
+    <Box
+        {...props}
         ref={ref}
-        tabIndex={0}
-        className={className}
-        onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-                e.preventDefault()
-                e.currentTarget.querySelector<HTMLElement>('a, button, [role="button"]')?.click()
-            }
+        onClick={(e) => {
+            e.stopPropagation()
         }}
     >
-        {children}
-    </div>
+        {props.children}
+    </Box>
 ))
 
 RefWrapper.displayName = 'RefWrapper'

--- a/src/components/layout/org-admin-dashboard-link.tsx
+++ b/src/components/layout/org-admin-dashboard-link.tsx
@@ -6,9 +6,9 @@ import Link from 'next/link'
 import { GearIcon, UsersThreeIcon, SlidersIcon, GlobeIcon } from '@phosphor-icons/react/dist/ssr'
 import styles from './navbar-items.module.css'
 import { useSession } from '@/hooks/session'
-import { RefWrapper } from './nav-ref-wrapper'
 import { usePathname } from 'next/navigation'
 import { NavbarLink } from './navbar-link'
+import { RefWrapper } from './nav-ref-wrapper'
 
 interface OrgAdminDashboardLinkProps {
     isVisible: boolean
@@ -36,9 +36,17 @@ export const OrgAdminDashboardLink: FC<OrgAdminDashboardLinkProps> = ({ isVisibl
             <NavLink
                 label="Admin"
                 leftSection={<GearIcon />}
+                tabIndex={0}
                 onClick={() => {
                     if (!pathname.startsWith(orgAdminBaseUrl)) {
                         setIsAdminMenuOpen((prev) => !prev)
+                    }
+                }}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                        if (!pathname.startsWith(orgAdminBaseUrl)) {
+                            setIsAdminMenuOpen((prev) => !prev)
+                        }
                     }
                 }}
                 active={false}


### PR DESCRIPTION
Fix: Keyboard navigation for Admin Menu

Resolves an issue where users could not navigate to the "Manage Team" or "Settings" pages using the keyboard.


This change adds onKeyDown event handlers to ensure that pressing "Enter" on the focused menu items triggers navigation to the correct page.