### PR TITLE
Otter 213 improvements

### DIFF
--- a/src/components/activity-context.tsx
+++ b/src/components/activity-context.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
-import { useClerk, useSession } from '@clerk/clerk-react'
+import { useClerk, useSession } from '@clerk/nextjs'
 import { notifications } from '@mantine/notifications'
 import { Button, Space, Stack, Text } from '@mantine/core'
 import { INACTIVITY_TIMEOUT_MS, WARNING_THRESHOLD_MS } from '@/lib/types'

--- a/src/components/layout/focused-layout-shell.test.tsx
+++ b/src/components/layout/focused-layout-shell.test.tsx
@@ -1,19 +1,12 @@
-import { it, vi } from 'vitest'
+import { it } from 'vitest'
 import { FocusedLayoutShell } from './focused-layout-shell'
 import { render, screen } from '@testing-library/react'
-import { useClerk, useSession } from '@clerk/nextjs'
+import { mockClerkSession } from '@/tests/unit.helpers'
 
 import { TestingProviders } from '@/tests/providers'
 
 it('renders without a user', async () => {
-    vi.mocked(useSession).mockReturnValue({
-        session: null,
-        isLoaded: true,
-        isSignedIn: false,
-    })
-    vi.mocked(useClerk).mockReturnValue({
-        signOut: vi.fn(),
-    } as unknown as ReturnType<typeof useClerk>)
+    mockClerkSession(null)
 
     render(
         <FocusedLayoutShell>

--- a/src/components/layout/focused-layout-shell.test.tsx
+++ b/src/components/layout/focused-layout-shell.test.tsx
@@ -1,10 +1,18 @@
-import { it } from 'vitest'
+import { it, vi } from 'vitest'
 import { FocusedLayoutShell } from './focused-layout-shell'
 import { render, screen } from '@testing-library/react'
+import { useClerk, useSession } from '@clerk/nextjs'
 
 import { TestingProviders } from '@/tests/providers'
 
 it('renders without a user', async () => {
+    vi.mocked(useSession).mockReturnValue({
+        session: null,
+    } as any)
+    vi.mocked(useClerk).mockReturnValue({
+        signOut: vi.fn(),
+    } as any)
+
     render(
         <FocusedLayoutShell>
             <div>hello world</div>

--- a/src/components/layout/focused-layout-shell.test.tsx
+++ b/src/components/layout/focused-layout-shell.test.tsx
@@ -8,10 +8,12 @@ import { TestingProviders } from '@/tests/providers'
 it('renders without a user', async () => {
     vi.mocked(useSession).mockReturnValue({
         session: null,
-    } as any)
+        isLoaded: true,
+        isSignedIn: false,
+    })
     vi.mocked(useClerk).mockReturnValue({
         signOut: vi.fn(),
-    } as any)
+    } as unknown as ReturnType<typeof useClerk>)
 
     render(
         <FocusedLayoutShell>

--- a/src/components/layout/focused-layout-shell.tsx
+++ b/src/components/layout/focused-layout-shell.tsx
@@ -5,6 +5,7 @@ import { SafeInsightsLogo } from './si-logo'
 import { Notifications } from '@mantine/notifications'
 import '@mantine/notifications/styles.css'
 import { ReactNode } from 'react'
+import { ActivityContext } from '../activity-context'
 
 type Props = {
     children: ReactNode
@@ -16,6 +17,7 @@ export function FocusedLayoutShell({ children }: Props) {
     return (
         <AppShell header={{ height: 70 }} footer={{ height: 60 }}>
             <Notifications position="top-right" />
+            <ActivityContext />
 
             <AppShellHeader bg="purple.8" withBorder={false}>
                 <Group h="100%" p="md">

--- a/src/components/require-mfa.test.tsx
+++ b/src/components/require-mfa.test.tsx
@@ -33,8 +33,8 @@ describe('RequireMFA', () => {
         })
 
         it('redirects to /account/mfa until MFA is completed', async () => {
-            // 1. brand-new account, Clerk hasn’t set twoFactorEnabled yet (undefined)
-            ;(useUser as Mock).mockReturnValue({ user: { twoFactorEnabled: undefined } })
+            // 1. brand-new account, Clerk returns twoFactorEnabled: false
+            ;(useUser as Mock).mockReturnValue({ user: { twoFactorEnabled: false } })
 
             await act(async () => {
                 render(<RequireMFA />, { wrapper: TestingProviders })

--- a/src/components/require-mfa.test.tsx
+++ b/src/components/require-mfa.test.tsx
@@ -1,25 +1,57 @@
 import { TestingProviders } from '@/tests/providers'
 import { useUser } from '@clerk/nextjs'
-import { render, act } from '@testing-library/react'
+import { render, act, waitFor } from '@testing-library/react'
 import router from 'next-router-mock'
-import { beforeEach, expect, it, vi, type Mock } from 'vitest'
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
 import { RequireMFA } from './require-mfa'
 
 vi.mock('@/server/actions/org.actions', () => ({
     getReviewerPublicKeyAction: vi.fn(() => Promise.resolve(null)),
 }))
 
-beforeEach(() => {
-    router.setCurrentUrl('/')
-})
+describe('RequireMFA', () => {
+    describe('when MFA is not enabled', () => {
+        beforeEach(() => {
+            router.setCurrentUrl('/')
+        })
 
-it('redirects if mfa is not set', async () => {
-    ;(useUser as Mock).mockImplementation(() => ({ user: { twoFactorEnabled: false } }))
+        it('redirects if mfa is not set', async () => {
+            ;(useUser as Mock).mockImplementation(() => ({ user: { twoFactorEnabled: false } }))
 
-    // act waits for layoutEffect to finish
-    await act(async () => {
-        render(<RequireMFA />, { wrapper: TestingProviders })
+            // act waits for layoutEffect to finish
+            await act(async () => {
+                render(<RequireMFA />, { wrapper: TestingProviders })
+            })
+
+            expect(router.asPath).toEqual('/account/mfa')
+        })
     })
 
-    expect(router.asPath).toEqual('/account/mfa')
+    describe('invite signup → session lost → re-login MFA flow', () => {
+        beforeEach(() => {
+            router.setCurrentUrl('/researcher/dashboard')
+        })
+
+        it('redirects to /account/mfa until MFA is completed', async () => {
+            // 1. brand-new account, Clerk hasn’t set twoFactorEnabled yet (undefined)
+            ;(useUser as Mock).mockReturnValue({ user: { twoFactorEnabled: undefined } })
+
+            await act(async () => {
+                render(<RequireMFA />, { wrapper: TestingProviders })
+            })
+
+            await waitFor(() => expect(router.asPath).toBe('/account/mfa'))
+
+            // 2. user completes MFA → Clerk now returns twoFactorEnabled === true
+            ;(useUser as Mock).mockReturnValue({ user: { twoFactorEnabled: true } })
+            router.setCurrentUrl('/researcher/dashboard')
+
+            await act(async () => {
+                render(<RequireMFA />, { wrapper: TestingProviders })
+            })
+
+            // stays on requested page – no more redirect
+            expect(router.asPath).toBe('/researcher/dashboard')
+        })
+    })
 })

--- a/src/components/require-mfa.tsx
+++ b/src/components/require-mfa.tsx
@@ -10,7 +10,7 @@ export const RequireMFA = () => {
     const router = useRouter()
 
     useLayoutEffect(() => {
-        if (user?.twoFactorEnabled !== true && !pathname.startsWith('/account/mfa')) {
+        if (user?.twoFactorEnabled === false && !pathname.startsWith('/account/mfa')) {
             router.push('/account/mfa')
         }
     }, [pathname, router, user?.twoFactorEnabled])

--- a/src/components/require-mfa.tsx
+++ b/src/components/require-mfa.tsx
@@ -10,7 +10,7 @@ export const RequireMFA = () => {
     const router = useRouter()
 
     useLayoutEffect(() => {
-        if (user?.twoFactorEnabled === false && !pathname.startsWith('/account/mfa')) {
+        if (user?.twoFactorEnabled !== true && !pathname.startsWith('/account/mfa')) {
             router.push('/account/mfa')
         }
     }, [pathname, router, user?.twoFactorEnabled])


### PR DESCRIPTION
see https://openstax.atlassian.net/browse/OTTER-213

improvement branch:
* make the checks more fail safe
* add tests for accounts who do not have second factor set up
* do not use `@clerk/clerk-react` imports, use `@clerk/nextjs` !
* add `ActivityContext` for account pages