### PR TITLE
OTTER-501: implement post-feedback submission page with feature flags

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
@@ -127,6 +127,9 @@ describe('StudyReviewPage', () => {
     it('renders the proposal review feature flag swap for enclave without code', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
         const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
+        // insertTestStudyOnly defaults to APPROVED; reset to PENDING-REVIEW so this case
+        // exercises the in-flight review flow rather than OTTER-501's post-decision view.
+        await db.updateTable('study').set({ status: 'PENDING-REVIEW' }).where('id', '=', study.id).execute()
 
         const page = await StudyReviewPage({
             params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
@@ -141,6 +144,7 @@ describe('StudyReviewPage', () => {
     it('renders the LegacyProposalReviewView for non-OpenStax enclave orgs by default', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
         const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
+        await db.updateTable('study').set({ status: 'PENDING-REVIEW' }).where('id', '=', study.id).execute()
 
         const page = await StudyReviewPage({
             params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),

--- a/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
@@ -12,7 +12,8 @@ import {
 import StudyReviewPage from './page'
 import { CodeReviewView } from './code-review-view'
 import { LegacyProposalReviewView } from './legacy-proposal-review-view'
-import { ProposalReviewFeatureFlag } from '@/components/openstax-feature-flag'
+import { PostSubmissionFeatureFlag, ProposalReviewFeatureFlag } from '@/components/openstax-feature-flag'
+import { PostFeedbackView } from './post-feedback-view'
 import { ProposalReviewView } from './proposal-review-view'
 
 const mockRedirect = vi.mocked(redirect)
@@ -148,5 +149,25 @@ describe('StudyReviewPage', () => {
         renderWithProviders(page!)
 
         expect(screen.getByText('Review Study')).toBeInTheDocument()
+    })
+
+    describe('post-feedback branch', () => {
+        it.each(['APPROVED', 'REJECTED', 'CHANGE-REQUESTED'] as const)(
+            'renders the post-submission feature flag swap when status is %s',
+            async (status) => {
+                const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+                const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
+                await db.updateTable('study').set({ status }).where('id', '=', study.id).execute()
+
+                const page = await StudyReviewPage({
+                    params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+                    searchParams: Promise.resolve({}),
+                })
+
+                expect(page?.type).toBe(PostSubmissionFeatureFlag)
+                expect(page?.props.defaultContent.type).toBe(LegacyProposalReviewView)
+                expect(page?.props.optInContent.type).toBe(PostFeedbackView)
+            },
+        )
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/review/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.tsx
@@ -1,15 +1,17 @@
 'use server'
 
 import { AccessDeniedAlert, AlertNotFound } from '@/components/errors'
-import { ProposalReviewFeatureFlag } from '@/components/openstax-feature-flag'
+import { PostSubmissionFeatureFlag, ProposalReviewFeatureFlag } from '@/components/openstax-feature-flag'
 import { isActionError } from '@/lib/errors'
+import { isSubmittedProposalReviewStatus } from '@/lib/proposal-review'
 import { Routes } from '@/lib/routes'
 import { studyHasJobStatus } from '@/lib/studies'
-import { getStudyAction } from '@/server/actions/study.actions'
+import { getProposalFeedbackForStudyAction, getStudyAction } from '@/server/actions/study.actions'
 import { sessionFromClerk } from '@/server/clerk'
 import { redirect } from 'next/navigation'
 import { CodeReviewView } from './code-review-view'
 import { LegacyProposalReviewView } from './legacy-proposal-review-view'
+import { PostFeedbackView } from './post-feedback-view'
 import { ProposalReviewView } from './proposal-review-view'
 
 export default async function StudyReviewPage(props: {
@@ -59,6 +61,20 @@ export default async function StudyReviewPage(props: {
             }
             return <CodeReviewView orgSlug={orgSlug} study={study} />
         }
+
+        if (isSubmittedProposalReviewStatus(study.status)) {
+            const entries = await getProposalFeedbackForStudyAction({ studyId })
+            if (isActionError(entries)) {
+                return <AlertNotFound title="Feedback could not be loaded" message="please refresh and try again" />
+            }
+            return (
+                <PostSubmissionFeatureFlag
+                    defaultContent={<LegacyProposalReviewView orgSlug={orgSlug} study={study} />}
+                    optInContent={<PostFeedbackView orgSlug={orgSlug} study={study} entries={entries} />}
+                />
+            )
+        }
+
         return (
             <ProposalReviewFeatureFlag
                 defaultContent={<LegacyProposalReviewView orgSlug={orgSlug} study={study} />}

--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
@@ -75,7 +75,9 @@ describe('PostFeedbackView', () => {
             renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={entries} />)
 
             expect(screen.getByRole('heading', { name: 'Study Proposal', level: 1 })).toBeInTheDocument()
-            expect(screen.getByText('Review initial request')).toBeInTheDocument()
+            // "Review initial request" appears twice — once as the page subtitle and once as the
+            // ProposalSection's heading inside the (collapsed) dropdown. Both are expected.
+            expect(screen.getAllByText('Review initial request').length).toBeGreaterThan(0)
             expect(screen.getByText(/Effect of Reading Comprehension Tools/)).toBeInTheDocument()
         })
     })
@@ -181,7 +183,11 @@ describe('PostFeedbackView', () => {
         })
 
         it('titles researcher entries "Resubmission note"', () => {
-            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[researcherEntry]} />)
+            // Include a reviewer entry first so the view's decision header can render —
+            // PostFeedbackView returns null when the latest entry has no decision.
+            renderWithProviders(
+                <PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[reviewerEntry, researcherEntry]} />,
+            )
 
             const entry = screen.getByTestId('feedback-entry-researcher-1')
             expect(entry).toHaveTextContent('Resubmission note')
@@ -200,13 +206,13 @@ describe('PostFeedbackView', () => {
                 <PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[reviewerEntry, researcherEntry]} />,
             )
 
-            expect(screen.getAllByTestId('feedback-entry-divider')).toHaveLength(1)
+            expect(screen.getAllByTestId('entry-divider')).toHaveLength(1)
         })
 
         it('does not render a divider when there is only one entry', () => {
             renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[reviewerEntry]} />)
 
-            expect(screen.queryByTestId('feedback-entry-divider')).not.toBeInTheDocument()
+            expect(screen.queryByTestId('entry-divider')).not.toBeInTheDocument()
         })
 
         it('toggles entry expansion on caret click', async () => {

--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
@@ -75,10 +75,10 @@ describe('PostFeedbackView', () => {
             renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={entries} />)
 
             expect(screen.getByRole('heading', { name: 'Study Proposal', level: 1 })).toBeInTheDocument()
-            // "Review initial request" appears twice — once as the page subtitle and once as the
-            // ProposalSection's heading inside the (collapsed) dropdown. Both are expected.
+            // "Review initial request" and the study title both appear twice — once in the
+            // decision header, once in the ProposalSection's collapsed header. Both expected.
             expect(screen.getAllByText('Review initial request').length).toBeGreaterThan(0)
-            expect(screen.getByText(/Effect of Reading Comprehension Tools/)).toBeInTheDocument()
+            expect(screen.getAllByText(/Effect of Reading Comprehension Tools/).length).toBeGreaterThan(0)
         })
     })
 

--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
@@ -1,0 +1,234 @@
+import { lexicalJson } from '@/lib/word-count'
+import { getStudyAction, type ProposalFeedbackEntry, type SelectedStudy } from '@/server/actions/study.actions'
+import {
+    actionResult,
+    insertTestStudyJobData,
+    mockSessionWithTestData,
+    renderWithProviders,
+    screen,
+    userEvent,
+    type Mock,
+} from '@/tests/unit.helpers'
+import { useParams } from 'next/navigation'
+import { memoryRouter } from 'next-router-mock'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { PostFeedbackView } from './post-feedback-view'
+
+const ORG_SLUG = 'test-org'
+
+const buildEntry = (overrides: Partial<ProposalFeedbackEntry> = {}): ProposalFeedbackEntry =>
+    ({
+        id: overrides.id ?? 'entry-1',
+        authorId: overrides.authorId ?? 'author-1',
+        authorName: overrides.authorName ?? 'Reviewer One',
+        authorRole: overrides.authorRole ?? 'REVIEWER',
+        entryType: overrides.entryType ?? 'REVIEWER-FEEDBACK',
+        decision: overrides.decision === undefined ? 'APPROVE' : overrides.decision,
+        body: overrides.body ?? JSON.parse(lexicalJson('This is the reviewer feedback body.')),
+        createdAt: overrides.createdAt ?? new Date('2026-04-16T10:00:00Z'),
+    }) as ProposalFeedbackEntry
+
+describe('PostFeedbackView', () => {
+    let study: SelectedStudy
+
+    beforeEach(async () => {
+        const { org, user } = await mockSessionWithTestData({ orgSlug: ORG_SLUG, orgType: 'enclave' })
+        const { study: dbStudy } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'PENDING-REVIEW',
+            title: 'Effect of Reading Comprehension Tools',
+        })
+        study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+        ;(useParams as Mock).mockReturnValue({ orgSlug: ORG_SLUG, studyId: study.id })
+        memoryRouter.setCurrentUrl('/')
+    })
+
+    describe('decision header', () => {
+        it('renders "Approved on {date}" timestamp for approve decision', () => {
+            const entries = [buildEntry({ decision: 'APPROVE', createdAt: new Date('2026-04-16T10:00:00Z') })]
+            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={entries} />)
+
+            expect(screen.getByTestId('decision-timestamp')).toHaveTextContent('Approved on Apr 16, 2026')
+        })
+
+        it('renders "Clarification requested on {date}" for needs-clarification', () => {
+            const entries = [
+                buildEntry({ decision: 'NEEDS-CLARIFICATION', createdAt: new Date('2026-04-16T10:00:00Z') }),
+            ]
+            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={entries} />)
+
+            expect(screen.getByTestId('decision-timestamp')).toHaveTextContent(
+                'Clarification requested on Apr 16, 2026',
+            )
+        })
+
+        it('renders "Rejected on {date}" for reject decision', () => {
+            const entries = [buildEntry({ decision: 'REJECT', createdAt: new Date('2026-04-16T10:00:00Z') })]
+            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={entries} />)
+
+            expect(screen.getByTestId('decision-timestamp')).toHaveTextContent('Rejected on Apr 16, 2026')
+        })
+
+        it('renders the page title and study title', () => {
+            const entries = [buildEntry()]
+            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={entries} />)
+
+            expect(screen.getByRole('heading', { name: 'Study Proposal', level: 1 })).toBeInTheDocument()
+            expect(screen.getByText('Review initial request')).toBeInTheDocument()
+            expect(screen.getByText(/Effect of Reading Comprehension Tools/)).toBeInTheDocument()
+        })
+    })
+
+    describe('decision banner', () => {
+        it('renders the approved banner with the expected copy', () => {
+            const entries = [buildEntry({ decision: 'APPROVE' })]
+            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={entries} />)
+
+            const banner = screen.getByTestId('decision-banner-approved')
+            expect(banner).toHaveTextContent(
+                "This initial request has been approved. You'll receive email notifications when the researcher proceeds to the next step.",
+            )
+        })
+
+        it('renders the clarification banner with the expected copy', () => {
+            const entries = [buildEntry({ decision: 'NEEDS-CLARIFICATION' })]
+            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={entries} />)
+
+            const banner = screen.getByTestId('decision-banner-clarification')
+            expect(banner).toHaveTextContent(
+                'You have requested clarification. The researcher has been notified, and we will inform you once they resubmit.',
+            )
+        })
+
+        it('renders the rejected banner with the expected copy', () => {
+            const entries = [buildEntry({ decision: 'REJECT' })]
+            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={entries} />)
+
+            const banner = screen.getByTestId('decision-banner-rejected')
+            expect(banner).toHaveTextContent(
+                'This initial request has been rejected. No further action is required at this time.',
+            )
+        })
+
+        it('renders only one banner at a time', () => {
+            const entries = [buildEntry({ decision: 'APPROVE' })]
+            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={entries} />)
+
+            expect(screen.getByTestId('decision-banner-approved')).toBeInTheDocument()
+            expect(screen.queryByTestId('decision-banner-clarification')).not.toBeInTheDocument()
+            expect(screen.queryByTestId('decision-banner-rejected')).not.toBeInTheDocument()
+        })
+    })
+
+    describe('full initial request dropdown', () => {
+        it('renders the proposal section collapsed by default', () => {
+            const entries = [buildEntry()]
+            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={entries} />)
+
+            // ProposalSection's collapsed-state toggle says "Show full initial request"
+            expect(screen.getByTestId('proposal-toggle-header')).toHaveTextContent('Show full initial request')
+        })
+    })
+
+    describe('feedback and notes', () => {
+        const reviewerEntry = buildEntry({
+            id: 'reviewer-1',
+            authorRole: 'REVIEWER',
+            entryType: 'REVIEWER-FEEDBACK',
+            authorName: 'Dr. Reviewer',
+            decision: 'NEEDS-CLARIFICATION',
+            createdAt: new Date('2026-04-20T12:00:00Z'),
+            body: JSON.parse(lexicalJson('Latest reviewer note.')),
+        })
+
+        const researcherEntry = buildEntry({
+            id: 'researcher-1',
+            authorRole: 'RESEARCHER',
+            entryType: 'RESUBMISSION-NOTE',
+            authorName: 'Dr. Researcher',
+            decision: null,
+            createdAt: new Date('2026-04-18T08:00:00Z'),
+            body: JSON.parse(lexicalJson('Original resubmission note.')),
+        })
+
+        it('orders entries from most recent to oldest', () => {
+            renderWithProviders(
+                <PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[reviewerEntry, researcherEntry]} />,
+            )
+
+            const entries = screen.getByTestId('feedback-entries')
+            const titles = entries.querySelectorAll('[data-testid^="feedback-entry-"]')
+            // Latest first
+            expect(titles[0]).toHaveAttribute('data-testid', 'feedback-entry-reviewer-1')
+            expect(titles[1]).toHaveAttribute('data-testid', 'feedback-entry-researcher-1')
+        })
+
+        it('expands the latest entry by default and collapses older entries', () => {
+            renderWithProviders(
+                <PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[reviewerEntry, researcherEntry]} />,
+            )
+
+            expect(screen.getByTestId('feedback-toggle-reviewer-1')).toHaveAttribute('aria-expanded', 'true')
+            expect(screen.getByTestId('feedback-toggle-researcher-1')).toHaveAttribute('aria-expanded', 'false')
+        })
+
+        it('titles reviewer entries "Reviewer feedback"', () => {
+            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[reviewerEntry]} />)
+
+            const entry = screen.getByTestId('feedback-entry-reviewer-1')
+            expect(entry).toHaveTextContent('Reviewer feedback')
+        })
+
+        it('titles researcher entries "Resubmission note"', () => {
+            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[researcherEntry]} />)
+
+            const entry = screen.getByTestId('feedback-entry-researcher-1')
+            expect(entry).toHaveTextContent('Resubmission note')
+        })
+
+        it('renders author name and date for each entry', () => {
+            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[reviewerEntry]} />)
+
+            const entry = screen.getByTestId('feedback-entry-reviewer-1')
+            expect(entry).toHaveTextContent('Dr. Reviewer')
+            expect(entry).toHaveTextContent('Apr 20, 2026')
+        })
+
+        it('renders a divider between entries when there are multiple', () => {
+            renderWithProviders(
+                <PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[reviewerEntry, researcherEntry]} />,
+            )
+
+            expect(screen.getAllByTestId('feedback-entry-divider')).toHaveLength(1)
+        })
+
+        it('does not render a divider when there is only one entry', () => {
+            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[reviewerEntry]} />)
+
+            expect(screen.queryByTestId('feedback-entry-divider')).not.toBeInTheDocument()
+        })
+
+        it('toggles entry expansion on caret click', async () => {
+            const user = userEvent.setup()
+            renderWithProviders(
+                <PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[reviewerEntry, researcherEntry]} />,
+            )
+
+            const olderToggle = screen.getByTestId('feedback-toggle-researcher-1')
+            expect(olderToggle).toHaveAttribute('aria-expanded', 'false')
+            await user.click(olderToggle)
+            expect(olderToggle).toHaveAttribute('aria-expanded', 'true')
+        })
+    })
+
+    describe('navigation', () => {
+        it('navigates to the personal dashboard when "Go to dashboard" is clicked', async () => {
+            const user = userEvent.setup()
+            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[buildEntry()]} />)
+
+            await user.click(screen.getByRole('button', { name: 'Go to dashboard' }))
+            expect(memoryRouter.asPath).toBe('/dashboard')
+        })
+    })
+})

