### PR TITLE
fix date for old studies

### DIFF
--- a/src/components/dashboard/studies-table/study-row.tsx
+++ b/src/components/dashboard/studies-table/study-row.tsx
@@ -59,7 +59,11 @@ export function StudyRow({ study, audience, scope, orgSlug }: StudyRowProps) {
             </TableTd>
 
             {/* Submitted On - common to all */}
-            <TableTd>{study.submittedAt ? dayjs(study.submittedAt).format('MMM DD, YYYY') : '-'}</TableTd>
+            <TableTd>
+                {study.status !== 'DRAFT'
+                    ? dayjs(study.submittedAt ?? study.createdAt).format('MMM DD, YYYY')
+                    : '-'}
+            </TableTd>
 
             {/* Third column differs by audience */}
             {audience === 'researcher' ? <TableTd>{submittedTo}</TableTd> : <TableTd>{submittedBy}</TableTd>}


### PR DESCRIPTION
## Summary

Falls back to `createdAt` when `submittedAt` is null in the "Submitted On" column, so older studies submitted before the migration still display a date instead of `-`.
