### PR TITLE
fix: seed uses persisted org id, not hardcoded constant

### DIFF
--- a/src/database/seeds/1743608138837_test_users.ts
+++ b/src/database/seeds/1743608138837_test_users.ts
@@ -41,7 +41,13 @@ const ORG_MEMBERSHIPS: { role: TestUserRole; slug: string; isAdmin: boolean }[] 
 export async function seed(db: Kysely<DB>): Promise<void> {
     if (process.env.NO_TESTING_DATA) return
 
-    // Upsert orgs
+    // Upsert orgs and capture the actual persisted id for each slug.
+    // Existing deployments may already have rows for these slugs with
+    // different (random) ids — the onConflict update cannot change the
+    // primary key, so we must use whatever id the DB returns when
+    // inserting child rows below.
+    const orgIdBySlug = new Map<string, string>()
+
     for (const org of ORGS) {
         const isEnclave = org.type === 'enclave'
         const name =
@@ -69,7 +75,7 @@ export async function seed(db: Kysely<DB>): Promise<void> {
 
         const settings = isEnclave ? { publicKey: 'BAD KEY, UPDATE ME' } : {}
 
-        await db
+        const persisted = await db
             .insertInto('org')
             .values({ id: org.id, slug: org.slug, name, email, type: org.type, settings, description })
             .onConflict((oc) =>
@@ -78,12 +84,14 @@ export async function seed(db: Kysely<DB>): Promise<void> {
                     name: eb.ref('excluded.name'),
                 })),
             )
-            .returningAll()
+            .returning('id')
             .executeTakeFirstOrThrow()
+
+        orgIdBySlug.set(org.slug, persisted.id)
     }
 
     // Code environments for openstax
-    const openstaxId = ORGS.find((o) => o.slug === 'openstax')!.id
+    const openstaxId = orgIdBySlug.get('openstax')!
     const existingOpenstaxEnvs = await db.selectFrom('orgCodeEnv').where('orgId', '=', openstaxId).execute()
 
     if (existingOpenstaxEnvs.length === 0) {
@@ -140,7 +148,7 @@ export async function seed(db: Kysely<DB>): Promise<void> {
     }
 
     // Code environment for single-lang-r-enclave
-    const singleLangId = ORGS.find((o) => o.slug === 'single-lang-r-enclave')!.id
+    const singleLangId = orgIdBySlug.get('single-lang-r-enclave')!
     const existingSingleLangEnvs = await db.selectFrom('orgCodeEnv').where('orgId', '=', singleLangId).execute()
 
     if (existingSingleLangEnvs.length === 0) {
@@ -187,7 +195,7 @@ export async function seed(db: Kysely<DB>): Promise<void> {
     // Org memberships
     for (const membership of ORG_MEMBERSHIPS) {
         const userId = TEST_USERS.find((u) => u.role === membership.role)!.id
-        const orgId = ORGS.find((o) => o.slug === membership.slug)!.id
+        const orgId = orgIdBySlug.get(membership.slug)!
 
         const existing = await db
             .selectFrom('orgUser')


### PR DESCRIPTION
## Summary
- Deploy was failing with `insert or update on table "org_code_env" violates foreign key constraint "org_base_image_org_id_fkey"` during the test-users seed
- Root cause: commit f99b5fcd introduced hardcoded fixed UUIDs for test orgs, but existing deployments already had rows for these slugs with different (random) ids. The seed's `onConflict('slug').doUpdateSet(...)` cannot change the primary key, so the existing row kept its old id while child inserts used the hardcoded constant — hitting the FK (whose auto-generated name still reflects the old `org_base_image` table name after the rename migration)
- Fix: capture the id the DB actually returned from the upsert and use it for all child rows (`orgCodeEnv`, `orgDataSource`, `orgUser`). On fresh DBs the hardcoded UUIDs apply; on environments with pre-existing orgs, the existing ids are reused

## Test plan
- [ ] Deploy passes the `Migrate database` step
- [ ] Fresh local DB: `npm run db:migrate` seeds with the fixed UUIDs as before
- [ ] Existing deployment: child rows insert against the existing org id (no FK violation)