### PR TITLE
OTTER-270 fix invite error message

### DIFF
--- a/src/app/admin/team/[orgSlug]/invitation.tsx
+++ b/src/app/admin/team/[orgSlug]/invitation.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { zodResolver, useMutation, useQueryClient, useForm } from '@/components/common'
+import { useForm, useMutation, useQueryClient, zodResolver } from '@/components/common'
 import { InputError, handleMutationErrorsWithForm } from '@/components/errors'
 import { AppModal } from '@/components/modal'
 import { SuccessPanel } from '@/components/panel'
@@ -45,17 +45,25 @@ const InviteForm: FC<{ orgSlug: string; onInvited: () => void }> = ({ orgSlug, o
         mutationFn: (invite: InviteUserFormValues) => orgAdminInviteUserAction({ invite, orgSlug }),
         onError: handleMutationErrorsWithForm(studyProposalForm),
         onSuccess(data) {
-            studyProposalForm.reset()
             queryClient.invalidateQueries({ queryKey: ['pendingUsers', orgSlug] })
+
+            if (data?.alreadyMember) {
+                studyProposalForm.setFieldError('email', 'This team member is already in this organization.')
+                return
+            }
+
             if (data?.alreadyInvited) {
                 notifications.show({
                     color: 'green',
                     title: 'Invite resent',
                     message: 'This user has already been invited. Resending invite.',
                 })
-            } else {
-                onInvited()
+                studyProposalForm.reset()
+                return
             }
+
+            studyProposalForm.reset()
+            onInvited()
         },
     })
 


### PR DESCRIPTION
- Removes the thrown `ActionFailure` error from the server component. Next.js appears to mask this custom error in production builds, showing the default 'An error occurred' toast instead of the inline form error. 

See my confirmation below, using 2 PR builds to show the current error and the fix that this PR introduces: 

https://github.com/user-attachments/assets/d3da541a-766e-4309-97ab-86129aaea285

