### PR TITLE
update BMA URLs pointing to the Knowledge Base

### DIFF
--- a/src/lib/routes/definitions.ts
+++ b/src/lib/routes/definitions.ts
@@ -175,8 +175,8 @@ export const Routes = {
 // ============================================================================
 
 export const ExternalLinks = {
-    dataCatalog: 'https://kb.safeinsights.org/data-catalog',
-    resourceCenter: 'https://kb.safeinsights.org/resource-center',
+    dataCatalog: 'https://dev-docs.sandbox.safeinsights.org/data-catalog/',
+    resourceCenter: 'https://dev-docs.sandbox.safeinsights.org/data-organizations/',
 } as const
 
 // ============================================================================


### PR DESCRIPTION
Jira Card: [OTTER-532](https://openstax.atlassian.net/browse/OTTER-532)

## Summary
- Updated the Resource Center URL in the Data Organizations dashboard nav to `https://dev-docs.sandbox.safeinsights.org/data-organizations/`
- Updated the Data Catalog URL in the Research Lab dashboard nav to `https://dev-docs.sandbox.safeinsights.org/data-catalog/`
- Both changes are made in `src/lib/routes/definitions.ts` via the `ExternalLinks` constant, which is consumed by `src/components/layout/nav-org-links.tsx`

## Test plan
- [ ] Sign in as a user with a Data Organization (enclave) membership and verify the "Resource Center" sidebar link opens `https://dev-docs.sandbox.safeinsights.org/data-organizations/` in a new tab
- [ ] Sign in as a user with a Research Lab membership and verify the "Data Catalog" sidebar link opens `https://dev-docs.sandbox.safeinsights.org/data-catalog/` in a new tab
- [ ] Confirm both links still render with the correct icon, label, and `newTab` behavior

[OTTER-532]: https://openstax.atlassian.net/browse/OTTER-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