### PR TITLE
OTTER-491: Add Clerk auth to editor service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,9 @@ services:
                 condition: service_healthy
         environment:
             - DATABASE_URL=postgres://mgmnt:mgmntpass@postgres:5432/mgmnt_dev
+            - CLERK_JWT_KEY=$CLERK_JWT_KEY
+            - CLERK_SECRET_KEY=$CLERK_SECRET_KEY
+            - CLERK_AUTHORIZED_PARTIES=$CLERK_AUTHORIZED_PARTIES
         networks:
             - mgmnt-app
         ports:

--- a/services/editor/package-lock.json
+++ b/services/editor/package-lock.json
@@ -5,9 +5,730 @@
     "packages": {
         "": {
             "dependencies": {
+                "@aws-sdk/client-secrets-manager": "^3.893.0",
+                "@clerk/backend": "^2.33.2",
                 "@hocuspocus/extension-database": "^3.4.4",
                 "@hocuspocus/server": "^3.4.4",
                 "pg": "^8.20.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager": {
+            "version": "3.1038.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1038.0.tgz",
+            "integrity": "sha512-cTNiqnVErYo8fCb7dw/BnHiubfWJIE1Ur97DT5faTncI8OEibs1A7E1GyD9Y5L77xn8edB5XJ4WBwBlTdyzk+Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "^3.974.6",
+                "@aws-sdk/credential-provider-node": "^3.972.37",
+                "@aws-sdk/middleware-host-header": "^3.972.10",
+                "@aws-sdk/middleware-logger": "^3.972.10",
+                "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+                "@aws-sdk/middleware-user-agent": "^3.972.36",
+                "@aws-sdk/region-config-resolver": "^3.972.13",
+                "@aws-sdk/types": "^3.973.8",
+                "@aws-sdk/util-endpoints": "^3.996.8",
+                "@aws-sdk/util-user-agent-browser": "^3.972.10",
+                "@aws-sdk/util-user-agent-node": "^3.973.22",
+                "@smithy/config-resolver": "^4.4.17",
+                "@smithy/core": "^3.23.17",
+                "@smithy/fetch-http-handler": "^5.3.17",
+                "@smithy/hash-node": "^4.2.14",
+                "@smithy/invalid-dependency": "^4.2.14",
+                "@smithy/middleware-content-length": "^4.2.14",
+                "@smithy/middleware-endpoint": "^4.4.32",
+                "@smithy/middleware-retry": "^4.5.6",
+                "@smithy/middleware-serde": "^4.2.20",
+                "@smithy/middleware-stack": "^4.2.14",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/node-http-handler": "^4.6.1",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-body-length-browser": "^4.2.2",
+                "@smithy/util-body-length-node": "^4.2.3",
+                "@smithy/util-defaults-mode-browser": "^4.3.49",
+                "@smithy/util-defaults-mode-node": "^4.2.54",
+                "@smithy/util-endpoints": "^3.4.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-retry": "^4.3.5",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/core": {
+            "version": "3.974.6",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.6.tgz",
+            "integrity": "sha512-8Vu7zGxu+39ChR/s5J7nXBw3a2kMHAi0OfKT8ohgTVjX0qYed/8mIfdBb638oBmKrWCwwKjYAM5J/4gMJ8nAJA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.8",
+                "@aws-sdk/xml-builder": "^3.972.20",
+                "@smithy/core": "^3.23.17",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/signature-v4": "^5.3.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-retry": "^4.3.5",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.972.32",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.32.tgz",
+            "integrity": "sha512-7vA4GHg8NSmQxquJHSBcSM3RgB4ZaaRi6u4+zGFKOmOH6aqlgr2Sda46clkZDYzlirgfY96w15Zj0jh6PT48ng==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.6",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.972.34",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.34.tgz",
+            "integrity": "sha512-vBrhWujFCLp1u8ptJRWYlipMutzPptb8pDQ00rKVH9q67T7rGd3VTWIj63aKrlLuY6qSsw1Rt5F/D/7wnNgryA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.6",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/fetch-http-handler": "^5.3.17",
+                "@smithy/node-http-handler": "^4.6.1",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-stream": "^4.5.25",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.972.36",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.36.tgz",
+            "integrity": "sha512-FBHyCmV8EB0gUvh1d+CZm87zt2PrdC7OyWexLRoH3I5zWSOUGa+9t58Y5jbxRfwUp3AWpHAFvKY6YzgR845sVA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.6",
+                "@aws-sdk/credential-provider-env": "^3.972.32",
+                "@aws-sdk/credential-provider-http": "^3.972.34",
+                "@aws-sdk/credential-provider-login": "^3.972.36",
+                "@aws-sdk/credential-provider-process": "^3.972.32",
+                "@aws-sdk/credential-provider-sso": "^3.972.36",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.36",
+                "@aws-sdk/nested-clients": "^3.997.4",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/credential-provider-imds": "^4.2.14",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-login": {
+            "version": "3.972.36",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.36.tgz",
+            "integrity": "sha512-IFap01lJKxQc0C/OHmZwZQr/cKq0DhrcmKedRrdnnl42D+P0SImnnnWQjv07uIPqpEdtqmkPXb9TiPYTU+prxQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.6",
+                "@aws-sdk/nested-clients": "^3.997.4",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.972.37",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.37.tgz",
+            "integrity": "sha512-/WFixFAAiw8WpmjZcI0l4t3DerXLmVinOIfuotmRZnu2qmsFPoqqmstASz0z8bi1pGdFXzeLzf6bwucM3mZcUQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "^3.972.32",
+                "@aws-sdk/credential-provider-http": "^3.972.34",
+                "@aws-sdk/credential-provider-ini": "^3.972.36",
+                "@aws-sdk/credential-provider-process": "^3.972.32",
+                "@aws-sdk/credential-provider-sso": "^3.972.36",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.36",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/credential-provider-imds": "^4.2.14",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.972.32",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.32.tgz",
+            "integrity": "sha512-uZp4tlGbpczV8QxmtIwOpSkcyGtBRR8/T4BAumRKfAt1nwCig3FSCZvrKl6ARDIDVRYn5p2oRcAsfFR01EgMGA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.6",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.972.36",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.36.tgz",
+            "integrity": "sha512-DsLr0UHMyKzRJKe2bjlwU8q1cfoXg8TIJKV/xwvnalAemiZLOZunFzj/whGnFDZIBVLdnbLiwv5SvRf1+CSwkg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.6",
+                "@aws-sdk/nested-clients": "^3.997.4",
+                "@aws-sdk/token-providers": "3.1038.0",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.972.36",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.36.tgz",
+            "integrity": "sha512-uzrURO7frJhHQVVNR5zBJcCYeMYflmXcWBK1+MiBym2Dfjh6nXATrMixrmGZi+97Q7ETZ+y/4lUwAy0Nfnznjw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.6",
+                "@aws-sdk/nested-clients": "^3.997.4",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.972.10",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+            "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.972.10",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+            "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.972.11",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+            "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.8",
+                "@aws/lambda-invoke-store": "^0.2.2",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-s3": {
+            "version": "3.972.35",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.35.tgz",
+            "integrity": "sha512-lLppaNTAz+wNgLdi4FtHzrlwrGF0ODTnBWHBaFg85SKs0eJ+M+tP5ifrA8f/0lNd+Ak3MC1NGC6RavV3ny4HTg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.6",
+                "@aws-sdk/types": "^3.973.8",
+                "@aws-sdk/util-arn-parser": "^3.972.3",
+                "@smithy/core": "^3.23.17",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/signature-v4": "^5.3.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-config-provider": "^4.2.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-stream": "^4.5.25",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.972.36",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.36.tgz",
+            "integrity": "sha512-O2beToxguBvrZFFZ+fFgPbbae8MvyIBjQ6lImee4APHEXXNAD5ZJ2ayLF1mb7rsKw86TM81y5czg82bZncjSjg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.6",
+                "@aws-sdk/types": "^3.973.8",
+                "@aws-sdk/util-endpoints": "^3.996.8",
+                "@smithy/core": "^3.23.17",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-retry": "^4.3.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients": {
+            "version": "3.997.4",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.4.tgz",
+            "integrity": "sha512-4Sf+WY1lMJzXlw5MiyCMe/UzdILCwvuaHThbqMXS6dfh9gZy3No360I42RXquOI/ULUOhWy2HCyU0Fp20fQGPQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "^3.974.6",
+                "@aws-sdk/middleware-host-header": "^3.972.10",
+                "@aws-sdk/middleware-logger": "^3.972.10",
+                "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+                "@aws-sdk/middleware-user-agent": "^3.972.36",
+                "@aws-sdk/region-config-resolver": "^3.972.13",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.23",
+                "@aws-sdk/types": "^3.973.8",
+                "@aws-sdk/util-endpoints": "^3.996.8",
+                "@aws-sdk/util-user-agent-browser": "^3.972.10",
+                "@aws-sdk/util-user-agent-node": "^3.973.22",
+                "@smithy/config-resolver": "^4.4.17",
+                "@smithy/core": "^3.23.17",
+                "@smithy/fetch-http-handler": "^5.3.17",
+                "@smithy/hash-node": "^4.2.14",
+                "@smithy/invalid-dependency": "^4.2.14",
+                "@smithy/middleware-content-length": "^4.2.14",
+                "@smithy/middleware-endpoint": "^4.4.32",
+                "@smithy/middleware-retry": "^4.5.6",
+                "@smithy/middleware-serde": "^4.2.20",
+                "@smithy/middleware-stack": "^4.2.14",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/node-http-handler": "^4.6.1",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-body-length-browser": "^4.2.2",
+                "@smithy/util-body-length-node": "^4.2.3",
+                "@smithy/util-defaults-mode-browser": "^4.3.49",
+                "@smithy/util-defaults-mode-node": "^4.2.54",
+                "@smithy/util-endpoints": "^3.4.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-retry": "^4.3.5",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.972.13",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+            "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/config-resolver": "^4.4.17",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4-multi-region": {
+            "version": "3.996.23",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.23.tgz",
+            "integrity": "sha512-wBbys3Y53Ikly556vyADurKpYQHXS7Jjaskbz+Ga9PZCz7PB/9f3VdKbDlz7dqIzn+xwz7L/a6TR4iXcOi8IRw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-sdk-s3": "^3.972.35",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/signature-v4": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers": {
+            "version": "3.1038.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1038.0.tgz",
+            "integrity": "sha512-Qniru+9oGGb/HNK/gGZWbV3jsD0k71ngE7qMQ/x6gYNYLd2EOwHCS6E2E6jfkaqO4i0d+nNKmfRy8bNcshKdGQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.6",
+                "@aws-sdk/nested-clients": "^3.997.4",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/types": {
+            "version": "3.973.8",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+            "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-arn-parser": {
+            "version": "3.972.3",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+            "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.996.8",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+            "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-endpoints": "^3.4.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-locate-window": {
+            "version": "3.965.5",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+            "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.972.10",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+            "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/types": "^4.14.1",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.973.22",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.22.tgz",
+            "integrity": "sha512-YTYqTmOUrwbm1h99Ee4y/mVYpFRl0oSO/amtP5cc1BZZWdaAVWs9zj3TkyRHWvR9aI/ZS8m3mS6awXtYUlWyaw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "^3.972.36",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-config-provider": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/xml-builder": {
+            "version": "3.972.21",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.21.tgz",
+            "integrity": "sha512-qxNiHUtlrsjTeSlrPWiFkWps7uD6YB4eKzg7eLAFH8jbiHTlt0ePNlo2Xu+WlftP38JIcMaIX4jTUjOlE2ySWw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@nodable/entities": "2.1.0",
+                "@smithy/types": "^4.14.1",
+                "fast-xml-parser": "5.7.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws/lambda-invoke-store": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+            "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@clerk/backend": {
+            "version": "2.33.3",
+            "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.33.3.tgz",
+            "integrity": "sha512-cgkFVEYFG2nZn4QDuYBhiAwPtMdo8Yj7DAtq/SBQ5C/ainh3uxNRDgUj4bFn52qJkWLiCkraYJIw1b8dEUbUBg==",
+            "license": "MIT",
+            "dependencies": {
+                "@clerk/shared": "^3.47.5",
+                "@clerk/types": "^4.101.23",
+                "standardwebhooks": "^1.0.0",
+                "tslib": "2.8.1"
+            },
+            "engines": {
+                "node": ">=18.17.0"
+            }
+        },
+        "node_modules/@clerk/shared": {
+            "version": "3.47.5",
+            "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.5.tgz",
+            "integrity": "sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "csstype": "3.1.3",
+                "dequal": "2.0.3",
+                "glob-to-regexp": "0.4.1",
+                "js-cookie": "3.0.5",
+                "std-env": "^3.9.0",
+                "swr": "2.3.4"
+            },
+            "engines": {
+                "node": ">=18.17.0"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+                "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@clerk/types": {
+            "version": "4.101.23",
+            "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.23.tgz",
+            "integrity": "sha512-t5ypYYDkT5TPaNIDjLnYk9GpkJgwNTBiS7h6FuUTjoySQtf7amNDS1A1eOu7NOcVpqiSeKg+0wzGxxcre00kMA==",
+            "license": "MIT",
+            "dependencies": {
+                "@clerk/shared": "^3.47.5"
+            },
+            "engines": {
+                "node": ">=18.17.0"
             }
         },
         "node_modules/@hocuspocus/common": {
@@ -49,6 +770,592 @@
                 "yjs": "^13.6.8"
             }
         },
+        "node_modules/@nodable/entities": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+            "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodable"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/@smithy/config-resolver": {
+            "version": "4.4.17",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+            "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-config-provider": "^4.2.2",
+                "@smithy/util-endpoints": "^3.4.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/core": {
+            "version": "3.23.17",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+            "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-body-length-browser": "^4.2.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-stream": "^4.5.25",
+                "@smithy/util-utf8": "^4.2.2",
+                "@smithy/uuid": "^1.1.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/credential-provider-imds": {
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+            "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/fetch-http-handler": {
+            "version": "5.3.17",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+            "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/querystring-builder": "^4.2.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-base64": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/hash-node": {
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+            "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/invalid-dependency": {
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+            "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/is-array-buffer": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+            "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-content-length": {
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+            "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-endpoint": {
+            "version": "4.4.32",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+            "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.23.17",
+                "@smithy/middleware-serde": "^4.2.20",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-middleware": "^4.2.14",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-retry": {
+            "version": "4.5.7",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
+            "integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.23.17",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/service-error-classification": "^4.3.1",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-retry": "^4.3.6",
+                "@smithy/uuid": "^1.1.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-serde": {
+            "version": "4.2.20",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+            "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.23.17",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-stack": {
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+            "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/node-config-provider": {
+            "version": "4.3.14",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+            "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/node-http-handler": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+            "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/querystring-builder": "^4.2.14",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/property-provider": {
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+            "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/protocol-http": {
+            "version": "5.3.14",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+            "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-builder": {
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+            "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-uri-escape": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-parser": {
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+            "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/service-error-classification": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
+            "integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.14.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.4.9",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+            "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/signature-v4": {
+            "version": "5.3.14",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+            "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.2.2",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-hex-encoding": "^4.2.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-uri-escape": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/smithy-client": {
+            "version": "4.12.13",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+            "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.23.17",
+                "@smithy/middleware-endpoint": "^4.4.32",
+                "@smithy/middleware-stack": "^4.2.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-stream": "^4.5.25",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/types": {
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+            "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/url-parser": {
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+            "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.2.14",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-base64": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+            "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-body-length-browser": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+            "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-body-length-node": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+            "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-buffer-from": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+            "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-config-provider": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+            "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "4.3.49",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+            "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-node": {
+            "version": "4.2.54",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+            "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^4.4.17",
+                "@smithy/credential-provider-imds": "^4.2.14",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-endpoints": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+            "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-hex-encoding": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+            "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-middleware": {
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+            "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-retry": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.6.tgz",
+            "integrity": "sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^4.3.1",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-stream": {
+            "version": "4.5.25",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+            "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^5.3.17",
+                "@smithy/node-http-handler": "^4.6.1",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/util-hex-encoding": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-uri-escape": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+            "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-utf8": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+            "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/uuid": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+            "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@stablelib/base64": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+            "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+            "license": "MIT"
+        },
         "node_modules/async-lock": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
@@ -64,6 +1371,75 @@
                 "tslib": "^2.4.0"
             }
         },
+        "node_modules/bowser": {
+            "version": "2.14.1",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+            "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+            "license": "MIT"
+        },
+        "node_modules/csstype": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "license": "MIT"
+        },
+        "node_modules/dequal": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/fast-sha256": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+            "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+            "license": "Unlicense"
+        },
+        "node_modules/fast-xml-builder": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+            "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "path-expression-matcher": "^1.1.3"
+            }
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+            "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@nodable/entities": "^2.1.0",
+                "fast-xml-builder": "^1.1.5",
+                "path-expression-matcher": "^1.5.0",
+                "strnum": "^2.2.3"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
+        },
+        "node_modules/glob-to-regexp": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+            "license": "BSD-2-Clause"
+        },
         "node_modules/isomorphic.js": {
             "version": "0.2.5",
             "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
@@ -72,6 +1448,15 @@
             "funding": {
                 "type": "GitHub Sponsors ❤",
                 "url": "https://github.com/sponsors/dmonad"
+            }
+        },
+        "node_modules/js-cookie": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+            "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/kleur": {
@@ -104,11 +1489,27 @@
                 "url": "https://github.com/sponsors/dmonad"
             }
         },
+        "node_modules/path-expression-matcher": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+            "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/pg": {
             "version": "8.20.0",
             "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
             "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "pg-connection-string": "^2.12.0",
                 "pg-pool": "^3.13.0",
@@ -232,6 +1633,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/react": {
+            "version": "19.2.5",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+            "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/split2": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -241,11 +1652,61 @@
                 "node": ">= 10.x"
             }
         },
+        "node_modules/standardwebhooks": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+            "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+            "license": "MIT",
+            "dependencies": {
+                "@stablelib/base64": "^1.0.0",
+                "fast-sha256": "^1.3.0"
+            }
+        },
+        "node_modules/std-env": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+            "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+            "license": "MIT"
+        },
+        "node_modules/strnum": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+            "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/swr": {
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+            "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+            "license": "MIT",
+            "dependencies": {
+                "dequal": "^2.0.3",
+                "use-sync-external-store": "^1.4.0"
+            },
+            "peerDependencies": {
+                "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
         "node_modules/tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
+        },
+        "node_modules/use-sync-external-store": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+            "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
         },
         "node_modules/ws": {
             "version": "8.19.0",

--- a/services/editor/package.json
+++ b/services/editor/package.json
@@ -1,6 +1,8 @@
 {
     "type": "module",
     "dependencies": {
+        "@aws-sdk/client-secrets-manager": "^3.893.0",
+        "@clerk/backend": "^2.33.2",
         "@hocuspocus/extension-database": "^3.4.4",
         "@hocuspocus/server": "^3.4.4",
         "pg": "^8.20.0"

--- a/services/editor/server.ts
+++ b/services/editor/server.ts
@@ -1,11 +1,51 @@
 import { Server } from '@hocuspocus/server'
 import { Database } from '@hocuspocus/extension-database'
+import { verifyToken } from '@clerk/backend'
+import { GetSecretValueCommand, SecretsManagerClient } from '@aws-sdk/client-secrets-manager'
 import pg from 'pg'
 import type { IncomingMessage, ServerResponse } from 'http'
 
-const pool = new pg.Pool({
-    connectionString: process.env.DATABASE_URL,
-})
+const jwtKey = process.env.CLERK_JWT_KEY
+if (!jwtKey) {
+    // Fail closed: refuse to start rather than silently allow anonymous WS connections.
+    throw new Error('CLERK_JWT_KEY is required')
+}
+const secretKey = process.env.CLERK_SECRET_KEY
+const authorizedParties = (process.env.CLERK_AUTHORIZED_PARTIES ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+
+const SI_ADMIN_ORG_SLUG = 'safe-insights'
+const REVIEW_FEEDBACK_PREFIX = 'review-feedback-'
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function studyIdFromDocumentName(documentName: string): string | null {
+    if (!documentName.startsWith(REVIEW_FEEDBACK_PREFIX)) return null
+    const candidate = documentName.slice(REVIEW_FEEDBACK_PREFIX.length)
+    return UUID_RE.test(candidate) ? candidate : null
+}
+
+// Mirrors src/server/config.ts:databaseURL() — accept DATABASE_URL directly for local/dev,
+// otherwise fetch the RDS-managed secret JSON (host/username/password/dbname) and assemble.
+async function resolvePoolConfig(): Promise<pg.PoolConfig> {
+    if (process.env.DATABASE_URL) return { connectionString: process.env.DATABASE_URL }
+
+    const arn = process.env.DB_SECRET_ARN
+    if (!arn) throw new Error('DATABASE_URL or DB_SECRET_ARN is required')
+
+    const client = new SecretsManagerClient({})
+    const data = await client.send(new GetSecretValueCommand({ SecretId: arn }))
+    if (!data.SecretString) throw new Error(`failed to fetch db secret from ${arn}`)
+    const db = JSON.parse(data.SecretString) as { username: string; password: string; host: string; dbname: string }
+    return {
+        connectionString: `postgres://${encodeURIComponent(db.username)}:${encodeURIComponent(db.password)}@${db.host}/${db.dbname}`,
+        // Aurora Postgres has rds.force_ssl=1; matches src/database/dialect.ts.
+        ssl: { rejectUnauthorized: false },
+    }
+}
+
+const pool = new pg.Pool(await resolvePoolConfig())
 
 const server = new Server({
     port: 1234,
@@ -26,6 +66,50 @@ const server = new Server({
             },
         }),
     ],
+    async onAuthenticate({ token, documentName }) {
+        if (!token) throw new Error('Not authorized: missing token')
+
+        const payload = await verifyToken(token, {
+            jwtKey,
+            secretKey,
+            authorizedParties: authorizedParties.length ? authorizedParties : undefined,
+        })
+        const clerkUserId = payload.sub
+        if (!clerkUserId) throw new Error('Not authorized: token has no subject')
+
+        const studyId = studyIdFromDocumentName(documentName)
+        if (!studyId) throw new Error(`Not authorized: unrecognized document "${documentName}"`)
+
+        const userRow = await pool.query<{ id: string }>('SELECT id FROM "user" WHERE clerk_id = $1', [clerkUserId])
+        const internalUserId = userRow.rows[0]?.id
+        if (!internalUserId) throw new Error('Not authorized: user not provisioned')
+
+        const studyRow = await pool.query<{ org_id: string; submitted_by_org_id: string }>(
+            'SELECT org_id, submitted_by_org_id FROM study WHERE id = $1',
+            [studyId],
+        )
+        const study = studyRow.rows[0]
+        if (!study) throw new Error('Not authorized: study not found')
+
+        // Mirrors src/lib/permissions.ts `view Study` rule plus the SI-admin override
+        // (admin of the `safe-insights` org). All three checks collapse into one query.
+        const accessRow = await pool.query(
+            `SELECT 1
+               FROM org_user ou
+               JOIN org o ON o.id = ou.org_id
+              WHERE ou.user_id = $1
+                AND (
+                    (o.slug = $2 AND ou.is_admin = TRUE)
+                    OR ou.org_id = $3
+                    OR ou.org_id = $4
+                )
+              LIMIT 1`,
+            [internalUserId, SI_ADMIN_ORG_SLUG, study.org_id, study.submitted_by_org_id],
+        )
+        if (accessRow.rowCount === 0) throw new Error('Not authorized: no membership in study orgs')
+
+        return { user: { id: internalUserId } }
+    },
     async onRequest({ request, response }: { request: IncomingMessage; response: ServerResponse }) {
         if (request.url === '/health') {
             response.writeHead(200, { 'Content-Type': 'text/plain' })

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-section.test.tsx
@@ -146,7 +146,7 @@ describe('ProposalSection', () => {
     })
 
     it('renders submitted date when study has been submitted', () => {
-        const submittedStudy = { ...study, submittedAt: new Date('2025-03-15T00:00:00Z') }
+        const submittedStudy = { ...study, submittedAt: new Date('2025-03-15T12:00:00Z') }
 
         renderWithProviders(<ProposalSection study={submittedStudy} orgSlug="test-org" />)
 

--- a/src/components/editable-text/collaborative-editor.tsx
+++ b/src/components/editable-text/collaborative-editor.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { useUser } from '@clerk/nextjs'
-import { Badge, Box, Group, Paper, Stack, Text } from '@mantine/core'
+import { useAuth, useUser } from '@clerk/nextjs'
+import { Alert, Badge, Box, Group, Paper, Stack, Text } from '@mantine/core'
 import { LexicalComposer } from '@lexical/react/LexicalComposer'
 import { ContentEditable } from '@lexical/react/LexicalContentEditable'
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin'
@@ -254,7 +254,12 @@ function EditorChangePlugin({ onChange }: { onChange: (json: string) => void }) 
     return null
 }
 
-function useCollaborationProvider(wsUrl: string, providerRef: React.MutableRefObject<HocuspocusProvider | null>) {
+function useCollaborationProvider(
+    wsUrl: string,
+    providerRef: React.MutableRefObject<HocuspocusProvider | null>,
+    getToken: () => Promise<string | null>,
+    onAuthError: (reason: string) => void,
+) {
     return useCallback(
         (id: string, yjsDocMap: Map<string, Doc>): Provider => {
             let doc = yjsDocMap.get(id)
@@ -268,13 +273,15 @@ function useCollaborationProvider(wsUrl: string, providerRef: React.MutableRefOb
                 name: id,
                 document: doc,
                 autoConnect: false,
+                token: async () => (await getToken()) ?? '',
+                onAuthenticationFailed: ({ reason }) => onAuthError(reason),
             } as ConstructorParameters<typeof HocuspocusProvider>[0])
 
             providerRef.current = provider
 
             return provider as unknown as Provider
         },
-        [wsUrl, providerRef],
+        [wsUrl, providerRef, getToken, onAuthError],
     )
 }
 
@@ -308,10 +315,22 @@ export function CollaborativeEditor({
     footerRight,
 }: CollaborativeEditorProps) {
     const { user } = useUser()
+    const { getToken } = useAuth()
     const providerRef = useRef<HocuspocusProvider | null>(null)
+    const [authError, setAuthError] = useState<string | null>(null)
     const username = [user?.firstName, user?.lastName].filter(Boolean).join(' ') || 'Anonymous'
     const cursorColor = pickCursorColor(username)
-    const providerFactory = useCollaborationProvider(wsUrl, providerRef)
+    const fetchToken = useCallback(async () => getToken(), [getToken])
+    const onAuthError = useCallback((reason: string) => setAuthError(reason || 'Not authorized'), [])
+    const providerFactory = useCollaborationProvider(wsUrl, providerRef, fetchToken, onAuthError)
+
+    if (authError) {
+        return (
+            <Alert color="red" title="Editor unavailable">
+                You don&apos;t have access to this collaborative document.
+            </Alert>
+        )
+    }
 
     return (
         <LexicalComposer initialConfig={initialConfig}>


### PR DESCRIPTION
**Stacked on top of #651.** Targeting `OTTER-491-feedback` so the diff stays scoped to the auth changes; rebase to `main` once #651 lands.

Companion infra: safeinsights/iac#146 wires `CLERK_JWT_KEY`, `CLERK_SECRET_KEY`, and `DB_SECRET_ARN` into the editor task definition.

## Summary

- **Server-side auth gate**: `services/editor/server.ts` now refuses to start without `CLERK_JWT_KEY` and verifies a Clerk JWT on every WebSocket connection via `onAuthenticate`. After verification it parses the `studyId` out of the `review-feedback-<uuid>` document name and authorizes against the study's reviewing or submitting org — or admin of the `safe-insights` org. Mirrors the `'view' Study` rule in `src/lib/permissions.ts:46-50`.
- **Client-side token plumbing**: `CollaborativeEditor` calls `useAuth().getToken` and passes it as `HocuspocusProvider`'s async `token`. Auth failures surface as a red Mantine `Alert` instead of a silent broken editor.
- **DATABASE_URL wiring**: closes a pre-existing gap on the branch — the editor reads `DATABASE_URL` but the IaC was injecting only `DB_PASSWORD/HOST/PORT/USERNAME` (which nothing read). Service now resolves the URL at startup via `DB_SECRET_ARN`, mirroring `src/server/config.ts:databaseURL()`. Adds Aurora-required SSL.
- **Test fix**: `proposal-section.test.tsx` used `2025-03-15T00:00:00Z` which rendered as `Mar 14` in negative-UTC timezones; bumped to `T12:00:00Z`.

## Test plan

- [ ] Locally: `docker compose up` (with `CLERK_JWT_KEY` set), open the proposal review page, type in two windows, confirm sync + persistence.
- [ ] Anonymous WS connection (`wscat -c ws://localhost:1234`) is rejected.
- [ ] Service refuses to start when `CLERK_JWT_KEY` is unset.
- [ ] Wrong-org user (researcher in an org that neither owns nor submitted the study) sees the red "Editor unavailable" alert.
- [ ] SI admin can open any study's feedback document.
- [ ] `/health` still returns `ok` without auth.
- [ ] `npm run checks` and `npm test` (S3 integration tests require local SeaweedFS to be healthy).