### PR TITLE
OTTER-284 add backup codes

### DIFF
--- a/src/app/(root)/user-nav.tsx
+++ b/src/app/(root)/user-nav.tsx
@@ -2,6 +2,7 @@
 
 import DashboardSkeleton from '@/components/layout/skeleton/dashboard'
 import { useSession } from '@/hooks/session'
+import { navigateToDashboard } from '@/lib/session'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
@@ -14,11 +15,7 @@ export const UserNav = () => {
         if (!session) return
 
         setIsNavigating(true)
-        if (session.team.isResearcher) {
-            router.push('/researcher/dashboard')
-        } else if (session.team.isReviewer) {
-            router.push(`/reviewer/${session.team.slug}/dashboard`)
-        }
+        navigateToDashboard(router, session)
     }, [session, router])
 
     // Show dashboard skeleton while session is loading or during navigation

--- a/src/app/account/mfa/app/add-app-mfa.tsx
+++ b/src/app/account/mfa/app/add-app-mfa.tsx
@@ -45,6 +45,8 @@ function AddTotpScreenContent({
     const [totp, setTOTP] = useState<TOTPResource | undefined>(undefined)
     const [canRegenerate, setCanRegenerate] = useState(true)
     const [displayFormat, setDisplayFormat] = useState<DisplayFormat>('qr')
+    const [isVerifying, setIsVerifying] = useState(false)
+
     const secret = useMemo(() => {
         if (totp?.uri) {
             try {
@@ -68,6 +70,7 @@ function AddTotpScreenContent({
     })
 
     const verifyTotp = async (values: { code: string }) => {
+        setIsVerifying(true)
         try {
             await user?.verifyTOTP({ code: values.code })
             // Generate backup codes after verification
@@ -83,6 +86,8 @@ function AddTotpScreenContent({
             setStep('success')
         } catch {
             form.setErrors({ code: 'Invalid verification code. Please try again.' })
+        } finally {
+            setIsVerifying(false)
         }
     }
 
@@ -187,7 +192,14 @@ function AddTotpScreenContent({
                         {...form.getInputProps('code')}
                     />
                     <InputError error={form.errors.code} />
-                    <Button type="submit" fullWidth disabled={!/^\d{6}$/.test(form.values.code)} size="lg" mt="md">
+                    <Button
+                        type="submit"
+                        loading={isVerifying}
+                        fullWidth
+                        disabled={!/^\d{6}$/.test(form.values.code)}
+                        size="lg"
+                        mt="md"
+                    >
                         Verify code
                     </Button>
                     <Link

--- a/src/app/account/mfa/app/add-app-mfa.tsx
+++ b/src/app/account/mfa/app/add-app-mfa.tsx
@@ -210,7 +210,7 @@ export function AddAppMFA() {
     }
 
     return (
-        <Paper bg="white" p="xxl" radius="sm" w={600} my={{ base: '1rem', lg: 0 }}>
+        <Paper bg="white" p="xxl" radius="sm" maw={500} my={{ base: '1rem', lg: 0 }}>
             {step === 'add' && <AddTotpScreenContent setStep={setStep} />}
             {step === 'success' && <SuccessScreenContent />}
         </Paper>

--- a/src/app/account/mfa/app/backup-codes.tsx
+++ b/src/app/account/mfa/app/backup-codes.tsx
@@ -81,7 +81,7 @@ const BackupCodes = ({ codes }: BackupCodesProps) => {
                             <Stack gap={4}>
                                 <Button
                                     fullWidth
-                                    size="md"
+                                    size="lg"
                                     onClick={() => {
                                         copy()
                                         setHasCopied(true)
@@ -108,7 +108,7 @@ const BackupCodes = ({ codes }: BackupCodesProps) => {
                         fullWidth
                         variant="outline"
                         mt="xs"
-                        size="md"
+                        size="lg"
                         onClick={() => {
                             if (!hasCopied) {
                                 setModalOpened(true)
@@ -149,10 +149,10 @@ const ConfirmationModal: FC<ConfirmationModalProps> = ({ isOpen, onClose, onConf
                 Do you want to proceed?
             </Text>
             <Group>
-                <Button variant="outline" onClick={onClose}>
+                <Button variant="outline" onClick={onClose} size="md">
                     Back
                 </Button>
-                <Button loading={isLoading} onClick={onConfirm}>
+                <Button loading={isLoading} onClick={onConfirm} size="md">
                     Go to SafeInsights
                 </Button>
             </Group>

--- a/src/app/account/mfa/app/backup-codes.tsx
+++ b/src/app/account/mfa/app/backup-codes.tsx
@@ -1,6 +1,7 @@
 import { useState, type FC } from '@/components/common'
 import { AppModal } from '@/components/modal'
 import { useSession } from '@/hooks/session'
+import { navigateToDashboard } from '@/lib/session'
 import { useUser } from '@clerk/nextjs'
 import { Box, Button, CopyButton, Group, Stack, Text, Title, useMantineTheme } from '@mantine/core'
 import { CheckIcon } from '@phosphor-icons/react'
@@ -30,15 +31,7 @@ const BackupCodes = ({ codes }: BackupCodesProps) => {
 
     const goToDashboard = () => {
         if (!isSessionLoaded || !session) return
-        if (session.team.isResearcher) {
-            router.push('/researcher/dashboard')
-            return
-        }
-        if (session.team.isReviewer) {
-            router.push(`/reviewer/${session.team.slug}/dashboard`)
-            return
-        }
-        router.push('/')
+        navigateToDashboard(router, session)
     }
 
     if (!isLoaded) return null

--- a/src/app/account/mfa/app/backup-codes.tsx
+++ b/src/app/account/mfa/app/backup-codes.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from '@/components/common'
+import { useSession } from '@/hooks/session'
+import { useUser } from '@clerk/nextjs'
+import { Box, Button, CopyButton, Group, Stack, Text, Title, useMantineTheme } from '@mantine/core'
+import { CheckIcon } from '@phosphor-icons/react'
+import { useRouter } from 'next/navigation'
+
+type BackupCodesProps = {
+    codes?: string[] | null
+}
+
+const BackupCodes = ({ codes: initialCodes }: BackupCodesProps) => {
+    const theme = useMantineTheme()
+    const { user, isLoaded } = useUser()
+    const { isLoaded: isSessionLoaded, session } = useSession()
+    const router = useRouter()
+    const [codes, setCodes] = useState<string[] | null>(initialCodes || null)
+
+    useEffect(() => {
+        if (initialCodes) return
+        if (!isLoaded || !user) return
+
+        if (!user.backupCodeEnabled) {
+            let cancelled = false
+            ;(async () => {
+                try {
+                    const resource = await user.createBackupCode()
+                    if (!cancelled) setCodes(resource.codes || [])
+                } catch {
+                    setCodes([])
+                }
+            })()
+            return () => {
+                cancelled = true
+            }
+        }
+    }, [isLoaded, user, initialCodes])
+
+    const codesAsText = codes && codes.length ? codes.join('\n') : ''
+
+    const goToDashboard = () => {
+        if (!isSessionLoaded || !session) return
+        if (session.team.isResearcher) {
+            router.push('/researcher/dashboard')
+            return
+        }
+        if (session.team.isReviewer) {
+            router.push(`/reviewer/${session.team.slug}/dashboard`)
+            return
+        }
+        router.push('/')
+    }
+
+    if (!isLoaded) return null
+
+    return (
+        <Stack gap="md" mb="xxl">
+            <Title mb="xs" ta="center" order={3}>
+                Multi-factor authentication is set up successfully!
+            </Title>
+            <Text mb="xs" size="md">
+                These are your recovery codes. Please store them in a secure location. You will need one of them to
+                access your account if you lose access to your authentication device.
+            </Text>
+
+            <Box
+                bg="gray.0"
+                py="md"
+                px="lg"
+                style={{ border: `1px solid ${theme.colors?.grey[2]}`, maxHeight: 130, overflowY: 'auto' }}
+            >
+                {codes && codes.length ? (
+                    <Stack gap={2} style={{ overflowY: 'auto' }}>
+                        {codes.map((code, index) => (
+                            <Text key={index} size="sm">
+                                {code}
+                            </Text>
+                        ))}
+                    </Stack>
+                ) : (
+                    <Text size="sm" c="dimmed">
+                        Generating recovery codes...
+                    </Text>
+                )}
+            </Box>
+
+            <Stack gap="md" mt="xs">
+                <CopyButton value={codesAsText} timeout={1000}>
+                    {({ copied, copy }) => (
+                        <Stack gap={4}>
+                            <Button fullWidth onClick={copy} variant="primary" disabled={!codes || codes.length === 0}>
+                                Copy codes
+                            </Button>
+                            {copied && (
+                                <Group gap={6} justify="center" align="center">
+                                    <CheckIcon size={16} color={theme.colors.green[9]} />
+                                    <Text size="sm" c="green.9">
+                                        Copied!
+                                    </Text>
+                                </Group>
+                            )}
+                        </Stack>
+                    )}
+                </CopyButton>
+
+                <Button fullWidth variant="outline" mt="xs" onClick={goToDashboard} disabled={!isSessionLoaded}>
+                    Go to dashboard
+                </Button>
+            </Stack>
+        </Stack>
+    )
+}
+
+export default BackupCodes

--- a/src/app/account/mfa/app/backup-codes.tsx
+++ b/src/app/account/mfa/app/backup-codes.tsx
@@ -1,40 +1,30 @@
-import { useEffect, useState } from '@/components/common'
+import { useState, type FC } from '@/components/common'
+import { AppModal } from '@/components/modal'
 import { useSession } from '@/hooks/session'
 import { useUser } from '@clerk/nextjs'
 import { Box, Button, CopyButton, Group, Stack, Text, Title, useMantineTheme } from '@mantine/core'
 import { CheckIcon } from '@phosphor-icons/react'
 import { useRouter } from 'next/navigation'
 
+type ConfirmationModalProps = {
+    isOpen: boolean
+    onClose: () => void
+    onConfirm: () => void
+    isLoading?: boolean
+}
+
 type BackupCodesProps = {
     codes?: string[] | null
 }
 
-const BackupCodes = ({ codes: initialCodes }: BackupCodesProps) => {
+const BackupCodes = ({ codes }: BackupCodesProps) => {
     const theme = useMantineTheme()
-    const { user, isLoaded } = useUser()
+    const { isLoaded } = useUser()
     const { isLoaded: isSessionLoaded, session } = useSession()
     const router = useRouter()
-    const [codes, setCodes] = useState<string[] | null>(initialCodes || null)
-
-    useEffect(() => {
-        if (initialCodes) return
-        if (!isLoaded || !user) return
-
-        if (!user.backupCodeEnabled) {
-            let cancelled = false
-            ;(async () => {
-                try {
-                    const resource = await user.createBackupCode()
-                    if (!cancelled) setCodes(resource.codes || [])
-                } catch {
-                    setCodes([])
-                }
-            })()
-            return () => {
-                cancelled = true
-            }
-        }
-    }, [isLoaded, user, initialCodes])
+    const [hasCopied, setHasCopied] = useState(false)
+    const [modalOpened, setModalOpened] = useState(false)
+    const [isRedirecting, setIsRedirecting] = useState(false)
 
     const codesAsText = codes && codes.length ? codes.join('\n') : ''
 
@@ -54,61 +44,120 @@ const BackupCodes = ({ codes: initialCodes }: BackupCodesProps) => {
     if (!isLoaded) return null
 
     return (
-        <Stack gap="md" mb="xxl">
-            <Title mb="xs" ta="center" order={3}>
-                Multi-factor authentication is set up successfully!
-            </Title>
-            <Text mb="xs" size="md">
-                These are your recovery codes. Please store them in a secure location. You will need one of them to
-                access your account if you lose access to your authentication device.
-            </Text>
+        <>
+            <Stack gap="md" mb="xxl">
+                <Title mb="xs" ta="center" order={3}>
+                    Multi-factor authentication is set up successfully!
+                </Title>
+                <Text mb="xs" size="md">
+                    These are your recovery codes. Please store them in a secure location. You will need one of them to
+                    access your account <b>if you lose access</b> to your authentication device.
+                </Text>
 
-            <Box
-                bg="gray.0"
-                py="md"
-                px="lg"
-                style={{ border: `1px solid ${theme.colors?.grey[2]}`, maxHeight: 130, overflowY: 'auto' }}
-            >
-                {codes && codes.length ? (
-                    <Stack gap={2} style={{ overflowY: 'auto' }}>
-                        {codes.map((code, index) => (
-                            <Text key={index} size="sm">
-                                {code}
-                            </Text>
-                        ))}
-                    </Stack>
-                ) : (
-                    <Text size="sm" c="dimmed">
-                        Generating recovery codes...
-                    </Text>
-                )}
-            </Box>
-
-            <Stack gap="md" mt="xs">
-                <CopyButton value={codesAsText} timeout={1000}>
-                    {({ copied, copy }) => (
-                        <Stack gap={4}>
-                            <Button fullWidth onClick={copy} variant="primary" disabled={!codes || codes.length === 0}>
-                                Copy codes
-                            </Button>
-                            {copied && (
-                                <Group gap={6} justify="center" align="center">
-                                    <CheckIcon size={16} color={theme.colors.green[9]} />
-                                    <Text size="sm" c="green.9">
-                                        Copied!
-                                    </Text>
-                                </Group>
-                            )}
+                <Box
+                    bg="gray.0"
+                    py="md"
+                    px="lg"
+                    style={{ border: `1px solid ${theme.colors?.grey[2]}`, maxHeight: 130, overflowY: 'auto' }}
+                >
+                    {codes && codes.length ? (
+                        <Stack gap={2} style={{ overflowY: 'auto' }}>
+                            {codes.map((code, index) => (
+                                <Text key={index} size="sm">
+                                    {code}
+                                </Text>
+                            ))}
                         </Stack>
+                    ) : (
+                        <Text size="sm" c="dimmed">
+                            Generating recovery codes...
+                        </Text>
                     )}
-                </CopyButton>
+                </Box>
 
-                <Button fullWidth variant="outline" mt="xs" onClick={goToDashboard} disabled={!isSessionLoaded}>
-                    Go to dashboard
-                </Button>
+                <Stack gap="md" mt="xs">
+                    <CopyButton value={codesAsText} timeout={1000}>
+                        {({ copied, copy }) => (
+                            <Stack gap={4}>
+                                <Button
+                                    fullWidth
+                                    size="md"
+                                    onClick={() => {
+                                        copy()
+                                        setHasCopied(true)
+                                    }}
+                                    variant="primary"
+                                    disabled={!codes || codes.length === 0}
+                                >
+                                    Copy codes
+                                </Button>
+                                {copied && (
+                                    <Group gap={6} justify="center" align="center">
+                                        <CheckIcon size={16} color={theme.colors.green[9]} />
+                                        <Text size="sm" c="green.9" fw={600}>
+                                            Copied!
+                                        </Text>
+                                    </Group>
+                                )}
+                            </Stack>
+                        )}
+                    </CopyButton>
+
+                    <Button
+                        loading={isRedirecting}
+                        fullWidth
+                        variant="outline"
+                        mt="xs"
+                        size="md"
+                        onClick={() => {
+                            if (!hasCopied) {
+                                setModalOpened(true)
+                            } else {
+                                setIsRedirecting(true)
+                                goToDashboard()
+                            }
+                        }}
+                        disabled={!isSessionLoaded}
+                    >
+                        Go to SafeInsights
+                    </Button>
+                </Stack>
             </Stack>
-        </Stack>
+
+            <ConfirmationModal
+                isOpen={modalOpened}
+                onClose={() => setModalOpened(false)}
+                onConfirm={() => {
+                    setModalOpened(false)
+                    setIsRedirecting(true)
+                    goToDashboard()
+                }}
+                isLoading={isRedirecting}
+            />
+        </>
     )
 }
+
+const ConfirmationModal: FC<ConfirmationModalProps> = ({ isOpen, onClose, onConfirm, isLoading = false }) => (
+    <AppModal isOpen={isOpen} onClose={onClose} title="Have you stored your MFA recovery codes?">
+        <Stack>
+            <Text size="md">Make sure you have securely saved your MFA recovery codes.</Text>
+            <Text size="sm" c="red.9">
+                <b>Note:</b> Each code can be used once. We will not show these codes again.
+            </Text>
+            <Text size="md" mb="md">
+                Do you want to proceed?
+            </Text>
+            <Group>
+                <Button variant="outline" onClick={onClose}>
+                    Back
+                </Button>
+                <Button loading={isLoading} onClick={onConfirm}>
+                    Go to SafeInsights
+                </Button>
+            </Group>
+        </Stack>
+    </AppModal>
+)
 
 export default BackupCodes

--- a/src/app/account/mfa/manage-mfa.tsx
+++ b/src/app/account/mfa/manage-mfa.tsx
@@ -35,7 +35,7 @@ export function ManageMFA() {
     if (user.twoFactorEnabled && !window.location.search.includes('TESTING_FORCE_NO_MFA')) return <HasMFA />
 
     return (
-        <Paper bg="white" p="xxl" radius="sm" w={600} my={{ base: '1rem', lg: 0 }}>
+        <Paper bg="white" p="xxl" radius="sm" maw={500} my={{ base: '1rem', lg: 0 }}>
             <Stack mb="xxl">
                 <Title mb="xs" ta="center" order={3}>
                     Secure your account with <br /> Multi-Factor Authentication

--- a/src/components/require-org-admin.tsx
+++ b/src/components/require-org-admin.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useLayoutEffect } from 'react'
 import { useRouter } from 'next/navigation'
+import { useLayoutEffect } from 'react'
 import { useSession } from '../hooks/session'
+import { navigateToDashboard } from '../lib/session'
 
 export const RequireOrgAdmin = () => {
     const { session } = useSession()
@@ -11,11 +12,7 @@ export const RequireOrgAdmin = () => {
     useLayoutEffect(() => {
         if (!session || session.team.isAdmin) return
 
-        if (session.team.isResearcher) {
-            router.push('/researcher/dashboard')
-        } else if (session.team.isReviewer) {
-            router.push(`/reviewer/${session.team.slug}/dashboard`)
-        }
+        navigateToDashboard(router, session)
     }, [session, router])
 
     return null

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -56,3 +56,15 @@ export const sessionFromMetadata = ({
         ability,
     }
 }
+
+export const navigateToDashboard = (router: { push: (path: string) => void }, session: UserSessionWithAbility) => {
+    if (session.team.isResearcher) {
+        router.push('/researcher/dashboard')
+        return
+    }
+    if (session.team.isReviewer) {
+        router.push(`/reviewer/${session.team.slug}/dashboard`)
+        return
+    }
+    router.push('/')
+}


### PR DESCRIPTION
**MFA Setup Flow Improvements:**

* Added a new `BackupCodes` component that displays recovery codes to the user after successful TOTP verification, including copy functionality and a confirmation modal to ensure users store their codes securely.
* Modified the TOTP verification logic in `add-app-mfa.tsx` to generate and show backup codes upon successful verification, and replaced the previous generic success screen with the new backup codes screen. 
* Updated the TOTP setup form to show a loading state during verification for better user feedback.

**UI and Consistency Updates:**

* Standardized the maximum width of MFA-related forms by changing the `Paper` container from a fixed width to `maw={500}` in both the add and manage MFA screens for visual consistency. 
* Cleaned up unused imports and removed the old success screen component from `add-app-mfa.tsx`. 