### PR TITLE
chore(deps): fix moderate npm audit vulnerabilities (postcss, fast-xml-parser, uuid)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
                 "remeda": "^2.33.6",
                 "server-only": "^0.0.1",
                 "si-encryption": "github:safeinsights/encryption#2e35d3bb56f02bfc0e6d5cd9d83c54637ed0ac20",
-                "uuid": "^13.0.0",
+                "uuid": "^14.0.0",
                 "validator": "^13.15.26",
                 "zod": "^4.3.6",
                 "zustand": "^5.0.11"
@@ -627,6 +627,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.893.0.tgz",
             "integrity": "sha512-/P74KDJhOijnIAQR93sq1DQn8vbU3WaPZDyy1XUMRJJIY6iEJnDo1toD9XY6AFDz5TRto8/8NbcXT30AMOUtJQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha1-browser": "5.2.0",
                 "@aws-crypto/sha256-browser": "5.2.0",
@@ -704,19 +705,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-s3/node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
         "node_modules/@aws-sdk/client-secrets-manager": {
             "version": "3.893.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.893.0.tgz",
@@ -780,19 +768,6 @@
             },
             "engines": {
                 "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-secrets-manager/node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@aws-sdk/client-sso": {
@@ -2031,6 +2006,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -3888,7 +3864,6 @@
             "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
             "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25"
@@ -4200,6 +4175,7 @@
             "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.9.tgz",
             "integrity": "sha512-ivj0Crn5N521cI2eWZBsBGckg0ZYRqfOJz5vbbvYmfj65bp0EdsyqZuOxXzIcn2aUScQhskfvzyhV5XIUv81PQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@floating-ui/react": "^0.27.16",
                 "clsx": "^2.1.1",
@@ -4234,6 +4210,7 @@
             "resolved": "https://registry.npmjs.org/@mantine/form/-/form-8.3.9.tgz",
             "integrity": "sha512-G7eCo5TEWGcsWHrNGwp/o1yPcCYbaMdLq6SClN+wMhAA+qaEO1ZHf9mX8fSOX78nkaoyIrZHGOhbVXcZ7hmVrQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "klona": "^2.0.6"
@@ -4511,6 +4488,18 @@
                 "node": ">= 10"
             }
         },
+        "node_modules/@nodable/entities": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+            "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodable"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4565,6 +4554,7 @@
             "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@octokit/auth-token": "^6.0.0",
                 "@octokit/graphql": "^9.0.3",
@@ -4720,6 +4710,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
             "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -4741,6 +4732,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.5.1.tgz",
             "integrity": "sha512-MHbu8XxCHcBn6RwvCt2Vpn1WnLMNECfNKYB14LI5XypcgH4IE0/DiVifVR9tAkwPMyLXN8dOoPJfya3IryLQVw==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": "^18.19.0 || >=20.6.0"
             },
@@ -4753,6 +4745,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.1.tgz",
             "integrity": "sha512-Dwlc+3HAZqpgTYq0MUyZABjFkcrKTePwuiFVLjahGD8cx3enqihmpAmdgNFO1R4m/sIe5afjJrA25Prqy4NXlA==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "^1.29.0"
             },
@@ -5176,6 +5169,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.1.tgz",
             "integrity": "sha512-BViBCdE/GuXRlp9k7nS1w6wJvY5fnFX5XvuEtWsTAOQFIO89Eru7lGW3WbfbxtCuZ/GbrJfAziXG0w0dpxL7eQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/core": "2.5.1",
                 "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -5192,6 +5186,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.5.1.tgz",
             "integrity": "sha512-iZH3Gw8cxQn0gjpOjJMmKLd9GIaNh/E3v3ST67vyzLSxHBs14HsG4dy7jMYyC5WXGdBVEcM7U/XTF5hCQxjDMw==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/core": "2.5.1",
                 "@opentelemetry/resources": "2.5.1",
@@ -5209,6 +5204,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
             "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=14"
             }
@@ -5602,6 +5598,7 @@
             "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
             "devOptional": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "playwright": "1.58.0"
             },
@@ -6555,19 +6552,6 @@
                 "webpack": ">=5.0.0"
             }
         },
-        "node_modules/@sentry/webpack-plugin/node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
         "node_modules/@sinonjs/commons": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -7515,8 +7499,7 @@
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
             "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -7605,7 +7588,6 @@
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
             "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -7616,7 +7598,6 @@
             "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
             "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/eslint": "*",
                 "@types/estree": "*"
@@ -7738,6 +7719,7 @@
             "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -7849,6 +7831,7 @@
             "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.56.1",
                 "@typescript-eslint/types": "8.56.1",
@@ -8628,7 +8611,6 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
             "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/helper-numbers": "1.13.2",
                 "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -8638,29 +8620,25 @@
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
             "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-api-error": {
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
             "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-buffer": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
             "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-numbers": {
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
             "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/floating-point-hex-parser": "1.13.2",
                 "@webassemblyjs/helper-api-error": "1.13.2",
@@ -8671,15 +8649,13 @@
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
             "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
             "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -8692,7 +8668,6 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
             "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@xtuc/ieee754": "^1.2.0"
             }
@@ -8702,7 +8677,6 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
             "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@xtuc/long": "4.2.2"
             }
