### PR TITLE
Fix breadcrumb overflow with long study titles

### DIFF
--- a/src/components/page-breadcrumbs.tsx
+++ b/src/components/page-breadcrumbs.tsx
@@ -4,39 +4,26 @@ import type { Route } from 'next'
 import { Routes } from '@/lib/routes'
 import { Link } from '@/components/links'
 
+const truncateStyle = {
+    maxWidth: 300,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+} as const
+
 export const PageBreadcrumbs: FC<{
     crumbs: Array<[string, string?]>
 }> = ({ crumbs }) => {
     return (
         <>
-            <Breadcrumbs separator="/">
+            <Breadcrumbs separator="/" style={{ flexWrap: 'nowrap' }}>
                 {crumbs.map(([title, href], index) =>
                     href ? (
-                        <Link
-                            c="blue.7"
-                            href={href as Route}
-                            key={index}
-                            style={{
-                                display: 'inline-block',
-                                maxWidth: 300,
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                whiteSpace: 'nowrap',
-                            }}
-                        >
+                        <Link c="blue.7" href={href as Route} key={index} display="block" style={truncateStyle}>
                             {title}
                         </Link>
                     ) : (
-                        <Text
-                            c="grey.5"
-                            key={index}
-                            style={{
-                                maxWidth: 300,
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                whiteSpace: 'nowrap',
-                            }}
-                        >
+                        <Text c="grey.5" key={index} display="block" style={truncateStyle}>
                             {title}
                         </Text>
                     ),

--- a/src/components/page-breadcrumbs.tsx
+++ b/src/components/page-breadcrumbs.tsx
@@ -4,7 +4,6 @@ import type { Route } from 'next'
 import { Routes } from '@/lib/routes'
 import { Link } from '@/components/links'
 
-
 export const PageBreadcrumbs: FC<{
     crumbs: Array<[string, string?]>
 }> = ({ crumbs }) => {

--- a/src/components/page-breadcrumbs.tsx
+++ b/src/components/page-breadcrumbs.tsx
@@ -4,12 +4,6 @@ import type { Route } from 'next'
 import { Routes } from '@/lib/routes'
 import { Link } from '@/components/links'
 
-const truncateStyle = {
-    maxWidth: 300,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-} as const
 
 export const PageBreadcrumbs: FC<{
     crumbs: Array<[string, string?]>
@@ -19,11 +13,11 @@ export const PageBreadcrumbs: FC<{
             <Breadcrumbs separator="/" style={{ flexWrap: 'nowrap' }}>
                 {crumbs.map(([title, href], index) =>
                     href ? (
-                        <Link c="blue.7" href={href as Route} key={index} display="block" style={truncateStyle}>
+                        <Link c="blue.7" href={href as Route} key={index} truncate maw="300">
                             {title}
                         </Link>
                     ) : (
-                        <Text c="grey.5" key={index} display="block" style={truncateStyle}>
+                        <Text c="grey.5" key={index} display="block" truncate maw="300">
                             {title}
                         </Text>
                     ),

--- a/src/components/page-breadcrumbs.tsx
+++ b/src/components/page-breadcrumbs.tsx
@@ -17,6 +17,7 @@ export const PageBreadcrumbs: FC<{
                             href={href as Route}
                             key={index}
                             style={{
+                                display: 'inline-block',
                                 maxWidth: 300,
                                 overflow: 'hidden',
                                 textOverflow: 'ellipsis',


### PR DESCRIPTION
## Summary
- Breadcrumb links with long study titles were not truncating on the proposal confirmation and edit pages
- The `<a>` element rendered by the `Link` component is inline by default, which causes `maxWidth` to be ignored
- Adding `display: inline-block` to the Link style makes the existing ellipsis truncation work correctly

Fixes [OTTER-448](https://openstax.atlassian.net/browse/OTTER-448)

## Test plan
- [ ] Create a study with a very long title (80+ characters)
- [ ] Navigate to the proposal edit page — verify breadcrumb truncates with ellipsis
- [ ] Navigate to the proposal confirmation page — verify breadcrumb truncates with ellipsis
- [ ] Check other pages with breadcrumbs (code upload, study view) still work correctly

[OTTER-448]: https://openstax.atlassian.net/browse/OTTER-448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