### PR TITLE
OTTER-488: scaffold new DO proposal review page

### DIFF
--- a/src/app/[orgSlug]/admin/team/admin-users.actions.test.ts
+++ b/src/app/[orgSlug]/admin/team/admin-users.actions.test.ts
@@ -1,6 +1,6 @@
 import { db } from '@/database'
 import { sendInviteEmail } from '@/server/mailer'
-import { actionResult, faker, mockSessionWithTestData } from '@/tests/unit.helpers'
+import { actionResult, mockSessionWithTestData } from '@/tests/unit.helpers'
 import { clerkClient } from '@clerk/nextjs/server'
 import { Mock, describe, expect, it, vi } from 'vitest'
 import { getPendingUsersAction, orgAdminInviteUserAction, reInviteUserAction } from './admin-users.actions'
@@ -32,7 +32,7 @@ describe('Admin Users Actions', () => {
             permission: 'admin' as const,
         }
 
-        await orgAdminInviteUserAction({ orgSlug: org.slug, invite, invitedByUserId: faker.string.uuid() })
+        await orgAdminInviteUserAction({ orgSlug: org.slug, invite })
 
         const pendingUser = await db
             .selectFrom('pendingUser')
@@ -64,7 +64,6 @@ describe('Admin Users Actions', () => {
         const result = await orgAdminInviteUserAction({
             orgSlug: org.slug,
             invite,
-            invitedByUserId: user.id,
         })
 
         expect(result).toEqual({
@@ -73,7 +72,7 @@ describe('Admin Users Actions', () => {
     })
 
     it('orgAdminInviteUserAction allows invite when user exists in Clerk but not in this org', async () => {
-        const { org, user } = await mockSessionWithTestData({ isAdmin: true })
+        const { org } = await mockSessionWithTestData({ isAdmin: true })
 
         // Mock Clerk to return a different user (not in this org)
         mockClerkClient.mockResolvedValue({
@@ -90,7 +89,7 @@ describe('Admin Users Actions', () => {
             permission: 'contributor' as const,
         }
 
-        await orgAdminInviteUserAction({ orgSlug: org.slug, invite, invitedByUserId: user.id })
+        await orgAdminInviteUserAction({ orgSlug: org.slug, invite })
 
         const pendingUser = await db
             .selectFrom('pendingUser')

--- a/src/app/[orgSlug]/admin/team/admin-users.actions.ts
+++ b/src/app/[orgSlug]/admin/team/admin-users.actions.ts
@@ -12,14 +12,14 @@ export const orgAdminInviteUserAction = new Action('orgAdminInviteUserAction')
         z.object({
             orgSlug: z.string(),
             invite: inviteUserSchema,
-            invitedByUserId: z.string(),
         }),
     )
     .middleware(async ({ params: { orgSlug }, db }) =>
         db.selectFrom('org').select(['id as orgId']).where('slug', '=', orgSlug).executeTakeFirstOrThrow(),
     )
     .requireAbilityTo('invite', 'User')
-    .handler(async ({ params: { invite, invitedByUserId }, orgId, db }) => {
+    .handler(async ({ params: { invite }, orgId, db, session }) => {
+        const invitedByUserId = session.user.id
         // clerk normalizes the email to lowercase, do the same here to avoid case-insensitive matching issues
         invite.email = invite.email.toLowerCase()
         // Check if email belongs to any existing Clerk user (handles both primary and merged emails)

--- a/src/app/[orgSlug]/admin/team/invitation.tsx
+++ b/src/app/[orgSlug]/admin/team/invitation.tsx
@@ -40,8 +40,7 @@ const InviteForm: FC<{ orgSlug: string; onInvited: () => void }> = ({ orgSlug, o
     })
 
     const { mutate: inviteUser, isPending: isInviting } = useMutation({
-        mutationFn: (invite: InviteUserFormValues) =>
-            orgAdminInviteUserAction({ invite, orgSlug }),
+        mutationFn: (invite: InviteUserFormValues) => orgAdminInviteUserAction({ invite, orgSlug }),
         onError: handleMutationErrorsWithForm(studyProposalForm),
         onSuccess(data) {
             studyProposalForm.reset()
@@ -94,12 +93,7 @@ const InviteForm: FC<{ orgSlug: string; onInvited: () => void }> = ({ orgSlug, o
                 </Radio.Group>
             </Flex>
 
-            <Button
-                type="submit"
-                mt="sm"
-                loading={isInviting}
-                disabled={!studyProposalForm.isValid() || !isLoaded}
-            >
+            <Button type="submit" mt="sm" loading={isInviting} disabled={!studyProposalForm.isValid() || !isLoaded}>
                 Send invitation
             </Button>
         </form>

--- a/src/app/[orgSlug]/admin/team/invitation.tsx
+++ b/src/app/[orgSlug]/admin/team/invitation.tsx
@@ -28,7 +28,7 @@ const InviteSuccess: FC<{ onContinue: () => void }> = ({ onContinue }) => {
 
 const InviteForm: FC<{ orgSlug: string; onInvited: () => void }> = ({ orgSlug, onInvited }) => {
     const queryClient = useQueryClient()
-    const { session, isLoaded } = useSession()
+    const { isLoaded } = useSession()
 
     const studyProposalForm = useForm({
         validate: zodResolver(inviteUserSchema),
@@ -41,7 +41,7 @@ const InviteForm: FC<{ orgSlug: string; onInvited: () => void }> = ({ orgSlug, o
 
     const { mutate: inviteUser, isPending: isInviting } = useMutation({
         mutationFn: (invite: InviteUserFormValues) =>
-            orgAdminInviteUserAction({ invite, orgSlug, invitedByUserId: session?.user.id ?? '' }),
+            orgAdminInviteUserAction({ invite, orgSlug }),
         onError: handleMutationErrorsWithForm(studyProposalForm),
         onSuccess(data) {
             studyProposalForm.reset()
@@ -98,7 +98,7 @@ const InviteForm: FC<{ orgSlug: string; onInvited: () => void }> = ({ orgSlug, o
                 type="submit"
                 mt="sm"
                 loading={isInviting}
-                disabled={!studyProposalForm.isValid() || !isLoaded || !session}
+                disabled={!studyProposalForm.isValid() || !isLoaded}
             >
                 Send invitation
             </Button>

--- a/src/app/[orgSlug]/study/[studyId]/review/new-proposal-review-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/new-proposal-review-view.test.tsx
@@ -1,0 +1,61 @@
+import { getStudyAction, type SelectedStudy } from '@/server/actions/study.actions'
+import {
+    actionResult,
+    insertTestStudyJobData,
+    mockSessionWithTestData,
+    renderWithProviders,
+    screen,
+    type Mock,
+} from '@/tests/unit.helpers'
+import { useParams } from 'next/navigation'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { NewProposalReviewView } from './new-proposal-review-view'
+
+describe('NewProposalReviewView', () => {
+    let study: SelectedStudy
+
+    beforeEach(async () => {
+        const { org, user } = await mockSessionWithTestData({ orgSlug: 'test-org', orgType: 'enclave' })
+        const { study: dbStudy } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'PENDING-REVIEW',
+            title: 'Test Study Title',
+        })
+        study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+        ;(useParams as Mock).mockReturnValue({ orgSlug: 'test-org', studyId: study.id })
+    })
+
+    it('renders all stub sections', () => {
+        renderWithProviders(<NewProposalReviewView orgSlug="test-org" study={study} />)
+
+        expect(screen.getByTestId('review-progress-bar')).toBeInTheDocument()
+        expect(screen.getByTestId('proposal-section')).toBeInTheDocument()
+        expect(screen.getByTestId('review-feedback-section')).toBeInTheDocument()
+        expect(screen.getByTestId('review-decision-section')).toBeInTheDocument()
+    })
+
+    it('renders the page title', () => {
+        renderWithProviders(<NewProposalReviewView orgSlug="test-org" study={study} />)
+
+        expect(screen.getByRole('heading', { name: 'Study proposal', level: 1 })).toBeInTheDocument()
+    })
+
+    it('renders the study title in proposal section', () => {
+        renderWithProviders(<NewProposalReviewView orgSlug="test-org" study={study} />)
+
+        expect(screen.getByText(/Test Study Title/)).toBeInTheDocument()
+    })
+
+    it('renders the submit button as disabled initially', () => {
+        renderWithProviders(<NewProposalReviewView orgSlug="test-org" study={study} />)
+
+        expect(screen.getByRole('button', { name: 'Submit review' })).toBeDisabled()
+    })
+
+    it('renders the back button', () => {
+        renderWithProviders(<NewProposalReviewView orgSlug="test-org" study={study} />)
+
+        expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument()
+    })
+})

--- a/src/app/[orgSlug]/study/[studyId]/review/new-proposal-review-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/new-proposal-review-view.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { PageBreadcrumbs } from '@/components/page-breadcrumbs'
+import { useReviewDecision } from '@/hooks/use-review-decision'
+import { useReviewFeedback } from '@/hooks/use-review-feedback'
+import { Routes } from '@/lib/routes'
+import { Box, Button, Group, Stack, Title } from '@mantine/core'
+import { useRouter } from 'next/navigation'
+import { ProposalSection } from './proposal-section'
+import { ReviewDecisionSection } from './review-decision-section'
+import { ReviewFeedbackSection } from './review-feedback-section'
+import { ReviewProgressBar } from './review-progress-bar'
+import { REVIEW_STEPS, type StudyForReview } from './review-types'
+
+type NewProposalReviewViewProps = {
+    orgSlug: string
+    study: StudyForReview
+}
+
+function useNewProposalReview({ orgSlug }: { orgSlug: string }) {
+    const feedback = useReviewFeedback()
+    const decision = useReviewDecision()
+    const router = useRouter()
+
+    const canSubmit = feedback.isValid && decision.selected !== null
+
+    const handleBack = () => {
+        router.push(Routes.orgDashboard({ orgSlug }))
+    }
+
+    const handleSubmit = () => {
+        // Will be implemented in a future ticket
+    }
+
+    return { feedback, decision, canSubmit, handleBack, handleSubmit }
+}
+
+export function NewProposalReviewView({ orgSlug, study }: NewProposalReviewViewProps) {
+    const { feedback, decision, canSubmit, handleBack, handleSubmit } = useNewProposalReview({ orgSlug })
+
+    return (
+        <Box bg="grey.10">
+            <Stack px="xl" gap="xl" py="xl">
+                <PageBreadcrumbs
+                    crumbs={[
+                        ['Dashboard', Routes.orgDashboard({ orgSlug })],
+                        ['Study proposal', Routes.studyReview({ orgSlug, studyId: study.id })],
+                        ['Review initial request'],
+                    ]}
+                />
+
+                <Title order={1} fz={40} fw={700}>
+                    Study proposal
+                </Title>
+
+                <ReviewProgressBar currentStep={0} steps={REVIEW_STEPS} />
+                <ProposalSection study={study} />
+                <ReviewFeedbackSection feedback={feedback} />
+                <ReviewDecisionSection decision={decision} />
+
+                <Group justify="space-between">
+                    <Button variant="outline" onClick={handleBack}>
+                        Back
+                    </Button>
+                    <Button disabled={!canSubmit} onClick={handleSubmit}>
+                        Submit review
+                    </Button>
+                </Group>
+            </Stack>
+        </Box>
+    )
+}

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-review-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-review-view.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { PageBreadcrumbs } from '@/components/page-breadcrumbs'
+import { ProposalReviewFeatureFlag } from '@/components/openstax-feature-flag'
 import StudyApprovalStatus from '@/components/study/study-approval-status'
 import { DatasetsField, LexicalProposalField, PIField, ResearcherField } from '@/components/study/proposal-fields'
 import { stringifyJson } from '@/lib/string'
@@ -8,6 +9,7 @@ import { Routes } from '@/lib/routes'
 import { Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
 import type { SelectedStudy } from '@/server/actions/study.actions'
 import { usePopover } from '@/hooks/use-popover'
+import { NewProposalReviewView } from './new-proposal-review-view'
 import { ProposalReviewButtons } from './proposal-review-buttons'
 
 type ProposalReviewViewProps = {
@@ -19,7 +21,7 @@ type ProposalReviewViewProps = {
 export function ProposalReviewView({ orgSlug, study, agreementsHref }: ProposalReviewViewProps) {
     const { getPopoverProps } = usePopover()
 
-    return (
+    const existingView = (
         <Stack px="xl" gap="xl">
             <PageBreadcrumbs
                 crumbs={[['Dashboard', Routes.orgDashboard({ orgSlug })], ['Data use request / Review study proposal']]}
@@ -71,5 +73,12 @@ export function ProposalReviewView({ orgSlug, study, agreementsHref }: ProposalR
 
             <ProposalReviewButtons study={study} orgSlug={orgSlug} agreementsHref={agreementsHref} />
         </Stack>
+    )
+
+    return (
+        <ProposalReviewFeatureFlag
+            defaultContent={existingView}
+            optInContent={<NewProposalReviewView orgSlug={orgSlug} study={study} />}
+        />
     )
 }

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-section.tsx
@@ -1,0 +1,17 @@
+import { Paper, Skeleton, Text } from '@mantine/core'
+import type { StudyForReview } from './review-types'
+
+type ProposalSectionProps = {
+    study: StudyForReview
+}
+
+export function ProposalSection({ study }: ProposalSectionProps) {
+    return (
+        <Paper p="xl" data-testid="proposal-section">
+            <Text fw={600} mb="sm">
+                Proposal — {study.title}
+            </Text>
+            <Skeleton height={120} radius="md" />
+        </Paper>
+    )
+}

--- a/src/app/[orgSlug]/study/[studyId]/review/review-decision-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/review-decision-section.tsx
@@ -1,0 +1,17 @@
+import { Paper, Skeleton, Text } from '@mantine/core'
+import type { useReviewDecision } from '@/hooks/use-review-decision'
+
+type ReviewDecisionSectionProps = {
+    decision: ReturnType<typeof useReviewDecision>
+}
+
+export function ReviewDecisionSection({ decision }: ReviewDecisionSectionProps) {
+    return (
+        <Paper p="xl" data-testid="review-decision-section">
+            <Text fw={600} mb="sm">
+                Decision — {decision.selected ?? 'None selected'}
+            </Text>
+            <Skeleton height={80} radius="md" />
+        </Paper>
+    )
+}

--- a/src/app/[orgSlug]/study/[studyId]/review/review-feedback-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/review-feedback-section.tsx
@@ -1,5 +1,6 @@
-import { Paper, Skeleton, Text } from '@mantine/core'
+import { Group, Paper, Skeleton, Text } from '@mantine/core'
 import type { useReviewFeedback } from '@/hooks/use-review-feedback'
+import { WordCounter } from '@/components/word-counter'
 
 type ReviewFeedbackSectionProps = {
     feedback: ReturnType<typeof useReviewFeedback>
@@ -8,9 +9,10 @@ type ReviewFeedbackSectionProps = {
 export function ReviewFeedbackSection({ feedback }: ReviewFeedbackSectionProps) {
     return (
         <Paper p="xl" data-testid="review-feedback-section">
-            <Text fw={600} mb="sm">
-                Feedback — {feedback.wordCount}/{feedback.maxWords} words
-            </Text>
+            <Group gap="xs" mb="sm">
+                <Text fw={600}>Feedback</Text>
+                <WordCounter wordCount={feedback.wordCount} maxWords={feedback.maxWords} />
+            </Group>
             <Skeleton height={160} radius="md" />
         </Paper>
     )

--- a/src/app/[orgSlug]/study/[studyId]/review/review-feedback-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/review-feedback-section.tsx
@@ -1,0 +1,17 @@
+import { Paper, Skeleton, Text } from '@mantine/core'
+import type { useReviewFeedback } from '@/hooks/use-review-feedback'
+
+type ReviewFeedbackSectionProps = {
+    feedback: ReturnType<typeof useReviewFeedback>
+}
+
+export function ReviewFeedbackSection({ feedback }: ReviewFeedbackSectionProps) {
+    return (
+        <Paper p="xl" data-testid="review-feedback-section">
+            <Text fw={600} mb="sm">
+                Feedback — {feedback.wordCount}/{feedback.maxWords} words
+            </Text>
+            <Skeleton height={160} radius="md" />
+        </Paper>
+    )
+}

--- a/src/app/[orgSlug]/study/[studyId]/review/review-progress-bar.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/review-progress-bar.tsx
@@ -1,0 +1,18 @@
+import { Paper, Skeleton, Text } from '@mantine/core'
+import type { StepDef } from './review-types'
+
+type ReviewProgressBarProps = {
+    currentStep: number
+    steps: StepDef[]
+}
+
+export function ReviewProgressBar({ currentStep, steps }: ReviewProgressBarProps) {
+    return (
+        <Paper p="xl" data-testid="review-progress-bar">
+            <Text fw={600} mb="sm">
+                Review progress — Step {currentStep + 1} of {steps.length}
+            </Text>
+            <Skeleton height={8} radius="xl" />
+        </Paper>
+    )
+}

--- a/src/app/[orgSlug]/study/[studyId]/review/review-types.ts
+++ b/src/app/[orgSlug]/study/[studyId]/review/review-types.ts
@@ -1,0 +1,18 @@
+import type { SelectedStudy } from '@/server/actions/study.actions'
+
+export type Decision = 'approve' | 'needs-clarification' | 'reject'
+
+export type StepDef = { label: string; description: string }
+
+export type StudyForReview = SelectedStudy
+
+export const REVIEW_STEPS: StepDef[] = [
+    { label: 'Review proposal', description: 'Review the study proposal details' },
+    { label: 'Provide feedback', description: 'Share your feedback on the proposal' },
+    { label: 'Make decision', description: 'Approve, reject, or request clarification' },
+    { label: 'Review agreements', description: 'Review data use agreements' },
+    { label: 'Submit review', description: 'Submit your final review' },
+]
+
+export const FEEDBACK_MIN_WORDS = 50
+export const FEEDBACK_MAX_WORDS = 500

--- a/src/app/account/invitation/[inviteId]/create-account.action.ts
+++ b/src/app/account/invitation/[inviteId]/create-account.action.ts
@@ -27,7 +27,7 @@ export const getOrgInfoForInviteAction = new Action('getOrgInfoForInviteAction')
         return await db
             .selectFrom('org')
             .innerJoin('pendingUser', 'pendingUser.orgId', 'org.id')
-            .innerJoin('user as invitingUser', 'invitingUser.id', 'pendingUser.invitedByUserId')
+            .leftJoin('user as invitingUser', 'invitingUser.id', 'pendingUser.invitedByUserId')
             .select([
                 'org.id',
                 'org.name',

--- a/src/app/account/invitation/[inviteId]/join-team/page.tsx
+++ b/src/app/account/invitation/[inviteId]/join-team/page.tsx
@@ -80,7 +80,11 @@ const AddTeam: FC<InviteProps> = ({ params }) => {
     })
 
     if (isLoading || !org || !user) {
-        return <LoadingMessage message="Loading account invitation" />
+        return (
+            <Paper bg="white" p="xxl" radius="sm" w={600} my={{ base: '1rem', lg: 0 }}>
+                <LoadingMessage message="Loading account invitation" />
+            </Paper>
+        )
     }
 
     if (emailMismatch) {
@@ -112,8 +116,10 @@ const AddTeam: FC<InviteProps> = ({ params }) => {
                     You’ve been invited to join {org.name}.
                 </Title>
                 <Text size="md">
-                    {org.invitingUserFirstName} {org.invitingUserLastName} has invited you to join {org.name} as a{' '}
-                    {org.isAdmin ? 'admin' : 'contributor'}.
+                    {org.invitingUserFirstName
+                        ? `${org.invitingUserFirstName} ${org.invitingUserLastName} has invited you`
+                        : 'You have been invited'}{' '}
+                    to join {org.name} as a {org.isAdmin ? 'admin' : 'contributor'}.
                 </Text>
                 <Text size="md">
                     Join the team to access its dashboard and studies. If opting to skip, you can find the invitation in

--- a/src/app/account/invitation/[inviteId]/join-team/page.tsx
+++ b/src/app/account/invitation/[inviteId]/join-team/page.tsx
@@ -119,7 +119,7 @@ const AddTeam: FC<InviteProps> = ({ params }) => {
                     {org.invitingUserFirstName
                         ? `${org.invitingUserFirstName} ${org.invitingUserLastName} has invited you`
                         : 'You have been invited'}{' '}
-                    to join {org.name} as a {org.isAdmin ? 'admin' : 'contributor'}.
+                    to join {org.name} as {org.isAdmin ? 'an admin' : 'a contributor'}.
                 </Text>
                 <Text size="md">
                     Join the team to access its dashboard and studies. If opting to skip, you can find the invitation in

--- a/src/components/loading.tsx
+++ b/src/components/loading.tsx
@@ -8,7 +8,7 @@ export const LoadingMessage: React.FC<{ message: string; isVisible?: boolean } &
     if (isVisible === false) return null
 
     return (
-        <Flex align="center">
+        <Flex align="center" gap="sm">
             <Spinner color={'blue'} />
             <Text component="span" {...textProps}>
                 {message}

--- a/src/components/openstax-feature-flag.tsx
+++ b/src/components/openstax-feature-flag.tsx
@@ -53,4 +53,7 @@ export {
     useOpenStaxFeatureFlag as useUnusedOpenStaxFeatureFlag,
     OpenStaxFeatureFlag as UnusedOpenStaxFeatureFlag,
     FeatureFlagRequiredAlert as UnusedFeatureFlagRequiredAlert,
+    // Card 64: DO Proposal Review redesign
+    useOpenStaxFeatureFlag as useProposalReviewFeatureFlag,
+    OpenStaxFeatureFlag as ProposalReviewFeatureFlag,
 }

--- a/src/hooks/use-review-decision.ts
+++ b/src/hooks/use-review-decision.ts
@@ -1,0 +1,11 @@
+import { useState } from 'react'
+import type { Decision } from '@/app/[orgSlug]/study/[studyId]/review/review-types'
+
+export function useReviewDecision() {
+    const [selected, setSelected] = useState<Decision | null>(null)
+
+    return {
+        selected,
+        onSelect: setSelected,
+    }
+}

--- a/src/hooks/use-review-feedback.ts
+++ b/src/hooks/use-review-feedback.ts
@@ -1,9 +1,6 @@
 import { useState } from 'react'
 import { FEEDBACK_MAX_WORDS, FEEDBACK_MIN_WORDS } from '@/app/[orgSlug]/study/[studyId]/review/review-types'
-
-function countWords(text: string): number {
-    return text.split(/\s+/).filter(Boolean).length
-}
+import { countWords } from '@/lib/word-count'
 
 export function useReviewFeedback() {
     const [value, setValue] = useState('')

--- a/src/hooks/use-review-feedback.ts
+++ b/src/hooks/use-review-feedback.ts
@@ -1,0 +1,22 @@
+import { useState } from 'react'
+import { FEEDBACK_MAX_WORDS, FEEDBACK_MIN_WORDS } from '@/app/[orgSlug]/study/[studyId]/review/review-types'
+
+function countWords(text: string): number {
+    return text.split(/\s+/).filter(Boolean).length
+}
+
+export function useReviewFeedback() {
+    const [value, setValue] = useState('')
+
+    const wordCount = countWords(value)
+    const isValid = wordCount >= FEEDBACK_MIN_WORDS && wordCount <= FEEDBACK_MAX_WORDS
+
+    return {
+        value,
+        onChange: setValue,
+        wordCount,
+        minWords: FEEDBACK_MIN_WORDS,
+        maxWords: FEEDBACK_MAX_WORDS,
+        isValid,
+    }
+}

--- a/tests/unit.helpers.tsx
+++ b/tests/unit.helpers.tsx
@@ -11,6 +11,7 @@ import { auth as clerkAuth, clerkClient, currentUser as currentClerkUser } from 
 import { faker } from '@faker-js/faker'
 import { MantineProvider } from '@mantine/core'
 import { ModalsProvider } from '@mantine/modals'
+import { SpyModeProvider } from '@/components/spy-mode-context'
 // eslint-disable-next-line no-restricted-imports
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render } from '@testing-library/react'
@@ -70,7 +71,9 @@ export function renderWithProviders(ui: ReactElement, options?: Parameters<typeo
     return render(
         <QueryClientProvider client={testQueryClient}>
             <MantineProvider theme={theme}>
-                <ModalsProvider>{ui}</ModalsProvider>
+                <SpyModeProvider>
+                    <ModalsProvider>{ui}</ModalsProvider>
+                </SpyModeProvider>
             </MantineProvider>
         </QueryClientProvider>,
         options,


### PR DESCRIPTION
## Summary
- Scaffolds the new multi-step DO proposal review page (Card 64) behind the `ProposalReviewFeatureFlag` (spy mode + OpenStax org)
- Creates stub components with labeled skeletons for OTTER-489 (progress bar), OTTER-490 (proposal section), OTTER-491 (feedback section), and OTTER-492 (decision section) so team members can build against stable interfaces
- Adds shared types (`Decision`, `StepDef`, `StudyForReview`), constants (`REVIEW_STEPS`, `FEEDBACK_MIN/MAX_WORDS`), and two hooks (`useReviewFeedback`, `useReviewDecision`) that manage state at the top level and pass down as props
- Wraps existing `ProposalReviewView` with `ProposalReviewFeatureFlag` — flag off shows the existing view unchanged, flag on shows the new scaffold
- Adds `SpyModeProvider` to `renderWithProviders` test helper so any component using feature flags works in tests
- Fixes `invitedByUserId` to source from server session instead of client param
- Fixes prettier formatting in `invitation.tsx`

## New files
| File | Purpose |
|------|---------|
| `review-types.ts` | Shared types and constants for the review flow |
| `use-review-feedback.ts` | Hook: feedback text, word count, validation (50–500 words) |
| `use-review-decision.ts` | Hook: decision state (approve / needs-clarification / reject) |
| `review-progress-bar.tsx` | Stub for OTTER-489 |
| `proposal-section.tsx` | Stub for OTTER-490 |
| `review-feedback-section.tsx` | Stub for OTTER-491 |
| `review-decision-section.tsx` | Stub for OTTER-492 |
| `new-proposal-review-view.tsx` | Main scaffold composing all stubs |
| `new-proposal-review-view.test.tsx` | 5 tests for the scaffold |

## Test plan
- [ ] All stubs render with correct `data-testid` attributes
- [ ] Page title "Study proposal" renders as h1
- [ ] Study title appears in proposal section
- [ ] Submit button is disabled by default (requires valid feedback + decision)
- [ ] Back button is present and navigates to dashboard
- [ ] Existing `ProposalReviewView` tests still pass (flag defaults to off)
- [ ] Enable spy mode as OpenStax org user → see new scaffold with labeled skeletons
- [ ] Without spy mode → see existing review page unchanged