### PR TITLE
Otter 261 rerun errored code

### DIFF
--- a/src/app/researcher/study/[studyId]/resubmit/[orgSlug]/page.tsx
+++ b/src/app/researcher/study/[studyId]/resubmit/[orgSlug]/page.tsx
@@ -1,0 +1,22 @@
+import { Stack, Title } from '@mantine/core'
+import { ResearcherBreadcrumbs } from '@/components/page-breadcrumbs'
+import { getStudyAction } from '@/server/actions/study.actions'
+import { ResubmitStudyCodeForm } from './form'
+
+export default async function ResubmitStudyCodePage(props: { params: { studyId: string; orgSlug: string } }) {
+    const { studyId } = props.params
+    const study = await getStudyAction({ studyId })
+
+    return (
+        <Stack p="xl" gap="xl">
+            <ResearcherBreadcrumbs
+                crumbs={{
+                    studyId,
+                    current: 'Resubmit study code',
+                }}
+            />
+            <Title order={1}>Resubmit study code</Title>
+            <ResubmitStudyCodeForm study={study} />
+        </Stack>
+    )
+}

--- a/src/app/researcher/study/[studyId]/review/page.tsx
+++ b/src/app/researcher/study/[studyId]/review/page.tsx
@@ -13,7 +13,7 @@ import { JobResultsStatusMessage } from '@/app/researcher/study/[studyId]/review
 
 export const dynamic = 'force-dynamic'
 
