### PR TITLE
OTTER-369 upload study code improvement

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/code/code-upload-modal.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/code/code-upload-modal.tsx
@@ -70,12 +70,12 @@ export const CodeUploadModal: FC<CodeUploadModalProps> = ({
                     </Text>
                     {starterCodeUrls.length > 0 && (
                         <Group gap="xs">
-                            <Text size="sm" c="blue.7" fw="bold">
-                                Starter Code:
-                            </Text>
                             {starterCodeUrls.map((entry) => (
                                 <Anchor key={entry.fileName} href={entry.url} target="_blank">
                                     <Group gap={4}>
+                                        <Text size="sm" c="blue.7" fw="bold">
+                                            Starter Code:
+                                        </Text>
                                         <Text size="sm">{entry.fileName}</Text>
                                         <ArrowSquareOutIcon size={14} weight="bold" color={theme.colors.blue[7]} />
                                     </Group>

--- a/src/server/actions/org.actions.ts
+++ b/src/server/actions/org.actions.ts
@@ -170,7 +170,9 @@ export const getStarterCodeUrlAction = new Action('getStarterCodeUrlAction')
         const starterCodeUrls = await Promise.all(
             row.starterCodeFileNames.map(async (fileName) => ({
                 fileName,
-                url: await signedUrlForFile(pathForStarterCode({ orgSlug, codeEnvId: row.id, fileName })),
+                url: await signedUrlForFile(pathForStarterCode({ orgSlug, codeEnvId: row.id, fileName }), {
+                    ResponseContentDisposition: 'inline',
+                }),
             })),
         )
 

--- a/src/server/aws.ts
+++ b/src/server/aws.ts
@@ -239,10 +239,15 @@ export const storeS3File = async (
     await uploader.done()
 }
 
-export async function signedUrlForFile(Key: string) {
-    return await getSignedUrl(getS3BrowserClient(), new GetObjectCommand({ Bucket: s3BucketName(), Key }), {
-        expiresIn: 3600,
-    })
+export async function signedUrlForFile(
+    Key: string,
+    commandOverrides: Partial<{ ResponseContentDisposition: string }> = {},
+) {
+    return await getSignedUrl(
+        getS3BrowserClient(),
+        new GetObjectCommand({ Bucket: s3BucketName(), Key, ...commandOverrides }),
+        { expiresIn: 3600 },
+    )
 }
 
 export const createSignedUploadUrl = async (path: string) => {


### PR DESCRIPTION
Fix starter code link behavior in upload modal per QA feedback: 
make the full "Starter Code" label clickable (not just the filename), and open the file in a new tab instead of downloading by setting ResponseContentDisposition: inline on the presigned S3 URL.