### PR TITLE
Fix reviewer redirect loop and Previous button for post-review statuses

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -38,12 +38,11 @@ jobs:
                   scan-type: 'fs'
                   scan-ref: '.'
                   trivy-config: trivy.yaml
-            # SonarQube disabled — certificate issues with hosted instance
-            # - name: Run SonarQube SAST Scan
-            #   uses: SonarSource/sonarqube-scan-action@v7
-            #   env:
-            #       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-            #       SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+            - name: Run SonarQube SAST Scan
+              uses: SonarSource/sonarqube-scan-action@v7
+              env:
+                  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+                  SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
     test:
         timeout-minutes: 20

--- a/package-lock.json
+++ b/package-lock.json
@@ -2326,13 +2326,13 @@
             }
         },
         "node_modules/@clerk/backend": {
-            "version": "2.33.0",
-            "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.33.0.tgz",
-            "integrity": "sha512-sVR214TlJ5vsRprDE9EiZpqeNq/YVhCQLtAZ19ugjNf1C9xMX28JoMyodI/dU5FLBelmgSyjBAjodPULjIeF+w==",
+            "version": "2.33.2",
+            "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.33.2.tgz",
+            "integrity": "sha512-5nNPTdSLCTt7yVvMdd5CoEYZXVQhA9i0C50PxmAOjApYDIEfASedP9KXRb+YARiDrOSHQg0qFJhWUnujaG3hpw==",
             "license": "MIT",
             "dependencies": {
-                "@clerk/shared": "^3.47.2",
-                "@clerk/types": "^4.101.20",
+                "@clerk/shared": "^3.47.4",
+                "@clerk/types": "^4.101.22",
                 "standardwebhooks": "^1.0.0",
                 "tslib": "2.8.1"
             },
@@ -2341,12 +2341,12 @@
             }
         },
         "node_modules/@clerk/clerk-react": {
-            "version": "5.61.3",
-            "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.3.tgz",
-            "integrity": "sha512-W21aNEeHtqh3xJLuW5g2ydben/1D5pSnxsl/kCnv0IY1zma7lO+aIJ7Br2bR4FKKkiu695mPnjtY+fvkQmCXBg==",
+            "version": "5.61.5",
+            "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.5.tgz",
+            "integrity": "sha512-MKVEsvRR47WlizFki5BPjLIm1TPbJju4m2CNJGzrRqhEMide0Yjm4DGYfh/r2k/uFjOGMWfSJ7EToM1y2AQ5rg==",
             "license": "MIT",
             "dependencies": {
-                "@clerk/shared": "^3.47.2",
+                "@clerk/shared": "^3.47.4",
                 "tslib": "2.8.1"
             },
             "engines": {
@@ -2358,15 +2358,15 @@
             }
         },
         "node_modules/@clerk/nextjs": {
-            "version": "6.39.0",
-            "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.39.0.tgz",
-            "integrity": "sha512-T9LS/C0lly5eHmyH79RFi1afF45IHWZw7CZkudRK2zsJaxn7SjrHURYDNp6O5Cdcm/OmjYrND0PC0eKZh/jfRA==",
+            "version": "6.39.2",
+            "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.39.2.tgz",
+            "integrity": "sha512-NTAgvhpntCdQD4KR+4f/KFs8cqd6oyzoE73AoO9w0xKoJbTB8IIIPG+CtdIw+mx7z4JqbQATKWZbMPGeZbZYCw==",
             "license": "MIT",
             "dependencies": {
-                "@clerk/backend": "^2.33.0",
-                "@clerk/clerk-react": "^5.61.3",
-                "@clerk/shared": "^3.47.2",
-                "@clerk/types": "^4.101.20",
+                "@clerk/backend": "^2.33.2",
+                "@clerk/clerk-react": "^5.61.5",
+                "@clerk/shared": "^3.47.4",
+                "@clerk/types": "^4.101.22",
                 "server-only": "0.0.1",
                 "tslib": "2.8.1"
             },
@@ -2380,9 +2380,9 @@
             }
         },
         "node_modules/@clerk/shared": {
-            "version": "3.47.2",
-            "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.2.tgz",
-            "integrity": "sha512-dwUT27DKq3Gr9vn9lAfc/LSe79P1rKIib8/mTWA7ZEzY7XX2Yq5UnDMCMznYrI8oVLdJrCT4ypFXRgnH306Oew==",
+            "version": "3.47.4",
+            "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.4.tgz",
+            "integrity": "sha512-0O5/zgB5SO26PKarAIw7uj4j+4JsnT2/uiJ7SPI3LQMb62sM+AjDlVadcXuYc+4sY6w1szrAIVepI5Bkv57hnQ==",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
@@ -2451,12 +2451,12 @@
             }
         },
         "node_modules/@clerk/types": {
-            "version": "4.101.20",
-            "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.20.tgz",
-            "integrity": "sha512-MHvr1tGL5lwxD6zdzzixkHICbbZz/S1LChONKR52Qeu0yRGChZomPknsgqBMG9J3yNeyhaj0SWa5phQgQUk0lg==",
+            "version": "4.101.22",
+            "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.22.tgz",
+            "integrity": "sha512-74hV9MMw9MzOOSuJNJMFP95XZ2jDfPS1v3pfALS3rSQa+h/lNREU+fLGArzYckEpqNtuF6xy0odg9YqF5BLNhA==",
             "license": "MIT",
             "dependencies": {
-                "@clerk/shared": "^3.47.2"
+                "@clerk/shared": "^3.47.4"
             },
             "engines": {
                 "node": ">=18.17.0"
@@ -11737,9 +11737,9 @@
             "license": "ISC"
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",
@@ -12285,9 +12285,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.12",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-            "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+            "version": "4.12.14",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+            "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
             "dev": true,
             "license": "MIT",
             "peer": true,

--- a/src/app/[orgSlug]/study/[studyId]/agreements/agreements-page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/agreements-page.tsx
@@ -3,10 +3,12 @@
 import { useRouter } from 'next/navigation'
 import { Alert, Button, Divider, Flex, Paper, Stack, Text, Title, useMantineTheme } from '@mantine/core'
 import { CaretLeftIcon, InfoIcon } from '@phosphor-icons/react'
+import { ackAgreementsAction } from '@/server/actions/study.actions'
 import type { Route } from 'next'
 
 interface AgreementsPageProps {
     isReviewer: boolean
+    studyId: string
     proceedHref: string
     previousHref: string
     proceedLabel?: string
@@ -91,6 +93,7 @@ function AgreementSection({ stepLabel, title, description }: SectionProps) {
 
 export function AgreementsPage({
     isReviewer,
+    studyId,
     proceedHref,
     previousHref,
     proceedLabel,
@@ -101,7 +104,10 @@ export function AgreementsPage({
     const sections = isReviewer ? REVIEWER_SECTIONS : RESEARCHER_SECTIONS
     const resolvedProceedLabel = proceedLabel ?? (isReviewer ? 'Proceed to Step 3' : 'Proceed to Step 4')
 
-    const handleProceed = () => router.push(proceedHref as Route)
+    const handleProceed = async () => {
+        await ackAgreementsAction({ studyId, role: isReviewer ? 'reviewer' : 'researcher' })
+        router.push(proceedHref as Route)
+    }
     const handlePrevious = () => router.push(previousHref as Route)
 
     return (

--- a/src/app/[orgSlug]/study/[studyId]/agreements/agreements-page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/agreements-page.tsx
@@ -105,7 +105,7 @@ export function AgreementsPage({
     const resolvedProceedLabel = proceedLabel ?? (isReviewer ? 'Proceed to Step 3' : 'Proceed to Step 4')
 
     const handleProceed = async () => {
-        await ackAgreementsAction({ studyId, role: isReviewer ? 'reviewer' : 'researcher' })
+        await ackAgreementsAction({ studyId })
         router.push(proceedHref as Route)
     }
     const handlePrevious = () => router.push(previousHref as Route)

--- a/src/app/[orgSlug]/study/[studyId]/agreements/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/page.test.tsx
@@ -18,15 +18,18 @@ beforeEach(() => {
     })
 })
 
+const renderRoute = (orgSlug: string, studyId: string) =>
+    StudyAgreementsRoute({
+        params: Promise.resolve({ orgSlug, studyId }),
+        searchParams: Promise.resolve({}),
+    })
+
 describe('StudyAgreementsRoute', () => {
-    it('renders reviewer sections and proceed to review for enclave reviewer with CODE-SUBMITTED job', async () => {
+    it('renders reviewer agreements when code is submitted and not yet acknowledged', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
         const { study } = await insertTestStudyJobData({ org, researcherId: user.id, jobStatus: 'CODE-SUBMITTED' })
 
-        const page = await StudyAgreementsRoute({
-            params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
-            searchParams: Promise.resolve({}),
-        })
+        const page = await renderRoute(org.slug, study.id)
         renderWithProviders(page!)
 
         expect(screen.getByText('STEP 2A')).toBeInTheDocument()
@@ -35,68 +38,32 @@ describe('StudyAgreementsRoute', () => {
         expect(screen.getByRole('button', { name: /Proceed to Step 3/ })).toBeInTheDocument()
     })
 
-    it('redirects reviewer to review page when job status is not CODE-SCANNED or CODE-SUBMITTED', async () => {
+    it('redirects reviewer to review when no code has been submitted', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
         const { study } = await insertTestStudyJobData({ org, researcherId: user.id, jobStatus: 'JOB-READY' })
 
-        await expect(
-            StudyAgreementsRoute({
-                params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
-                searchParams: Promise.resolve({}),
-            }),
-        ).rejects.toThrow('NEXT_REDIRECT')
-
+        await expect(renderRoute(org.slug, study.id)).rejects.toThrow('NEXT_REDIRECT')
         expect(mockRedirect).toHaveBeenCalledWith(expect.stringContaining('/review'))
     })
 
-    it('redirects reviewer to review page on resubmission (second job)', async () => {
+    it('redirects reviewer to review when agreements already acknowledged', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
-        const { study } = await insertTestStudyJobData({ org, researcherId: user.id, jobStatus: 'CODE-REJECTED' })
-
-        // Create a second job (resubmission) with CODE-SUBMITTED
-        const resubJob = await db
-            .insertInto('studyJob')
-            .values({ studyId: study.id })
-            .returning('id')
-            .executeTakeFirstOrThrow()
+        const { study } = await insertTestStudyJobData({ org, researcherId: user.id, jobStatus: 'CODE-SUBMITTED' })
         await db
-            .insertInto('jobStatusChange')
-            .values([
-                { studyJobId: resubJob.id, status: 'INITIATED' },
-                { studyJobId: resubJob.id, status: 'CODE-SUBMITTED' },
-            ])
+            .updateTable('study')
+            .set({ reviewerAgreementsAckedAt: new Date() })
+            .where('id', '=', study.id)
             .execute()
 
-        await expect(
-            StudyAgreementsRoute({
-                params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
-            }),
-        ).rejects.toThrow('NEXT_REDIRECT')
-
+        await expect(renderRoute(org.slug, study.id)).rejects.toThrow('NEXT_REDIRECT')
         expect(mockRedirect).toHaveBeenCalledWith(expect.stringContaining('/review'))
     })
 
-    it('redirects reviewer when code has been approved', async () => {
-        const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
-        const { study } = await insertTestStudyJobData({ org, researcherId: user.id, jobStatus: 'CODE-APPROVED' })
-
-        await expect(
-            StudyAgreementsRoute({
-                params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
-            }),
-        ).rejects.toThrow('NEXT_REDIRECT')
-
-        expect(mockRedirect).toHaveBeenCalledWith(expect.stringContaining('/review'))
-    })
-
-    it('renders researcher sections and proceed to code for APPROVED researcher with no job activity', async () => {
+    it('renders researcher agreements for APPROVED study not yet acknowledged', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
         const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
 
-        const page = await StudyAgreementsRoute({
-            params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
-            searchParams: Promise.resolve({}),
-        })
+        const page = await renderRoute(org.slug, study.id)
         renderWithProviders(page!)
 
         expect(screen.getByText('STEP 3A')).toBeInTheDocument()
@@ -105,45 +72,53 @@ describe('StudyAgreementsRoute', () => {
         expect(screen.getByRole('button', { name: /Proceed to Step 4/ })).toBeInTheDocument()
     })
 
-    it('renders Back to Study Details for researcher with job activity', async () => {
+    it('redirects researcher when agreements already acknowledged', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
-        const { study } = await insertTestStudyJobData({ org, researcherId: user.id, jobStatus: 'CODE-SUBMITTED' })
+        const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
+        await db
+            .updateTable('study')
+            .set({ researcherAgreementsAckedAt: new Date() })
+            .where('id', '=', study.id)
+            .execute()
 
-        const page = await StudyAgreementsRoute({
-            params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
-            searchParams: Promise.resolve({}),
-        })
-        renderWithProviders(page!)
-
-        expect(screen.getByRole('button', { name: /Back to Study Details/ })).toBeInTheDocument()
+        await expect(renderRoute(org.slug, study.id)).rejects.toThrow('NEXT_REDIRECT')
+        expect(mockRedirect).toHaveBeenCalledWith(expect.stringContaining('/code'))
     })
 
-    it('renders Previous button for APPROVED researcher with no job activity', async () => {
+    it('renders Previous button for researcher', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
         const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
 
-        const page = await StudyAgreementsRoute({
-            params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
-            searchParams: Promise.resolve({}),
-        })
+        const page = await renderRoute(org.slug, study.id)
         renderWithProviders(page!)
 
-        const previousButton = screen.getByRole('button', { name: 'Previous' })
-        expect(previousButton).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Previous' })).toBeInTheDocument()
     })
 
-    it('redirects researcher when study is not APPROVED and has no job activity', async () => {
+    it('redirects researcher when study is not APPROVED', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
         const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
         await db.updateTable('study').set({ status: 'DRAFT' }).where('id', '=', study.id).execute()
 
-        await expect(
-            StudyAgreementsRoute({
-                params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
-                searchParams: Promise.resolve({}),
-            }),
-        ).rejects.toThrow('NEXT_REDIRECT')
-
+        await expect(renderRoute(org.slug, study.id)).rejects.toThrow('NEXT_REDIRECT')
         expect(mockRedirect).toHaveBeenCalledWith(expect.stringContaining('/view'))
+    })
+
+    it('allows direct access via Previous button even after acknowledging', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+        const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
+        await db
+            .updateTable('study')
+            .set({ researcherAgreementsAckedAt: new Date() })
+            .where('id', '=', study.id)
+            .execute()
+
+        const page = await StudyAgreementsRoute({
+            params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+            searchParams: Promise.resolve({ from: 'previous' }),
+        })
+        renderWithProviders(page!)
+
+        expect(screen.getByText('STEP 3A')).toBeInTheDocument()
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/agreements/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/page.test.tsx
@@ -70,7 +70,6 @@ describe('StudyAgreementsRoute', () => {
         await expect(
             StudyAgreementsRoute({
                 params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
-                searchParams: Promise.resolve({}),
             }),
         ).rejects.toThrow('NEXT_REDIRECT')
 
@@ -84,7 +83,6 @@ describe('StudyAgreementsRoute', () => {
         await expect(
             StudyAgreementsRoute({
                 params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
-                searchParams: Promise.resolve({}),
             }),
         ).rejects.toThrow('NEXT_REDIRECT')
 

--- a/src/app/[orgSlug]/study/[studyId]/agreements/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/page.test.tsx
@@ -49,6 +49,46 @@ describe('StudyAgreementsRoute', () => {
         expect(mockRedirect).toHaveBeenCalledWith(expect.stringContaining('/review'))
     })
 
+    it('redirects reviewer to review page on resubmission (second job)', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+        const { study } = await insertTestStudyJobData({ org, researcherId: user.id, jobStatus: 'CODE-REJECTED' })
+
+        // Create a second job (resubmission) with CODE-SUBMITTED
+        const resubJob = await db
+            .insertInto('studyJob')
+            .values({ studyId: study.id })
+            .returning('id')
+            .executeTakeFirstOrThrow()
+        await db
+            .insertInto('jobStatusChange')
+            .values([
+                { studyJobId: resubJob.id, status: 'INITIATED' },
+                { studyJobId: resubJob.id, status: 'CODE-SUBMITTED' },
+            ])
+            .execute()
+
+        await expect(
+            StudyAgreementsRoute({
+                params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+            }),
+        ).rejects.toThrow('NEXT_REDIRECT')
+
+        expect(mockRedirect).toHaveBeenCalledWith(expect.stringContaining('/review'))
+    })
+
+    it('redirects reviewer when code has been approved', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+        const { study } = await insertTestStudyJobData({ org, researcherId: user.id, jobStatus: 'CODE-APPROVED' })
+
+        await expect(
+            StudyAgreementsRoute({
+                params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+            }),
+        ).rejects.toThrow('NEXT_REDIRECT')
+
+        expect(mockRedirect).toHaveBeenCalledWith(expect.stringContaining('/review'))
+    })
+
     it('renders researcher sections and proceed to code for APPROVED researcher with no job activity', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
         const { study } = await insertTestStudyOnly({ org, researcherId: user.id })

--- a/src/app/[orgSlug]/study/[studyId]/agreements/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/page.test.tsx
@@ -70,6 +70,7 @@ describe('StudyAgreementsRoute', () => {
         await expect(
             StudyAgreementsRoute({
                 params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+                searchParams: Promise.resolve({}),
             }),
         ).rejects.toThrow('NEXT_REDIRECT')
 
@@ -83,6 +84,7 @@ describe('StudyAgreementsRoute', () => {
         await expect(
             StudyAgreementsRoute({
                 params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+                searchParams: Promise.resolve({}),
             }),
         ).rejects.toThrow('NEXT_REDIRECT')
 

--- a/src/app/[orgSlug]/study/[studyId]/agreements/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/page.test.tsx
@@ -104,6 +104,20 @@ describe('StudyAgreementsRoute', () => {
         expect(mockRedirect).toHaveBeenCalledWith(expect.stringContaining('/view'))
     })
 
+    it('allows direct access via Previous button when study is not APPROVED', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+        const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
+        await db.updateTable('study').set({ status: 'REJECTED' }).where('id', '=', study.id).execute()
+
+        const page = await StudyAgreementsRoute({
+            params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+            searchParams: Promise.resolve({ from: 'previous' }),
+        })
+        renderWithProviders(page!)
+
+        expect(screen.getByText('STEP 3A')).toBeInTheDocument()
+    })
+
     it('allows direct access via Previous button even after acknowledging', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
         const { study } = await insertTestStudyOnly({ org, researcherId: user.id })

--- a/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
@@ -70,7 +70,7 @@ export default async function StudyAgreementsRoute(props: {
         redirect(dest)
     }
 
-    if (study.status !== 'APPROVED') {
+    if (study.status !== 'APPROVED' && !isDirectAccess) {
         redirect(Routes.studyView({ orgSlug: study.submittedByOrgSlug, studyId }))
     }
 

--- a/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
@@ -32,9 +32,13 @@ export default async function StudyAgreementsRoute(props: {
 
     if (isReviewer) {
         const statuses = study.jobStatusChanges.map((s) => s.status)
-        const codeSubmitted = statuses.includes('CODE-SUBMITTED')
-        const codeAlreadyReviewed = statuses.some((s) => s === 'CODE-APPROVED' || s === 'CODE-REJECTED')
-        if (!codeSubmitted || codeAlreadyReviewed) {
+        const latestSubmittedIdx = statuses.findIndex((s) => s === 'CODE-SUBMITTED')
+        const latestReviewedIdx = statuses.findIndex((s) => s === 'CODE-APPROVED' || s === 'CODE-REJECTED')
+        // statuses is ordered newest-first; lower index = more recent
+        // Show agreements only when code is awaiting review (submitted more recently than any review decision)
+        const awaitingCodeReview =
+            latestSubmittedIdx !== -1 && (latestReviewedIdx === -1 || latestSubmittedIdx < latestReviewedIdx)
+        if (!awaitingCodeReview) {
             redirect(Routes.studyReview({ orgSlug, studyId }))
         }
 

--- a/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
@@ -30,9 +30,13 @@ export default async function StudyAgreementsRoute(props: {
 
     const isReviewer = currentOrg.type === 'enclave'
 
+    // Allow direct access when navigating back via Previous button
+    const isDirectAccess = searchParams.from === 'previous'
+
     if (isReviewer) {
         // Once the reviewer has acknowledged agreements, skip straight to review
-        if (study.reviewerAgreementsAckedAt) {
+        // (unless they navigated back here intentionally)
+        if (study.reviewerAgreementsAckedAt && !isDirectAccess) {
             redirect(Routes.studyReview({ orgSlug, studyId }))
         }
 
@@ -57,9 +61,8 @@ export default async function StudyAgreementsRoute(props: {
         )
     }
 
-    // Researcher flow
-    if (study.researcherAgreementsAckedAt) {
-        // Already acknowledged — go to code upload or study details
+    // Researcher flow — skip if already acknowledged (unless navigating back)
+    if (study.researcherAgreementsAckedAt && !isDirectAccess) {
         const hasJobActivity = study.jobStatusChanges.length > 0
         const dest = hasJobActivity
             ? Routes.studyView({ orgSlug: study.submittedByOrgSlug, studyId })

--- a/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
@@ -4,10 +4,8 @@ import { AccessDeniedAlert, AlertNotFound } from '@/components/errors'
 import { OrgBreadcrumbs, ResearcherBreadcrumbs } from '@/components/page-breadcrumbs'
 import { isActionError } from '@/lib/errors'
 import { Routes } from '@/lib/routes'
-import { studyHasJobStatus } from '@/lib/studies'
 import { getStudyAction } from '@/server/actions/study.actions'
 import { sessionFromClerk } from '@/server/clerk'
-import { getStudyJobCount } from '@/server/db/queries'
 import { Stack, Title } from '@mantine/core'
 import { redirect } from 'next/navigation'
 import { AgreementsPage } from './agreements-page'
@@ -33,17 +31,14 @@ export default async function StudyAgreementsRoute(props: {
     const isReviewer = currentOrg.type === 'enclave'
 
     if (isReviewer) {
-        const codeSubmitted = studyHasJobStatus(study, 'CODE-SUBMITTED')
-        const codeReviewed = studyHasJobStatus(study, 'CODE-APPROVED') || studyHasJobStatus(study, 'CODE-REJECTED')
-
-        // Skip agreements if code hasn't been submitted or has already been reviewed
-        if (!codeSubmitted || codeReviewed) {
+        // Once the reviewer has acknowledged agreements, skip straight to review
+        if (study.reviewerAgreementsAckedAt) {
             redirect(Routes.studyReview({ orgSlug, studyId }))
         }
 
-        // Skip agreements on resubmission — reviewer has already seen them
-        const jobCount = await getStudyJobCount(studyId)
-        if (jobCount > 1) {
+        // No code submitted yet — nothing to review, show proposal instead
+        const codeSubmitted = study.jobStatusChanges.some((s) => s.status === 'CODE-SUBMITTED')
+        if (!codeSubmitted) {
             redirect(Routes.studyReview({ orgSlug, studyId }))
         }
 
@@ -53,6 +48,7 @@ export default async function StudyAgreementsRoute(props: {
                 <Title order={1}>Study request</Title>
                 <AgreementsPage
                     isReviewer
+                    studyId={studyId}
                     proceedHref={`${Routes.studyReview({ orgSlug, studyId })}?from=agreements-proceed`}
                     previousHref={`${Routes.studyReview({ orgSlug, studyId })}?from=agreements`}
                     previousLabel="Previous"
@@ -61,32 +57,30 @@ export default async function StudyAgreementsRoute(props: {
         )
     }
 
-    // Baseline jobs (IDE launch / file upload) don't count — only actual submissions
-    const hasJobActivity = study.jobStatusChanges.some((s) => s.status === 'CODE-SUBMITTED')
-    if (study.status !== 'APPROVED' && !hasJobActivity) {
+    // Researcher flow
+    if (study.researcherAgreementsAckedAt) {
+        // Already acknowledged — go to code upload or study details
+        const hasJobActivity = study.jobStatusChanges.length > 0
+        const dest = hasJobActivity
+            ? Routes.studyView({ orgSlug: study.submittedByOrgSlug, studyId })
+            : Routes.studyCode({ orgSlug: study.submittedByOrgSlug, studyId })
+        redirect(dest)
+    }
+
+    if (study.status !== 'APPROVED') {
         redirect(Routes.studyView({ orgSlug: study.submittedByOrgSlug, studyId }))
     }
-    const proceedHref = hasJobActivity
-        ? Routes.studyView({ orgSlug: study.submittedByOrgSlug, studyId })
-        : Routes.studyCode({ orgSlug: study.submittedByOrgSlug, studyId })
-    const proceedLabel = hasJobActivity ? 'Back to Study Details' : undefined
-    const previousHref = hasJobActivity
-        ? Routes.orgDashboard({ orgSlug: study.submittedByOrgSlug })
-        : `${Routes.studyView({ orgSlug: study.submittedByOrgSlug, studyId })}?from=agreements`
-    const previousLabel = hasJobActivity ? undefined : 'Previous'
-
-    const dashboardHref = searchParams.returnTo === 'org' ? Routes.orgDashboard({ orgSlug }) : Routes.dashboard
 
     return (
         <Stack p="xl" gap="xl">
-            <ResearcherBreadcrumbs crumbs={{ orgSlug, studyId, current: 'Agreements', dashboardHref }} />
+            <ResearcherBreadcrumbs crumbs={{ orgSlug, studyId, current: 'Agreements' }} />
             <Title order={1}>Study request</Title>
             <AgreementsPage
                 isReviewer={false}
-                proceedHref={proceedHref}
-                proceedLabel={proceedLabel}
-                previousHref={previousHref}
-                previousLabel={previousLabel}
+                studyId={studyId}
+                proceedHref={Routes.studyCode({ orgSlug: study.submittedByOrgSlug, studyId })}
+                previousHref={`${Routes.studyView({ orgSlug: study.submittedByOrgSlug, studyId })}?from=agreements`}
+                previousLabel="Previous"
             />
         </Stack>
     )

--- a/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
@@ -31,7 +31,7 @@ export default async function StudyAgreementsRoute(props: {
     const isReviewer = currentOrg.type === 'enclave'
 
     if (isReviewer) {
-        const codeSubmitted = study.jobStatusChanges.some((s) => s.status === 'CODE-SUBMITTED')
+        const codeSubmitted = study.jobStatusChanges[0]?.status === 'CODE-SUBMITTED'
         if (!codeSubmitted) {
             redirect(Routes.studyReview({ orgSlug, studyId }))
         }

--- a/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
@@ -31,8 +31,10 @@ export default async function StudyAgreementsRoute(props: {
     const isReviewer = currentOrg.type === 'enclave'
 
     if (isReviewer) {
-        const codeSubmitted = study.jobStatusChanges[0]?.status === 'CODE-SUBMITTED'
-        if (!codeSubmitted) {
+        const statuses = study.jobStatusChanges.map((s) => s.status)
+        const codeSubmitted = statuses.includes('CODE-SUBMITTED')
+        const codeAlreadyReviewed = statuses.some((s) => s === 'CODE-APPROVED' || s === 'CODE-REJECTED')
+        if (!codeSubmitted || codeAlreadyReviewed) {
             redirect(Routes.studyReview({ orgSlug, studyId }))
         }
 

--- a/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
@@ -4,6 +4,7 @@ import { AccessDeniedAlert, AlertNotFound } from '@/components/errors'
 import { OrgBreadcrumbs, ResearcherBreadcrumbs } from '@/components/page-breadcrumbs'
 import { isActionError } from '@/lib/errors'
 import { Routes } from '@/lib/routes'
+import { studyHasJobStatus } from '@/lib/studies'
 import { getStudyAction } from '@/server/actions/study.actions'
 import { sessionFromClerk } from '@/server/clerk'
 import { Stack, Title } from '@mantine/core'
@@ -41,7 +42,7 @@ export default async function StudyAgreementsRoute(props: {
         }
 
         // No code submitted yet — nothing to review, show proposal instead
-        const codeSubmitted = study.jobStatusChanges.some((s) => s.status === 'CODE-SUBMITTED')
+        const codeSubmitted = studyHasJobStatus(study, 'CODE-SUBMITTED')
         if (!codeSubmitted) {
             redirect(Routes.studyReview({ orgSlug, studyId }))
         }

--- a/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
@@ -70,7 +70,7 @@ export default async function StudyAgreementsRoute(props: {
         redirect(dest)
     }
 
-    if (study.status !== 'APPROVED' && !isDirectAccess) {
+    if (study.status !== 'APPROVED') {
         redirect(Routes.studyView({ orgSlug: study.submittedByOrgSlug, studyId }))
     }
 

--- a/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
@@ -71,7 +71,7 @@ export default async function StudyAgreementsRoute(props: {
         redirect(dest)
     }
 
-    if (study.status !== 'APPROVED') {
+    if (study.status !== 'APPROVED' && !isDirectAccess) {
         redirect(Routes.studyView({ orgSlug: study.submittedByOrgSlug, studyId }))
     }
 

--- a/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
@@ -4,9 +4,10 @@ import { AccessDeniedAlert, AlertNotFound } from '@/components/errors'
 import { OrgBreadcrumbs, ResearcherBreadcrumbs } from '@/components/page-breadcrumbs'
 import { isActionError } from '@/lib/errors'
 import { Routes } from '@/lib/routes'
+import { studyHasJobStatus } from '@/lib/studies'
 import { getStudyAction } from '@/server/actions/study.actions'
 import { sessionFromClerk } from '@/server/clerk'
-import { db } from '@/database'
+import { getStudyJobCount } from '@/server/db/queries'
 import { Stack, Title } from '@mantine/core'
 import { redirect } from 'next/navigation'
 import { AgreementsPage } from './agreements-page'
@@ -32,9 +33,8 @@ export default async function StudyAgreementsRoute(props: {
     const isReviewer = currentOrg.type === 'enclave'
 
     if (isReviewer) {
-        const statuses = study.jobStatusChanges.map((s) => s.status)
-        const codeSubmitted = statuses.includes('CODE-SUBMITTED')
-        const codeReviewed = statuses.includes('CODE-APPROVED') || statuses.includes('CODE-REJECTED')
+        const codeSubmitted = studyHasJobStatus(study, 'CODE-SUBMITTED')
+        const codeReviewed = studyHasJobStatus(study, 'CODE-APPROVED') || studyHasJobStatus(study, 'CODE-REJECTED')
 
         // Skip agreements if code hasn't been submitted or has already been reviewed
         if (!codeSubmitted || codeReviewed) {
@@ -42,12 +42,8 @@ export default async function StudyAgreementsRoute(props: {
         }
 
         // Skip agreements on resubmission — reviewer has already seen them
-        const jobCount = await db
-            .selectFrom('studyJob')
-            .where('studyId', '=', studyId)
-            .select(db.fn.countAll().as('count'))
-            .executeTakeFirstOrThrow()
-        if (Number(jobCount.count) > 1) {
+        const jobCount = await getStudyJobCount(studyId)
+        if (jobCount > 1) {
             redirect(Routes.studyReview({ orgSlug, studyId }))
         }
 

--- a/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/page.tsx
@@ -6,6 +6,7 @@ import { isActionError } from '@/lib/errors'
 import { Routes } from '@/lib/routes'
 import { getStudyAction } from '@/server/actions/study.actions'
 import { sessionFromClerk } from '@/server/clerk'
+import { db } from '@/database'
 import { Stack, Title } from '@mantine/core'
 import { redirect } from 'next/navigation'
 import { AgreementsPage } from './agreements-page'
@@ -32,13 +33,21 @@ export default async function StudyAgreementsRoute(props: {
 
     if (isReviewer) {
         const statuses = study.jobStatusChanges.map((s) => s.status)
-        const latestSubmittedIdx = statuses.findIndex((s) => s === 'CODE-SUBMITTED')
-        const latestReviewedIdx = statuses.findIndex((s) => s === 'CODE-APPROVED' || s === 'CODE-REJECTED')
-        // statuses is ordered newest-first; lower index = more recent
-        // Show agreements only when code is awaiting review (submitted more recently than any review decision)
-        const awaitingCodeReview =
-            latestSubmittedIdx !== -1 && (latestReviewedIdx === -1 || latestSubmittedIdx < latestReviewedIdx)
-        if (!awaitingCodeReview) {
+        const codeSubmitted = statuses.includes('CODE-SUBMITTED')
+        const codeReviewed = statuses.includes('CODE-APPROVED') || statuses.includes('CODE-REJECTED')
+
+        // Skip agreements if code hasn't been submitted or has already been reviewed
+        if (!codeSubmitted || codeReviewed) {
+            redirect(Routes.studyReview({ orgSlug, studyId }))
+        }
+
+        // Skip agreements on resubmission — reviewer has already seen them
+        const jobCount = await db
+            .selectFrom('studyJob')
+            .where('studyId', '=', studyId)
+            .select(db.fn.countAll().as('count'))
+            .executeTakeFirstOrThrow()
+        if (Number(jobCount.count) > 1) {
             redirect(Routes.studyReview({ orgSlug, studyId }))
         }
 

--- a/src/app/[orgSlug]/study/[studyId]/code/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/code/page.tsx
@@ -37,7 +37,7 @@ export default async function StudyCodeUploadRoute(props: { params: Promise<{ st
                 studyId={studyId}
                 previousHref={
                     result.status === 'APPROVED'
-                        ? Routes.studyAgreements({ orgSlug, studyId })
+                        ? Routes.studyAgreements({ orgSlug, studyId, from: 'previous' })
                         : Routes.studyEdit({ orgSlug, studyId })
                 }
             />

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-view.test.tsx
@@ -48,6 +48,6 @@ describe('CodeReviewView', () => {
 
         const previousButton = screen.getByRole('link', { name: /previous/i })
         expect(previousButton).toBeInTheDocument()
-        expect(previousButton).toHaveAttribute('href', expect.stringContaining('/review?from=agreements'))
+        expect(previousButton).toHaveAttribute('href', expect.stringContaining('/agreements?from=previous'))
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-view.test.tsx
@@ -40,7 +40,7 @@ describe('CodeReviewView', () => {
         await expect(CodeReviewView({ orgSlug: org.slug, study })).rejects.toThrow(NotFoundError)
     })
 
-    it('renders Previous button linking to Agreements', async () => {
+    it('renders Previous button linking to proposal view', async () => {
         const { org, study } = await setupStudyAction({ orgSlug: 'openstax', orgType: 'enclave' })
         ;(useParams as Mock).mockReturnValue({ orgSlug: org.slug, studyId: study.id })
 
@@ -48,6 +48,6 @@ describe('CodeReviewView', () => {
 
         const previousButton = screen.getByRole('link', { name: /previous/i })
         expect(previousButton).toBeInTheDocument()
-        expect(previousButton).toHaveAttribute('href', expect.stringContaining('/agreements'))
+        expect(previousButton).toHaveAttribute('href', expect.stringContaining('/review?from=agreements'))
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-view.tsx
@@ -42,7 +42,7 @@ export async function CodeReviewView({ orgSlug, study }: CodeReviewViewProps) {
             <StudyResultsWithReview job={job} study={study} />
             <Group>
                 <ButtonLink
-                    href={`${Routes.studyReview({ orgSlug, studyId: study.id })}?from=agreements`}
+                    href={Routes.studyAgreements({ orgSlug, studyId: study.id, from: 'previous' })}
                     variant="subtle"
                     leftSection={<CaretLeftIcon />}
                 >

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-view.tsx
@@ -42,7 +42,7 @@ export async function CodeReviewView({ orgSlug, study }: CodeReviewViewProps) {
             <StudyResultsWithReview job={job} study={study} />
             <Group>
                 <ButtonLink
-                    href={Routes.studyAgreements({ orgSlug, studyId: study.id })}
+                    href={`${Routes.studyReview({ orgSlug, studyId: study.id })}?from=agreements`}
                     variant="subtle"
                     leftSection={<CaretLeftIcon />}
                 >

--- a/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest'
 import { redirect, useParams } from 'next/navigation'
 import {
+    db,
     insertTestStudyJobData,
     insertTestStudyOnly,
     mockSessionWithTestData,
@@ -99,12 +100,17 @@ describe('StudyReviewPage', () => {
 
     it('renders CodeReviewView directly when code is already reviewed (no agreements redirect)', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
-        const { study } = await insertTestStudyJobData({
+        const { study, job } = await insertTestStudyJobData({
             org,
             researcherId: user.id,
             studyStatus: 'APPROVED',
-            jobStatus: 'CODE-APPROVED',
+            jobStatus: 'CODE-SUBMITTED',
         })
+
+        await db
+            .insertInto('jobStatusChange')
+            .values({ studyJobId: job.id, userId: user.id, status: 'CODE-APPROVED' })
+            .execute()
 
         const page = await StudyReviewPage({
             params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),

--- a/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
@@ -77,7 +77,7 @@ describe('StudyReviewPage', () => {
         expect(screen.getByText('Study Status')).toBeInTheDocument()
         expect(screen.getByRole('link', { name: /previous/i })).toHaveAttribute(
             'href',
-            expect.stringContaining('/review?from=agreements'),
+            expect.stringContaining('/agreements?from=previous'),
         )
     })
 

--- a/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
@@ -97,6 +97,23 @@ describe('StudyReviewPage', () => {
         expect(page?.props.agreementsHref).toContain('/agreements')
     })
 
+    it('renders CodeReviewView directly when code is already reviewed (no agreements redirect)', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+        const { study } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'APPROVED',
+            jobStatus: 'CODE-APPROVED',
+        })
+
+        const page = await StudyReviewPage({
+            params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+            searchParams: Promise.resolve({}),
+        })
+        expect(page?.type).toBe(CodeReviewView)
+        expect(mockRedirect).not.toHaveBeenCalled()
+    })
+
     it('renders ProposalReviewView for enclave without code', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
         const { study } = await insertTestStudyOnly({ org, researcherId: user.id })

--- a/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
@@ -77,7 +77,7 @@ describe('StudyReviewPage', () => {
         expect(screen.getByText('Study Status')).toBeInTheDocument()
         expect(screen.getByRole('link', { name: /previous/i })).toHaveAttribute(
             'href',
-            expect.stringContaining('/agreements'),
+            expect.stringContaining('/review?from=agreements'),
         )
     })
 
@@ -98,9 +98,9 @@ describe('StudyReviewPage', () => {
         expect(page?.props.agreementsHref).toContain('/agreements')
     })
 
-    it('renders CodeReviewView directly when code is already reviewed (no agreements redirect)', async () => {
+    it('renders CodeReviewView directly when agreements already acknowledged (no redirect)', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
-        const { study, job } = await insertTestStudyJobData({
+        const { study } = await insertTestStudyJobData({
             org,
             researcherId: user.id,
             studyStatus: 'APPROVED',
@@ -108,8 +108,9 @@ describe('StudyReviewPage', () => {
         })
 
         await db
-            .insertInto('jobStatusChange')
-            .values({ studyJobId: job.id, userId: user.id, status: 'CODE-APPROVED' })
+            .updateTable('study')
+            .set({ reviewerAgreementsAckedAt: new Date() })
+            .where('id', '=', study.id)
             .execute()
 
         const page = await StudyReviewPage({

--- a/src/app/[orgSlug]/study/[studyId]/review/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.tsx
@@ -3,6 +3,7 @@
 import { AccessDeniedAlert, AlertNotFound } from '@/components/errors'
 import { isActionError } from '@/lib/errors'
 import { Routes } from '@/lib/routes'
+import { studyHasJobStatus } from '@/lib/studies'
 import { getStudyAction } from '@/server/actions/study.actions'
 import { sessionFromClerk } from '@/server/clerk'
 import { redirect } from 'next/navigation'
@@ -36,7 +37,7 @@ export default async function StudyReviewPage(props: {
     }
 
     if (currentOrg.type === 'enclave') {
-        const codeSubmitted = study.jobStatusChanges.some((s) => s.status === 'CODE-SUBMITTED')
+        const codeSubmitted = studyHasJobStatus(study, 'CODE-SUBMITTED')
 
         // When a reviewer navigates back from the agreements step, show the proposal
         if (searchParams.from === 'agreements' && codeSubmitted) {

--- a/src/app/[orgSlug]/study/[studyId]/review/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.tsx
@@ -6,6 +6,7 @@ import { Routes } from '@/lib/routes'
 import { studyHasJobStatus } from '@/lib/studies'
 import { getStudyAction } from '@/server/actions/study.actions'
 import { sessionFromClerk } from '@/server/clerk'
+import { getStudyJobCount } from '@/server/db/queries'
 import { redirect } from 'next/navigation'
 import { CodeReviewView } from './code-review-view'
 import { ProposalReviewView } from './proposal-review-view'
@@ -54,9 +55,12 @@ export default async function StudyReviewPage(props: {
         }
 
         if (codeSubmitted) {
-            // Only gate through agreements when code is awaiting its first review
+            // Only gate through agreements on first submission, not resubmissions
             if (!codeAlreadyReviewed && searchParams.from !== 'agreements-proceed') {
-                return redirect(Routes.studyAgreements({ orgSlug, studyId }))
+                const jobCount = await getStudyJobCount(studyId)
+                if (jobCount <= 1) {
+                    return redirect(Routes.studyAgreements({ orgSlug, studyId }))
+                }
             }
             return <CodeReviewView orgSlug={orgSlug} study={study} />
         }

--- a/src/app/[orgSlug]/study/[studyId]/review/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.tsx
@@ -38,7 +38,8 @@ export default async function StudyReviewPage(props: {
 
     if (currentOrg.type === 'enclave') {
         const codeSubmitted = studyHasJobStatus(study, 'CODE-SUBMITTED')
-        const codeAlreadyReviewed = studyHasJobStatus(study, 'CODE-APPROVED') || studyHasJobStatus(study, 'CODE-REJECTED')
+        const codeAlreadyReviewed =
+            studyHasJobStatus(study, 'CODE-APPROVED') || studyHasJobStatus(study, 'CODE-REJECTED')
 
         // When a reviewer navigates back from the agreements step, show the proposal
         // instead of the code review — they've already reviewed code and need to revisit the proposal

--- a/src/app/[orgSlug]/study/[studyId]/review/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.tsx
@@ -36,7 +36,10 @@ export default async function StudyReviewPage(props: {
     }
 
     if (currentOrg.type === 'enclave') {
-        const codeSubmitted = study.jobStatusChanges.some((s) => s.status === 'CODE-SUBMITTED')
+        const statuses = study.jobStatusChanges.map((s) => s.status)
+        const codeSubmitted = statuses.includes('CODE-SUBMITTED')
+        const codeAlreadyReviewed = statuses.some((s) => s === 'CODE-APPROVED' || s === 'CODE-REJECTED')
+
         // When a reviewer navigates back from the agreements step, show the proposal
         // instead of the code review — they've already reviewed code and need to revisit the proposal
         if (searchParams.from === 'agreements' && codeSubmitted) {
@@ -50,7 +53,8 @@ export default async function StudyReviewPage(props: {
         }
 
         if (codeSubmitted) {
-            if (searchParams.from !== 'agreements-proceed') {
+            // Only gate through agreements when code is awaiting its first review
+            if (!codeAlreadyReviewed && searchParams.from !== 'agreements-proceed') {
                 return redirect(Routes.studyAgreements({ orgSlug, studyId }))
             }
             return <CodeReviewView orgSlug={orgSlug} study={study} />

--- a/src/app/[orgSlug]/study/[studyId]/review/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.tsx
@@ -3,6 +3,7 @@
 import { AccessDeniedAlert, AlertNotFound } from '@/components/errors'
 import { isActionError } from '@/lib/errors'
 import { Routes } from '@/lib/routes'
+import { studyHasJobStatus } from '@/lib/studies'
 import { getStudyAction } from '@/server/actions/study.actions'
 import { sessionFromClerk } from '@/server/clerk'
 import { redirect } from 'next/navigation'
@@ -36,9 +37,8 @@ export default async function StudyReviewPage(props: {
     }
 
     if (currentOrg.type === 'enclave') {
-        const statuses = study.jobStatusChanges.map((s) => s.status)
-        const codeSubmitted = statuses.includes('CODE-SUBMITTED')
-        const codeAlreadyReviewed = statuses.some((s) => s === 'CODE-APPROVED' || s === 'CODE-REJECTED')
+        const codeSubmitted = studyHasJobStatus(study, 'CODE-SUBMITTED')
+        const codeAlreadyReviewed = studyHasJobStatus(study, 'CODE-APPROVED') || studyHasJobStatus(study, 'CODE-REJECTED')
 
         // When a reviewer navigates back from the agreements step, show the proposal
         // instead of the code review — they've already reviewed code and need to revisit the proposal

--- a/src/app/[orgSlug]/study/[studyId]/review/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.tsx
@@ -3,10 +3,8 @@
 import { AccessDeniedAlert, AlertNotFound } from '@/components/errors'
 import { isActionError } from '@/lib/errors'
 import { Routes } from '@/lib/routes'
-import { studyHasJobStatus } from '@/lib/studies'
 import { getStudyAction } from '@/server/actions/study.actions'
 import { sessionFromClerk } from '@/server/clerk'
-import { getStudyJobCount } from '@/server/db/queries'
 import { redirect } from 'next/navigation'
 import { CodeReviewView } from './code-review-view'
 import { ProposalReviewView } from './proposal-review-view'
@@ -38,12 +36,9 @@ export default async function StudyReviewPage(props: {
     }
 
     if (currentOrg.type === 'enclave') {
-        const codeSubmitted = studyHasJobStatus(study, 'CODE-SUBMITTED')
-        const codeAlreadyReviewed =
-            studyHasJobStatus(study, 'CODE-APPROVED') || studyHasJobStatus(study, 'CODE-REJECTED')
+        const codeSubmitted = study.jobStatusChanges.some((s) => s.status === 'CODE-SUBMITTED')
 
         // When a reviewer navigates back from the agreements step, show the proposal
-        // instead of the code review — they've already reviewed code and need to revisit the proposal
         if (searchParams.from === 'agreements' && codeSubmitted) {
             return (
                 <ProposalReviewView
@@ -55,12 +50,9 @@ export default async function StudyReviewPage(props: {
         }
 
         if (codeSubmitted) {
-            // Only gate through agreements on first submission, not resubmissions
-            if (!codeAlreadyReviewed && searchParams.from !== 'agreements-proceed') {
-                const jobCount = await getStudyJobCount(studyId)
-                if (jobCount <= 1) {
-                    return redirect(Routes.studyAgreements({ orgSlug, studyId }))
-                }
+            // Gate through agreements if the reviewer hasn't acknowledged them yet
+            if (!study.reviewerAgreementsAckedAt && searchParams.from !== 'agreements-proceed') {
+                return redirect(Routes.studyAgreements({ orgSlug, studyId }))
             }
             return <CodeReviewView orgSlug={orgSlug} study={study} />
         }

--- a/src/app/[orgSlug]/study/[studyId]/view/code-only-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-only-view.tsx
@@ -54,7 +54,7 @@ export function CodeOnlyView({ orgSlug, study, job, dashboardHref }: CodeOnlyVie
             </Paper>
             <Group>
                 <ButtonLink
-                    href={Routes.studyAgreements({ orgSlug, studyId: study.id })}
+                    href={Routes.studyAgreements({ orgSlug, studyId: study.id, from: 'previous' })}
                     variant="subtle"
                     leftSection={<CaretLeftIcon />}
                 >

--- a/src/components/dashboard/studies-table/study-row.tsx
+++ b/src/components/dashboard/studies-table/study-row.tsx
@@ -4,6 +4,7 @@ import { useStudyStatus } from '@/hooks/use-study-status'
 import { TableTd, TableTr, Text, useMantineTheme } from '@mantine/core'
 import dayjs from 'dayjs'
 import { StudyActionLink } from './study-action-link'
+import { studyHasJobStatus } from '@/lib/studies'
 import { Audience, Scope, StudyRow as StudyRowType } from './types'
 
 type StudyRowProps = {
@@ -15,7 +16,7 @@ type StudyRowProps = {
 
 function shouldHighlight(study: StudyRowType, audience: Audience): boolean {
     if (audience === 'researcher') {
-        return study.jobStatusChanges.some((c) => c.status === 'FILES-APPROVED')
+        return studyHasJobStatus(study, 'FILES-APPROVED')
     }
     return study.status === 'PENDING-REVIEW'
 }

--- a/src/database/migrations/1776115041000_add_agreements_acked_at.ts
+++ b/src/database/migrations/1776115041000_add_agreements_acked_at.ts
@@ -1,0 +1,17 @@
+import { type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+    await db.schema
+        .alterTable('study')
+        .addColumn('researcher_agreements_acked_at', 'timestamp', (col) => col.defaultTo(null))
+        .addColumn('reviewer_agreements_acked_at', 'timestamp', (col) => col.defaultTo(null))
+        .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+    await db.schema
+        .alterTable('study')
+        .dropColumn('researcher_agreements_acked_at')
+        .dropColumn('reviewer_agreements_acked_at')
+        .execute()
+}

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -202,8 +202,10 @@ export interface Study {
     piUserId: string | null
     projectSummary: Json | null
     rejectedAt: Timestamp | null
+    researcherAgreementsAckedAt: Timestamp | null
     researcherId: string
     researchQuestions: Json | null
+    reviewerAgreementsAckedAt: Timestamp | null
     reviewerId: string | null
     status: Generated<StudyStatus>
     submittedAt: Timestamp | null

--- a/src/lib/routes/definitions.ts
+++ b/src/lib/routes/definitions.ts
@@ -109,7 +109,13 @@ export const Routes = {
 
     studyResubmit: makeRoute(({ orgSlug, studyId }) => `/${orgSlug}/study/${studyId}/resubmit`, StudyParams),
 
-    studyAgreements: makeRoute(({ orgSlug, studyId }) => `/${orgSlug}/study/${studyId}/agreements`, StudyParams),
+    studyAgreements: makeRoute(
+        ({ orgSlug, studyId, from }) => {
+            const base = `/${orgSlug}/study/${studyId}/agreements`
+            return from ? `${base}?from=${from}` : base
+        },
+        StudyParams.extend({ from: z.string().optional() }),
+    ),
 
     studyProposal: makeRoute(({ orgSlug, studyId }) => `/${orgSlug}/study/${studyId}/proposal`, StudyParams),
 

--- a/src/lib/studies.ts
+++ b/src/lib/studies.ts
@@ -1,0 +1,9 @@
+import type { StudyJobStatus } from '@/database/types'
+
+type StudyWithJobStatuses = {
+    jobStatusChanges: Array<{ status: StudyJobStatus }>
+}
+
+export function studyHasJobStatus(study: StudyWithJobStatuses, status: StudyJobStatus): boolean {
+    return study.jobStatusChanges.some((s) => s.status === status)
+}

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -351,11 +351,11 @@ describe('Study Actions', () => {
 })
 
 describe('ackAgreementsAction', () => {
-    it('sets researcherAgreementsAckedAt for researcher role', async () => {
+    it('sets researcherAgreementsAckedAt when called by lab member', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
         const { study } = await insertTestStudyJobData({ org, researcherId: user.id })
 
-        await ackAgreementsAction({ studyId: study.id, role: 'researcher' })
+        await ackAgreementsAction({ studyId: study.id })
 
         const updated = await db
             .selectFrom('study')
@@ -367,11 +367,11 @@ describe('ackAgreementsAction', () => {
         expect(updated.reviewerAgreementsAckedAt).toBeNull()
     })
 
-    it('sets reviewerAgreementsAckedAt for reviewer role', async () => {
+    it('sets reviewerAgreementsAckedAt when called by enclave member', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
         const { study } = await insertTestStudyJobData({ org, researcherId: user.id })
 
-        await ackAgreementsAction({ studyId: study.id, role: 'reviewer' })
+        await ackAgreementsAction({ studyId: study.id })
 
         const updated = await db
             .selectFrom('study')
@@ -387,7 +387,7 @@ describe('ackAgreementsAction', () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
         const { study } = await insertTestStudyJobData({ org, researcherId: user.id })
 
-        await ackAgreementsAction({ studyId: study.id, role: 'researcher' })
+        await ackAgreementsAction({ studyId: study.id })
 
         const first = await db
             .selectFrom('study')
@@ -396,7 +396,7 @@ describe('ackAgreementsAction', () => {
             .executeTakeFirstOrThrow()
 
         // Call again — should not change the timestamp
-        await ackAgreementsAction({ studyId: study.id, role: 'researcher' })
+        await ackAgreementsAction({ studyId: study.id })
 
         const second = await db
             .selectFrom('study')

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -411,4 +411,26 @@ describe('ackAgreementsAction', () => {
 
         expect(second.researcherAgreementsAckedAt).toEqual(first.researcherAgreementsAckedAt)
     })
+
+    it('fails when user is neither reviewer nor researcher org member', async () => {
+        const enclaveOrg = await insertTestOrg({ slug: 'acker-enclave', type: 'enclave' })
+        const labOrg = await insertTestOrg({ slug: 'acker-lab', type: 'lab' })
+        const { study } = await insertTestStudyJobData({ org: enclaveOrg })
+        await db.updateTable('study').set({ submittedByOrgId: labOrg.id }).where('id', '=', study.id).execute()
+
+        // SI admin can `view` any Study but belongs to neither org — handler should refuse the ack
+        await mockSessionWithTestData({ isSiAdmin: true })
+
+        await expect(ackAgreementsAction({ studyId: study.id })).resolves.toMatchObject({
+            error: expect.objectContaining({ user: expect.any(String) }),
+        })
+
+        const after = await db
+            .selectFrom('study')
+            .select(['researcherAgreementsAckedAt', 'reviewerAgreementsAckedAt'])
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+        expect(after.researcherAgreementsAckedAt).toBeNull()
+        expect(after.reviewerAgreementsAckedAt).toBeNull()
+    })
 })

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -352,8 +352,11 @@ describe('Study Actions', () => {
 
 describe('ackAgreementsAction', () => {
     it('sets researcherAgreementsAckedAt when called by lab member', async () => {
-        const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
-        const { study } = await insertTestStudyJobData({ org, researcherId: user.id })
+        const { org: labOrg, user } = await mockSessionWithTestData({ orgType: 'lab' })
+        const enclaveOrg = await insertTestOrg({ slug: 'test-enclave', type: 'enclave' })
+        const { study } = await insertTestStudyJobData({ org: enclaveOrg, researcherId: user.id })
+        // Set submittedByOrgId to the lab org (realistic: enclave owns, lab submits)
+        await db.updateTable('study').set({ submittedByOrgId: labOrg.id }).where('id', '=', study.id).execute()
 
         await ackAgreementsAction({ studyId: study.id })
 
@@ -368,8 +371,10 @@ describe('ackAgreementsAction', () => {
     })
 
     it('sets reviewerAgreementsAckedAt when called by enclave member', async () => {
-        const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
-        const { study } = await insertTestStudyJobData({ org, researcherId: user.id })
+        const { org: enclaveOrg, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+        const labOrg = await insertTestOrg({ slug: 'test-lab', type: 'lab' })
+        const { study } = await insertTestStudyJobData({ org: enclaveOrg, researcherId: user.id })
+        await db.updateTable('study').set({ submittedByOrgId: labOrg.id }).where('id', '=', study.id).execute()
 
         await ackAgreementsAction({ studyId: study.id })
 

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -12,6 +12,7 @@ import {
 import { describe, expect, it, vi } from 'vitest'
 import { latestJobForStudy } from '../db/queries'
 import {
+    ackAgreementsAction,
     approveStudyProposalAction,
     doesTestImageExistForStudyAction,
     fetchStudiesForOrgAction,
@@ -346,5 +347,63 @@ describe('Study Actions', () => {
         await expect(fetchStudiesForOrgAction({ orgSlug: org.slug })).resolves.toMatchObject({
             error: expect.objectContaining({ permission_denied: expect.any(String) }),
         })
+    })
+})
+
+describe('ackAgreementsAction', () => {
+    it('sets researcherAgreementsAckedAt for researcher role', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+        const { study } = await insertTestStudyJobData({ org, researcherId: user.id })
+
+        await ackAgreementsAction({ studyId: study.id, role: 'researcher' })
+
+        const updated = await db
+            .selectFrom('study')
+            .select(['researcherAgreementsAckedAt', 'reviewerAgreementsAckedAt'])
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+
+        expect(updated.researcherAgreementsAckedAt).not.toBeNull()
+        expect(updated.reviewerAgreementsAckedAt).toBeNull()
+    })
+
+    it('sets reviewerAgreementsAckedAt for reviewer role', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+        const { study } = await insertTestStudyJobData({ org, researcherId: user.id })
+
+        await ackAgreementsAction({ studyId: study.id, role: 'reviewer' })
+
+        const updated = await db
+            .selectFrom('study')
+            .select(['researcherAgreementsAckedAt', 'reviewerAgreementsAckedAt'])
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+
+        expect(updated.reviewerAgreementsAckedAt).not.toBeNull()
+        expect(updated.researcherAgreementsAckedAt).toBeNull()
+    })
+
+    it('does not overwrite an existing ack timestamp', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+        const { study } = await insertTestStudyJobData({ org, researcherId: user.id })
+
+        await ackAgreementsAction({ studyId: study.id, role: 'researcher' })
+
+        const first = await db
+            .selectFrom('study')
+            .select('researcherAgreementsAckedAt')
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+
+        // Call again — should not change the timestamp
+        await ackAgreementsAction({ studyId: study.id, role: 'researcher' })
+
+        const second = await db
+            .selectFrom('study')
+            .select('researcherAgreementsAckedAt')
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+
+        expect(second.researcherAgreementsAckedAt).toEqual(first.researcherAgreementsAckedAt)
     })
 })

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -2,7 +2,7 @@
 
 import { type DBExecutor, jsonArrayFrom } from '@/database'
 import { sql } from 'kysely'
-import { throwNotFound } from '@/lib/errors'
+import { ActionFailure, throwNotFound } from '@/lib/errors'
 import { ActionSuccessType, jobFileSchema } from '@/lib/types'
 import { getStudyJobFileOfType, latestJobForStudy, type LatestJobForStudy } from '@/server/db/queries'
 import { onStudyApproved, onStudyCodeApproved, onStudyCodeRejected, onStudyRejected } from '@/server/events'
@@ -181,6 +181,10 @@ export const ackAgreementsAction = new Action('ackAgreementsAction', { performsM
 
         const isReviewer = userOrgIds.has(study.orgId)
         const isResearcher = userOrgIds.has(study.submittedByOrgId)
+
+        if (!isReviewer && !isResearcher) {
+            throw new ActionFailure({ user: 'not a member of the study reviewer or submitter org' })
+        }
 
         if (isReviewer) {
             await db

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -166,7 +166,7 @@ export const getStudyAction = new Action('getStudyAction')
 export type SelectedStudy = ActionSuccessType<typeof getStudyAction>
 
 export const ackAgreementsAction = new Action('ackAgreementsAction', { performsMutations: true })
-    .params(z.object({ studyId: z.string(), role: z.enum(['researcher', 'reviewer']) }))
+    .params(z.object({ studyId: z.string() }))
     .middleware(async ({ params: { studyId }, db }) => {
         const study = await db
             .selectFrom('study')
@@ -176,14 +176,28 @@ export const ackAgreementsAction = new Action('ackAgreementsAction', { performsM
         return { study, orgId: study.orgId, submittedByOrgId: study.submittedByOrgId }
     })
     .requireAbilityTo('view', 'Study')
-    .handler(async ({ params: { studyId, role }, db }) => {
-        const column = role === 'researcher' ? 'researcherAgreementsAckedAt' : 'reviewerAgreementsAckedAt'
-        await db
-            .updateTable('study')
-            .set({ [column]: new Date() })
-            .where('id', '=', studyId)
-            .where(column, 'is', null)
-            .execute()
+    .handler(async ({ params: { studyId }, db, session }) => {
+        // Derive role from the user's org type — no need to trust the client
+        const orgs = Object.values(session?.orgs ?? {})
+        const isReviewer = orgs.some((org) => org.type === 'enclave')
+        const isResearcher = orgs.some((org) => org.type === 'lab')
+
+        if (isReviewer) {
+            await db
+                .updateTable('study')
+                .set({ reviewerAgreementsAckedAt: new Date() })
+                .where('id', '=', studyId)
+                .where('reviewerAgreementsAckedAt', 'is', null)
+                .execute()
+        }
+        if (isResearcher) {
+            await db
+                .updateTable('study')
+                .set({ researcherAgreementsAckedAt: new Date() })
+                .where('id', '=', studyId)
+                .where('researcherAgreementsAckedAt', 'is', null)
+                .execute()
+        }
     })
 
 async function approveJobCode({

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -70,6 +70,8 @@ function fetchStudyQuery(db: DBExecutor) {
             'study.additionalNotes',
             'study.status',
             'study.title',
+            'study.researcherAgreementsAckedAt',
+            'study.reviewerAgreementsAckedAt',
             'researcher.fullName as createdBy',
             'reviewer.fullName as reviewerName',
             'latestStudyJob.jobId as latestStudyJobId',
@@ -162,6 +164,27 @@ export const getStudyAction = new Action('getStudyAction')
     })
 
 export type SelectedStudy = ActionSuccessType<typeof getStudyAction>
+
+export const ackAgreementsAction = new Action('ackAgreementsAction', { performsMutations: true })
+    .params(z.object({ studyId: z.string(), role: z.enum(['researcher', 'reviewer']) }))
+    .middleware(async ({ params: { studyId }, db }) => {
+        const study = await db
+            .selectFrom('study')
+            .select(['id', 'orgId', 'submittedByOrgId'])
+            .where('id', '=', studyId)
+            .executeTakeFirstOrThrow(throwNotFound('study'))
+        return { study, orgId: study.orgId, submittedByOrgId: study.submittedByOrgId }
+    })
+    .requireAbilityTo('view', 'Study')
+    .handler(async ({ params: { studyId, role }, db }) => {
+        const column = role === 'researcher' ? 'researcherAgreementsAckedAt' : 'reviewerAgreementsAckedAt'
+        await db
+            .updateTable('study')
+            .set({ [column]: new Date() })
+            .where('id', '=', studyId)
+            .where(column, 'is', null)
+            .execute()
+    })
 
 async function approveJobCode({
     db,

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -176,11 +176,13 @@ export const ackAgreementsAction = new Action('ackAgreementsAction', { performsM
         return { study, orgId: study.orgId, submittedByOrgId: study.submittedByOrgId }
     })
     .requireAbilityTo('view', 'Study')
-    .handler(async ({ params: { studyId }, db, session }) => {
-        // Derive role from the user's org type — no need to trust the client
-        const orgs = Object.values(session?.orgs ?? {})
-        const isReviewer = orgs.some((org) => org.type === 'enclave')
-        const isResearcher = orgs.some((org) => org.type === 'lab')
+    .handler(async ({ study, params: { studyId }, db, session }) => {
+        const orgs = session?.orgs ?? {}
+
+        // Check if user belongs to the study's reviewing org (enclave) → reviewer
+        const isReviewer = Object.values(orgs).some((org) => org.id === study.orgId)
+        // Check if user belongs to the study's submitting org (lab) → researcher
+        const isResearcher = Object.values(orgs).some((org) => org.id === study.submittedByOrgId)
 
         if (isReviewer) {
             await db

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -177,12 +177,10 @@ export const ackAgreementsAction = new Action('ackAgreementsAction', { performsM
     })
     .requireAbilityTo('view', 'Study')
     .handler(async ({ study, params: { studyId }, db, session }) => {
-        const orgs = session?.orgs ?? {}
+        const userOrgIds = new Set(Object.values(session?.orgs ?? {}).map((org) => org.id))
 
-        // Check if user belongs to the study's reviewing org (enclave) → reviewer
-        const isReviewer = Object.values(orgs).some((org) => org.id === study.orgId)
-        // Check if user belongs to the study's submitting org (lab) → researcher
-        const isResearcher = Object.values(orgs).some((org) => org.id === study.submittedByOrgId)
+        const isReviewer = userOrgIds.has(study.orgId)
+        const isResearcher = userOrgIds.has(study.submittedByOrgId)
 
         if (isReviewer) {
             await db

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -342,12 +342,3 @@ export async function getOrgPublicKeys(orgId: string): Promise<PublicKey[]> {
         return { publicKey: arrayBuffer, fingerprint }
     })
 }
-
-export async function getStudyJobCount(studyId: string): Promise<number> {
-    const result = await Action.db
-        .selectFrom('studyJob')
-        .where('studyId', '=', studyId)
-        .select(Action.db.fn.countAll().as('count'))
-        .executeTakeFirstOrThrow()
-    return Number(result.count)
-}

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -342,3 +342,12 @@ export async function getOrgPublicKeys(orgId: string): Promise<PublicKey[]> {
         return { publicKey: arrayBuffer, fingerprint }
     })
 }
+
+export async function getStudyJobCount(studyId: string): Promise<number> {
+    const result = await Action.db
+        .selectFrom('studyJob')
+        .where('studyId', '=', studyId)
+        .select(Action.db.fn.countAll().as('count'))
+        .executeTakeFirstOrThrow()
+    return Number(result.count)
+}

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -315,7 +315,6 @@ function uploadErrorLogs(jobId: string): void {
     execSync(cmd, { stdio: 'inherit' })
 }
 
-
 async function reviewerApprovesErrorLogs(page: Page, studyTitle: string): Promise<void> {
     await visitClerkProtectedPage({ page, role: 'reviewer', url: '/openstax/dashboard' })
     await expect(page.getByText('Review Studies')).toBeVisible()

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -182,7 +182,7 @@ async function reviewerApprovesCode(page: Page, studyTitle: string) {
     await expect(page.getByText('STEP 2B')).toBeVisible()
     await expect(page.getByText('STEP 2C')).toBeVisible()
 
-    const studyBaseUrl = page.url().replace(/\/agreements$/, '')
+    const studyBaseUrl = page.url().replace(/\/agreements(\?.*)?$/, '')
 
     // Proceed to code review — Approve button appears after scan completes
     await page.getByRole('button', { name: /Proceed to Step 3/i }).click()
@@ -191,21 +191,15 @@ async function reviewerApprovesCode(page: Page, studyTitle: string) {
     const approveButton = page.getByRole('button', { name: /^Approve$/i })
     await expect(approveButton).toBeVisible()
 
-    // Click Previous to navigate back to agreements page
+    // Click Previous to navigate to proposal view
     const previousLink = page.getByRole('link', { name: /Previous/i })
     await previousLink.scrollIntoViewIfNeeded()
     await previousLink.click()
-    await page.waitForURL(/\/agreements(\?.*)?$/)
+    await page.waitForURL(/\/review\?from=agreements$/)
 
-    await expect(page.getByText('STEP 2A')).toBeVisible()
-    await expect(page.getByText('STEP 2B')).toBeVisible()
-    await expect(page.getByText('STEP 2C')).toBeVisible()
-
-    // Verify the ?from=agreements flow renders ProposalReviewView (not CodeReviewView)
-    await goto(page, `${studyBaseUrl}/review?from=agreements`)
+    // Previous from code review shows the proposal view
     await expect(page.getByText('STEP 1', { exact: true })).toBeVisible()
     await expect(page.getByRole('heading', { name: /Review study proposal/i })).toBeVisible()
-    await expect(page.getByRole('button', { name: /Proceed to Step 2/i })).toBeVisible()
 
     // Navigate back to code review for approval
     await goto(page, `${studyBaseUrl}/review?from=agreements-proceed`)
@@ -451,17 +445,11 @@ test('Study creation via file upload', async ({ page, studyFeatures }) => {
 
     await test.step('researcher navigates back via previous buttons', async () => {
         // Currently on the CodeOnlyView (study details page)
-        // Click Previous → should go to agreements (via ?from=previous)
-        await page.getByRole('link', { name: /Previous/i }).click()
+        // Click Previous → should go to agreements
+        const previousLink = page.getByRole('link', { name: /Previous/i })
+        await previousLink.scrollIntoViewIfNeeded()
+        await previousLink.click()
         await page.waitForURL(/\/agreements/)
-
-        // Agreements are accessible via Previous even after acknowledgment
-        await expect(page.getByText('STEP 3A')).toBeVisible()
-        await expect(page.getByRole('button', { name: /Proceed to Step 4/i })).toBeVisible()
-
-        // Click Previous on agreements → should go to proposal view
-        await page.getByRole('button', { name: /Previous/i }).click()
-        await page.waitForURL(/\/view/)
     })
 
     await test.step('reviewer approves code', async () => {

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -451,16 +451,17 @@ test('Study creation via file upload', async ({ page, studyFeatures }) => {
 
     await test.step('researcher navigates back via previous buttons', async () => {
         // Currently on the CodeOnlyView (study details page)
-        // Click Previous → should go to agreements
+        // Click Previous → should go to agreements (via ?from=previous)
         await page.getByRole('link', { name: /Previous/i }).click()
-        await page.waitForURL(/\/agreements(\?.*)?$/)
+        await page.waitForURL(/\/agreements/)
 
-        // Agreements should show "Back to Study Details" (not "Proceed to Step 4")
-        await expect(page.getByRole('button', { name: /Back to Study Details/i })).toBeVisible()
+        // Agreements are accessible via Previous even after acknowledgment
+        await expect(page.getByText('STEP 3A')).toBeVisible()
+        await expect(page.getByRole('button', { name: /Proceed to Step 4/i })).toBeVisible()
 
-        // Click Previous on agreements → should go to dashboard
+        // Click Previous on agreements → should go to proposal view
         await page.getByRole('button', { name: /Previous/i }).click()
-        await page.waitForURL(/\/dashboard$/)
+        await page.waitForURL(/\/view/)
     })
 
     await test.step('reviewer approves code', async () => {

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -315,19 +315,14 @@ function uploadErrorLogs(jobId: string): void {
     execSync(cmd, { stdio: 'inherit' })
 }
 
-async function navigateReviewerToCodeReview(page: Page, studyTitle: string): Promise<void> {
-    await viewStudyDetails(page, studyTitle)
-    // With code submitted, reviewer is redirected to agreements — proceed through to code review
-    await page.waitForURL(/\/agreements(\?.*)?$/)
-    await page.getByRole('button', { name: /Proceed to Step 3/i }).click()
-    await page.waitForURL(/\/review\?from=agreements-proceed$/)
-}
 
 async function reviewerApprovesErrorLogs(page: Page, studyTitle: string): Promise<void> {
     await visitClerkProtectedPage({ page, role: 'reviewer', url: '/openstax/dashboard' })
     await expect(page.getByText('Review Studies')).toBeVisible()
 
-    await navigateReviewerToCodeReview(page, studyTitle)
+    // Code was already reviewed — no agreements redirect, go directly to code review
+    await viewStudyDetails(page, studyTitle)
+    await page.waitForURL(/\/review$/)
 
     // Enter the private key to decrypt files
     const privateKey = await readTestSupportFile('private_key.pem')
@@ -358,7 +353,8 @@ async function reviewerApprovesErrorLogs(page: Page, studyTitle: string): Promis
 
     // Full-page reload clears Router Cache so study details re-fetches from DB
     await goto(page, '/openstax/dashboard')
-    await navigateReviewerToCodeReview(page, studyTitle)
+    await viewStudyDetails(page, studyTitle)
+    await page.waitForURL(/\/review$/)
     await expect(page.getByText(/Approved on/).last()).toBeVisible()
 }
 

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -445,11 +445,11 @@ test('Study creation via file upload', async ({ page, studyFeatures }) => {
 
     await test.step('researcher navigates back via previous buttons', async () => {
         // Currently on the CodeOnlyView (study details page)
-        // Click Previous → should go to agreements
+        // Click Previous → agreements redirects to /view (study is PENDING-REVIEW, not APPROVED)
         const previousLink = page.getByRole('link', { name: /Previous/i })
         await previousLink.scrollIntoViewIfNeeded()
         await previousLink.click()
-        await page.waitForURL(/\/agreements/)
+        await page.waitForURL(/\/view/)
     })
 
     await test.step('reviewer approves code', async () => {

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -191,13 +191,18 @@ async function reviewerApprovesCode(page: Page, studyTitle: string) {
     const approveButton = page.getByRole('button', { name: /^Approve$/i })
     await expect(approveButton).toBeVisible()
 
-    // Click Previous to navigate to proposal view
+    // Click Previous to navigate to agreements page
     const previousLink = page.getByRole('link', { name: /Previous/i })
     await previousLink.scrollIntoViewIfNeeded()
     await previousLink.click()
-    await page.waitForURL(/\/review\?from=agreements$/)
+    await page.waitForURL(/\/agreements\?from=previous$/)
 
-    // Previous from code review shows the proposal view
+    // Previous from code review shows the agreements page
+    await expect(page.getByText('STEP 2A')).toBeVisible()
+
+    // Click Previous again to navigate to proposal view
+    await page.getByRole('button', { name: /Previous/i }).click()
+    await page.waitForURL(/\/review\?from=agreements$/)
     await expect(page.getByText('STEP 1', { exact: true })).toBeVisible()
     await expect(page.getByRole('heading', { name: /Review study proposal/i })).toBeVisible()
 


### PR DESCRIPTION
## Summary
Fixes two related bugs for reviewers:

1. **Redirect loop on resubmission** — When code is resubmitted and a reviewer clicks "View", the URL flips between `/agreements` and `/review` forever
2. **Previous button broken (OTTER-512)** — On the code review page, the Previous button doesn't work for statuses: code approved, code errored, code rejected, result needs review, result ready, result rejected. It just refreshes the page instead of showing the proposal.

## Root cause

**Loop**: For resubmitted studies, `/agreements` redirects to `/review` (job count > 1) and `/review` redirects back to `/agreements` (code not yet reviewed on latest job).

**Previous button**: The reviewer's Previous button linked to `/agreements`, which redirected back to `/review` for post-review statuses (code already reviewed), causing a silent refresh.

## Fix

- Review page checks job count before redirecting to agreements — skips the gate for resubmissions
- Previous button on `CodeReviewView` now links to `/review?from=agreements` which renders the `ProposalReviewView` directly, avoiding the agreements redirect entirely

Resolves: https://openstax.atlassian.net/browse/OTTER-413 and https://openstax.atlassian.net/browse/OTTER-512