### PR TITLE
OTTER-355 IDE launch empty state (Part 1 - needs ide and file logic to hook up to buttons)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
                 "mailgun.js": "^12.0.3",
                 "mantine-datatable": "^8.2.0",
                 "mantine-form-zod-resolver": "^1.3.0",
-                "next": "^15.5.2",
+                "next": "^15.5.8",
                 "next-swagger-doc": "^0.4",
                 "papaparse": "^5.5.3",
                 "pg": "^8.16.3",
@@ -67,7 +67,7 @@
             "devDependencies": {
                 "@clerk/testing": "^1.12.3",
                 "@eslint/js": "^9.34.0",
-                "@next/eslint-plugin-next": "^15.5.2",
+                "@next/eslint-plugin-next": "^15.5.8",
                 "@octokit/rest": "^22.0.0",
                 "@pandacss/dev": "^1.2.0",
                 "@playwright/test": "^1.56",
@@ -3294,15 +3294,15 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "15.5.7",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.7.tgz",
-            "integrity": "sha512-4h6Y2NyEkIEN7Z8YxkA27pq6zTkS09bUSYC0xjd0NpwFxjnIKeZEeH591o5WECSmjpUhLn3H2QLJcDye3Uzcvg==",
+            "version": "15.5.9",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.9.tgz",
+            "integrity": "sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==",
             "license": "MIT"
         },
         "node_modules/@next/eslint-plugin-next": {
-            "version": "15.5.7",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.7.tgz",
-            "integrity": "sha512-DtRU2N7BkGr8r+pExfuWHwMEPX5SD57FeA6pxdgCHODo+b/UgIgjE+rgWKtJAbEbGhVZ2jtHn4g3wNhWFoNBQQ==",
+            "version": "15.5.9",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.9.tgz",
+            "integrity": "sha512-kUzXx0iFiXw27cQAViE1yKWnz/nF8JzRmwgMRTMh8qMY90crNsdXJRh2e+R0vBpFR3kk1yvAR7wev7+fCCb79Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13384,12 +13384,12 @@
             "peer": true
         },
         "node_modules/next": {
-            "version": "15.5.7",
-            "resolved": "https://registry.npmjs.org/next/-/next-15.5.7.tgz",
-            "integrity": "sha512-+t2/0jIJ48kUpGKkdlhgkv+zPTEOoXyr60qXe68eB/pl3CMJaLeIGjzp5D6Oqt25hCBiBTt8wEeeAzfJvUKnPQ==",
+            "version": "15.5.9",
+            "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
+            "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
             "license": "MIT",
             "dependencies": {
-                "@next/env": "15.5.7",
+                "@next/env": "15.5.9",
                 "@swc/helpers": "0.5.15",
                 "caniuse-lite": "^1.0.30001579",
                 "postcss": "8.4.31",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "mailgun.js": "^12.0.3",
         "mantine-datatable": "^8.2.0",
         "mantine-form-zod-resolver": "^1.3.0",
-        "next": "^15.5.2",
+        "next": "^15.5.8",
         "next-swagger-doc": "^0.4",
         "papaparse": "^5.5.3",
         "pg": "^8.16.3",
@@ -93,7 +93,7 @@
     "devDependencies": {
         "@clerk/testing": "^1.12.3",
         "@eslint/js": "^9.34.0",
-        "@next/eslint-plugin-next": "^15.5.2",
+        "@next/eslint-plugin-next": "^15.5.8",
         "@octokit/rest": "^22.0.0",
         "@pandacss/dev": "^1.2.0",
         "@playwright/test": "^1.56",

--- a/src/components/study-code-ide.tsx
+++ b/src/components/study-code-ide.tsx
@@ -1,0 +1,106 @@
+import { Box, Button, Divider, Group, Paper, Stack, Text, Title, UnstyledButton, useMantineTheme } from '@mantine/core'
+import { ArrowSquareOutIcon, CaretLeftIcon, DownloadSimpleIcon } from '@phosphor-icons/react/dist/ssr'
+import { FC, useState } from 'react'
+
+interface StudyCodeIDEProps {
+    showStepIndicator?: boolean
+    title?: string
+    onBack?: () => void
+    hasExistingFiles?: boolean
+}
+
+export const StudyCodeIDE: FC<StudyCodeIDEProps> = ({
+    showStepIndicator = false,
+    title = 'Study code',
+    onBack,
+    hasExistingFiles = false,
+}) => {
+    const [importedFiles, setImportedFiles] = useState<string[]>([])
+
+    const handleOpenIDEWindow = () => {
+        // TODO: Open the IDE in a new browser tab/window
+        // This will use the Coder workspace for the study once integrated
+        window.open('about:blank', '_blank') // Placeholder for now
+    }
+
+    const handleImportFromIDE = () => {
+        // TODO: Implement logic to show imported files from the IDE workspace
+        setImportedFiles([]) // Or navigate to existing view?
+    }
+
+    return (
+        <Paper p="xl">
+            {showStepIndicator && (
+                <Text fz="sm" fw={700} c="gray.6" pb="sm">
+                    STEP 4 OF 4
+                </Text>
+            )}
+            <Title order={4}>{title}</Title>
+            <Divider my="sm" mt="sm" mb="md" />
+
+            <Group justify="space-between" align="center" mb="lg">
+                <Text fw={600}>Review files from IDE</Text>
+                <Group gap="sm">
+                    <Button
+                        variant="outline"
+                        rightSection={<ArrowSquareOutIcon size={16} />}
+                        onClick={handleOpenIDEWindow}
+                    >
+                        Launch IDE
+                    </Button>
+                    <Button leftSection={<DownloadSimpleIcon size={16} />} onClick={handleImportFromIDE}>
+                        Import files from IDE
+                    </Button>
+                </Group>
+            </Group>
+
+            {!hasExistingFiles && (
+                <IDEFilesEmptyState importedFiles={importedFiles} onImportClick={handleImportFromIDE} />
+            )}
+
+            {onBack && (
+                <Button variant="subtle" mt="md" onClick={onBack} leftSection={<CaretLeftIcon size={16} />}>
+                    Back to upload options
+                </Button>
+            )}
+        </Paper>
+    )
+}
+
+// IDE Files Empty State Component - shown when no files have been imported from IDE
+const IDEFilesEmptyState: FC<{
+    importedFiles: string[]
+    onImportClick: () => void
+}> = ({ importedFiles, onImportClick }) => {
+    const theme = useMantineTheme()
+
+    if (importedFiles.length > 0) {
+        // navigate to view of imported files where main code file should be selected
+    }
+
+    return (
+        <Box
+            style={{
+                backgroundColor: theme.colors.gray[0],
+                borderRadius: theme.radius.sm,
+                padding: theme.spacing.xxl,
+                minHeight: 200,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+            }}
+        >
+            <Stack align="center" gap="md">
+                <Text c="charcoal.9">You have not imported any files yet.</Text>
+                <UnstyledButton onClick={onImportClick}>
+                    <Group gap={6}>
+                        <DownloadSimpleIcon size={18} color={theme.colors.purple[5]} />
+                        <Text c="purple.5" fw={600} fz="md">
+                            Import files from IDE
+                        </Text>
+                    </Group>
+                </UnstyledButton>
+            </Stack>
+        </Box>
+    )
+}

--- a/src/components/study-code-ide.tsx
+++ b/src/components/study-code-ide.tsx
@@ -1,18 +1,16 @@
 import { Box, Button, Divider, Group, Paper, Stack, Text, Title, UnstyledButton, useMantineTheme } from '@mantine/core'
-import { ArrowSquareOutIcon, CaretLeftIcon, DownloadSimpleIcon } from '@phosphor-icons/react/dist/ssr'
+import { ArrowSquareOutIcon, DownloadSimpleIcon } from '@phosphor-icons/react/dist/ssr'
 import { FC, useState } from 'react'
 
 interface StudyCodeIDEProps {
     showStepIndicator?: boolean
     title?: string
-    onBack?: () => void
     hasExistingFiles?: boolean
 }
 
 export const StudyCodeIDE: FC<StudyCodeIDEProps> = ({
     showStepIndicator = false,
     title = 'Study code',
-    onBack,
     hasExistingFiles = false,
 }) => {
     const [importedFiles, setImportedFiles] = useState<string[]>([])
@@ -56,12 +54,6 @@ export const StudyCodeIDE: FC<StudyCodeIDEProps> = ({
 
             {!hasExistingFiles && (
                 <IDEFilesEmptyState importedFiles={importedFiles} onImportClick={handleImportFromIDE} />
-            )}
-
-            {onBack && (
-                <Button variant="subtle" mt="md" onClick={onBack} leftSection={<CaretLeftIcon size={16} />}>
-                    Back to upload options
-                </Button>
             )}
         </Paper>
     )

--- a/src/components/study-code-upload.tsx
+++ b/src/components/study-code-upload.tsx
@@ -74,14 +74,7 @@ export const StudyCodeUpload = ({
 
     // IDE mode view
     if (mode === 'ide') {
-        return (
-            <StudyCodeIDE
-                showStepIndicator={showStepIndicator}
-                title={title}
-                onBack={() => setMode('initial')}
-                hasExistingFiles={hasCodeFiles}
-            />
-        )
+        return <StudyCodeIDE showStepIndicator={showStepIndicator} title={title} hasExistingFiles={hasCodeFiles} />
     }
 
     return (

--- a/src/components/study-code-upload.tsx
+++ b/src/components/study-code-upload.tsx
@@ -29,6 +29,13 @@ import { StudyJobCodeFilesValues } from '@/schema/study-proposal'
 import { LightbulbIcon } from '@phosphor-icons/react'
 import { uniqueBy } from 'remeda'
 import { LaunchIDEButton, OrDivider, UploadFilesButton } from './study/study-upload-buttons'
+import { StudyCodeIDE } from './study-code-ide'
+
+/**
+ * - 'initial': The initial mode, where the user can upload files or launch the IDE.
+ * - 'ide': The IDE mode, where the user can view the IDE and import files from it.
+ */
+type CodeUploadMode = 'initial' | 'ide'
 
 interface StudyCodeUploadProps {
     studyUploadForm: UseFormReturnType<StudyJobCodeFilesValues>
@@ -47,6 +54,7 @@ export const StudyCodeUpload = ({
 }: StudyCodeUploadProps) => {
     const [isModalOpen, { open: openModal, close: closeModal }] = useDisclosure(false)
     const [isAlertVisible, setIsAlertVisible] = useState(true)
+    const [mode, setMode] = useState<CodeUploadMode>('initial')
     const theme = useMantineTheme()
 
     const handleConfirmAndProceed = () => {
@@ -55,10 +63,26 @@ export const StudyCodeUpload = ({
     }
 
     const handleLaunchIDE = () => {
-        // TODO: Implement logic to launch the IDE
+        setMode('ide')
     }
 
     const isOpenstaxOrg = orgSlug === OPENSTAX_ORG_SLUG
+
+    const hasCodeFiles = !!(
+        studyUploadForm.getValues().mainCodeFile || studyUploadForm.getValues().additionalCodeFiles.length > 0
+    )
+
+    // IDE mode view
+    if (mode === 'ide') {
+        return (
+            <StudyCodeIDE
+                showStepIndicator={showStepIndicator}
+                title={title}
+                onBack={() => setMode('initial')}
+                hasExistingFiles={hasCodeFiles}
+            />
+        )
+    }
 
     return (
         <Paper p="xl">


### PR DESCRIPTION
This ticket implements the empty state after selecting Launch IDE from the upload buttons. This will need to be updated when the launch IDE/importing files logic is integrated.

**IDE Integration and Upload Flow Enhancements:**

* Added a new `StudyCodeIDE` component (`src/components/study-code-ide.tsx`) that provides UI and logic for launching the IDE, importing files, and displaying an empty state when no files have been imported.
* Introduced a `CodeUploadMode` type and a `mode` state in `StudyCodeUpload` to toggle between the initial upload view and the IDE integration view. 
* Added logic to determine if code files have already been uploaded, and passed this state to the `StudyCodeIDE` component for conditional rendering.

<img width="1022" height="665" alt="Screenshot 2025-12-11 at 7 51 51 PM" src="https://github.com/user-attachments/assets/e013ccbb-a8ed-4663-a5d5-e81a82cdc67d" />
