### PR TITLE
OTTER-495: Consolidate initial request views into shared component

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
@@ -128,8 +128,7 @@ describe('PostFeedbackView', () => {
             const entries = [buildEntry()]
             renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={entries} />)
 
-            // ProposalSection's collapsed-state toggle says "Show full initial request"
-            expect(screen.getByTestId('proposal-toggle-header')).toHaveTextContent('Show full initial request')
+            expect(screen.getByTestId('proposal-toggle-header')).toHaveTextContent('View full initial request')
         })
     })
 

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-section.test.tsx
@@ -102,7 +102,7 @@ describe('ProposalSection', () => {
 
         fireEvent.click(screen.getByTestId('proposal-toggle-header'))
 
-        expect(screen.getByTestId('proposal-toggle-header')).toHaveTextContent('Show full initial request')
+        expect(screen.getByTestId('proposal-toggle-header')).toHaveTextContent('View full initial request')
     })
 
     it('toggles between hide and show text on repeated clicks', async () => {
@@ -113,7 +113,7 @@ describe('ProposalSection', () => {
         expect(headerToggle).toHaveTextContent('Hide full initial request')
 
         await user.click(headerToggle)
-        expect(headerToggle).toHaveTextContent('Show full initial request')
+        expect(headerToggle).toHaveTextContent('View full initial request')
 
         await user.click(headerToggle)
         expect(headerToggle).toHaveTextContent('Hide full initial request')

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-section.tsx
@@ -1,12 +1,7 @@
 'use client'
 
-import { DatasetsField, LexicalProposalField, PIField, ResearcherField } from '@/components/study/proposal-fields'
-import { usePopover } from '@/hooks/use-popover'
-import { stringifyJson } from '@/lib/string'
-import { Anchor, Box, Collapse, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
-import { useDisclosure } from '@mantine/hooks'
-import { CaretDownIcon, CaretUpIcon } from '@phosphor-icons/react'
-import dayjs from 'dayjs'
+import { ProposalRequest } from '@/components/study/proposal-initial-request'
+import { Box, Stack, Text } from '@mantine/core'
 import type { StudyForReview } from './review-types'
 
 type ProposalSectionProps = {
@@ -31,31 +26,6 @@ const EVALUATION_CRITERIA = [
     },
 ]
 
-function useProposalSection(initialExpanded: boolean) {
-    const [isExpanded, { toggle }] = useDisclosure(initialExpanded)
-    const { getPopoverProps } = usePopover()
-    return { isExpanded, toggle, getPopoverProps }
-}
-
-function formatSubmittedDate(date: Date | null | undefined): string | null {
-    if (!date) return null
-    return dayjs(date).format('MMM DD, YYYY')
-}
-
-function ToggleLink({ isExpanded, onToggle, testId }: { isExpanded: boolean; onToggle: () => void; testId: string }) {
-    const label = isExpanded ? 'Hide full initial request' : 'Show full initial request'
-    const Icon = isExpanded ? CaretUpIcon : CaretDownIcon
-
-    return (
-        <Anchor component="button" onClick={onToggle} c="blue" size="sm" data-testid={testId}>
-            <Group gap={4} align="center">
-                {label}
-                <Icon size={14} />
-            </Group>
-        </Anchor>
-    )
-}
-
 function CriteriaList() {
     return (
         <Stack gap={4} data-testid="evaluation-criteria">
@@ -70,7 +40,13 @@ function CriteriaList() {
 
 function StatusBanner({ labName }: { labName: string }) {
     return (
-        <Box bg="purple.0" p="md" style={{ borderRadius: 'var(--mantine-radius-sm)' }} data-testid="status-banner">
+        <Box
+            bg="purple.0"
+            p="md"
+            mb="md"
+            style={{ borderRadius: 'var(--mantine-radius-sm)' }}
+            data-testid="status-banner"
+        >
             <Stack gap="xs">
                 <Text size="sm">
                     <strong>{labName}</strong> has submitted an initial request requesting permission to use your data.
@@ -84,67 +60,16 @@ function StatusBanner({ labName }: { labName: string }) {
 }
 
 export function ProposalSection({ study, orgSlug, initialExpanded = true }: ProposalSectionProps) {
-    const { isExpanded, toggle, getPopoverProps } = useProposalSection(initialExpanded)
-    const submittedDate = formatSubmittedDate(study.submittedAt)
     const labName = study.submittingLabName ?? study.submittedByOrgSlug
 
     return (
-        <Stack gap="md" data-testid="proposal-section">
-            <Paper p="xl" data-testid="proposal-section-header">
-                <Stack gap="md">
-                    <Group justify="space-between" align="flex-start" wrap="nowrap">
-                        <Stack gap={4}>
-                            <Text fz="xs" fw={700} c="gray.6">
-                                STEP 1
-                            </Text>
-                            <Title order={2} fz={20} fw={700}>
-                                Review initial request
-                            </Title>
-                            <Text size="sm">Title: {study.title}</Text>
-                        </Stack>
-                        {submittedDate && (
-                            <Text fz={12} c="gray.6" style={{ whiteSpace: 'nowrap' }}>
-                                Submitted on {submittedDate}
-                            </Text>
-                        )}
-                    </Group>
-
-                    <Divider />
-
-                    <StatusBanner labName={labName} />
-
-                    <ToggleLink isExpanded={isExpanded} onToggle={toggle} testId="proposal-toggle-header" />
-                </Stack>
-            </Paper>
-
-            <Collapse in={isExpanded}>
-                <Paper p="xl" data-testid="proposal-body">
-                    <Stack gap="md">
-                        <DatasetsField datasets={study.datasets ?? []} orgDataSources={study.orgDataSources} />
-                        <LexicalProposalField
-                            label="Research question(s)"
-                            value={stringifyJson(study.researchQuestions)}
-                            divider="default"
-                        />
-                        <LexicalProposalField label="Project summary" value={stringifyJson(study.projectSummary)} />
-                        <LexicalProposalField label="Impact" value={stringifyJson(study.impact)} />
-                        <LexicalProposalField
-                            label="Additional notes or requests"
-                            value={stringifyJson(study.additionalNotes)}
-                        />
-                        <PIField study={study} orgSlug={orgSlug} size="sm" {...getPopoverProps('pi')} />
-                        <ResearcherField
-                            study={study}
-                            orgSlug={orgSlug}
-                            size="sm"
-                            mt="md"
-                            {...getPopoverProps('researcher')}
-                        />
-                        <Divider />
-                        <ToggleLink isExpanded={isExpanded} onToggle={toggle} testId="proposal-toggle-body" />
-                    </Stack>
-                </Paper>
-            </Collapse>
-        </Stack>
+        <ProposalRequest
+            study={study}
+            orgSlug={orgSlug}
+            stepLabel="STEP 1"
+            heading="Review initial request"
+            banner={<StatusBanner labName={labName} />}
+            initialExpanded={initialExpanded}
+        />
     )
 }

--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
@@ -1,12 +1,8 @@
 'use client'
 
-import { useState } from 'react'
-import { Alert, Anchor, Button, Collapse, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
-import { CaretRightIcon } from '@phosphor-icons/react/dist/ssr'
-import dayjs from 'dayjs'
-import { displayOrgName, stringifyJson } from '@/lib/string'
-import { DatasetsField, LexicalProposalField, PIField, ResearcherField } from '@/components/study/proposal-fields'
-import { usePopover } from '@/hooks/use-popover'
+import { Alert, Button, Stack } from '@mantine/core'
+import { displayOrgName } from '@/lib/string'
+import { ProposalRequest } from '@/components/study/proposal-initial-request'
 import type { SelectedStudy } from '@/server/actions/study.actions'
 import { ProposalHeader } from '../../request/page-header'
 import { Routes } from '@/lib/routes'
@@ -18,120 +14,29 @@ interface ProposalSubmittedProps {
     orgName: string
 }
 
-export function ProposalSubmitted({ orgSlug, study, orgName }: ProposalSubmittedProps) {
-    const [expanded, setExpanded] = useState(false)
-    const { getPopoverProps } = usePopover()
+function SubmissionAlert({ orgName }: { orgName: string }) {
+    return (
+        <Alert color="yellow" mb="md">
+            Your initial request has been successfully submitted to {displayOrgName(orgName)}. They will review it and
+            respond with feedback or a decision. You&apos;ll receive email notifications as your request progresses
+            through the review process. Please allow an estimated 7 to 10 days for a complete review.
+        </Alert>
+    )
+}
 
+export function ProposalSubmitted({ orgSlug, study, orgName }: ProposalSubmittedProps) {
     return (
         <Stack p="xl" gap="xl">
             <ProposalHeader orgSlug={orgSlug} title="Study proposal" studyId={study.id} studyTitle={study.title} />
             <Stack gap="xxl">
-                <Paper p="xxl">
-                    <Text fz={10} fw={700} c="charcoal.7" pb={4}>
-                        STEP 2
-                    </Text>
-                    <Title fz={20} order={4} c="charcoal.9" pb={4}>
-                        Initial request
-                    </Title>
-                    <Group justify="space-between" align="center">
-                        <Text c="charcoal.9" style={{ maxWidth: '60ch', wordBreak: 'break-word' }}>
-                            Title: {study.title}
-                        </Text>
-                        {study.submittedAt && (
-                            <Text fz={12} c="charcoal.7">
-                                Submitted on {dayjs(study.submittedAt).format('MMM DD, YYYY')}
-                            </Text>
-                        )}
-                    </Group>
-                    <Divider my="md" />
-                    <Alert color="yellow" mt="md">
-                        Your initial request has been successfully submitted to {displayOrgName(orgName)}. They will
-                        review it and respond with feedback or a decision. You&apos;ll receive email notifications as
-                        your request progresses through the review process. Please allow an estimated 7 to 10 days for a
-                        complete review.
-                    </Alert>
-                    <Anchor
-                        component="button"
-                        size="sm"
-                        fw={700}
-                        onClick={() => setExpanded((prev) => !prev)}
-                        mt="md"
-                        display="inline-flex"
-                        style={{ alignItems: 'center', gap: 4 }}
-                    >
-                        {expanded ? 'Hide full initial request' : 'View full initial request'}
-                        <CaretRightIcon
-                            size={12}
-                            style={{
-                                transition: 'transform 200ms',
-                                transform: expanded ? 'rotate(-90deg)' : 'rotate(0deg)',
-                            }}
-                        />
-                    </Anchor>
-                </Paper>
-                <Collapse in={expanded}>
-                    <Paper p="xxl">
-                        <Stack gap="md">
-                            <DatasetsField
-                                datasets={study.datasets ?? []}
-                                orgDataSources={study.orgDataSources}
-                                size="sm"
-                            />
-                            <Divider />
-
-                            <LexicalProposalField
-                                label="Research question(s)"
-                                value={stringifyJson(study.researchQuestions)}
-                                divider="none"
-                                size="md"
-                            />
-                            <Divider />
-
-                            <LexicalProposalField
-                                label="Project summary"
-                                value={stringifyJson(study.projectSummary)}
-                                divider="none"
-                                size="md"
-                            />
-                            <Divider />
-
-                            <LexicalProposalField
-                                label="Impact"
-                                value={stringifyJson(study.impact)}
-                                divider="none"
-                                size="md"
-                            />
-
-                            {study.additionalNotes && <Divider />}
-
-                            <LexicalProposalField
-                                label="Additional notes or requests"
-                                value={stringifyJson(study.additionalNotes)}
-                                divider="none"
-                                size="md"
-                            />
-
-                            <PIField study={study} orgSlug={orgSlug} {...getPopoverProps('pi')} />
-                            <ResearcherField
-                                study={study}
-                                orgSlug={orgSlug}
-                                {...getPopoverProps('researcher')}
-                                mt="md"
-                            />
-                            <Divider />
-                            <Anchor
-                                component="button"
-                                size="sm"
-                                fw={700}
-                                onClick={() => setExpanded(false)}
-                                style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
-                            >
-                                Hide full initial request
-                                <CaretRightIcon size={12} style={{ transform: 'rotate(-90deg)' }} />
-                            </Anchor>
-                        </Stack>
-                    </Paper>
-                </Collapse>
+                <ProposalRequest
+                    study={study}
+                    orgSlug={orgSlug}
+                    stepLabel="STEP 2"
+                    heading="Initial request"
+                    banner={<SubmissionAlert orgName={orgName} />}
+                    initialExpanded={false}
+                />
                 <Stack gap="sm" align="flex-end">
                     <Button component={Link} href={Routes.dashboard} size="md">
                         Go to dashboard

--- a/src/components/study/proposal-initial-request.tsx
+++ b/src/components/study/proposal-initial-request.tsx
@@ -2,7 +2,7 @@
 
 import { useState, type ReactNode } from 'react'
 import { Anchor, Collapse, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
-import { CaretRightIcon } from '@phosphor-icons/react/dist/ssr'
+import { CaretRightIcon, CaretUpIcon } from '@phosphor-icons/react/dist/ssr'
 import dayjs from 'dayjs'
 import { stringifyJson } from '@/lib/string'
 import { usePopover } from '@/hooks/use-popover'
@@ -38,13 +38,7 @@ function ToggleLink({ isExpanded, onClick, testId }: { isExpanded: boolean; onCl
             data-testid={testId}
         >
             {isExpanded ? 'Hide full initial request' : 'View full initial request'}
-            <CaretRightIcon
-                size={12}
-                style={{
-                    transition: 'transform 200ms',
-                    transform: isExpanded ? 'rotate(-90deg)' : 'rotate(0deg)',
-                }}
-            />
+            {isExpanded ? <CaretUpIcon size={12} weight="bold" /> : <CaretRightIcon size={12} weight="bold" />}
         </Anchor>
     )
 }

--- a/src/components/study/proposal-initial-request.tsx
+++ b/src/components/study/proposal-initial-request.tsx
@@ -63,7 +63,7 @@ export function ProposalRequest({
                     {heading}
                 </Title>
                 <Group justify="space-between" align="center" wrap="nowrap">
-                    <Text c="charcoal.9" style={{ maxWidth: '100ch', wordBreak: 'break-word' }}>
+                    <Text c="charcoal.9" style={{ maxWidth: '105ch', wordBreak: 'break-word' }}>
                         Title: {study.title}
                     </Text>
                     {study.submittedAt && (

--- a/src/components/study/proposal-initial-request.tsx
+++ b/src/components/study/proposal-initial-request.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import { useState, type ReactNode } from 'react'
+import { Anchor, Collapse, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
+import { CaretRightIcon } from '@phosphor-icons/react/dist/ssr'
+import dayjs from 'dayjs'
+import { stringifyJson } from '@/lib/string'
+import { usePopover } from '@/hooks/use-popover'
+import type { SelectedStudy } from '@/server/actions/study.actions'
+import { DatasetsField, LexicalProposalField, PIField, ResearcherField } from './proposal-fields'
+
+type ProposalRequestProps = {
+    study: SelectedStudy
+    orgSlug: string
+    stepLabel: string
+    heading: string
+    banner: ReactNode
+    initialExpanded?: boolean
+}
+
+function useProposalRequest(initialExpanded: boolean) {
+    const [expanded, setExpanded] = useState(initialExpanded)
+    const { getPopoverProps } = usePopover()
+    const toggle = () => setExpanded((prev) => !prev)
+    const collapse = () => setExpanded(false)
+    return { expanded, toggle, collapse, getPopoverProps }
+}
+
+function ToggleLink({ isExpanded, onClick, testId }: { isExpanded: boolean; onClick: () => void; testId?: string }) {
+    return (
+        <Anchor
+            component="button"
+            size="sm"
+            fw={700}
+            onClick={onClick}
+            display="inline-flex"
+            style={{ alignItems: 'center', gap: 4 }}
+            data-testid={testId}
+        >
+            {isExpanded ? 'Hide full initial request' : 'View full initial request'}
+            <CaretRightIcon
+                size={12}
+                style={{
+                    transition: 'transform 200ms',
+                    transform: isExpanded ? 'rotate(-90deg)' : 'rotate(0deg)',
+                }}
+            />
+        </Anchor>
+    )
+}
+
+export function ProposalRequest({
+    study,
+    orgSlug,
+    stepLabel,
+    heading,
+    banner,
+    initialExpanded = true,
+}: ProposalRequestProps) {
+    const { expanded, toggle, collapse, getPopoverProps } = useProposalRequest(initialExpanded)
+
+    return (
+        <Stack gap="md" data-testid="proposal-section">
+            <Paper p="xxl" data-testid="proposal-section-header">
+                <Text fz={10} fw={700} c="charcoal.7" pb={4}>
+                    {stepLabel}
+                </Text>
+                <Title order={4} fz={20} c="charcoal.9" pb={4}>
+                    {heading}
+                </Title>
+                <Group justify="space-between" align="center" wrap="nowrap">
+                    <Text c="charcoal.9" style={{ maxWidth: '100ch', wordBreak: 'break-word' }}>
+                        Title: {study.title}
+                    </Text>
+                    {study.submittedAt && (
+                        <Text fz={12} c="charcoal.7" style={{ whiteSpace: 'nowrap' }}>
+                            Submitted on {dayjs(study.submittedAt).format('MMM DD, YYYY')}
+                        </Text>
+                    )}
+                </Group>
+                <Divider my="md" />
+                {banner}
+                <ToggleLink isExpanded={expanded} onClick={toggle} testId="proposal-toggle-header" />
+            </Paper>
+
+            <Collapse in={expanded}>
+                <Paper p="xxl" data-testid="proposal-body">
+                    <Stack gap="md">
+                        <DatasetsField
+                            datasets={study.datasets ?? []}
+                            orgDataSources={study.orgDataSources}
+                            size="sm"
+                        />
+                        <Divider />
+
+                        <LexicalProposalField
+                            label="Research question(s)"
+                            value={stringifyJson(study.researchQuestions)}
+                            divider="none"
+                            size="md"
+                        />
+                        <Divider />
+
+                        <LexicalProposalField
+                            label="Project summary"
+                            value={stringifyJson(study.projectSummary)}
+                            divider="none"
+                            size="md"
+                        />
+                        <Divider />
+
+                        <LexicalProposalField
+                            label="Impact"
+                            value={stringifyJson(study.impact)}
+                            divider="none"
+                            size="md"
+                        />
+
+                        {study.additionalNotes && <Divider />}
+
+                        <LexicalProposalField
+                            label="Additional notes or requests"
+                            value={stringifyJson(study.additionalNotes)}
+                            divider="none"
+                            size="md"
+                        />
+
+                        <PIField study={study} orgSlug={orgSlug} {...getPopoverProps('pi')} />
+                        <ResearcherField study={study} orgSlug={orgSlug} {...getPopoverProps('researcher')} mt="md" />
+                        <Divider />
+                        <ToggleLink isExpanded={true} onClick={collapse} testId="proposal-toggle-body" />
+                    </Stack>
+                </Paper>
+            </Collapse>
+        </Stack>
+    )
+}

--- a/src/components/study/proposal-initial-request.tsx
+++ b/src/components/study/proposal-initial-request.tsx
@@ -2,7 +2,7 @@
 
 import { useState, type ReactNode } from 'react'
 import { Anchor, Collapse, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
-import { CaretRightIcon, CaretUpIcon } from '@phosphor-icons/react/dist/ssr'
+import { CaretRightIcon } from '@phosphor-icons/react/dist/ssr'
 import dayjs from 'dayjs'
 import { stringifyJson } from '@/lib/string'
 import { usePopover } from '@/hooks/use-popover'
@@ -38,7 +38,14 @@ function ToggleLink({ isExpanded, onClick, testId }: { isExpanded: boolean; onCl
             data-testid={testId}
         >
             {isExpanded ? 'Hide full initial request' : 'View full initial request'}
-            {isExpanded ? <CaretUpIcon size={12} weight="bold" /> : <CaretRightIcon size={12} weight="bold" />}
+            <CaretRightIcon
+                size={12}
+                weight="bold"
+                style={{
+                    transform: isExpanded ? 'rotate(-90deg)' : 'rotate(0deg)',
+                    transition: 'transform 200ms ease',
+                }}
+            />
         </Anchor>
     )
 }


### PR DESCRIPTION
- Extracted shared `ProposalRequest` component (src/components/study/proposal-initial-request.tsx) to consolidate the duplicated initial request UI between the researcher submitted view and the DO review view                      
- Both `ProposalSubmitted` and `ProposalSection` now delegate to ProposalRequest, passing view-specific props (stepLabel, heading, banner)                                             
- Fixed title wrapping: added `wrap="nowrap"` to the title/date row and `whiteSpace: 'nowrap'` on the submitted date so it stays pinned to the right                                          
- Capped title width at `105ch` (~120 characters in Open Sans)