--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
@@ -70,7 +70,7 @@ function entryBodyText(entry: ProposalFeedbackEntry): string {
 function DecisionBanner({ decision }: { decision: ReviewDecision }) {
     const { banner } = DECISION_COPY[decision]
     return (
-        <Box bg={banner.bg} p="md" style={{ borderRadius: 'var(--mantine-radius-sm)' }} data-testid={banner.testId}>
+        <Box bg={banner.bg} p="md" bdrs="sm" data-testid={banner.testId}>
             <Text c={banner.color} size="sm">
                 {banner.copy}
             </Text>

--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
@@ -1,0 +1,241 @@
+'use client'
+
+import { PageBreadcrumbs } from '@/components/page-breadcrumbs'
+import type { ReviewDecision } from '@/database/types'
+import { Routes } from '@/lib/routes'
+import { extractTextFromLexical } from '@/lib/word-count'
+import { Anchor, Box, Button, Collapse, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
+import { CaretDownIcon, CaretUpIcon } from '@phosphor-icons/react'
+import dayjs from 'dayjs'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import type { ProposalFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
+import { ProposalSection } from './proposal-section'
+
+type PostFeedbackViewProps = {
+    orgSlug: string
+    study: SelectedStudy
+    entries: ProposalFeedbackEntry[]
+}
+
+type DecisionCopy = {
+    timestampLabel: string
+    banner: { bg: string; color: string; testId: string; copy: string }
+}
+
+const DECISION_COPY: Record<ReviewDecision, DecisionCopy> = {
+    APPROVE: {
+        timestampLabel: 'Approved',
+        banner: {
+            bg: 'green.1',
+            color: 'green.8',
+            testId: 'decision-banner-approved',
+            copy: "This initial request has been approved. You'll receive email notifications when the researcher proceeds to the next step.",
+        },
+    },
+    'NEEDS-CLARIFICATION': {
+        timestampLabel: 'Clarification requested',
+        banner: {
+            bg: 'yellow.1',
+            color: 'yellow.9',
+            testId: 'decision-banner-clarification',
+            copy: 'You have requested clarification. The researcher has been notified, and we will inform you once they resubmit.',
+        },
+    },
+    REJECT: {
+        timestampLabel: 'Rejected',
+        banner: {
+            bg: 'red.1',
+            color: 'red.8',
+            testId: 'decision-banner-rejected',
+            copy: 'This initial request has been rejected. No further action is required at this time.',
+        },
+    },
+}
+
+function formatDate(date: Date | string): string {
+    return dayjs(date).format('MMM DD, YYYY')
+}
+
+function entryTitle(entry: ProposalFeedbackEntry): string {
+    return entry.entryType === 'REVIEWER-FEEDBACK' ? 'Reviewer feedback' : 'Resubmission note'
+}
+
+// TODO(OTTER-491): swap plain-text rendering for a Lexical viewer once the editor
+// component lands; share node config with the textarea.
+function entryBodyText(entry: ProposalFeedbackEntry): string {
+    return extractTextFromLexical(JSON.stringify(entry.body))
+}
+
+function DecisionBanner({ decision }: { decision: ReviewDecision }) {
+    const { banner } = DECISION_COPY[decision]
+    return (
+        <Box bg={banner.bg} p="md" style={{ borderRadius: 'var(--mantine-radius-sm)' }} data-testid={banner.testId}>
+            <Text c={banner.color} size="sm">
+                {banner.copy}
+            </Text>
+        </Box>
+    )
+}
+
+function FullProposalDropdown({ orgSlug, study }: { orgSlug: string; study: SelectedStudy }) {
+    return <ProposalSection orgSlug={orgSlug} study={study} initialExpanded={false} />
+}
+
+function ToggleCaret({ isExpanded }: { isExpanded: boolean }) {
+    const Icon = isExpanded ? CaretUpIcon : CaretDownIcon
+    return <Icon size={14} />
+}
+
+type FeedbackEntryProps = {
+    entry: ProposalFeedbackEntry
+    isExpanded: boolean
+    onToggle: () => void
+}
+
+function FeedbackEntry({ entry, isExpanded, onToggle }: FeedbackEntryProps) {
+    const title = entryTitle(entry)
+    const body = entryBodyText(entry)
+    const date = formatDate(entry.createdAt)
+
+    return (
+        <Stack gap="sm" data-testid={`feedback-entry-${entry.id}`}>
+            <Group justify="space-between" align="center">
+                <Stack gap={2}>
+                    <Text fw={600}>{title}</Text>
+                    <Text size="sm" c="gray.7">
+                        {entry.authorName} · {date}
+                    </Text>
+                </Stack>
+                <Anchor
+                    component="button"
+                    onClick={onToggle}
+                    c="blue"
+                    size="sm"
+                    data-testid={`feedback-toggle-${entry.id}`}
+                    aria-expanded={isExpanded}
+                >
+                    <ToggleCaret isExpanded={isExpanded} />
+                </Anchor>
+            </Group>
+            <Collapse in={isExpanded}>
+                <Text size="sm" data-testid={`feedback-body-${entry.id}`} style={{ whiteSpace: 'pre-wrap' }}>
+                    {body}
+                </Text>
+            </Collapse>
+        </Stack>
+    )
+}
+
+function useExpandedEntries(entries: ProposalFeedbackEntry[]) {
+    const [expandedIds, setExpandedIds] = useState<Set<string>>(() => {
+        const latest = entries[0]?.id
+        return latest ? new Set([latest]) : new Set()
+    })
+
+    const toggle = (id: string) => {
+        setExpandedIds((prev) => {
+            const next = new Set(prev)
+            if (next.has(id)) {
+                next.delete(id)
+            } else {
+                next.add(id)
+            }
+            return next
+        })
+    }
+
+    const isExpanded = (id: string) => expandedIds.has(id)
+
+    return { isExpanded, toggle }
+}
+
+function FeedbackAndNotesSection({ entries }: { entries: ProposalFeedbackEntry[] }) {
+    const { isExpanded, toggle } = useExpandedEntries(entries)
+
+    return (
+        <Paper p="xl" data-testid="feedback-and-notes-section">
+            <Stack gap="md">
+                <Text fw={600} fz={20}>
+                    Feedback and notes
+                </Text>
+                <Divider />
+                <Stack gap="md" data-testid="feedback-entries">
+                    {entries.map((entry, idx) => (
+                        <Stack key={entry.id} gap="md">
+                            <FeedbackEntry
+                                entry={entry}
+                                isExpanded={isExpanded(entry.id)}
+                                onToggle={() => toggle(entry.id)}
+                            />
+                            {idx < entries.length - 1 && <Divider data-testid="feedback-entry-divider" />}
+                        </Stack>
+                    ))}
+                </Stack>
+            </Stack>
+        </Paper>
+    )
+}
+
+function GoToDashboardButton() {
+    const router = useRouter()
+    const handleClick = () => router.push(Routes.dashboard)
+    return (
+        <Button onClick={handleClick} data-testid="go-to-dashboard">
+            Go to dashboard
+        </Button>
+    )
+}
+
+type DecisionHeaderProps = {
+    study: SelectedStudy
+    decision: ReviewDecision
+    decidedAt: Date | string
+}
+
+function DecisionHeader({ study, decision, decidedAt }: DecisionHeaderProps) {
+    const copy = DECISION_COPY[decision]
+    const date = formatDate(decidedAt)
+
+    return (
+        <Stack gap="md" data-testid="decision-header">
+            <Stack gap={4}>
+                <Title order={1} fz={40} fw={700}>
+                    Study Proposal
+                </Title>
+                <Text fz={20} fw={600}>
+                    Review initial request
+                </Text>
+                <Text size="sm">Title: {study.title}</Text>
+                <Text size="sm" c="gray.7" data-testid="decision-timestamp">
+                    {copy.timestampLabel} on {date}
+                </Text>
+            </Stack>
+            <Divider />
+        </Stack>
+    )
+}
+
+export function PostFeedbackView({ orgSlug, study, entries }: PostFeedbackViewProps) {
+    const latest = entries[0]
+    if (!latest || latest.decision === null) {
+        return null
+    }
+
+    const decision = latest.decision
+
+    return (
+        <Box bg="grey.10">
+            <Stack px="xl" gap="xl" py="xl">
+                <PageBreadcrumbs crumbs={[['Dashboard', Routes.orgDashboard({ orgSlug })], ['Study proposal']]} />
+                <DecisionHeader study={study} decision={decision} decidedAt={latest.createdAt} />
+                <DecisionBanner decision={decision} />
+                <FullProposalDropdown orgSlug={orgSlug} study={study} />
+                <FeedbackAndNotesSection entries={entries} />
+                <Group justify="flex-end">
+                    <GoToDashboardButton />
+                </Group>
+            </Stack>
+        </Box>
+    )
+}

--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
@@ -168,7 +168,7 @@ function FeedbackAndNotesSection({ entries }: { entries: ProposalFeedbackEntry[]
                                 isExpanded={isExpanded(entry.id)}
                                 onToggle={() => toggle(entry.id)}
                             />
-                            {idx < entries.length - 1 && <Divider data-testid="feedback-entry-divider" />}
+                            {idx < entries.length - 1 && <Divider data-testid="entry-divider" />}
                         </Stack>
                     ))}
                 </Stack>

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-section.tsx
@@ -12,6 +12,7 @@ import type { StudyForReview } from './review-types'
 type ProposalSectionProps = {
     study: StudyForReview
     orgSlug: string
+    initialExpanded?: boolean
 }
 
 const EVALUATION_CRITERIA = [
@@ -30,8 +31,8 @@ const EVALUATION_CRITERIA = [
     },
 ]
 
-function useProposalSection() {
-    const [isExpanded, { toggle }] = useDisclosure(true)
+function useProposalSection(initialExpanded: boolean) {
+    const [isExpanded, { toggle }] = useDisclosure(initialExpanded)
     const { getPopoverProps } = usePopover()
     return { isExpanded, toggle, getPopoverProps }
 }
@@ -82,8 +83,8 @@ function StatusBanner({ labName }: { labName: string }) {
     )
 }
 
-export function ProposalSection({ study, orgSlug }: ProposalSectionProps) {
-    const { isExpanded, toggle, getPopoverProps } = useProposalSection()
+export function ProposalSection({ study, orgSlug, initialExpanded = true }: ProposalSectionProps) {
+    const { isExpanded, toggle, getPopoverProps } = useProposalSection(initialExpanded)
     const submittedDate = formatSubmittedDate(study.submittedAt)
     const labName = study.submittingLabName ?? study.submittedByOrgSlug
 

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -4,22 +4,21 @@ import { type DBExecutor, jsonArrayFrom } from '@/database'
 import { sql } from 'kysely'
 import { ActionFailure, throwNotFound } from '@/lib/errors'
 import { ActionSuccessType, jobFileSchema } from '@/lib/types'
-import type { StudyStatus } from '@/database/types'
-import { countWordsFromLexical, lexicalJson } from '@/lib/word-count'
-import { FEEDBACK_MAX_WORDS, FEEDBACK_MIN_WORDS, toReviewDecision, type Decision } from '@/lib/proposal-review'
-import { getStudyJobFileOfType, latestJobForStudy, type LatestJobForStudy } from '@/server/db/queries'
 import {
-    onStudyApproved,
-    onStudyCodeApproved,
-    onStudyCodeRejected,
-    onStudyNeedsClarification,
-    onStudyRejected,
-} from '@/server/events'
+    getProposalFeedbackForStudy,
+    getStudyJobFileOfType,
+    latestJobForStudy,
+    type LatestJobForStudy,
+} from '@/server/db/queries'
+import { onStudyApproved, onStudyCodeApproved, onStudyCodeRejected, onStudyRejected } from '@/server/events'
 import { storeApprovedJobFile } from '@/server/storage'
 import { triggerBuildImageForJob } from '../aws'
 import { SIMULATE_CODE_BUILD } from '../config'
 import { bareExtension } from '@/lib/paths'
 import { Action, z } from './action'
+import { StudyStatus } from '@/database/types'
+import { Decision, toReviewDecision, FEEDBACK_MIN_WORDS, FEEDBACK_MAX_WORDS } from '@/lib/proposal-review'
+import { lexicalJson, countWordsFromLexical } from '@/lib/word-count'
 
 // NOT exported, for internal use by actions in this file
 function fetchStudyQuery(db: DBExecutor) {
@@ -559,8 +558,44 @@ export const submitProposalReviewAction = new Action('submitProposalReviewAction
             .where('id', '=', studyId)
             .execute()
 
-        onStudyNeedsClarification({ studyId, userId })
+        const latestJob = await db
+            .selectFrom('studyJob')
+            .select('id')
+            .where('studyId', '=', studyId)
+            .orderBy('createdAt', 'desc')
+            .executeTakeFirst()
+
+        if (latestJob) {
+            await db
+                .insertInto('jobStatusChange')
+                .values({
+                    userId,
+                    status: 'CODE-REJECTED',
+                    studyJobId: latestJob.id,
+                })
+                .executeTakeFirstOrThrow()
+            onStudyCodeRejected({ studyId, userId })
+        } else {
+            onStudyRejected({ studyId, userId })
+        }
     })
+
+export const getProposalFeedbackForStudyAction = new Action('getProposalFeedbackForStudyAction')
+    .params(z.object({ studyId: z.string() }))
+    .middleware(async ({ params: { studyId }, db }) => {
+        const study = await db
+            .selectFrom('study')
+            .select(['orgId', 'submittedByOrgId'])
+            .where('id', '=', studyId)
+            .executeTakeFirstOrThrow(throwNotFound('study'))
+        return { study, orgId: study.orgId, submittedByOrgId: study.submittedByOrgId }
+    })
+    .requireAbilityTo('view', 'Study')
+    .handler(async ({ params: { studyId } }) => {
+        return await getProposalFeedbackForStudy(studyId)
+    })
+
+export type ProposalFeedbackEntry = ActionSuccessType<typeof getProposalFeedbackForStudyAction>[number]
 
 export const doesTestImageExistForStudyAction = new Action('doesTestImageExistForStudyAction')
     .params(z.object({ studyId: z.string() }))

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -10,7 +10,13 @@ import {
     latestJobForStudy,
     type LatestJobForStudy,
 } from '@/server/db/queries'
-import { onStudyApproved, onStudyCodeApproved, onStudyCodeRejected, onStudyRejected } from '@/server/events'
+import {
+    onStudyApproved,
+    onStudyCodeApproved,
+    onStudyCodeRejected,
+    onStudyNeedsClarification,
+    onStudyRejected,
+} from '@/server/events'
 import { storeApprovedJobFile } from '@/server/storage'
 import { triggerBuildImageForJob } from '../aws'
 import { SIMULATE_CODE_BUILD } from '../config'
@@ -558,26 +564,7 @@ export const submitProposalReviewAction = new Action('submitProposalReviewAction
             .where('id', '=', studyId)
             .execute()
 
-        const latestJob = await db
-            .selectFrom('studyJob')
-            .select('id')
-            .where('studyId', '=', studyId)
-            .orderBy('createdAt', 'desc')
-            .executeTakeFirst()
-
-        if (latestJob) {
-            await db
-                .insertInto('jobStatusChange')
-                .values({
-                    userId,
-                    status: 'CODE-REJECTED',
-                    studyJobId: latestJob.id,
-                })
-                .executeTakeFirstOrThrow()
-            onStudyCodeRejected({ studyId, userId })
-        } else {
-            onStudyRejected({ studyId, userId })
-        }
+        onStudyNeedsClarification({ studyId, userId })
     })
 
 export const getProposalFeedbackForStudyAction = new Action('getProposalFeedbackForStudyAction')

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -4,6 +4,9 @@ import { type DBExecutor, jsonArrayFrom } from '@/database'
 import { sql } from 'kysely'
 import { ActionFailure, throwNotFound } from '@/lib/errors'
 import { ActionSuccessType, jobFileSchema } from '@/lib/types'
+import type { StudyStatus } from '@/database/types'
+import { countWordsFromLexical, lexicalJson } from '@/lib/word-count'
+import { FEEDBACK_MAX_WORDS, FEEDBACK_MIN_WORDS, toReviewDecision, type Decision } from '@/lib/proposal-review'
 import {
     getProposalFeedbackForStudy,
     getStudyJobFileOfType,
@@ -22,9 +25,6 @@ import { triggerBuildImageForJob } from '../aws'
 import { SIMULATE_CODE_BUILD } from '../config'
 import { bareExtension } from '@/lib/paths'
 import { Action, z } from './action'
-import { StudyStatus } from '@/database/types'
-import { Decision, toReviewDecision, FEEDBACK_MIN_WORDS, FEEDBACK_MAX_WORDS } from '@/lib/proposal-review'
-import { lexicalJson, countWordsFromLexical } from '@/lib/word-count'
 
 // NOT exported, for internal use by actions in this file
 function fetchStudyQuery(db: DBExecutor) {
@@ -569,18 +569,12 @@ export const submitProposalReviewAction = new Action('submitProposalReviewAction
 
 export const getProposalFeedbackForStudyAction = new Action('getProposalFeedbackForStudyAction')
     .params(z.object({ studyId: z.string() }))
-    .middleware(async ({ params: { studyId }, db }) => {
-        const study = await db
-            .selectFrom('study')
-            .select(['orgId', 'submittedByOrgId'])
-            .where('id', '=', studyId)
-            .executeTakeFirstOrThrow(throwNotFound('study'))
-        return { study, orgId: study.orgId, submittedByOrgId: study.submittedByOrgId }
+    .middleware(async ({ params: { studyId } }) => {
+        const { study, entries } = await getProposalFeedbackForStudy(studyId)
+        return { study, orgId: study.orgId, submittedByOrgId: study.submittedByOrgId, entries }
     })
     .requireAbilityTo('view', 'Study')
-    .handler(async ({ params: { studyId } }) => {
-        return await getProposalFeedbackForStudy(studyId)
-    })
+    .handler(async ({ entries }) => entries)
 
 export type ProposalFeedbackEntry = ActionSuccessType<typeof getProposalFeedbackForStudyAction>[number]
 

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -134,6 +134,25 @@ export const jobInfoForJobId = async (jobId: string) => {
         .executeTakeFirstOrThrow()
 }
 
+export const getProposalFeedbackForStudy = async (studyId: string) => {
+    return await Action.db
+        .selectFrom('studyProposalComment')
+        .innerJoin('user as author', 'author.id', 'studyProposalComment.authorId')
+        .select([
+            'studyProposalComment.id',
+            'studyProposalComment.authorId',
+            'studyProposalComment.authorRole',
+            'studyProposalComment.entryType',
+            'studyProposalComment.decision',
+            'studyProposalComment.body',
+            'studyProposalComment.createdAt',
+            'author.fullName as authorName',
+        ])
+        .where('studyProposalComment.studyId', '=', studyId)
+        .orderBy('studyProposalComment.createdAt', 'desc')
+        .execute()
+}
+
 export const studyInfoForStudyId = async (studyId: string) => {
     return await Action.db
         .selectFrom('study')

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -135,22 +135,31 @@ export const jobInfoForJobId = async (jobId: string) => {
 }
 
 export const getProposalFeedbackForStudy = async (studyId: string) => {
-    return await Action.db
-        .selectFrom('studyProposalComment')
-        .innerJoin('user as author', 'author.id', 'studyProposalComment.authorId')
-        .select([
-            'studyProposalComment.id',
-            'studyProposalComment.authorId',
-            'studyProposalComment.authorRole',
-            'studyProposalComment.entryType',
-            'studyProposalComment.decision',
-            'studyProposalComment.body',
-            'studyProposalComment.createdAt',
-            'author.fullName as authorName',
-        ])
-        .where('studyProposalComment.studyId', '=', studyId)
-        .orderBy('studyProposalComment.createdAt', 'desc')
-        .execute()
+    const [study, entries] = await Promise.all([
+        Action.db
+            .selectFrom('study')
+            .select(['orgId', 'submittedByOrgId'])
+            .where('id', '=', studyId)
+            .executeTakeFirstOrThrow(throwNotFound('study')),
+        Action.db
+            .selectFrom('studyProposalComment')
+            .innerJoin('user as author', 'author.id', 'studyProposalComment.authorId')
+            .select([
+                'studyProposalComment.id',
+                'studyProposalComment.authorId',
+                'studyProposalComment.authorRole',
+                'studyProposalComment.entryType',
+                'studyProposalComment.decision',
+                'studyProposalComment.body',
+                'studyProposalComment.createdAt',
+                'author.fullName as authorName',
+            ])
+            .where('studyProposalComment.studyId', '=', studyId)
+            .orderBy('studyProposalComment.createdAt', 'desc')
+            .execute(),
+    ])
+
+    return { study, entries }
 }
 
 export const studyInfoForStudyId = async (studyId: string) => {


### PR DESCRIPTION
## Summary

OTTER-501: DO post-decision view shown after a reviewer submits feedback. Triggers when an enclave reviewer opens a study with `status ∈ {APPROVED, REJECTED, PROPOSAL-CHANGE-REQUESTED}` and no code submitted. Behind `PostSubmissionFeatureFlag` — legacy view stays as default.

## Depends on

- **OTTER-493** (#649) — adds the status, table, and types this PR reads. Will not typecheck against `main` until 493 merges; rebase after.

## Changes

- `post-feedback-view.tsx` — new view: decision header, banner (green/yellow/red), collapsed proposal dropdown, scalable feedback list (latest expanded), `Routes.dashboard` CTA
- `proposal-section.tsx` — adds `initialExpanded?: boolean` prop
- `review/page.tsx` — new branch behind `PostSubmissionFeatureFlag`
- `queries.ts` + `study.actions.ts` — read path joining `studyProposalFeedback` to `user`, gated on existing `'view' Study` ability (no permissions changes)

## Follow-ups (TODOs in code)

- OTTER-491: swap plain-text rendering for a Lexical viewer
- Researcher resubmission notes render automatically once that write path lands
