### PR TITLE
OTTER-273 add invite permissions

### DIFF
--- a/src/app/account/invitation/[inviteId]/create-account.action.test.ts
+++ b/src/app/account/invitation/[inviteId]/create-account.action.test.ts
@@ -57,6 +57,7 @@ describe('Create Account Actions', () => {
                 email: faker.internet.email({ provider: 'test.com' }),
                 isResearcher: true,
                 isReviewer: true,
+                isAdmin: false,
             })
             .returningAll()
             .executeTakeFirstOrThrow()
@@ -88,6 +89,7 @@ describe('Create Account Actions', () => {
                 email: user.email!,
                 isResearcher: true,
                 isReviewer: true,
+                isAdmin: false,
             })
             .returningAll()
             .executeTakeFirstOrThrow()
@@ -113,6 +115,7 @@ describe('Create Account Actions', () => {
                 email: user.email!,
                 isResearcher: true,
                 isReviewer: true,
+                isAdmin: false,
             })
             .returningAll()
             .executeTakeFirstOrThrow()
@@ -139,6 +142,7 @@ describe('Create Account Actions', () => {
                 email: user.email!,
                 isResearcher: true,
                 isReviewer: true,
+                isAdmin: false,
             })
             .returningAll()
             .executeTakeFirstOrThrow()
@@ -159,6 +163,7 @@ describe('Create Account Actions', () => {
                 email: faker.internet.email({ provider: 'test.com' }),
                 isResearcher: true,
                 isReviewer: true,
+                isAdmin: false,
             })
             .returningAll()
             .executeTakeFirstOrThrow()
@@ -182,6 +187,7 @@ describe('Create Account Actions', () => {
                 email: faker.internet.email({ provider: 'test.com' }),
                 isResearcher: true,
                 isReviewer: true,
+                isAdmin: false,
             })
             .returningAll()
             .executeTakeFirstOrThrow()

--- a/src/app/account/invitation/[inviteId]/create-account.action.ts
+++ b/src/app/account/invitation/[inviteId]/create-account.action.ts
@@ -78,7 +78,7 @@ export const onJoinTeamAccountAction = new Action('onJoinTeamAccountAction')
                     orgId: invite.orgId,
                     isResearcher: invite.isResearcher,
                     isReviewer: invite.isReviewer,
-                    isAdmin: false,
+                    isAdmin: invite.isAdmin,
                 })
                 .returning('id')
                 .executeTakeFirstOrThrow()
@@ -179,7 +179,7 @@ export const onCreateAccountAction = new Action('onCreateAccountAction')
                     orgId: invite.orgId,
                     isResearcher: invite.isResearcher,
                     isReviewer: invite.isReviewer,
-                    isAdmin: false,
+                    isAdmin: invite.isAdmin,
                 })
                 .returning('id')
                 .executeTakeFirstOrThrow()

--- a/src/app/admin/team/[orgSlug]/admin-users.actions.ts
+++ b/src/app/admin/team/[orgSlug]/admin-users.actions.ts
@@ -1,10 +1,10 @@
 'use server'
 
-import { z, inviteUserSchema } from './invite-user.schema'
-import { sendInviteEmail } from '@/server/mailer'
-import { onUserInvited } from '@/server/events'
-import { Action } from '@/server/actions/action'
 import { ActionFailure } from '@/lib/errors'
+import { Action } from '@/server/actions/action'
+import { onUserInvited } from '@/server/events'
+import { sendInviteEmail } from '@/server/mailer'
+import { inviteUserSchema, z } from './invite-user.schema'
 
 export const orgAdminInviteUserAction = new Action('orgAdminInviteUserAction')
     .params(
@@ -50,6 +50,7 @@ export const orgAdminInviteUserAction = new Action('orgAdminInviteUserAction')
                 email: invite.email,
                 isResearcher: invite.role == 'multiple' || invite.role == 'researcher',
                 isReviewer: invite.role == 'multiple' || invite.role == 'reviewer',
+                isAdmin: invite.permission == 'admin',
             })
             .returning('id')
             .executeTakeFirstOrThrow()

