### PR TITLE
OTTER-285 login flow - MFA fixes

### DIFF
--- a/src/app/account/signin/sign-in-form.tsx
+++ b/src/app/account/signin/sign-in-form.tsx
@@ -1,12 +1,12 @@
-import { zodResolver, useForm, Link, Flex, Button } from '@/common'
-import { TextInput, PasswordInput, Paper, Title } from '@mantine/core'
-import { clerkErrorOverrides, errorToString } from '@/lib/errors'
+import { Button, Flex, Link, useForm, zodResolver } from '@/common'
 import { reportError } from '@/components/errors'
+import { clerkErrorOverrides, errorToString } from '@/lib/errors'
 import { useAuth, useSignIn, useUser } from '@clerk/nextjs'
-import { type MFAState, signInToMFAState } from './logic'
-import { FC, useEffect, useState } from 'react'
+import { Paper, PasswordInput, TextInput, Title } from '@mantine/core'
 import { useRouter, useSearchParams } from 'next/navigation'
+import { FC, useEffect, useState } from 'react'
 import { z } from 'zod'
+import { type MFAState } from './logic'
 import { SignInError } from './sign-in-error'
 
 const signInSchema = z.object({
@@ -65,8 +65,8 @@ export const SignInForm: FC<{
                 router.push(redirectUrl || '/')
             }
             if (attempt.status === 'needs_second_factor') {
-                const state = await signInToMFAState(attempt)
-                await onComplete(state)
+                // Auth method not yet determined, set to false for now
+                await onComplete({ signIn: attempt, usingSMS: false })
             }
         } catch (err: unknown) {
             reportError(err, 'Failed Signin Attempt')


### PR DESCRIPTION
**MFA logic and flow improvements:**

* Added a `hasBoth` variable to determine if both SMS and TOTP authentication methods are available, enabling more precise UI logic and button styling.
* Updated the `onSelectMethod` function to only prepare the SMS second factor when the sign-in status is `needs_second_factor`, preventing unnecessary calls and improving reliability.
* Changed the logic for passing MFA state in the sign-in form to always set `usingSMS` to false when the authentication method is not yet determined, simplifying downstream handling.

**User interface adjustments:**

* Improved the MFA prompt by removing redundant text and adjusting spacing for clarity; the Authenticator app button now uses a primary variant only when it is the sole available method.