@@ -8711,15 +8685,13 @@
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
             "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/wasm-edit": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
             "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -8736,7 +8708,6 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
             "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -8750,7 +8721,6 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
             "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -8763,7 +8733,6 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
             "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-api-error": "1.13.2",
@@ -8778,7 +8747,6 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
             "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@xtuc/long": "4.2.2"
@@ -8788,15 +8756,13 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
             "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@xtuc/long": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-            "license": "Apache-2.0",
-            "peer": true
+            "license": "Apache-2.0"
         },
         "node_modules/@zip.js/zip.js": {
             "version": "2.8.23",
@@ -8828,6 +8794,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -8849,7 +8816,6 @@
             "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
             "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.13.0"
             },
@@ -9470,6 +9436,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -9504,8 +9471,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/bundle-n-require": {
             "version": "1.1.2",
@@ -9739,7 +9705,6 @@
             "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
             "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.0"
             }
@@ -9917,6 +9882,7 @@
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
             "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -10451,8 +10417,7 @@
             "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
             "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/dom-helpers": {
             "version": "5.2.1",
@@ -10577,7 +10542,6 @@
             "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
             "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
                 "tapable": "^2.3.0"
@@ -10876,6 +10840,7 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -11062,6 +11027,7 @@
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",
@@ -11585,9 +11551,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/fast-xml-builder": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-            "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+            "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
             "funding": [
                 {
                     "type": "github",
@@ -11600,9 +11566,9 @@
             }
         },
         "node_modules/fast-xml-parser": {
-            "version": "5.5.7",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.7.tgz",
-            "integrity": "sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+            "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
             "funding": [
                 {
                     "type": "github",
@@ -11611,9 +11577,10 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "fast-xml-builder": "^1.1.4",
-                "path-expression-matcher": "^1.1.3",
-                "strnum": "^2.2.0"
+                "@nodable/entities": "^2.1.0",
+                "fast-xml-builder": "^1.1.5",
+                "path-expression-matcher": "^1.5.0",
+                "strnum": "^2.2.3"
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
@@ -12297,6 +12264,7 @@
             "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=16.9.0"
             }
@@ -13162,7 +13130,6 @@
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
             "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
@@ -13177,7 +13144,6 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -13501,6 +13467,7 @@
             "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.14.tgz",
             "integrity": "sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.0.0"
             }
@@ -14033,7 +14000,6 @@
             "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
             "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.11.5"
             },
@@ -14243,7 +14209,6 @@
             "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "lz-string": "bin/bin.js"
             }
@@ -14270,6 +14235,7 @@
             "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.28.5",
                 "@babel/types": "^7.28.5",
@@ -14385,8 +14351,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -14615,14 +14580,14 @@
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/next": {
             "version": "16.2.3",
             "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
             "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@next/env": "16.2.3",
                 "@swc/helpers": "0.5.15",
@@ -14701,34 +14666,6 @@
             },
             "peerDependencies": {
                 "next": ">=9"
-            }
-        },
-        "node_modules/next/node_modules/postcss": {
-            "version": "8.4.31",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-            "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.6",
-                "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
             }
         },
         "node_modules/nise": {
@@ -15190,9 +15127,9 @@
             }
         },
         "node_modules/path-expression-matcher": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
-            "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+            "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
             "funding": [
                 {
                     "type": "github",
@@ -15283,6 +15220,7 @@
             "resolved": "https://registry.npmjs.org/pg/-/pg-8.19.0.tgz",
             "integrity": "sha512-QIcLGi508BAHkQ3pJNptsFz5WQMlpGbuBGBaIaXsWK8mel2kQ/rThYI+DbgjUvZrIr7MiuEuc9LcChJoEZK1xQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "pg-connection-string": "^2.11.0",
                 "pg-pool": "^3.12.0",
@@ -15469,10 +15407,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-            "dev": true,
+            "version": "8.5.12",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+            "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -15488,6 +15425,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -15588,6 +15526,7 @@
             "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -15674,7 +15613,6 @@
             "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1",
                 "ansi-styles": "^5.0.0",
@@ -15690,7 +15628,6 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -15703,8 +15640,7 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/prismjs": {
             "version": "1.30.0",
@@ -15876,6 +15812,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
             "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -15885,6 +15822,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
             "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -16277,6 +16215,7 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
             "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -16460,7 +16399,6 @@
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
             "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.9",
                 "ajv": "^8.9.0",
@@ -16497,7 +16435,6 @@
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
             "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ajv": "^8.0.0"
             },
@@ -16515,7 +16452,6 @@
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
             "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3"
             },
@@ -16527,8 +16463,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/semver": {
             "version": "6.3.1",
