### PR TITLE
update full name var for reviewer email delivery

### DIFF
--- a/src/server/mailer.test.ts
+++ b/src/server/mailer.test.ts
@@ -102,7 +102,7 @@ describe('mailgun email functions', () => {
                 subject: expect.stringContaining('ready for review'),
                 template: 'vb - encrypted results ready for review',
                 vars: expect.objectContaining({
-                    userFullName: reviewer.fullName,
+                    fullName: reviewer.fullName,
                     studyTitle: study.title,
                     submittedBy: expect.any(String),
                     studyURL: expect.stringContaining(`/reviewer/${org.slug}/study/${study.id}/review`),

--- a/src/server/mailer.ts
+++ b/src/server/mailer.ts
@@ -86,7 +86,7 @@ export const sendResultsReadyForReviewEmail = async (studyId: string) => {
         subject: 'Results ready for review',
         template: 'vb - encrypted results ready for review',
         vars: {
-            userFullName: study.reviewerFullName,
+            fullName: study.reviewerFullName,
             studyTitle: study.title,
             submittedBy: study.researcherFullName,
             submittedOn: dayjs(study.createdAt).format('MM/DD/YYYY'),


### PR DESCRIPTION
[OTTER-269](https://openstax.atlassian.net/browse/OTTER-269)

**Issue**: Full name not being displayed in `Results ready for review` email.

**Solution**: I noticed that the `var` name for the reviewer's full name did not match other email functions, so I updated `userFullName` to `fullName`. 

[OTTER-269]: https://openstax.atlassian.net/browse/OTTER-269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