### PR TITLE
OTTER-417 temp fix, do not check cert for now

### DIFF
--- a/src/database/dialect.ts
+++ b/src/database/dialect.ts
@@ -7,7 +7,7 @@ export const dialect = new PostgresDialect({
         const config = await databaseURL()
         return new PG.Pool({
             connectionString: config,
-            ...(DEPLOYED_ENV && { ssl: true }),
+            ...(DEPLOYED_ENV && { ssl: { rejectUnauthorized: false } }),
         })
     },
 })


### PR DESCRIPTION
Disable strict TLS cert verification on the RDS connection as a hotfix, because enabling `ssl: true` started rejecting AWS's RDS CA which Node doesn't trust by default.
Traffic stays encrypted; proper CA bundling will follow.