### PR TITLE
Remove checksum call

### DIFF
--- a/src/server/aws.ts
+++ b/src/server/aws.ts
@@ -35,7 +35,6 @@ import { strToAscii } from '@/lib/string'
 import { parseCsv } from '@/lib/file-content-helpers'
 import logger from '@/lib/logger'
 import { Readable } from 'stream'
-import { createHash } from 'crypto'
 import { MinimalJobInfo, MinimalOrgInfo, MinimalStudyInfo } from '@/lib/types'
 import { createPresignedPost } from '@aws-sdk/s3-presigned-post'
 
@@ -350,7 +349,7 @@ export const storeS3File = async (
     body: ReadableStream,
     Key: string,
 ) => {
-    const [csStream, upStream] = body.tee()
+    const [_, upStream] = body.tee()
     const uploader = new Upload({
         client: getS3Client(),
         tags: objectToAWSTags(info),

--- a/src/server/aws.ts
+++ b/src/server/aws.ts
@@ -345,32 +345,17 @@ export const getAWSInfo = async () => {
     }
 }
 
-const calculateChecksum = async (body: ReadableStream) => {
-    const hash = createHash('sha256')
-    const reader = body.getReader()
-    let done, value
-    while (!done) {
-        ;({ done, value } = await reader.read())
-        if (value) {
-            hash.update(value)
-        }
-    }
-    return hash.digest('base64')
-}
-
 export const storeS3File = async (
     info: MinimalStudyInfo | MinimalJobInfo | MinimalOrgInfo,
     body: ReadableStream,
     Key: string,
 ) => {
     const [csStream, upStream] = body.tee()
-    const hash = await calculateChecksum(csStream)
     const uploader = new Upload({
         client: getS3Client(),
         tags: objectToAWSTags(info),
         params: {
             Bucket: s3BucketName(),
-            ChecksumSHA256: hash,
             Key,
             Body: upStream,
         },


### PR DESCRIPTION
Upload from @aws-sdk/lib-storage does multipart above ~5MB. ChecksumSHA256 in params is single-object semantic — S3 expects it to match one PutObject body. Multipart computes per-part checksums and a composite ETag instead. Passing whole-body SHA256 to multipart = mismatch = upload fails.