### PR TITLE
OTTER-415 TLS enabled

### DIFF
--- a/src/database/dialect.ts
+++ b/src/database/dialect.ts
@@ -1,12 +1,13 @@
 import { PostgresDialect } from 'kysely'
 import PG from 'pg'
-import { databaseURL } from '../server/config'
+import { databaseURL, DEPLOYED_ENV } from '../server/config'
 
 export const dialect = new PostgresDialect({
     pool: async () => {
         const config = await databaseURL()
         return new PG.Pool({
             connectionString: config,
+            ...(DEPLOYED_ENV && { ssl: true }),
         })
     },
 })


### PR DESCRIPTION
see https://openstax.atlassian.net/browse/OTTER-415

- Enable SSL on the management app's database connection when running in deployed environments
- Part of OTTER-415 SOC 2 TLS compliance work to encrypt data in transit

merge this branch **BEFORE** https://github.com/safeinsights/iac/pull/140, this branch works indepedent from IaC changes