### PR TITLE
OTTER-480 - add Athena table creation from uploaded CSVs via Glue CreateTable API

### DIFF
--- a/src/app/[orgSlug]/admin/settings/code-envs.actions.test.ts
+++ b/src/app/[orgSlug]/admin/settings/code-envs.actions.test.ts
@@ -24,6 +24,12 @@ vi.mock('@/server/aws', async () => {
         deleteFolderContents: vi.fn().mockResolvedValue(undefined),
         createAthenaDatabase: vi.fn().mockResolvedValue(undefined),
         deleteAthenaDatabase: vi.fn().mockResolvedValue(undefined),
+        deleteAllAthenaTables: vi.fn().mockResolvedValue(undefined),
+        deleteTestDataBucketPrefix: vi.fn().mockResolvedValue(undefined),
+        copyToTestDataBucket: vi.fn().mockResolvedValue([]),
+        inferColumnsFromCsv: vi.fn().mockResolvedValue([]),
+        createAthenaTable: vi.fn().mockResolvedValue(undefined),
+        testDataBucketName: vi.fn().mockReturnValue(null),
         createPgDatabase: vi.fn().mockResolvedValue(undefined),
         deletePgDatabase: vi.fn().mockResolvedValue(undefined),
     }

--- a/src/app/[orgSlug]/admin/settings/code-envs.actions.ts
+++ b/src/app/[orgSlug]/admin/settings/code-envs.actions.ts
@@ -497,25 +497,37 @@ export const createAthenaTablesAction = new Action('createAthenaTablesAction', {
     .middleware(codeEnvFromId)
     .requireAbilityTo('update', 'Org')
     .handler(async ({ codeEnv }) => {
+        if (codeEnv.dataSourceType !== 'athena' || SIMULATE_CODE_BUILD) return
+
         const bucket = testDataBucketName()
-        if (codeEnv.dataSourceType !== 'athena' || SIMULATE_CODE_BUILD || !bucket) return
+        if (!bucket) {
+            logger.error('TEST_DATA_BUCKET_NAME not configured, cannot create Athena tables. Deploy IAC changes first.', {
+                codeEnvId: codeEnv.id,
+            })
+            return
+        }
 
-        const dbName = toAthenaDbName(codeEnv.orgSlug, codeEnv.identifier)
-        const sourcePrefix = pathForSampleData({
-            orgSlug: codeEnv.orgSlug,
-            codeEnvId: codeEnv.id,
-            sampleDataPath: codeEnv.sampleDataPath ?? undefined,
-        })
-        const targetPrefix = `${codeEnv.orgSlug}/${codeEnv.identifier}`
+        try {
+            const dbName = toAthenaDbName(codeEnv.orgSlug, codeEnv.identifier)
+            const sourcePrefix = pathForSampleData({
+                orgSlug: codeEnv.orgSlug,
+                codeEnvId: codeEnv.id,
+                sampleDataPath: codeEnv.sampleDataPath ?? undefined,
+            })
+            const targetPrefix = `${codeEnv.orgSlug}/${codeEnv.identifier}`
 
-        await deleteAllAthenaTables(dbName)
+            await deleteAllAthenaTables(dbName)
 
-        const tables = await copyToTestDataBucket(sourcePrefix, targetPrefix)
+            const tables = await copyToTestDataBucket(sourcePrefix, targetPrefix)
 
-        for (const { tableName, sourceKey } of tables) {
-            const columns = await inferColumnsFromCsv(sourceKey)
-            const s3Location = `s3://${bucket}/${targetPrefix}/${tableName}/`
-            await createAthenaTable(dbName, tableName, columns, s3Location)
+            for (const { tableName, sourceKey } of tables) {
+                const columns = await inferColumnsFromCsv(sourceKey)
+                const s3Location = `s3://${bucket}/${targetPrefix}/${tableName}/`
+                await createAthenaTable(dbName, tableName, columns, s3Location)
+            }
+        } catch (err) {
+            logger.error('Failed to create Athena tables', err, { codeEnvId: codeEnv.id })
+            throw new Error('Failed to create Athena tables from uploaded CSVs. The code environment was saved but tables were not created.')
         }
     })
 

--- a/src/app/[orgSlug]/admin/settings/code-envs.actions.ts
+++ b/src/app/[orgSlug]/admin/settings/code-envs.actions.ts
@@ -501,9 +501,12 @@ export const createAthenaTablesAction = new Action('createAthenaTablesAction', {
 
         const bucket = testDataBucketName()
         if (!bucket) {
-            logger.error('TEST_DATA_BUCKET_NAME not configured, cannot create Athena tables. Deploy IAC changes first.', {
-                codeEnvId: codeEnv.id,
-            })
+            logger.error(
+                'TEST_DATA_BUCKET_NAME not configured, cannot create Athena tables. Deploy IAC changes first.',
+                {
+                    codeEnvId: codeEnv.id,
+                },
+            )
             return
         }
 
@@ -517,6 +520,7 @@ export const createAthenaTablesAction = new Action('createAthenaTablesAction', {
             const targetPrefix = `${codeEnv.orgSlug}/${codeEnv.identifier}`
 
             await deleteAllAthenaTables(dbName)
+            await deleteTestDataBucketPrefix(targetPrefix)
 
             const tables = await copyToTestDataBucket(sourcePrefix, targetPrefix)
 
@@ -527,7 +531,9 @@ export const createAthenaTablesAction = new Action('createAthenaTablesAction', {
             }
         } catch (err) {
             logger.error('Failed to create Athena tables', err, { codeEnvId: codeEnv.id })
-            throw new Error('Failed to create Athena tables from uploaded CSVs. The code environment was saved but tables were not created.')
+            throw new Error(
+                'Failed to create Athena tables from uploaded CSVs. The code environment was saved but tables were not created.',
+            )
         }
     })
 

--- a/src/app/[orgSlug]/admin/settings/code-envs.actions.ts
+++ b/src/app/[orgSlug]/admin/settings/code-envs.actions.ts
@@ -14,6 +14,12 @@ import {
     triggerScanForCodeEnv,
     createAthenaDatabase,
     deleteAthenaDatabase,
+    deleteAllAthenaTables,
+    deleteTestDataBucketPrefix,
+    copyToTestDataBucket,
+    inferColumnsFromCsv,
+    createAthenaTable,
+    testDataBucketName,
     toAthenaDbName,
     createPgDatabase,
     deletePgDatabase,
@@ -266,7 +272,9 @@ export const updateOrgCodeEnvAction = new Action('updateOrgCodeEnvAction', { per
                     fieldValues.dataSourceType === 'athena' ? toAthenaDbName(orgSlug, fieldValues.identifier) : null
 
                 if (oldAthenaName && oldAthenaName !== newAthenaName) {
+                    await deleteAllAthenaTables(oldAthenaName)
                     await deleteAthenaDatabase(oldAthenaName)
+                    await deleteTestDataBucketPrefix(`${prevOrgSlug}/${prevIdentifier}`)
                 }
                 if (newAthenaName && newAthenaName !== oldAthenaName) {
                     await createAthenaDatabase(newAthenaName)
@@ -405,7 +413,10 @@ export const deleteOrgCodeEnvAction = new Action('deleteOrgCodeEnvAction', { per
 
         if (!SIMULATE_CODE_BUILD) {
             if (codeEnv.dataSourceType === 'athena') {
-                await deleteAthenaDatabase(toAthenaDbName(codeEnv.orgSlug, codeEnv.identifier))
+                const dbName = toAthenaDbName(codeEnv.orgSlug, codeEnv.identifier)
+                await deleteAllAthenaTables(dbName)
+                await deleteAthenaDatabase(dbName)
+                await deleteTestDataBucketPrefix(`${codeEnv.orgSlug}/${codeEnv.identifier}`)
             } else if (codeEnv.dataSourceType === 'postgres') {
                 await deletePgDatabase(toPgDbName(codeEnv.orgSlug, codeEnv.identifier))
             }
@@ -450,7 +461,14 @@ const codeEnvFromId = async ({ params: { codeEnvId }, db }: { params: { codeEnvI
     const codeEnv = await db
         .selectFrom('orgCodeEnv')
         .innerJoin('org', 'org.id', 'orgCodeEnv.orgId')
-        .select(['orgCodeEnv.id', 'orgCodeEnv.sampleDataPath', 'org.slug as orgSlug', 'org.id as orgId'])
+        .select([
+            'orgCodeEnv.id',
+            'orgCodeEnv.sampleDataPath',
+            'orgCodeEnv.identifier',
+            'orgCodeEnv.dataSourceType',
+            'org.slug as orgSlug',
+            'org.id as orgId',
+        ])
         .where('orgCodeEnv.id', '=', codeEnvId)
         .executeTakeFirstOrThrow()
 
@@ -468,6 +486,37 @@ export const getSampleDataUploadUrlAction = new Action('getSampleDataUploadUrlAc
             sampleDataPath: codeEnv.sampleDataPath ?? undefined,
         })
         return await createSignedUploadUrl(prefix)
+    })
+
+const createAthenaTablesSchema = z.object({
+    codeEnvId: z.string(),
+})
+
+export const createAthenaTablesAction = new Action('createAthenaTablesAction', { performsMutations: true })
+    .params(createAthenaTablesSchema)
+    .middleware(codeEnvFromId)
+    .requireAbilityTo('update', 'Org')
+    .handler(async ({ codeEnv }) => {
+        const bucket = testDataBucketName()
+        if (codeEnv.dataSourceType !== 'athena' || SIMULATE_CODE_BUILD || !bucket) return
+
+        const dbName = toAthenaDbName(codeEnv.orgSlug, codeEnv.identifier)
+        const sourcePrefix = pathForSampleData({
+            orgSlug: codeEnv.orgSlug,
+            codeEnvId: codeEnv.id,
+            sampleDataPath: codeEnv.sampleDataPath ?? undefined,
+        })
+        const targetPrefix = `${codeEnv.orgSlug}/${codeEnv.identifier}`
+
+        await deleteAllAthenaTables(dbName)
+
+        const tables = await copyToTestDataBucket(sourcePrefix, targetPrefix)
+
+        for (const { tableName, sourceKey } of tables) {
+            const columns = await inferColumnsFromCsv(sourceKey)
+            const s3Location = `s3://${bucket}/${targetPrefix}/${tableName}/`
+            await createAthenaTable(dbName, tableName, columns, s3Location)
+        }
     })
 
 const getStarterCodeUploadUrlSchema = z.object({

--- a/src/app/[orgSlug]/admin/settings/use-code-env-form.ts
+++ b/src/app/[orgSlug]/admin/settings/use-code-env-form.ts
@@ -164,9 +164,6 @@ export function useCodeEnvForm(image: CodeEnv | undefined, onCompleteAction: () 
         const starterCodeUploaded = !!starterCodes?.length
 
         const sampleDataUploaded = await uploadSampleData(image!.id, sampleDataFiles)
-        if (sampleDataUploaded && image!.dataSourceType === 'athena') {
-            await createAthenaTablesAction({ codeEnvId: image!.id })
-        }
 
         const result = await updateOrgCodeEnvAction({
             orgSlug,
@@ -177,6 +174,10 @@ export function useCodeEnvForm(image: CodeEnv | undefined, onCompleteAction: () 
             sampleDataUploaded,
         })
         if (isActionError(result)) throw result
+
+        if (sampleDataUploaded && result.dataSourceType === 'athena') {
+            await createAthenaTablesAction({ codeEnvId: image!.id })
+        }
 
         if (starterCodes?.length) {
             await uploadStarterCodes(orgSlug, image!.id, starterCodes)

--- a/src/app/[orgSlug]/admin/settings/use-code-env-form.ts
+++ b/src/app/[orgSlug]/admin/settings/use-code-env-form.ts
@@ -11,6 +11,7 @@ import {
     fetchOrgCodeEnvsAction,
     getSampleDataUploadUrlAction,
     getStarterCodeUploadUrlAction,
+    createAthenaTablesAction,
 } from './code-envs.actions'
 import {
     createOrgCodeEnvSchema,
@@ -151,6 +152,9 @@ export function useCodeEnvForm(image: CodeEnv | undefined, onCompleteAction: () 
 
         if (values.sampleDataPath) {
             await uploadSampleData(result.id, sampleDataFiles)
+            if (values.dataSourceType === 'athena') {
+                await createAthenaTablesAction({ codeEnvId: result.id })
+            }
         }
         return result
     }
@@ -160,6 +164,9 @@ export function useCodeEnvForm(image: CodeEnv | undefined, onCompleteAction: () 
         const starterCodeUploaded = !!starterCodes?.length
 
         const sampleDataUploaded = await uploadSampleData(image!.id, sampleDataFiles)
+        if (sampleDataUploaded && image!.dataSourceType === 'athena') {
+            await createAthenaTablesAction({ codeEnvId: image!.id })
+        }
 
         const result = await updateOrgCodeEnvAction({
             orgSlug,

--- a/src/server/aws.test.ts
+++ b/src/server/aws.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest'
-import { triggerBuildImageForJob, triggerScanForStudyJob, toAthenaDbName, toPgDbName } from './aws'
+import {
+    triggerBuildImageForJob,
+    triggerScanForStudyJob,
+    toAthenaDbName,
+    toPgDbName,
+    sanitizeColumnName,
+    testDataBucketName,
+} from './aws'
 import { CodeBuildClient, StartBuildCommand } from '@aws-sdk/client-codebuild'
 
 vi.mock('./config', async (importOriginal) => {
@@ -181,8 +188,52 @@ describe('triggerScanForStudyJob', () => {
         expect(startBuildCommandArgs.environmentVariablesOverride).toEqual(expect.arrayContaining(expectedEnvVars))
         expect(startBuildCommandArgs.environmentVariablesOverride.length).toBe(expectedEnvVars.length)
 
-        const codeBuildClientInstance = (CodeBuildClient as unknown as Mock).mock.results[0].value
-        expect(codeBuildClientInstance.send).toHaveBeenCalledTimes(1)
-        expect(codeBuildClientInstance.send).toHaveBeenCalledWith(expect.any(StartBuildCommand))
+        const codeBuildClientInstance2 = (CodeBuildClient as unknown as Mock).mock.results[0].value
+        expect(codeBuildClientInstance2.send).toHaveBeenCalledTimes(1)
+        expect(codeBuildClientInstance2.send).toHaveBeenCalledWith(expect.any(StartBuildCommand))
+    })
+})
+
+describe('sanitizeColumnName', () => {
+    it('should lowercase and replace spaces with underscores', () => {
+        expect(sanitizeColumnName('CLS GRADE AVG')).toBe('cls_grade_avg')
+    })
+
+    it('should collapse multiple underscores', () => {
+        expect(sanitizeColumnName('col  name--here')).toBe('col_name_here')
+    })
+
+    it('should prefix col_ when starting with a digit', () => {
+        expect(sanitizeColumnName('1st_column')).toBe('col_1st_column')
+    })
+
+    it('should prefix col_ when empty after sanitization', () => {
+        expect(sanitizeColumnName('---')).toBe('col_')
+    })
+
+    it('should trim leading and trailing underscores', () => {
+        expect(sanitizeColumnName(' hello ')).toBe('hello')
+    })
+})
+
+describe('testDataBucketName', () => {
+    const originalEnv = process.env.TEST_DATA_BUCKET_NAME
+
+    afterEach(() => {
+        if (originalEnv !== undefined) {
+            process.env.TEST_DATA_BUCKET_NAME = originalEnv
+        } else {
+            delete process.env.TEST_DATA_BUCKET_NAME
+        }
+    })
+
+    it('should return null when not configured', () => {
+        delete process.env.TEST_DATA_BUCKET_NAME
+        expect(testDataBucketName()).toBeNull()
+    })
+
+    it('should return the bucket name when configured', () => {
+        process.env.TEST_DATA_BUCKET_NAME = 'safeinsights-test-data-s3-dev'
+        expect(testDataBucketName()).toBe('safeinsights-test-data-s3-dev')
     })
 })

--- a/src/server/aws.ts
+++ b/src/server/aws.ts
@@ -7,7 +7,16 @@ import {
     ListObjectsV2Command,
     S3Client,
 } from '@aws-sdk/client-s3'
-import { GlueClient, CreateDatabaseCommand, DeleteDatabaseCommand, type DatabaseInput } from '@aws-sdk/client-glue'
+import {
+    GlueClient,
+    CreateDatabaseCommand,
+    DeleteDatabaseCommand,
+    CreateTableCommand,
+    DeleteTableCommand,
+    GetTablesCommand,
+    type DatabaseInput,
+    type Column,
+} from '@aws-sdk/client-glue'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { CodeBuildClient, StartBuildCommand } from '@aws-sdk/client-codebuild'
 import { Upload } from '@aws-sdk/lib-storage'
@@ -23,6 +32,8 @@ import {
 } from '@/lib/paths'
 import type { MinimalCodeEnvInfo } from '@/lib/types'
 import { strToAscii } from '@/lib/string'
+import { parseCsv } from '@/lib/file-content-helpers'
+import logger from '@/lib/logger'
 import { Readable } from 'stream'
 import { createHash } from 'crypto'
 import { MinimalJobInfo, MinimalOrgInfo, MinimalStudyInfo } from '@/lib/types'
@@ -95,6 +106,134 @@ export async function deleteAthenaDatabase(dbName: string) {
         if (err instanceof Error && err.name === 'EntityNotFoundException') return
         throw err
     }
+}
+
+export const testDataBucketName = (): string | null => process.env.TEST_DATA_BUCKET_NAME || null
+
+export function sanitizeColumnName(raw: string): string {
+    let name = raw
+        .toLowerCase()
+        .replace(/[^a-z0-9]/g, '_')
+        .replace(/_+/g, '_')
+        .replace(/^_|_$/g, '')
+    if (!name || /^\d/.test(name)) name = `col_${name}`
+    return name
+}
+
+export async function inferColumnsFromCsv(s3Key: string): Promise<Column[]> {
+    const result = await getS3Client().send(
+        new GetObjectCommand({
+            Bucket: s3BucketName(),
+            Key: s3Key,
+            Range: 'bytes=0-8192',
+        }),
+    )
+    const text = await result.Body?.transformToString()
+    if (!text) throw new Error(`Empty file at ${s3Key}`)
+
+    const headerLine = text.split('\n')[0]
+    const { headers } = parseCsv(headerLine)
+
+    const seen = new Set<string>()
+    return headers.map((raw) => {
+        let name = sanitizeColumnName(raw)
+        while (seen.has(name)) name = `${name}_dup`
+        seen.add(name)
+        return { Name: name, Type: 'string' }
+    })
+}
+
+export async function createAthenaTable(dbName: string, tableName: string, columns: Column[], s3Location: string) {
+    try {
+        await getGlueClient().send(
+            new CreateTableCommand({
+                DatabaseName: dbName,
+                TableInput: {
+                    Name: tableName,
+                    TableType: 'EXTERNAL_TABLE',
+                    Parameters: {
+                        classification: 'csv',
+                        'skip.header.line.count': '1',
+                    },
+                    StorageDescriptor: {
+                        Columns: columns,
+                        Location: s3Location,
+                        InputFormat: 'org.apache.hadoop.mapred.TextInputFormat',
+                        OutputFormat: 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat',
+                        SerdeInfo: {
+                            SerializationLibrary: 'org.apache.hadoop.hive.serde2.OpenCSVSerde',
+                            Parameters: {
+                                separatorChar: ',',
+                                quoteChar: '"',
+                                escapeChar: '\\',
+                            },
+                        },
+                    },
+                },
+            }),
+        )
+    } catch (err: unknown) {
+        if (err instanceof Error && err.name === 'AlreadyExistsException') return
+        throw err
+    }
+}
+
+export async function deleteAllAthenaTables(dbName: string) {
+    try {
+        const result = await getGlueClient().send(new GetTablesCommand({ DatabaseName: dbName }))
+        for (const table of result.TableList || []) {
+            if (table.Name) {
+                await getGlueClient().send(new DeleteTableCommand({ DatabaseName: dbName, Name: table.Name }))
+            }
+        }
+    } catch (err: unknown) {
+        if (err instanceof Error && err.name === 'EntityNotFoundException') return
+        throw err
+    }
+}
+
+export type CopiedTable = { tableName: string; sourceKey: string }
+
+export async function copyToTestDataBucket(sourcePrefix: string, targetPrefix: string): Promise<CopiedTable[]> {
+    const bucket = testDataBucketName()
+    if (!bucket) {
+        logger.warn('TEST_DATA_BUCKET_NAME not configured, skipping copy to test-data bucket')
+        return []
+    }
+
+    const sourceBucket = s3BucketName()
+    const listed = await getS3Client().send(new ListObjectsV2Command({ Bucket: sourceBucket, Prefix: sourcePrefix }))
+    if (!listed.Contents?.length) return []
+
+    const tables: CopiedTable[] = []
+    for (const obj of listed.Contents) {
+        if (!obj.Key) continue
+        const fileName = obj.Key.split('/').pop() || ''
+        if (!fileName.toLowerCase().endsWith('.csv')) continue
+        const tableName = sanitizeColumnName(fileName.replace(/\.csv$/i, ''))
+        tables.push({ tableName, sourceKey: obj.Key })
+
+        const targetKey = `${targetPrefix}/${tableName}/${fileName}`
+        await getS3Client().send(
+            new CopyObjectCommand({
+                Bucket: bucket,
+                CopySource: `${sourceBucket}/${obj.Key}`,
+                Key: targetKey,
+            }),
+        )
+    }
+    return tables
+}
+
+export async function deleteTestDataBucketPrefix(prefix: string) {
+    const bucket = testDataBucketName()
+    if (!bucket) return
+
+    const listed = await getS3Client().send(new ListObjectsV2Command({ Bucket: bucket, Prefix: prefix }))
+    if (!listed.Contents?.length) return
+
+    const objectsToDelete = listed.Contents.map(({ Key }) => ({ Key }))
+    await getS3Client().send(new DeleteObjectsCommand({ Bucket: bucket, Delete: { Objects: objectsToDelete } }))
 }
 
 async function connectToPgAdmin(database = 'postgres'): Promise<PG.Client> {

--- a/src/server/aws.ts
+++ b/src/server/aws.ts
@@ -197,7 +197,7 @@ export type CopiedTable = { tableName: string; sourceKey: string }
 export async function copyToTestDataBucket(sourcePrefix: string, targetPrefix: string): Promise<CopiedTable[]> {
     const bucket = testDataBucketName()
     if (!bucket) {
-        logger.warn('TEST_DATA_BUCKET_NAME not configured, skipping copy to test-data bucket')
+        logger.error('TEST_DATA_BUCKET_NAME not configured, skipping copy to test-data bucket')
         return []
     }
 

--- a/src/server/coder.test.ts
+++ b/src/server/coder.test.ts
@@ -330,6 +330,7 @@ describe('createUserAndWorkspace', () => {
             if (key === 'CODER_TEMPLATE') return Promise.resolve('aws-fargate')
             if (key === 'CODER_FILES') return Promise.resolve('/tmp/coder-files')
             if (key === 'CODER_ATHENA_WORK_GROUP') return Promise.resolve('my-workgroup')
+            if (key === 'ATHENA_RESULTS_BUCKET_NAME') return Promise.resolve(null)
             return Promise.resolve('https://api.coder.com')
         })
         getStudyAndOrgDisplayInfoMock.mockResolvedValue({
@@ -365,6 +366,7 @@ describe('createUserAndWorkspace', () => {
         expect(envVars).toContainEqual({ name: 'TEST_ENV_DATABASE_URL', value: expectedDbUrl })
         expect(envVars).toContainEqual({ name: 'AWS_ATHENA_S3_STAGING_DIR', value: dataPath })
         expect(envVars).toContainEqual({ name: 'AWS_ATHENA_WORK_GROUP', value: 'my-workgroup' })
+        expect(envVars).toContainEqual({ name: 'AWS_ATHENA_DATABASE_NAME', value: 'test_org_test_env' })
         expect(envVars).toContainEqual({ name: 'AWS_REGION', value: 'us-west-2' })
         expect(envVars).toContainEqual({ name: 'TEST_ENV_S3_BUCKET_NAME', value: process.env.BUCKET_NAME })
         expect(envVars).toContainEqual({

--- a/src/server/coder/workspaces.ts
+++ b/src/server/coder/workspaces.ts
@@ -102,11 +102,14 @@ async function buildWorkspaceEnvironment(codeEnv: Awaited<ReturnType<typeof fetc
 
     if (codeEnv.dataSourceType === 'athena') {
         const dbName = toAthenaDbName(codeEnv.slug, codeEnv.identifier)
-        const dbUrl = `athena://athena.${bucketRegion}.amazonaws.com:443/${dbName}?s3_location=${dataPath}`
+        const resultsBucket = await getConfigValue('ATHENA_RESULTS_BUCKET_NAME', false)
+        const athenaOutputPath = resultsBucket ? `s3://${resultsBucket}/query-results/` : dataPath
+        const dbUrl = `athena://athena.${bucketRegion}.amazonaws.com:443/${dbName}?s3_location=${athenaOutputPath}`
         environment.push({ name: 'DATABASE_URL', value: dbUrl })
         environment.push({ name: `${prefix}_DATABASE_URL`, value: dbUrl })
-        environment.push({ name: 'AWS_ATHENA_S3_STAGING_DIR', value: dataPath })
+        environment.push({ name: 'AWS_ATHENA_S3_STAGING_DIR', value: athenaOutputPath })
         environment.push({ name: 'AWS_ATHENA_WORK_GROUP', value: await getConfigValue('CODER_ATHENA_WORK_GROUP') })
+        environment.push({ name: 'AWS_ATHENA_DATABASE_NAME', value: dbName })
         environment.push({ name: 'AWS_REGION', value: bucketRegion })
     } else if (codeEnv.dataSourceType === 'postgres') {
         const dbName = toPgDbName(codeEnv.slug, codeEnv.identifier)


### PR DESCRIPTION
see [OTTER-480](https://openstax.atlassian.net/browse/OTTER-480)

## Why

When an admin creates an Athena-backed code environment and uploads CSV files, the app needs to make those CSVs queryable via Athena from Coder workspaces. Today it only creates an empty Glue database with no tables, so there's nothing to query. This PR adds the full pipeline: parsing CSV headers, copying files to the shared test-data bucket, and creating Glue tables so Athena can read them. It also fixes `AWS_ATHENA_S3_STAGING_DIR` which incorrectly pointed at the raw data path instead of the Athena results bucket.

Companion IAC PR: https://github.com/safeinsights/iac/pull/138 (adds Glue permissions, cross-bucket S3 access, env vars)
Depends on: https://github.com/safeinsights/iac/pull/120 (Coder workspace Athena/Glue query permissions)

Note: For end-to-end functionality, [IAC PR #120](https://github.com/safeinsights/iac/pull/120) also needs to be merged. It adds Athena/Glue IAM permissions to the Coder workspace template so researchers can actually query the tables. Without it, BMA creates the tables successfully but the workspace can't run queries.

## Summary

- After sample data upload for an Athena code env, copy CSVs to the shared test-data bucket in per-table subdirectories, parse headers with papaparse, and create Glue external tables using the `CreateTable` API with `OpenCSVSerde`
- Fix `AWS_ATHENA_S3_STAGING_DIR` and `DATABASE_URL` to use the Athena results bucket instead of the raw data path (falls back to current behavior if IAC not deployed)
- Add `AWS_ATHENA_DATABASE_NAME` env var to Coder workspaces
- Clean up Glue tables, database, and copied S3 data on code env delete/rename
- Gracefully degrade if IAC isn't deployed yet (log to Sentry, don't crash)

[OTTER-480]: https://openstax.atlassian.net/browse/OTTER-480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