-export default async function StudyReviewPage(props: { params: Promise<{ studyId: string }> }) {
+export default async function StudyReviewPage(props: { params: Promise<{ studyId: string; orgSlug: string }> }) {
     const { studyId } = await props.params
 
     // getStudyAction will check permissions
@@ -66,7 +66,7 @@ export default async function StudyReviewPage(props: { params: Promise<{ studyId
                         <Title order={4} size="xl">
                             Study Status
                         </Title>
-                        <FileApprovalStatus job={job} />
+                        <FileApprovalStatus job={job} orgSlug={study.orgSlug} />
                     </Group>
                     <Divider c="dimmed" />
                     <JobResultsStatusMessage job={job} />

--- a/src/app/researcher/study/request/[orgSlug]/actions.test.ts
+++ b/src/app/researcher/study/request/[orgSlug]/actions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { mockSessionWithTestData, insertTestStudyData } from '@/tests/unit.helpers'
-import { onCreateStudyAction, onDeleteStudyAction } from './actions'
+import { upsertStudyAction, onDeleteStudyAction } from './actions'
 import { db } from '@/database'
 import * as aws from '@/server/aws'
 
@@ -27,7 +27,7 @@ describe('Request Study Actions', () => {
             additionalCodeFilePaths: ['helpers.R'],
         }
 
-        const result = await onCreateStudyAction({
+        const result = await upsertStudyAction({
             orgSlug: org.slug,
             studyInfo,
             mainCodeFileName: 'main.R',

--- a/src/app/researcher/study/request/[orgSlug]/study-proposal.tsx
+++ b/src/app/researcher/study/request/[orgSlug]/study-proposal.tsx
@@ -9,7 +9,7 @@ import { studyProposalFormSchema, codeFilesSchema, StudyProposalFormValues } fro
 import { StudyProposalForm } from './study-proposal-form'
 import { UploadStudyJobCode } from './upload-study-job-code'
 import { useMutation } from '@tanstack/react-query'
-import { onCreateStudyAction, onDeleteStudyAction } from './actions'
+import { upsertStudyAction, onDeleteStudyAction } from './actions'
 import { useRouter } from 'next/navigation'
 import { zodResolver } from 'mantine-form-zod-resolver'
 import { CodeReviewManifest } from '@/lib/code-manifest'
@@ -133,7 +133,7 @@ export const StudyProposal: React.FC<{ orgSlug: string }> = ({ orgSlug }) => {
                 urlForAgreementUpload,
                 urlForIrbUpload,
                 urlForDescriptionUpload,
-            } = await onCreateStudyAction({
+            } = await upsertStudyAction({
                 orgSlug,
                 studyInfo: valuesWithFilenames,
                 mainCodeFileName: formValues.mainCodeFile!.name,

--- a/src/app/researcher/study/request/[orgSlug]/study-proposal.tsx
+++ b/src/app/researcher/study/request/[orgSlug]/study-proposal.tsx
@@ -52,7 +52,7 @@ const StepperButtons: React.FC<StepperButtonsProps> = ({ form, stepIndex, isPend
     return null
 }
 
-async function uploadFile(file: File, upload: PresignedPost) {
+export async function uploadFile(file: File, upload: PresignedPost) {
     const body = new FormData()
     for (const [key, value] of Object.entries(upload.fields)) {
         body.append(key, value)

--- a/src/app/researcher/study/request/[orgSlug]/upload-study-job-code.tsx
+++ b/src/app/researcher/study/request/[orgSlug]/upload-study-job-code.tsx
@@ -38,9 +38,10 @@ export const handleDuplicateUpload = (mainFile: File | null, additionalFiles: Fi
     return duplicateFound
 }
 
-export const UploadStudyJobCode: FC<{ studyProposalForm: UseFormReturnType<StudyProposalFormValues> }> = ({
-    studyProposalForm,
-}) => {
+export const UploadStudyJobCode: FC<{
+    studyProposalForm: UseFormReturnType<StudyProposalFormValues>
+    resubmit?: boolean
+}> = ({ studyProposalForm, resubmit }) => {
     const theme = useMantineTheme()
     const color = theme.colors.blue[7]
 
@@ -70,16 +71,14 @@ export const UploadStudyJobCode: FC<{ studyProposalForm: UseFormReturnType<Study
 
     return (
         <Paper p="xl">
-            <Text fz="sm" fw={700} c="gray.6" pb="sm">
-                Step 2 of 2
-            </Text>
+            {!resubmit && (
+                <Text fz="sm" fw={700} c="gray.6" pb="sm">
+                    Step 2 of 2
+                </Text>
+            )}
             <Title order={4}>Study Code</Title>
             <Divider my="sm" mt="sm" mb="md" />
-            <Text mb="md">
-                Upload the code you intend to run on the data organization&apos;s dataset. This is a critical step in
-                your proposal, as it defines the analysis that will produce the results you aim to obtain from the
-                organization&apos;s data.
-            </Text>
+            <Text mb="md">Upload the code you intend to run on the data organization&apos;s dataset. </Text>
             <Group grow justify="center" align="center" mt="md">
                 <Grid>
                     <Grid.Col span={titleSpan}>

--- a/src/components/study/job-approval-status.tsx
+++ b/src/components/study/job-approval-status.tsx
@@ -1,9 +1,10 @@
 import { CheckCircleIcon, XCircleIcon } from '@phosphor-icons/react/dist/ssr'
 import dayjs from 'dayjs'
-import { Group, Text } from '@mantine/core'
+import { Button, Group, Text } from '@mantine/core'
 import { FC } from 'react'
 import { type AllStatus } from '@/lib/types'
 import { LatestJobForStudy } from '@/server/db/queries'
+import { Link } from '../links'
 
 const allowedStatuses: AllStatus[] = ['CODE-APPROVED', 'CODE-REJECTED', 'FILES-APPROVED', 'FILES-REJECTED']
 
@@ -41,13 +42,25 @@ export const CodeApprovalStatus: FC<{ job: LatestJobForStudy }> = ({ job }) => {
     return <JobApprovalStatus statusChange={codeStatusChange} />
 }
 
-export const FileApprovalStatus: FC<{ job: LatestJobForStudy }> = ({ job }) => {
+export const FileApprovalStatus: FC<{ job: LatestJobForStudy; orgSlug: string }> = ({ job, orgSlug }) => {
     const filesStatusChange = job.statusChanges.find((statusChange) => {
-        return statusChange.status === 'FILES-APPROVED' || statusChange.status === 'FILES-REJECTED'
+        return (
+            statusChange.status === 'FILES-APPROVED' ||
+            statusChange.status === 'FILES-REJECTED' ||
+            statusChange.status === 'JOB-ERRORED'
+        )
     })
 
     if (!filesStatusChange) {
         return null
+    }
+
+    if (filesStatusChange.status === 'JOB-ERRORED') {
+        return (
+            <Button component={Link} href={`/researcher/study/${job.studyId}/resubmit/${orgSlug}`}>
+                Resubmit study code
+            </Button>
+        )
     }
 
     return <JobApprovalStatus statusChange={filesStatusChange} />

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -143,6 +143,7 @@ export const getStudyAction = new Action('getStudyAction')
         const study = await db
             .selectFrom('study')
             .innerJoin('user as researcher', (join) => join.onRef('study.researcherId', '=', 'researcher.id'))
+            .innerJoin('org', (join) => join.onRef('study.orgId', '=', 'org.id'))
             .select([
                 'study.id',
                 'study.approvedAt',
@@ -161,6 +162,7 @@ export const getStudyAction = new Action('getStudyAction')
                 'study.irbDocPath',
                 'study.reviewerId',
                 'study.agreementDocPath',
+                'org.slug as orgSlug',
             ])
             .select('researcher.fullName as createdBy')
             .where('study.id', '=', studyId)


### PR DESCRIPTION
This pull request introduces the ability for researchers to resubmit study code if a job fails, along with several related improvements and refactorings. The main changes include implementing a new resubmission flow, refactoring the study creation action to support both creation and updates, and updating UI components to support the resubmission process.