### PR TITLE
OTTER-495: direct pending-review studies to submitted page

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
@@ -34,7 +34,9 @@ export function ProposalSubmitted({ orgSlug, study, orgName }: ProposalSubmitted
                         Initial request
                     </Title>
                     <Group justify="space-between" align="center">
-                        <Text c="charcoal.9">Title: {study.title}</Text>
+                        <Text c="charcoal.9" style={{ maxWidth: '60ch', wordBreak: 'break-word' }}>
+                            Title: {study.title}
+                        </Text>
                         {study.submittedAt && (
                             <Text fz={12} c="charcoal.7">
                                 Submitted on {dayjs(study.submittedAt).format('MMM DD, YYYY')}
@@ -62,7 +64,7 @@ export function ProposalSubmitted({ orgSlug, study, orgName }: ProposalSubmitted
                             size={12}
                             style={{
                                 transition: 'transform 200ms',
-                                transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)',
+                                transform: expanded ? 'rotate(-90deg)' : 'rotate(0deg)',
                             }}
                         />
                     </Anchor>
@@ -99,7 +101,8 @@ export function ProposalSubmitted({ orgSlug, study, orgName }: ProposalSubmitted
                                 divider="none"
                                 size="md"
                             />
-                            <Divider />
+
+                            {study.additionalNotes && <Divider />}
 
                             <LexicalProposalField
                                 label="Additional notes or requests"
@@ -124,7 +127,7 @@ export function ProposalSubmitted({ orgSlug, study, orgName }: ProposalSubmitted
                                 style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
                             >
                                 Hide full initial request
-                                <CaretRightIcon size={12} style={{ transform: 'rotate(90deg)' }} />
+                                <CaretRightIcon size={12} style={{ transform: 'rotate(-90deg)' }} />
                             </Anchor>
                         </Stack>
                     </Paper>

--- a/src/components/dashboard/studies-table/study-action-link.test.tsx
+++ b/src/components/dashboard/studies-table/study-action-link.test.tsx
@@ -26,7 +26,7 @@ describe('StudyActionLink', () => {
             expect(link.getAttribute('href')).toBe(`/${ORG_SLUG}/study/${STUDY_ID}/edit`)
         })
 
-        it('links to view page for PENDING-REVIEW studies without job activity', () => {
+        it('links to submitted page for PENDING-REVIEW studies without job activity', () => {
             const study = mockStudyRow({ status: 'PENDING-REVIEW' as StudyStatus, jobStatusChanges: [] })
             renderWithProviders(
                 <StudyActionLink
@@ -39,7 +39,7 @@ describe('StudyActionLink', () => {
             )
 
             const link = screen.getByRole('link', { name: /view details/i })
-            expect(link.getAttribute('href')).toBe(`/${ORG_SLUG}/study/${STUDY_ID}/view`)
+            expect(link.getAttribute('href')).toBe(`/${ORG_SLUG}/study/${STUDY_ID}/submitted`)
         })
 
         it('links to view page for PENDING-REVIEW studies with job activity', () => {
@@ -134,7 +134,7 @@ describe('StudyActionLink', () => {
             )
 
             const link = screen.getByRole('link', { name: /view details/i })
-            expect(link.getAttribute('href')).toBe(`/lab-org/study/${STUDY_ID}/view`)
+            expect(link.getAttribute('href')).toBe(`/lab-org/study/${STUDY_ID}/submitted`)
         })
     })
 

--- a/src/hooks/use-study-href.test.ts
+++ b/src/hooks/use-study-href.test.ts
@@ -19,8 +19,8 @@ describe('useStudyHref', () => {
         expect(useStudyHref('REJECTED', true, PARAMS)).toBe(`${BASE}/view`)
     })
 
-    it('routes to /view for PENDING-REVIEW without job activity', () => {
-        expect(useStudyHref('PENDING-REVIEW', false, PARAMS)).toBe(`${BASE}/view`)
+    it('routes to /submitted for PENDING-REVIEW without job activity', () => {
+        expect(useStudyHref('PENDING-REVIEW', false, PARAMS)).toBe(`${BASE}/submitted`)
     })
 
     it('routes to /agreements for APPROVED without job activity', () => {

--- a/src/hooks/use-study-href.ts
+++ b/src/hooks/use-study-href.ts
@@ -13,7 +13,8 @@ export function useStudyHref(
     const hasCodeSubmitted = jobStatuses?.some((s) => s === 'CODE-SUBMITTED')
     if (status === 'APPROVED' && hasJobActivity && !hasCodeSubmitted) return Routes.studyCode(studyParams)
 
-    if (hasJobActivity || status === 'PENDING-REVIEW') return Routes.studyView(studyParams)
+    if (hasJobActivity) return Routes.studyView(studyParams)
+    if (status === 'PENDING-REVIEW') return Routes.studySubmitted(studyParams)
     if (status === 'APPROVED') return Routes.studyAgreements(studyParams)
     return Routes.studyView(studyParams)
 }


### PR DESCRIPTION
 ## Summary                                                                       
  - Route researchers to the submitted page (instead of the view page) when their study is pending review and has no job activity.
  - Fix expand/collapse caret direction on the proposal submitted page (rotate to `-90deg` instead of `90deg`)                                                       
  - Prevent rendering an extra divider when a study has no additional notes
  - Constrain long study titles to `60ch` with word-break to prevent layout overflow (this breaks around 65-75 characters depending on the character mix).