--- a/src/app/admin/team/[orgSlug]/invitation.tsx
+++ b/src/app/admin/team/[orgSlug]/invitation.tsx
@@ -1,23 +1,26 @@
 'use client'
 
-import { useDisclosure } from '@mantine/hooks'
-import { TextInput, Button, Flex, Radio } from '@mantine/core'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { notifications } from '@mantine/notifications'
-import { useForm } from '@mantine/form'
-import { orgAdminInviteUserAction } from './admin-users.actions'
-import { InviteUserFormValues, inviteUserSchema } from './invite-user.schema'
 import { InputError, handleMutationErrorsWithForm } from '@/components/errors'
-import { PlusIcon } from '@phosphor-icons/react/dist/ssr'
 import { AppModal } from '@/components/modal'
+import { SuccessPanel } from '@/components/panel'
+import { Button, Flex, Radio, TextInput } from '@mantine/core'
+import { useForm } from '@mantine/form'
+import { useDisclosure } from '@mantine/hooks'
+import { notifications } from '@mantine/notifications'
+import { PlusIcon } from '@phosphor-icons/react/dist/ssr'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { zodResolver } from 'mantine-form-zod-resolver'
 import { type FC, useState } from 'react'
+import { orgAdminInviteUserAction } from './admin-users.actions'
+import { InviteUserFormValues, inviteUserSchema } from './invite-user.schema'
 import { PendingUsers } from './pending-invites'
-import { SuccessPanel } from '@/components/panel'
 
 interface InviteFormProps {
     orgSlug: string
 }
