### PR TITLE
Otter 289 show tooltips on keyboard selection too

### DIFF
--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -2,20 +2,21 @@
 
 import { InfoIcon as SVGIcon } from '@phosphor-icons/react/dist/ssr'
 import { ActionIcon, ActionIconProps, useMantineTheme } from '@mantine/core'
+import { forwardRef } from 'react'
 
 type InfoIconProps = ActionIconProps & {
     size?: number
-    innerRef?: React.ForwardedRef<HTMLButtonElement>
 }
 
-export const InfoIcon: React.FC<InfoIconProps> = ({ innerRef, size, ...iconProps }) => {
+export const InfoIcon = forwardRef<HTMLButtonElement, InfoIconProps>(({ size, ...iconProps }, ref) => {
     const {
         colors: { blue },
     } = useMantineTheme()
 
     return (
-        <ActionIcon variant="transparent" {...iconProps} ref={innerRef}>
+        <ActionIcon variant="transparent" {...iconProps} ref={ref} aria-label="More information">
             <SVGIcon color={blue[7]} weight="fill" size={size} />
         </ActionIcon>
     )
-}
+})
+InfoIcon.displayName = 'InfoIcon'

--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -6,7 +6,7 @@ type InfoTooltipProps = {
 }
 
 export const InfoTooltip: React.FC<InfoTooltipProps> = ({ text }) => (
-    <Tooltip multiline withArrow refProp="innerRef" label={text}>
+    <Tooltip multiline withArrow label={text} events={{ hover: true, focus: true, touch: true }}>
         <InfoIcon size={14} />
     </Tooltip>
 )


### PR DESCRIPTION
see https://openstax.atlassian.net/browse/OTTER-289

* The InfoIcon component has been refactored to use forwardRef, allowing it to correctly receive focus.
* The Tooltip component has been configured to trigger on focus events, ensuring it displays for both mouse hover and keyboard navigation.
* An aria-label was added to the icon for better screen reader support.