### PR TITLE
Re-sync session metadata when cached user.id no longer exists

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -3,6 +3,7 @@ import logger from '@/lib/logger'
 import { JwtPayload } from 'jsonwebtoken'
 import { sessionFromMetadata, type UserSessionWithAbility } from '@/lib/session'
 import { clerkClient } from '@clerk/nextjs/server'
+import { db } from '@/database'
 import { getOrgInfoForUserId } from './db/queries'
 import { syncUserToDatabaseWithConflictResolution } from './user-sync'
 import { updateClerkUserMetadata } from './clerk'
@@ -73,11 +74,17 @@ export async function marshalSession(
 
     let info: UserInfo | null = (sessionClaims.userMetadata as UserInfo) || null
 
-    const needsUpdate = !info || info.format !== 'v3' || forceUpdate
+    let userMissing = false
+    if (info?.format === 'v3' && info.user?.id && !forceUpdate) {
+        const existing = await db.selectFrom('user').select('id').where('id', '=', info.user.id).executeTakeFirst()
+        userMissing = !existing
+    }
+
+    const needsUpdate = !info || info.format !== 'v3' || forceUpdate || userMissing
 
     if (needsUpdate) {
         logger.info(
-            `clerk user ${clerkUserId} needs metadata update (missing: ${!info}, format: ${info?.format}, forceUpdate: ${forceUpdate})`,
+            `clerk user ${clerkUserId} needs metadata update (missing: ${!info}, format: ${info?.format}, forceUpdate: ${forceUpdate}, userMissing: ${userMissing})`,
         )
 
         info = await syncAndUpdateUserMetadata(clerkUserId)


### PR DESCRIPTION
## Summary
- `marshalSession` trusted Clerk `publicMetadata.user.id` indefinitely once metadata reached v3 format — no DB existence check ever ran. The `1766441147000_unique_user_email` migration deleted duplicate `user` rows, orphaning the metadata for any Clerk user whose id pointed at a deleted twin.
- Affected users hit `insert or update on table "user_public_key" violates foreign key constraint "member_user_public_key_user_id_fkey"` when saving a freshly generated reviewer key (and the same FK class of error in any other action that writes `userId`).
- Add a cheap `SELECT id FROM user WHERE id = ?` before trusting cached metadata; on miss, fall through to `syncAndUpdateUserMetadata`, which re-resolves the user via `clerkId`/email and overwrites Clerk's `publicMetadata`.

## Caveat
In non-production this fully self-heals — the email-conflict branch in `syncUserToDatabase` reassigns the kept twin to the live `clerkId`. In production that branch throws (`user-sync.ts:91`), so this fix swaps the misleading FK error deep inside the reviewer-key flow for a louder "Email conflict during user sync" thrown earlier on the next session refresh. That's an improvement (fail-fast surfaces the real problem to ops) but it does not transparently heal already-affected prod users — those still need a one-time Clerk metadata backfill, which is intentionally deferred to a follow-up.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run src/server/user-sync.test.ts src/server/clerk.test.ts src/server/actions/user-keys.actions.test.ts` (18/18 pass)
- [ ] Manual: log in as a user whose Clerk `publicMetadata.user.id` was orphaned by the unique-email migration; verify the next session refresh re-syncs and the reviewer-key save no longer 500s