### PR TITLE
Otter 266 - refactor dashboard breadcrumb

### DIFF
--- a/src/app/admin/team/[orgSlug]/page.tsx
+++ b/src/app/admin/team/[orgSlug]/page.tsx
@@ -11,7 +11,7 @@ export default async function UsersListingPage(props: { params: Promise<{ orgSlu
 
     return (
         <Stack p="md">
-            <PageBreadcrumbs crumbs={[['Dashboard', `/`], ['Admin'], ['Manage team']]} />
+            <PageBreadcrumbs crumbs={[{ title: 'Admin' }, { title: 'Manage team' }]} />
             <RequireOrgAdmin />
             <Title my="lg">Manage team</Title>
             <Paper shadow="xs" p="xl">

--- a/src/app/admin/team/[orgSlug]/settings/page.tsx
+++ b/src/app/admin/team/[orgSlug]/settings/page.tsx
@@ -15,7 +15,7 @@ export default async function AdminSettingsPage({ params }: { params: Promise<{ 
     return (
         <Stack p="md">
             <RequireOrgAdmin />
-            <PageBreadcrumbs crumbs={[['Dashboard', `/`], ['Admin'], ['Settings']]} />
+            <PageBreadcrumbs crumbs={[{ title: 'Admin' }, { title: 'Settings' }]} />
             <Title order={1} mb="xl">
                 Settings
             </Title>

--- a/src/app/researcher/dashboard/page.tsx
+++ b/src/app/researcher/dashboard/page.tsx
@@ -26,6 +26,7 @@ import { ButtonLink, Link } from '@/components/links'
 import { PlusIcon } from '@phosphor-icons/react/dist/ssr'
 import { sessionFromClerk } from '@/server/clerk'
 import { ErrorAlert } from '@/components/errors'
+import { DashboardUrlSetter } from '@/components/dashboard-url-setter'
 
 export const dynamic = 'force-dynamic'
 
@@ -59,7 +60,6 @@ export default async function ResearcherDashboardPage(): Promise<React.ReactElem
     if (!session) {
         return <ErrorAlert error="Your account is not configured correctly. No organizations found" />
     }
-
     const rows = studies.map((study) => (
         <TableTr fz="md" key={study.id}>
             <TableTd>
@@ -81,41 +81,45 @@ export default async function ResearcherDashboardPage(): Promise<React.ReactElem
     ))
 
     return (
-        <Stack p="xl">
-            <Title order={1}>
-                Hi <UserName />!
-            </Title>
-            <Group gap="sm">
-                <Title order={4}>Welcome to SafeInsights!</Title>
-                <Text>
-                    This is your dashboard. Here, you can submit new research proposals, view their status and access
-                    its details. We continuously iterate to improve your experience and welcome your feedback.
-                </Text>
-            </Group>
-            <Paper shadow="xs" p="xl">
-                <Stack>
-                    <Group justify="space-between">
-                        <Title order={3}>Proposed Studies</Title>
-                        <Flex justify="flex-end">
-                            <NewStudyLink orgSlug={session.team.slug} />
-                        </Flex>
-                    </Group>
-                    <Divider c="charcoal.1" />
-                    <Table layout="fixed" verticalSpacing="md" striped="even" highlightOnHover stickyHeader>
-                        <NoStudiesCaption visible={!studies.length} slug={session.team.slug} />
-                        <TableThead fz="sm">
-                            <TableTr>
-                                <TableTh>Study Name</TableTh>
-                                <TableTh>Submitted On</TableTh>
-                                <TableTh>Submitted To</TableTh>
-                                <TableTh>Status</TableTh>
-                                <TableTh>Study Details</TableTh>
-                            </TableTr>
-                        </TableThead>
-                        <TableTbody>{rows}</TableTbody>
-                    </Table>
-                </Stack>
-            </Paper>
-        </Stack>
+        <>
+            <DashboardUrlSetter url="/researcher/dashboard" />
+            <Stack p="xl">
+                <Title order={1}>
+                    Hi <UserName />!
+                </Title>
+                <Group gap="sm">
+                    <Title order={4}>Welcome to SafeInsights!</Title>
+                    <Text>
+                        This is your dashboard. Here, you can submit new research proposals, view their status and
+                        access its details. We continuously iterate to improve your experience and welcome your
+                        feedback.
+                    </Text>
+                </Group>
+                <Paper shadow="xs" p="xl">
+                    <Stack>
+                        <Group justify="space-between">
+                            <Title order={3}>Proposed Studies</Title>
+                            <Flex justify="flex-end">
+                                <NewStudyLink orgSlug={session.team.slug} />
+                            </Flex>
+                        </Group>
+                        <Divider c="charcoal.1" />
+                        <Table layout="fixed" verticalSpacing="md" striped="even" highlightOnHover stickyHeader>
+                            <NoStudiesCaption visible={!studies.length} slug={session.team.slug} />
+                            <TableThead fz="sm">
+                                <TableTr>
+                                    <TableTh>Study Name</TableTh>
+                                    <TableTh>Submitted On</TableTh>
+                                    <TableTh>Submitted To</TableTh>
+                                    <TableTh>Status</TableTh>
+                                    <TableTh>Study Details</TableTh>
+                                </TableTr>
+                            </TableThead>
+                            <TableTbody>{rows}</TableTbody>
+                        </Table>
+                    </Stack>
+                </Paper>
+            </Stack>
+        </>
     )
 }

--- a/src/app/researcher/study/[studyId]/review/page.tsx
+++ b/src/app/researcher/study/[studyId]/review/page.tsx
@@ -1,6 +1,6 @@
 import { Divider, Group, Paper, Stack, Title } from '@mantine/core'
 import { AlertNotFound } from '@/components/errors'
-import { ResearcherBreadcrumbs } from '@/components/page-breadcrumbs'
+import { PageBreadcrumbs } from '@/components/page-breadcrumbs'
 import { latestJobForStudy } from '@/server/db/queries'
 import { JobResults } from '@/components/job-results'
 import { StudyDetails } from '@/components/study/study-details'
@@ -28,11 +28,11 @@ export default async function StudyReviewPage(props: { params: Promise<{ studyId
 
     return (
         <Stack p="xl" gap="xl">
-            <ResearcherBreadcrumbs
-                crumbs={{
-                    studyId,
-                    current: 'Study Details',
-                }}
+            <PageBreadcrumbs
+                crumbs={[
+                    { title: study.title, href: `/researcher/study/${studyId}/review` },
+                    { title: 'Study Details' },
+                ]}
             />
             <Title order={1}>Study Details</Title>
             <Paper bg="white" p="xxl">

--- a/src/app/researcher/study/request/[orgSlug]/page.tsx
+++ b/src/app/researcher/study/request/[orgSlug]/page.tsx
@@ -3,7 +3,7 @@
 import React from 'react'
 import { Stack, Title } from '@mantine/core'
 import { AlertNotFound } from '@/components/errors'
-import { ResearcherBreadcrumbs } from '@/components/page-breadcrumbs'
+import { PageBreadcrumbs } from '@/components/page-breadcrumbs'
 import { StudyProposal } from './study-proposal'
 import { sessionFromClerk } from '@/server/clerk'
 
@@ -15,7 +15,7 @@ export default async function OrgHomePage(props: { params: Promise<{ orgSlug: st
     if (session?.team.slug !== params.orgSlug) {
         return (
             <Stack p="xl" gap="xl">
-                <ResearcherBreadcrumbs crumbs={{ current: 'Propose a study' }} />
+                <PageBreadcrumbs crumbs={[{ title: 'Propose a study' }]} />
                 <AlertNotFound
                     title="Access Denied"
                     message="You are not authorized to propose studies for this organization."
@@ -26,7 +26,7 @@ export default async function OrgHomePage(props: { params: Promise<{ orgSlug: st
 
     return (
         <Stack p="xl" gap="xl">
-            <ResearcherBreadcrumbs crumbs={{ current: 'Propose a study' }} />
+            <PageBreadcrumbs crumbs={[{ title: 'Propose a study' }]} />
             <Title order={1}>Propose a study</Title>
             <StudyProposal orgSlug={params.orgSlug} />
         </Stack>

--- a/src/app/reviewer/[orgSlug]/dashboard/page.tsx
+++ b/src/app/reviewer/[orgSlug]/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { Paper, Stack, Text, Title } from '@mantine/core'
 import { fetchStudiesForOrgAction } from '@/server/actions/study.actions'
 
 import { UserName } from '@/components/user-name'
+import { DashboardUrlSetter } from '@/components/dashboard-url-setter'
 
 import { StudiesTable } from './table'
 
@@ -14,18 +15,21 @@ export default async function OrgDashboardPage(props: { params: Promise<{ orgSlu
     const studies = await fetchStudiesForOrgAction({ orgSlug })
 
     return (
-        <Stack p="md">
-            <Title>
-                Hi <UserName />!
-            </Title>
-            <Text>
-                <strong>Welcome to your SafeInsights dashboard!</strong> Here you can find study proposals submitted to
-                your organization, view their status and know when you need to take action. We continuously iterate to
-                improve your experience and welcome your feedback.
-            </Text>
-            <Paper shadow="xs" p="xl">
-                <StudiesTable studies={studies} orgSlug={orgSlug} />
-            </Paper>
-        </Stack>
+        <>
+            <DashboardUrlSetter url={`/reviewer/${orgSlug}/dashboard`} />
+            <Stack p="md">
+                <Title>
+                    Hi <UserName />!
+                </Title>
+                <Text>
+                    <strong>Welcome to your SafeInsights dashboard!</strong> Here you can find study proposals submitted
+                    to your organization, view their status and know when you need to take action. We continuously
+                    iterate to improve your experience and welcome your feedback.
+                </Text>
+                <Paper shadow="xs" p="xl">
+                    <StudiesTable studies={studies} orgSlug={orgSlug} />
+                </Paper>
+            </Stack>
+        </>
     )
 }

--- a/src/app/reviewer/[orgSlug]/study/[studyId]/review/page.tsx
+++ b/src/app/reviewer/[orgSlug]/study/[studyId]/review/page.tsx
@@ -2,7 +2,7 @@
 
 import { Divider, Group, Paper, Stack, Title } from '@mantine/core'
 import { AlertNotFound } from '@/components/errors'
-import { OrgBreadcrumbs } from '@/components/page-breadcrumbs'
+import { PageBreadcrumbs } from '@/components/page-breadcrumbs'
 import { getStudyAction } from '@/server/actions/study.actions'
 import React from 'react'
 import { StudyReviewButtons } from './study-review-buttons'
@@ -31,11 +31,11 @@ export default async function StudyReviewPage(props: {
 
     return (
         <Stack px="xl" gap="xl">
-            <OrgBreadcrumbs
-                crumbs={{
-                    orgSlug: orgSlug,
-                    current: 'Study Details',
-                }}
+            <PageBreadcrumbs
+                crumbs={[
+                    { title: study.title, href: `/reviewer/${orgSlug}/study/${studyId}/review` },
+                    { title: 'Study Details' },
+                ]}
             />
 
             <Title order={1}>Study details</Title>

--- a/src/app/reviewer/keys/regenerate-keys.tsx
+++ b/src/app/reviewer/keys/regenerate-keys.tsx
@@ -5,12 +5,10 @@ import { AppModal } from '@/components/modal'
 import { FC } from 'react'
 import { useDisclosure } from '@mantine/hooks'
 import { PageBreadcrumbs } from '@/components/page-breadcrumbs'
-import { useSession } from '@/hooks/session'
 import { useRouter } from 'next/navigation'
 
 export const RegenerateKeys: FC = () => {
     const [isModalOpen, { open: openModal, close: closeModal }] = useDisclosure(false)
-    const { session } = useSession()
     const router = useRouter()
 
     const handleConfirmAndProceed = () => {
@@ -20,7 +18,7 @@ export const RegenerateKeys: FC = () => {
 
     return (
         <Stack p="xl" mx="sm">
-            <PageBreadcrumbs crumbs={[['Dashboard', `/reviewer/${session?.team.slug}/dashboard`], ['Reviewer Key']]} />
+            <PageBreadcrumbs crumbs={[{ title: 'Reviewer Key' }]} />
             <Title my="xxl">Reviewer key</Title>
             <Paper shadow="xs" p="xxl">
                 <Stack>

--- a/src/components/dashboard-url-setter.tsx
+++ b/src/components/dashboard-url-setter.tsx
@@ -1,0 +1,18 @@
+
+'use client'
+
+import { useEffect } from 'react'
+import { setLastDashboardUrlAction } from '@/server/actions/session.actions'
+import { useUser } from '@clerk/nextjs'
+
+export const DashboardUrlSetter: React.FC<{ url: string }> = ({ url }) => {
+    const { user } = useUser()
+
+    useEffect(() => {
+        setLastDashboardUrlAction({ url }).then(() => {
+            user?.reload()
+        })
+    }, [url, user])
+
+    return null
+}

--- a/src/components/dashboard-url-setter.tsx
+++ b/src/components/dashboard-url-setter.tsx
@@ -1,4 +1,3 @@
-
 'use client'
 
 import { useEffect } from 'react'

--- a/src/components/page-breadcrumbs.tsx
+++ b/src/components/page-breadcrumbs.tsx
@@ -1,27 +1,41 @@
+'use client'
+
 import { Breadcrumbs, Anchor, Text, Divider } from '@mantine/core'
 import Link from 'next/link'
 import { FC } from 'react'
+import { useUser } from '@clerk/nextjs'
 
-export const PageBreadcrumbs: FC<{
-    crumbs: Array<[string, string?]>
-}> = ({ crumbs }) => {
+export type Crumb = { title: string; href?: string }
+
+export const PageBreadcrumbs: FC<{ crumbs: Crumb[] }> = ({ crumbs }) => {
+    const { user, isLoaded } = useUser()
+
+    const lastDashboardUrl = user?.unsafeMetadata?.lastDashboardUrl as string | undefined
+    const dashboardUrl = lastDashboardUrl || '/researcher/dashboard'
+
+    const allCrumbs: Crumb[] = [{ title: 'Dashboard', href: dashboardUrl }, ...crumbs]
+
+    if (!isLoaded) {
+        return null
+    }
+
     return (
         <>
             <Breadcrumbs separator="/">
-                {crumbs.map(([title, href], index) =>
-                    href ? (
+                {allCrumbs.map((crumb, index) =>
+                    crumb.href ? (
                         <Anchor
                             c="blue.7"
                             component={Link}
-                            href={href}
+                            href={crumb.href}
                             key={index}
                             style={{ whiteSpace: 'normal', wordBreak: 'break-word' }} //mobile breadcrumb overflows
                         >
-                            {title}
+                            {crumb.title}
                         </Anchor>
                     ) : (
                         <Text c="grey.5" key={index} style={{ whiteSpace: 'normal', wordBreak: 'break-word' }}>
-                            {title}
+                            {crumb.title}
                         </Text>
                     ),
                 )}
@@ -29,51 +43,4 @@ export const PageBreadcrumbs: FC<{
             <Divider />
         </>
     )
-}
-
-export const OrgBreadcrumbs: FC<{
-    crumbs: {
-        orgSlug: string
-        studyTitle?: string
-        studyId?: string
-        current?: string
-    }
-}> = ({ crumbs: { orgSlug, studyId, studyTitle, current } }) => {
-    const crumbs: Array<[string, string?]> = [['Dashboard', `/reviewer/${orgSlug}/dashboard`]]
-    if (studyTitle && studyId) {
-        crumbs.push([studyTitle, `/reviewer/${orgSlug}/study/${studyId}/review`])
-    }
-    if (current) {
-        crumbs.push([current])
-    }
-    return <PageBreadcrumbs crumbs={crumbs} />
-}
-
-export const ResearcherBreadcrumbs: FC<{
-    crumbs: {
-        studyTitle?: string
-        studyId?: string
-        current?: string
-    }
-}> = ({ crumbs: { studyId, studyTitle, current } }) => {
-    const crumbs: Array<[string, string?]> = [['Dashboard', `/researcher/dashboard`]]
-    if (studyTitle && studyId) {
-        crumbs.push([studyTitle, `/researcher/study/${studyId}/review`])
-    }
-    if (current) {
-        crumbs.push([current])
-    }
-    return <PageBreadcrumbs crumbs={crumbs} />
-}
-
-export const AdminBreadcrumbs: FC<{
-    crumbs: {
-        current?: string
-    }
-}> = ({ crumbs: { current } }) => {
-    const crumbs: Array<[string, string?]> = [['Dashboard', `/researcher/dashboard`], ['Admin']]
-    if (current) {
-        crumbs.push([current])
-    }
-    return <PageBreadcrumbs crumbs={crumbs} />
 }

--- a/src/server/actions/session.actions.ts
+++ b/src/server/actions/session.actions.ts
@@ -1,0 +1,25 @@
+
+'use server'
+
+import { clerkClient, currentUser } from '@clerk/nextjs/server'
+import { Action, z } from './action'
+
+export const setLastDashboardUrlAction = new Action('setLastDashboardUrlAction')
+    .params(
+        z.object({
+            url: z.string(),
+        }),
+    )
+    .handler(async ({ params }) => {
+        const user = await currentUser()
+        if (!user) {
+            return
+        }
+
+        await (await clerkClient()).users.updateUserMetadata(user.id, {
+            unsafeMetadata: {
+                ...user.unsafeMetadata,
+                lastDashboardUrl: params.url,
+            },
+        })
+    })

--- a/src/server/actions/session.actions.ts
+++ b/src/server/actions/session.actions.ts
@@ -1,4 +1,3 @@
-
 'use server'
 
 import { clerkClient, currentUser } from '@clerk/nextjs/server'
@@ -16,7 +15,9 @@ export const setLastDashboardUrlAction = new Action('setLastDashboardUrlAction')
             return
         }
 
-        await (await clerkClient()).users.updateUserMetadata(user.id, {
+        await (
+            await clerkClient()
+        ).users.updateUserMetadata(user.id, {
             unsafeMetadata: {
                 ...user.unsafeMetadata,
                 lastDashboardUrl: params.url,


### PR DESCRIPTION
feat: Improve breadcrumbs navigation for admin pages

This addresses an issue where the "Dashboard" link in the breadcrumbs for admin pages (e.g., settings, manage team) always routed to the researcher dashboard, regardless of the user's previous dashboard (reviewer or researcher).

Changes: 
• Dashboard URL Tracking: Introduced `setLastDashboardUrlAction` and `DashboardUrlSetter` to store and reload the last visited dashboard URL in Clerk `unsafeMetadata`.
• Breadcrumbs Refactoring: Consolidated `OrgBreadcrumbs`, `ResearcherBreadcrumbs`, and `AdminBreadcrumbs` into a single `PageBreadcrumbs` component.
• Dynamic Dashboard Link: `PageBreadcrumbs` now dynamically determines the “Dashboard” link based on the `lastDashboardUrl` stored in `unsafeMetadata`.
