### PR TITLE
Add right icon and new tab support to NavbarLink component

### DIFF
--- a/src/components/layout/navbar-items.tsx
+++ b/src/components/layout/navbar-items.tsx
@@ -2,7 +2,7 @@
 
 import { useSession } from '@/hooks/session'
 import { Stack } from '@mantine/core'
-import { StudentIcon, UserListIcon, BookOpenIcon, BooksIcon } from '@phosphor-icons/react/dist/ssr'
+import { StudentIcon, UserListIcon, BookOpenIcon, BooksIcon, ArrowSquareOutIcon } from '@phosphor-icons/react/dist/ssr'
 import { FC } from 'react'
 import { OrgSwitcher } from '../org/org-switcher'
 import { NavbarLink } from './navbar-link'
@@ -30,9 +30,11 @@ export const NavbarItems: FC = () => {
             />
             <NavbarLink
                 icon={<BookOpenIcon />}
+                rightIcon={<ArrowSquareOutIcon />}
                 isVisible={isAdmin || isReviewer}
                 url={'https://kb.safeinsights.org/resource-center'}
                 label={'Resource Center'}
+                newTab
             />
 
             <NavbarLink
@@ -43,9 +45,11 @@ export const NavbarItems: FC = () => {
             />
             <NavbarLink
                 icon={<BooksIcon />}
+                rightIcon={<ArrowSquareOutIcon />}
                 isVisible={isAdmin || isResearcher}
                 url={'https://kb.safeinsights.org/data-catalog'}
                 label={'Data Catalog'}
+                newTab
             />
         </Stack>
     )

--- a/src/components/layout/navbar-link.tsx
+++ b/src/components/layout/navbar-link.tsx
@@ -10,9 +10,11 @@ type NavbarLinkProps = NavLinkProps & {
     url: string
     label: string
     icon: React.ReactNode
+    rightIcon?: React.ReactNode
+    newTab?: boolean
 }
 
-export const NavbarLink: FC<NavbarLinkProps> = ({ isVisible, url, label, icon, ...linkProps }) => {
+export const NavbarLink: FC<NavbarLinkProps> = ({ isVisible, url, label, icon, rightIcon, newTab, ...linkProps }) => {
     const pathname = usePathname()
 
     if (!isVisible) return null
@@ -23,12 +25,14 @@ export const NavbarLink: FC<NavbarLinkProps> = ({ isVisible, url, label, icon, .
             <NavLink
                 label={label}
                 leftSection={icon}
+                rightSection={rightIcon}
                 component={isExternal ? undefined : Link}
                 href={url}
                 active={pathname === url}
                 c="white"
                 color="blue.7"
                 variant="filled"
+                target={newTab ? '_blank' : '_self'}
                 className={styles.navLinkHover}
                 {...linkProps}
             />


### PR DESCRIPTION
Add icon to the right end side of the ‘Resource Center’ and ‘Data Catalog’ buttons to indicate they open in a separate tab

Ensure buttons load their respective URL in separate tabs