### PR TITLE
Normalize UUID defaults to v7uuid() and timestamp columns to timestamptz

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,8 @@
 - Comments: Only add comments that explain "why", not "what". Avoid trivial comments like `// Delete users` before `deleteFrom('user')` or `// Create profile` before `insertInto('profile')`. If the code is self-explanatory, no comment is needed.
 - Testing: Write unit tests for new features. Only mock using helpers in tests/unit.helpers.tsx as needed, do not mock out any of our own components or actions.
 - E2E timeouts: Do not set inline timeouts in Playwright tests. Timeouts are configured globally in `playwright.config.ts` using constants from `tests/common.helpers.ts`.
+- Migrations - UUID primary keys: Always default `uuid` id columns to `v7uuid()` (defined in `1727370622500_uuid_fn.ts`), never `gen_random_uuid()`. v7 UUIDs are time-ordered, which gives better index locality and natural insertion order.
+- Migrations - timestamp columns: Always use `'timestamptz'` (timestamp with time zone), never `'timestamp'`. Pattern: `.addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql\`now()\`))`.
 
 ## Authority & Links
 

--- a/src/database/migrations/1776300000000_normalize_uuid_and_timestamp_defaults.ts
+++ b/src/database/migrations/1776300000000_normalize_uuid_and_timestamp_defaults.ts
@@ -1,0 +1,65 @@
+import { type Kysely, sql } from 'kysely'
+
+// Convert legacy gen_random_uuid() defaults to v7uuid() and timestamp columns to timestamptz
+// so the schema is consistent across all tables.
+
+const UUID_DEFAULT_COLUMNS: Array<{ table: string; column: string }> = [
+    { table: 'org_data_source', column: 'id' },
+    { table: 'pending_user', column: 'id' },
+    { table: 'researcher_position', column: 'id' },
+]
+
+const TIMESTAMP_COLUMNS: Array<{ table: string; column: string }> = [
+    { table: 'audit', column: 'created_at' },
+    { table: 'job_status_change', column: 'created_at' },
+    { table: 'org', column: 'created_at' },
+    { table: 'org', column: 'updated_at' },
+    { table: 'org_code_env', column: 'created_at' },
+    { table: 'org_user', column: 'joined_at' },
+    { table: 'pending_user', column: 'created_at' },
+    { table: 'researcher_position', column: 'created_at' },
+    { table: 'researcher_position', column: 'updated_at' },
+    { table: 'researcher_profile', column: 'created_at' },
+    { table: 'researcher_profile', column: 'updated_at' },
+    { table: 'study', column: 'approved_at' },
+    { table: 'study', column: 'created_at' },
+    { table: 'study', column: 'rejected_at' },
+    { table: 'study', column: 'researcher_agreements_acked_at' },
+    { table: 'study', column: 'reviewer_agreements_acked_at' },
+    { table: 'study', column: 'submitted_at' },
+    { table: 'study_job', column: 'created_at' },
+    { table: 'study_job_file', column: 'created_at' },
+    { table: 'user', column: 'created_at' },
+    { table: 'user', column: 'updated_at' },
+    { table: 'user_public_key', column: 'created_at' },
+    { table: 'user_public_key', column: 'updated_at' },
+    { table: 'yjs_document', column: 'updated_at' },
+]
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+    for (const { table, column } of UUID_DEFAULT_COLUMNS) {
+        await sql`ALTER TABLE ${sql.id(table)} ALTER COLUMN ${sql.id(column)} SET DEFAULT v7uuid()`.execute(db)
+    }
+
+    for (const { table, column } of TIMESTAMP_COLUMNS) {
+        await sql`
+            ALTER TABLE ${sql.id(table)}
+            ALTER COLUMN ${sql.id(column)} TYPE timestamptz
+            USING ${sql.id(column)} AT TIME ZONE 'UTC'
+        `.execute(db)
+    }
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+    for (const { table, column } of TIMESTAMP_COLUMNS) {
+        await sql`
+            ALTER TABLE ${sql.id(table)}
+            ALTER COLUMN ${sql.id(column)} TYPE timestamp
+            USING ${sql.id(column)} AT TIME ZONE 'UTC'
+        `.execute(db)
+    }
+
+    for (const { table, column } of UUID_DEFAULT_COLUMNS) {
+        await sql`ALTER TABLE ${sql.id(table)} ALTER COLUMN ${sql.id(column)} SET DEFAULT gen_random_uuid()`.execute(db)
+    }
+}


### PR DESCRIPTION
## Summary
- Switches three legacy `gen_random_uuid()` id defaults to `v7uuid()` (`org_data_source.id`, `pending_user.id`, `researcher_position.id`) so all tables use time-ordered v7 UUIDs for better index locality
- Converts 24 `timestamp` (without time zone) columns to `timestamptz` across `audit`, `job_status_change`, `org`, `org_code_env`, `org_user`, `pending_user`, `researcher_position`, `researcher_profile`, `study`, `study_job`, `study_job_file`, `user`, `user_public_key`, and `yjs_document`
- Documents both conventions as Hard Rules in `CLAUDE.md` so future migrations follow the pattern

The migration uses `AT TIME ZONE 'UTC'` when converting, treating existing naked timestamps as UTC. `down()` reverses both changes.

## Test plan
- [ ] `npm run db:migrate` runs cleanly on a fresh DB
- [ ] After migration, no `public` columns have `gen_random_uuid()` default or `timestamp without time zone` type (verified via `information_schema.columns`)
- [ ] Down migration reverts to prior state
- [ ] Existing unit tests still pass (S3 + lexical-seed failures observed locally are pre-existing, unrelated to this change)