### PR TITLE
OTTER-260: Reset password state fix

### DIFF
--- a/src/app/account/reset-password/pending-reset.tsx
+++ b/src/app/account/reset-password/pending-reset.tsx
@@ -1,7 +1,7 @@
 'use client'
 
+import { useForm, useMutation, useState, z, zodResolver } from '@/common'
 import { ClerkErrorAlert } from '@/components/clerk-errors'
-import { zodResolver, useMutation, useForm, useState, z } from '@/common'
 import { InputError } from '@/components/errors'
 import { errorToString, isClerkApiError } from '@/lib/errors'
 import { onUserResetPWAction } from '@/server/actions/user.actions'
@@ -39,11 +39,12 @@ type VerificationFormValues = z.infer<typeof verificationFormSchema>
 
 interface PendingResetProps {
     pendingReset: SignInResource
+    onResetUpdate?: (updated: SignInResource) => void
 }
 
-export function PendingReset({ pendingReset }: PendingResetProps) {
+export function PendingReset({ pendingReset, onResetUpdate }: PendingResetProps) {
     const { isLoaded, setActive, signIn } = useSignIn()
-    const [mfaSignIn, setNeedsMFA] = useState<MFAState>(false)
+    const [needsMFA, setNeedsMFA] = useState<MFAState>(false)
     const [verificationError, setVerificationError] = useState<string | null>(null)
     const [canResend, setCanResend] = useState(true)
     const router = useRouter()
@@ -62,10 +63,12 @@ export function PendingReset({ pendingReset }: PendingResetProps) {
 
     const { isPending, mutate: onSubmitVerification } = useMutation({
         async mutationFn(form: VerificationFormValues) {
-            if (!isLoaded || !pendingReset || Object.keys(pendingReset).length === 0) return
+            if (!isLoaded || (!signIn && (!pendingReset || Object.keys(pendingReset).length === 0))) return
             setVerificationError(null)
 
-            return await pendingReset.attemptFirstFactor({
+            const resetInstance = signIn ?? pendingReset
+
+            return await resetInstance!.attemptFirstFactor({
                 strategy: 'reset_password_email_code',
                 code: form.code,
                 password: form.password,
@@ -135,7 +138,12 @@ export function PendingReset({ pendingReset }: PendingResetProps) {
         onError: (error: unknown) => {
             console.error('Failed to resend code:', error)
         },
-        onSuccess: () => {
+        onSuccess: (newSignIn) => {
+            // use the latest sign-in instance
+            if (newSignIn && onResetUpdate) {
+                onResetUpdate(newSignIn)
+            }
+
             setCanResend(false)
             setTimeout(() => setCanResend(true), 30000)
         },
@@ -147,7 +155,7 @@ export function PendingReset({ pendingReset }: PendingResetProps) {
 
     const { requirements, shouldShowRequirements } = usePasswordRequirements(verificationForm.values.password)
 
-    if (mfaSignIn) return <RequestMFA mfa={mfaSignIn} onReset={() => setNeedsMFA(false)} />
+    if (needsMFA) return <RequestMFA mfa={needsMFA} onReset={() => setNeedsMFA(false)} />
 
     return (
         <form onSubmit={verificationForm.onSubmit((values) => onSubmitVerification(values))}>

--- a/src/app/account/reset-password/reset-password.tsx
+++ b/src/app/account/reset-password/reset-password.tsx
@@ -39,7 +39,7 @@ export function ResetPassword() {
     }
 
     if (pendingReset) {
-        return <PendingReset pendingReset={pendingReset} />
+        return <PendingReset pendingReset={pendingReset} onResetUpdate={setPendingReset} />
     }
 
     return <ResetForm onCompleteAction={onComplete} />


### PR DESCRIPTION
In verifying the functionality on QA, I noticed a bug where we're using a stale sign in resource after requesting a new code mid-reset. This causes an 'Update operations are not allowed on older sign ins' error.

**State and Prop Management Improvements:**

* Added an optional `onResetUpdate` callback prop to the `PendingReset` component, allowing parent components to update the `pendingReset` state when a new sign-in instance is received. 
* Updated the resend code logic to call `onResetUpdate` with the new sign-in instance upon success, ensuring the latest state is used throughout the reset process. 

**Code Consistency and Clarity:**

* Renamed the `mfaSignIn` state variable to `needsMFA` for consistency and updated all related references. 