@@ -16956,7 +16891,6 @@
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "license": "BSD-3-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -16975,7 +16909,6 @@
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -17339,9 +17272,9 @@
             }
         },
         "node_modules/strnum": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.1.tgz",
-            "integrity": "sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+            "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
             "funding": [
                 {
                     "type": "github",
@@ -17610,7 +17543,6 @@
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
             "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             },
@@ -17633,7 +17565,6 @@
             "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
             "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
                 "acorn": "^8.15.0",
@@ -17652,7 +17583,6 @@
             "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
             "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jest-worker": "^27.4.5",
@@ -17685,8 +17615,7 @@
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/test-exclude": {
             "version": "7.0.1",
@@ -18595,6 +18524,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "devOptional": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -18692,6 +18622,7 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "napi-postinstall": "^0.3.0"
             },
@@ -18859,6 +18790,7 @@
             "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
             "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
@@ -18870,9 +18802,9 @@
             "license": "MIT"
         },
         "node_modules/uuid": {
-            "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-            "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+            "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
@@ -18907,6 +18839,7 @@
             "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -19496,6 +19429,7 @@
             "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vitest/expect": "4.0.18",
                 "@vitest/mocker": "4.0.18",
@@ -19586,7 +19520,6 @@
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
             "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
@@ -19606,7 +19539,6 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.3.tgz",
             "integrity": "sha512-LLBBA4oLmT7sZdHiYE/PeVuifOxYyE2uL/V+9VQP7YSYdJU7bSf7H8bZRRxW8kEPMkmVjnrXmoR3oejIdX0xbg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -19655,7 +19587,6 @@
             "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
             "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.13.0"
             }
@@ -19664,15 +19595,13 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
             "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/webpack/node_modules/eslint-scope": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
             "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
@@ -19686,7 +19615,6 @@
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "license": "BSD-2-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -20175,6 +20103,7 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
             "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
         "remeda": "^2.33.6",
         "server-only": "^0.0.1",
         "si-encryption": "github:safeinsights/encryption#2e35d3bb56f02bfc0e6d5cd9d83c54637ed0ac20",
-        "uuid": "^13.0.0",
+        "uuid": "^14.0.0",
         "validator": "^13.15.26",
         "zod": "^4.3.6",
         "zustand": "^5.0.11"
@@ -146,11 +146,13 @@
     "overrides": {
         "@types/react": "19.2.14",
         "minimatch": "^10.2.1",
-        "fast-xml-parser": "^5.3.8",
+        "fast-xml-parser": "^5.7.0",
         "serialize-javascript": "^7.0.3",
         "express-rate-limit": "^8.2.2",
         "flatted": "^3.4.0",
         "nodemailer": "^8.0.4",
-        "picomatch": "^4.0.4"
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "uuid": "^14.0.0"
     }
 }


### PR DESCRIPTION
## Summary

- Bumps `uuid` from `^13.0.0` → `^14.0.0` (only `v7` is used in this repo, so no API impact)
- Bumps `fast-xml-parser` override from `^5.3.8` → `^5.7.0`
- Adds `postcss` override at `^8.5.10`

`npm audit` goes from **44 moderate → 0** vulnerabilities.

## Resolves

| Jira | CVE / GHSA | Package |
|---|---|---|
| [SIINFOSEC-372](https://openstax.atlassian.net/browse/SIINFOSEC-372) | CVE-2026-41650 / GHSA-gh4j-gqv2-49f6 | fast-xml-parser |
| [SIINFOSEC-373](https://openstax.atlassian.net/browse/SIINFOSEC-373) | GHSA-w5hq-g745-h8pq | uuid |
| [SIINFOSEC-374](https://openstax.atlassian.net/browse/SIINFOSEC-374) | GHSA-w5hq-g745-h8pq | uuid |
| [SIINFOSEC-391](https://openstax.atlassian.net/browse/SIINFOSEC-391) | CVE-2026-41305 / GHSA-qx2v-qp2m-jg93 | postcss |
| [SIINFOSEC-392](https://openstax.atlassian.net/browse/SIINFOSEC-392) | CVE-2026-41305 / GHSA-qx2v-qp2m-jg93 | postcss |

## Test plan

- [x] `npm install` clean
- [x] `npm audit` reports 0 vulnerabilities
- [x] `npm run checks` (typecheck + lint + validate-actions) passes
- [x] Verified all `uuid` imports use `v7` (unaffected by the v14 breaking change which only added bounds checks to `v3`/`v5`/`v6`)

[SIINFOSEC-372]: https://openstax.atlassian.net/browse/SIINFOSEC-372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SIINFOSEC-373]: https://openstax.atlassian.net/browse/SIINFOSEC-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SIINFOSEC-374]: https://openstax.atlassian.net/browse/SIINFOSEC-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SIINFOSEC-391]: https://openstax.atlassian.net/browse/SIINFOSEC-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SIINFOSEC-392]: https://openstax.atlassian.net/browse/SIINFOSEC-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