+
+type Role = 'reviewer' | 'researcher' | 'multiple'
+type Permissions = 'contributor' | 'admin'
 
 const InviteSuccess: FC<{ onContinue: () => void }> = ({ onContinue }) => {
     return (
@@ -36,6 +39,7 @@ const InviteForm: FC<{ orgSlug: string; onInvited: () => void }> = ({ orgSlug, o
         initialValues: {
             email: '',
             role: '',
+            permission: '',
         },
     })
 
@@ -62,7 +66,8 @@ const InviteForm: FC<{ orgSlug: string; onInvited: () => void }> = ({ orgSlug, o
             onSubmit={studyProposalForm.onSubmit((values) =>
                 inviteUser({
                     ...values,
-                    role: values.role as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+                    role: values.role as Role,
+                    permission: values.permission as Permissions,
                 }),
             )}
         >
@@ -75,7 +80,7 @@ const InviteForm: FC<{ orgSlug: string; onInvited: () => void }> = ({ orgSlug, o
                 {...studyProposalForm.getInputProps('email')}
                 error={studyProposalForm.errors.email && <InputError error={studyProposalForm.errors.email} />}
             />
-            <Flex mb="sm" fw="semibold">
+            <Flex mb="md" fw="semibold">
                 <Radio.Group
                     label="Assign Role"
                     styles={{ label: { fontWeight: 600, marginBottom: 4 } }}
@@ -86,6 +91,23 @@ const InviteForm: FC<{ orgSlug: string; onInvited: () => void }> = ({ orgSlug, o
                         <Radio value="multiple" label="Multiple (can switch between reviewer and researcher roles)" />
                         <Radio value="reviewer" label="Reviewer (can review and approve studies)" />
                         <Radio value="researcher" label="Researcher (can submit studies and access results)" />
+                    </Flex>
+                </Radio.Group>
+            </Flex>
+
+            <Flex mb="sm" fw="semibold">
+                <Radio.Group
+                    label="Assign Permissions"
+                    styles={{ label: { fontWeight: 600, marginBottom: 4 } }}
+                    name="permission"
+                    {...studyProposalForm.getInputProps('permission', { type: 'checkbox' })}
+                >
+                    <Flex gap="md" mt="xs" direction="column">
+                        <Radio
+                            value="contributor"
+                            label="Contributor (full access within their role; no admin privileges)"
+                        />
+                        <Radio value="admin" label="Administrator (manages team-level settings and contributors)" />
                     </Flex>
                 </Radio.Group>
             </Flex>

--- a/src/app/admin/team/[orgSlug]/invite-user.schema.ts
+++ b/src/app/admin/team/[orgSlug]/invite-user.schema.ts
@@ -7,6 +7,9 @@ export const inviteUserSchema = z.object({
     role: z.enum(['reviewer', 'researcher', 'multiple'], {
         errorMap: () => ({ message: 'A role must be selected' }),
     }),
+    permission: z.enum(['contributor', 'admin'], {
+        errorMap: () => ({ message: 'A permission must be selected' }),
+    }),
 })
 
 export type InviteUserFormValues = z.infer<typeof inviteUserSchema>

--- a/src/database/migrations/1754524775096_add_invite_permissions_to_pending_users.ts
+++ b/src/database/migrations/1754524775096_add_invite_permissions_to_pending_users.ts
@@ -1,0 +1,12 @@
+import type { Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+    await db.schema
+        .alterTable('pending_user')
+        .addColumn('is_admin', 'boolean', (col) => col.notNull().defaultTo(false))
+        .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+    await db.schema.alterTable('pending_user').dropColumn('is_admin').execute()
+}

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -117,6 +117,7 @@ export interface PendingUser {
     createdAt: Generated<Timestamp>
     email: string
     id: Generated<string>
+    isAdmin: boolean
     isResearcher: boolean
     isReviewer: boolean
     orgId: string

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -117,7 +117,7 @@ export interface PendingUser {
     createdAt: Generated<Timestamp>
     email: string
     id: Generated<string>
-    isAdmin: boolean
+    isAdmin: Generated<boolean>
     isResearcher: boolean
     isReviewer: boolean
     orgId: string

--- a/tests/org-admin.spec.ts
+++ b/tests/org-admin.spec.ts
@@ -20,16 +20,23 @@ test.describe('Organization Admin', () => {
         await page.waitForSelector('input[type="email"]', { state: 'visible' })
         await page.getByLabel(/email/i).fill('not an email')
         await page.keyboard.press('Tab')
-        await expect(page.getByText('invalid email address')).toBeVisible()
+        await expect(page.getByText(/invalid email address/i)).toBeVisible()
 
         await page.getByLabel(/email/i).fill(email)
         await page.keyboard.press('Tab')
-        await expect(page.getByText('role must be selected')).toBeVisible()
+        await expect(page.getByText(/a role must be selected/i)).toBeVisible()
 
         await page.getByLabel('Reviewer (can review and approve studies)').click()
 
-        await page.getByRole('button', { name: /send/i }).click()
-        await expect(page.getByText('sent successfully')).toBeVisible({ timeout: 10000 })
+        await page.keyboard.press('Tab')
+        await page.keyboard.press('Tab')
+
+        await expect(page.getByText(/a permission must be selected/i)).toBeVisible()
+
+        await page.getByLabel('Administrator (manages team-level settings and contributors)').click()
+
+        await page.getByRole('button', { name: /send invitation/i }).click()
+        await expect(page.getByText(/invitation sent successfully/i)).toBeVisible({ timeout: 10000 })
 
         await page.getByRole('button', { name: /continue to invite people/i }).click()
 


### PR DESCRIPTION
This pull request introduces support for assigning admin permissions to invited users. It adds a new `isAdmin` property to pending users, updates the invitation flow to handle permissions, and enhances the invite form to allow admins to specify permissions when inviting new users. The changes are covered by updates to the database schema, backend logic, and tests.

**Database and Data Model Updates:**

* Added a new `is_admin` column to the `pending_user` table with a default of `false` and updated the `PendingUser` interface to include the `isAdmin` property. 

**Backend Logic:**

* Updated account creation actions to set `isAdmin` based on the invitation, rather than always defaulting to `false`. 
* Modified the admin invite user action to set `isAdmin` according to the new `permission` field in the invite. 

**Frontend and Validation:**

* Enhanced the invite user schema and form to include a `permission` field, allowing selection between "contributor" and "admin" roles. 

**Testing:**

* Updated tests to cover the new `isAdmin` property and permission logic for invitations. 