### PR TITLE
scrub sensitive data from Sentry events and tighten Replay

### DIFF
--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -4,9 +4,12 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs'
+import { scrubSentryEvent } from '@/lib/sentry'
 
 Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+
+    beforeSend: scrubSentryEvent,
 
     // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
     tracesSampleRate: 1,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -4,6 +4,7 @@
 
 import * as Sentry from '@sentry/nextjs'
 import { consoleLoggingIntegration } from '@sentry/nextjs'
+import { scrubSentryEvent } from '@/lib/sentry'
 
 Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -12,6 +13,8 @@ Sentry.init({
         // send console.error and console.warn logs to Sentry
         consoleLoggingIntegration({ levels: ['error', 'warn'] }),
     ],
+
+    beforeSend: scrubSentryEvent,
 
     // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
     tracesSampleRate: 1,

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -4,6 +4,7 @@
 
 import * as Sentry from '@sentry/nextjs'
 import { captureRouterTransitionStart, replayIntegration } from '@sentry/nextjs'
+import { scrubSentryEvent } from '@/lib/sentry'
 
 Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN || '',
@@ -11,23 +12,25 @@ Sentry.init({
     // Add optional integrations for additional features
     integrations: [
         replayIntegration({
-            maskAllText: false,
+            maskAllText: true,
+            maskAllInputs: true,
+            blockAllMedia: true,
             minReplayDuration: 5000,
         }),
     ],
+
+    beforeSend: scrubSentryEvent,
 
     // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
     tracesSampleRate: 1,
     // Enable logs to be sent to Sentry
     enableLogs: true,
 
-    // Define how likely Replay events are sampled.
-    // This sets the sample rate to be 10%. You may want this to be 100% while
-    // in development and sample at a lower rate in production
-    replaysSessionSampleRate: 1.0,
-
-    // Define how likely Replay events are sampled when an error occurs.
-    replaysOnErrorSampleRate: 1.0,
+    // Replay is only captured for sessions where an error occurs, never proactively.
+    // Reason: study data, names, and emails render as page text, so background recording
+    // is a privacy risk even with masking on.
+    replaysSessionSampleRate: 0,
+    replaysOnErrorSampleRate: 0.1,
 
     // Setting this option to true will print useful information to the console while you're setting up Sentry.
     debug: false,

--- a/src/lib/sentry.test.ts
+++ b/src/lib/sentry.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import type { ErrorEvent } from '@sentry/nextjs'
+import { scrubSentryEvent } from './sentry'
+
+function makeEvent(overrides: Partial<ErrorEvent> = {}): ErrorEvent {
+    return { type: undefined, ...overrides } as ErrorEvent
+}
+
+describe('scrubSentryEvent', () => {
+    it('redacts sensitive request headers regardless of casing', () => {
+        const event = makeEvent({
+            request: {
+                headers: {
+                    Authorization: 'Bearer abc',
+                    cookie: '__session=xyz',
+                    'Set-Cookie': '__session=xyz; HttpOnly',
+                    'X-Api-Key': 'secret',
+                    'User-Agent': 'tests',
+                },
+            },
+        })
+
+        const result = scrubSentryEvent(event)
+
+        expect(result.request?.headers).toEqual({
+            Authorization: '[Filtered]',
+            cookie: '[Filtered]',
+            'Set-Cookie': '[Filtered]',
+            'X-Api-Key': '[Filtered]',
+            'User-Agent': 'tests',
+        })
+    })
+
+    it('redacts every cookie value in request.cookies', () => {
+        const event = makeEvent({
+            request: {
+                cookies: { __session: 'abc', csrf: 'xyz' },
+            },
+        })
+
+        const result = scrubSentryEvent(event)
+
+        expect(result.request?.cookies).toEqual({
+            __session: '[Filtered]',
+            csrf: '[Filtered]',
+        })
+    })
+
+    it('redacts sensitive keys in request body data, recursively', () => {
+        const event = makeEvent({
+            request: {
+                data: {
+                    email: 'user@example.com',
+                    password: 'hunter2',
+                    nested: { api_key: 'k', safe: 'ok' },
+                    list: [{ access_token: 't', other: 'fine' }],
+                },
+            },
+        })
+
+        const result = scrubSentryEvent(event)
+
+        expect(result.request?.data).toEqual({
+            email: 'user@example.com',
+            password: '[Filtered]',
+            nested: { api_key: '[Filtered]', safe: 'ok' },
+            list: [{ access_token: '[Filtered]', other: 'fine' }],
+        })
+    })
+
+    it('redacts sensitive keys in a query_string string', () => {
+        const event = makeEvent({
+            request: {
+                query_string: 'token=abc&page=2&api_key=xyz',
+            },
+        })
+
+        const result = scrubSentryEvent(event)
+
+        const params = new URLSearchParams(result.request?.query_string as string)
+        expect(params.get('token')).toBe('[Filtered]')
+        expect(params.get('api_key')).toBe('[Filtered]')
+        expect(params.get('page')).toBe('2')
+    })
+
+    it('redacts sensitive keys in a query_string tuple array', () => {
+        const event = makeEvent({
+            request: {
+                query_string: [
+                    ['token', 'abc'],
+                    ['page', '2'],
+                ],
+            },
+        })
+
+        const result = scrubSentryEvent(event)
+
+        expect(result.request?.query_string).toEqual([
+            ['token', '[Filtered]'],
+            ['page', '2'],
+        ])
+    })
+
+    it('redacts sensitive keys in event.extra', () => {
+        const event = makeEvent({
+            extra: { authorization: 'Bearer x', componentStack: 'stack' },
+        })
+
+        const result = scrubSentryEvent(event)
+
+        expect(result.extra).toEqual({
+            authorization: '[Filtered]',
+            componentStack: 'stack',
+        })
+    })
+
+    it('leaves the event untouched when there is no request payload', () => {
+        const event = makeEvent({ message: 'hi' })
+        const result = scrubSentryEvent(event)
+        expect(result).toBe(event)
+        expect(result.request).toBeUndefined()
+    })
+})

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,7 +1,105 @@
 import * as Sentry from '@sentry/nextjs'
+import type { ErrorEvent, EventHint } from '@sentry/nextjs'
 import { UserSession } from './types'
 
 export function setSentryFromSession(session: UserSession) {
     Sentry.setUser({ id: session.user.id })
     Sentry.setTag('orgs', Object.keys(session.orgs).join(','))
+}
+
+const SENSITIVE_HEADER_NAMES = [
+    'authorization',
+    'cookie',
+    'set-cookie',
+    'proxy-authorization',
+    'x-api-key',
+    'x-auth-token',
+    'x-csrf-token',
+    'x-clerk-auth-token',
+]
+
+const SENSITIVE_KEY_PATTERN =
+    /(^|[_-])(authorization|auth|password|passwd|secret|token|api[_-]?key|session|cookie|credential|private[_-]?key|access[_-]?key)([_-]|$)/i
+
+const REDACTED = '[Filtered]'
+
+function scrubHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
+    if (!headers) return headers
+    const out: Record<string, string> = {}
+    for (const [name, value] of Object.entries(headers)) {
+        if (SENSITIVE_HEADER_NAMES.includes(name.toLowerCase())) {
+            out[name] = REDACTED
+        } else {
+            out[name] = value
+        }
+    }
+    return out
+}
+
+function scrubObjectKeys(obj: unknown): unknown {
+    if (obj === null || obj === undefined) return obj
+    if (Array.isArray(obj)) return obj.map(scrubObjectKeys)
+    if (typeof obj !== 'object') return obj
+    const out: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+        if (SENSITIVE_KEY_PATTERN.test(key)) {
+            out[key] = REDACTED
+        } else {
+            out[key] = scrubObjectKeys(value)
+        }
+    }
+    return out
+}
+
+function scrubQueryString(qs: unknown): unknown {
+    if (!qs) return qs
+    if (typeof qs === 'string') {
+        try {
+            const params = new URLSearchParams(qs)
+            let mutated = false
+            for (const key of Array.from(params.keys())) {
+                if (SENSITIVE_KEY_PATTERN.test(key)) {
+                    params.set(key, REDACTED)
+                    mutated = true
+                }
+            }
+            return mutated ? params.toString() : qs
+        } catch {
+            return qs
+        }
+    }
+    if (Array.isArray(qs)) {
+        return qs.map((entry) => {
+            if (Array.isArray(entry) && entry.length === 2 && SENSITIVE_KEY_PATTERN.test(String(entry[0]))) {
+                return [entry[0], REDACTED]
+            }
+            return entry
+        })
+    }
+    return scrubObjectKeys(qs)
+}
+
+function scrubCookies(cookies: Record<string, string> | undefined): Record<string, string> | undefined {
+    if (!cookies) return cookies
+    const out: Record<string, string> = {}
+    for (const name of Object.keys(cookies)) {
+        out[name] = REDACTED
+    }
+    return out
+}
+
+export function scrubSentryEvent(event: ErrorEvent, _hint?: EventHint): ErrorEvent {
+    if (event.request) {
+        event.request.headers = scrubHeaders(event.request.headers)
+        event.request.cookies = scrubCookies(event.request.cookies)
+        event.request.query_string = scrubQueryString(event.request.query_string) as typeof event.request.query_string
+        event.request.data = scrubObjectKeys(event.request.data)
+    }
+    if (event.extra) {
+        event.extra = scrubObjectKeys(event.extra) as Record<string, unknown>
+    }
+    if (event.contexts) {
+        event.contexts = scrubObjectKeys(event.contexts) as typeof event.contexts
+    }
+    return event
 }


### PR DESCRIPTION
Add a beforeSend hook on all three Sentry inits (server, edge, client) that redacts Authorization/Cookie/Set-Cookie/X-Api-Key headers, every cookie value, and any body/query/extra/contexts key matching common secret patterns (auth, password, token, api_key, session, credential, private_key, access_key).

Tighten Session Replay: mask all text and inputs, block media, stop proactive recording (replaysSessionSampleRate=0) and sample 10% of error sessions only — page text contains study data, names, and emails.

https://openstax.atlassian.net/browse/OTTER-545