### PR TITLE
OTTER 497: more tests

### DIFF
--- a/src/app/[orgSlug]/admin/settings/use-code-env-form.test.ts
+++ b/src/app/[orgSlug]/admin/settings/use-code-env-form.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-// eslint-disable-next-line no-restricted-imports
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import React from 'react'
 import { useParams } from 'next/navigation'
+import { createTestQueryWrapper } from '@/tests/unit.helpers'
 import { useCodeEnvForm } from './use-code-env-form'
 
 vi.mock('./code-envs.actions', () => ({
@@ -48,19 +46,6 @@ const mockCodeEnv = {
     dataSources: [] as { id: string; name: string }[],
 }
 
-const createWrapper = () => {
-    const queryClient = new QueryClient({
-        defaultOptions: {
-            queries: { retry: false },
-            mutations: { retry: false },
-        },
-    })
-    const Wrapper = ({ children }: { children: React.ReactNode }) =>
-        React.createElement(QueryClientProvider, { client: queryClient }, children)
-    Wrapper.displayName = 'QueryClientWrapper'
-    return Wrapper
-}
-
 describe('useCodeEnvForm', () => {
     beforeEach(() => {
         ;(useParams as Mock).mockReturnValue({ orgSlug: TEST_ORG_SLUG })
@@ -70,7 +55,7 @@ describe('useCodeEnvForm', () => {
 
     it('returns create mode when no image is provided', () => {
         const { result } = renderHook(() => useCodeEnvForm(undefined, vi.fn()), {
-            wrapper: createWrapper(),
+            wrapper: createTestQueryWrapper(),
         })
 
         expect(result.current.isEditMode).toBe(false)
@@ -78,7 +63,7 @@ describe('useCodeEnvForm', () => {
 
     it('returns edit mode when image is provided', () => {
         const { result } = renderHook(() => useCodeEnvForm(mockCodeEnv, vi.fn()), {
-            wrapper: createWrapper(),
+            wrapper: createTestQueryWrapper(),
         })
 
         expect(result.current.isEditMode).toBe(true)
@@ -90,7 +75,7 @@ describe('useCodeEnvForm', () => {
 
         const onComplete = vi.fn()
         const { result } = renderHook(() => useCodeEnvForm(undefined, onComplete), {
-            wrapper: createWrapper(),
+            wrapper: createTestQueryWrapper(),
         })
 
         const starterCode = new File(['code'], 'main.py')
@@ -125,7 +110,7 @@ describe('useCodeEnvForm', () => {
 
         const onComplete = vi.fn()
         const { result } = renderHook(() => useCodeEnvForm(undefined, onComplete), {
-            wrapper: createWrapper(),
+            wrapper: createTestQueryWrapper(),
         })
 
         const starterCode = new File(['code'], 'main.py')
@@ -154,7 +139,7 @@ describe('useCodeEnvForm', () => {
         ;(createOrgCodeEnvAction as Mock).mockResolvedValue(createdEnv)
 
         const { result } = renderHook(() => useCodeEnvForm(undefined, vi.fn()), {
-            wrapper: createWrapper(),
+            wrapper: createTestQueryWrapper(),
         })
 
         const starterCode = new File(['code'], 'main.py')
@@ -180,7 +165,7 @@ describe('useCodeEnvForm', () => {
 
         const onComplete = vi.fn()
         const { result } = renderHook(() => useCodeEnvForm(mockCodeEnv, onComplete), {
-            wrapper: createWrapper(),
+            wrapper: createTestQueryWrapper(),
         })
 
         const newStarterCode = new File(['new code'], 'updated.py')
@@ -211,7 +196,7 @@ describe('useCodeEnvForm', () => {
         ;(updateOrgCodeEnvAction as Mock).mockResolvedValue(updatedEnv)
 
         const { result } = renderHook(() => useCodeEnvForm(mockCodeEnv, vi.fn()), {
-            wrapper: createWrapper(),
+            wrapper: createTestQueryWrapper(),
         })
 
         act(() => result.current.onSubmit())
@@ -231,7 +216,7 @@ describe('useCodeEnvForm', () => {
         ;(updateOrgCodeEnvAction as Mock).mockResolvedValue(mockCodeEnv)
 
         const { result } = renderHook(() => useCodeEnvForm(mockCodeEnv, vi.fn()), {
-            wrapper: createWrapper(),
+            wrapper: createTestQueryWrapper(),
         })
 
         const sampleFile = new File(['data'], 'data.csv')

--- a/src/app/[orgSlug]/admin/team/admin-users.actions.test.ts
+++ b/src/app/[orgSlug]/admin/team/admin-users.actions.test.ts
@@ -5,7 +5,8 @@ import { clerkClient } from '@clerk/nextjs/server'
 import { Mock, describe, expect, it, vi } from 'vitest'
 import { getPendingUsersAction, orgAdminInviteUserAction, reInviteUserAction } from './admin-users.actions'
 
-vi.mock('@/server/events', () => ({
+vi.mock('@/server/events', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@/server/events')>()),
     onUserInvited: vi.fn(({ invitedEmail, pendingId }) => {
         sendInviteEmail({ emailTo: invitedEmail, inviteId: pendingId })
     }),

--- a/src/app/[orgSlug]/study/[studyId]/agreements/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/page.test.tsx
@@ -2,14 +2,15 @@ import { beforeEach, describe, it, expect, vi } from 'vitest'
 import { redirect } from 'next/navigation'
 import * as RouterMock from 'next-router-mock'
 import {
+    db,
     insertTestStudyJobData,
     insertTestStudyOnly,
     mockSessionWithTestData,
     renderWithProviders,
     screen,
+    setTestStudyStatus,
     userEvent,
 } from '@/tests/unit.helpers'
-import { db } from '@/database'
 import StudyAgreementsRoute from './page'
 
 const mockRedirect = vi.mocked(redirect)
@@ -162,7 +163,7 @@ describe('StudyAgreementsRoute', () => {
     it('redirects researcher when study is not APPROVED', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
         const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
-        await db.updateTable('study').set({ status: 'DRAFT' }).where('id', '=', study.id).execute()
+        await setTestStudyStatus(study.id, 'DRAFT')
 
         await expect(renderRoute(org.slug, study.id)).rejects.toThrow('NEXT_REDIRECT')
         expect(mockRedirect).toHaveBeenCalledWith(expect.stringContaining('/view'))
@@ -171,7 +172,7 @@ describe('StudyAgreementsRoute', () => {
     it('allows direct access via Previous button when study is not APPROVED', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
         const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
-        await db.updateTable('study').set({ status: 'REJECTED' }).where('id', '=', study.id).execute()
+        await setTestStudyStatus(study.id, 'REJECTED')
 
         const page = await StudyAgreementsRoute({
             params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),

--- a/src/app/[orgSlug]/study/[studyId]/code/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/code/page.test.tsx
@@ -5,9 +5,9 @@ import {
     mockSessionWithTestData,
     renderWithProviders,
     screen,
+    setTestStudyStatus,
     waitFor,
 } from '@/tests/unit.helpers'
-import { db } from '@/database'
 import { memoryRouter } from 'next-router-mock'
 import StudyCodeUploadRoute from './page'
 
@@ -65,7 +65,7 @@ describe('StudyCodeUploadRoute', () => {
             researcherId: user.id,
             studyStatus: 'APPROVED',
         })
-        await db.updateTable('study').set({ status: 'PENDING-REVIEW' }).where('id', '=', study.id).execute()
+        await setTestStudyStatus(study.id, 'PENDING-REVIEW')
 
         await expect(
             StudyCodeUploadRoute({

--- a/src/app/[orgSlug]/study/[studyId]/review/legacy-proposal-review-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/legacy-proposal-review-view.test.tsx
@@ -5,22 +5,28 @@ import {
     insertTestStudyJobData,
     mockSessionWithTestData,
     renderWithProviders,
-    resetSpyMode,
     screen,
-    setSpyMode,
-    spyModeState,
     waitFor,
     type Mock,
 } from '@/tests/unit.helpers'
 import { useParams } from 'next/navigation'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
 import { LegacyProposalReviewView } from './legacy-proposal-review-view'
 
-vi.mock('@/components/spy-mode-context', async (importOriginal) => {
-    const actual = await importOriginal<typeof import('@/components/spy-mode-context')>()
+const featureFlagState = vi.hoisted(() => ({ enabled: false }))
+
+vi.mock('@/components/openstax-feature-flag', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@/components/openstax-feature-flag')>()
     return {
         ...actual,
-        useSpyMode: () => ({ isSpyMode: spyModeState.isSpyMode, toggleSpyMode: vi.fn() }),
+        ProposalReviewFeatureFlag: ({
+            defaultContent,
+            optInContent,
+        }: {
+            defaultContent: ReactNode
+            optInContent: ReactNode
+        }) => (featureFlagState.enabled ? optInContent : defaultContent),
     }
 })
 
@@ -28,7 +34,7 @@ describe('LegacyProposalReviewView', () => {
     let study: SelectedStudy
 
     beforeEach(async () => {
-        resetSpyMode()
+        featureFlagState.enabled = false
         const { org, user } = await mockSessionWithTestData({ orgSlug: 'openstax', orgType: 'enclave' })
         const { study: dbStudy } = await insertTestStudyJobData({
             org,
@@ -154,7 +160,7 @@ describe('LegacyProposalReviewView', () => {
         })
 
         it('renders "Proceed to Step 2" when agreementsHref is provided and feature flag is ON (bypass)', () => {
-            setSpyMode(true)
+            featureFlagState.enabled = true
 
             renderWithProviders(
                 <LegacyProposalReviewView orgSlug="openstax" study={study} agreementsHref={agreementsHref} />,
@@ -165,7 +171,7 @@ describe('LegacyProposalReviewView', () => {
         })
 
         it('renders the new flow when agreementsHref is absent and feature flag is ON', async () => {
-            setSpyMode(true)
+            featureFlagState.enabled = true
 
             renderWithProviders(<LegacyProposalReviewView orgSlug="openstax" study={study} />)
 

--- a/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
@@ -7,6 +7,7 @@ import {
     mockSessionWithTestData,
     renderWithProviders,
     screen,
+    setTestStudyStatus,
     type Mock,
 } from '@/tests/unit.helpers'
 import StudyReviewPage from './page'
@@ -129,7 +130,7 @@ describe('StudyReviewPage', () => {
         const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
         // insertTestStudyOnly defaults to APPROVED; reset to PENDING-REVIEW so this case
         // exercises the in-flight review flow rather than OTTER-501's post-decision view.
-        await db.updateTable('study').set({ status: 'PENDING-REVIEW' }).where('id', '=', study.id).execute()
+        await setTestStudyStatus(study.id, 'PENDING-REVIEW')
 
         const page = await StudyReviewPage({
             params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
@@ -144,7 +145,7 @@ describe('StudyReviewPage', () => {
     it('renders the LegacyProposalReviewView for non-OpenStax enclave orgs by default', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
         const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
-        await db.updateTable('study').set({ status: 'PENDING-REVIEW' }).where('id', '=', study.id).execute()
+        await setTestStudyStatus(study.id, 'PENDING-REVIEW')
 
         const page = await StudyReviewPage({
             params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
@@ -161,7 +162,7 @@ describe('StudyReviewPage', () => {
             async (status) => {
                 const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
                 const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
-                await db.updateTable('study').set({ status }).where('id', '=', study.id).execute()
+                await setTestStudyStatus(study.id, status)
 
                 const page = await StudyReviewPage({
                     params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),

--- a/src/app/[orgSlug]/study/[studyId]/view/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/page.test.tsx
@@ -6,10 +6,10 @@ import {
     mockSessionWithTestData,
     renderWithProviders,
     screen,
+    setTestStudyStatus,
     userEvent,
     faker,
 } from '@/tests/unit.helpers'
-import { db } from '@/database'
 import StudyReviewPage from './page'
 
 const defaultSearchParams = Promise.resolve({})
@@ -107,7 +107,7 @@ describe('StudyViewPage', () => {
     it('renders ResearcherProposalView for REJECTED study', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
         const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
-        await db.updateTable('study').set({ status: 'REJECTED' }).where('id', '=', study.id).execute()
+        await setTestStudyStatus(study.id, 'REJECTED')
 
         const page = await StudyReviewPage({
             params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
@@ -122,7 +122,7 @@ describe('StudyViewPage', () => {
     it('renders ResearcherProposalView for CHANGE-REQUESTED study without code placeholder content', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
         const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
-        await db.updateTable('study').set({ status: 'CHANGE-REQUESTED' }).where('id', '=', study.id).execute()
+        await setTestStudyStatus(study.id, 'CHANGE-REQUESTED')
 
         const page = await StudyReviewPage({
             params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
@@ -139,7 +139,7 @@ describe('StudyViewPage', () => {
     it('renders generic layout for DRAFT study without job', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
         const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
-        await db.updateTable('study').set({ status: 'DRAFT' }).where('id', '=', study.id).execute()
+        await setTestStudyStatus(study.id, 'DRAFT')
 
         const page = await StudyReviewPage({
             params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),

--- a/src/components/dashboard/studies-table/studies-table.test.tsx
+++ b/src/components/dashboard/studies-table/studies-table.test.tsx
@@ -12,7 +12,8 @@ vi.mock('@/server/actions/org.actions', () => ({
     getOrgFromSlugAction: vi.fn(),
 }))
 
-vi.mock('@/components/spy-mode-context', () => ({
+vi.mock('@/components/spy-mode-context', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@/components/spy-mode-context')>()),
     useSpyMode: () => ({ isSpyMode: false, toggleSpyMode: vi.fn() }),
 }))
 

--- a/src/components/openstax-feature-flag.test.tsx
+++ b/src/components/openstax-feature-flag.test.tsx
@@ -9,7 +9,8 @@ import {
 import { FC } from 'react'
 
 // Mock the dependencies
-vi.mock('./spy-mode-context', () => ({
+vi.mock('./spy-mode-context', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('./spy-mode-context')>()),
     useSpyMode: vi.fn(),
 }))
 

--- a/src/contexts/proposal/hooks/use-submit-proposal.test.ts
+++ b/src/contexts/proposal/hooks/use-submit-proposal.test.ts
@@ -1,0 +1,169 @@
+import { vi } from 'vitest'
+import {
+    act,
+    actionResult,
+    beforeEach,
+    createTestProposalDraft,
+    createTestQueryWrapper,
+    db,
+    describe,
+    expect,
+    faker,
+    it,
+    renderHook,
+    waitFor,
+    type Mock,
+} from '@/tests/unit.helpers'
+import { memoryRouter } from 'next-router-mock'
+import { notifications } from '@mantine/notifications'
+import { useForm } from '@mantine/form'
+import { zod4Resolver as zodResolver } from 'mantine-form-zod-resolver'
+import type { HocuspocusProvider } from '@hocuspocus/provider'
+import { finalizeStudySubmissionAction } from '@/server/actions/study-request'
+import { Routes } from '@/lib/routes'
+import { lexicalJson } from '@/lib/word-count'
+import {
+    initialProposalValues,
+    proposalFormSchema,
+    type ProposalFormValues,
+} from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
+import { useYjsFormMap } from '@/hooks/use-yjs-form-map'
+import { useSubmitProposal } from './use-submit-proposal'
+
+const buildValidProposalValues = (piUserId: string): ProposalFormValues => ({
+    title: 'Collaboration Title',
+    datasets: ['ds-1'],
+    researchQuestions: lexicalJson('What works for retention?'),
+    projectSummary: lexicalJson('Examines retention strategies in detail.'),
+    impact: lexicalJson('Findings inform future curriculum design.'),
+    additionalNotes: '',
+    piName: 'Dr. PI',
+    piUserId,
+})
+
+type StubYjsForm = ReturnType<typeof useYjsFormMap>
+
+const buildStubYjsForm = (): { yjsForm: StubYjsForm; sendStateless: Mock } => {
+    const sendStateless = vi.fn()
+    const yjsForm: StubYjsForm = {
+        provider: { sendStateless } as unknown as HocuspocusProvider,
+        fieldsMap: null,
+        isSynced: true,
+        pushField: vi.fn(),
+        pushPI: vi.fn(),
+    }
+    return { yjsForm, sendStateless }
+}
+
+describe('useSubmitProposal', () => {
+    let tabSessionId: string
+
+    beforeEach(() => {
+        tabSessionId = faker.string.uuid()
+        memoryRouter.setCurrentUrl('/start')
+        ;(notifications.show as Mock).mockClear()
+    })
+
+    it('successful submit broadcasts the event and navigates', async () => {
+        const { enclave, lab, studyId, user } = await createTestProposalDraft({ enclaveSlug: 'submit-happy' })
+        const { yjsForm, sendStateless } = buildStubYjsForm()
+
+        const { result } = renderHook(
+            () => {
+                const form = useForm<ProposalFormValues>({
+                    mode: 'controlled',
+                    initialValues: buildValidProposalValues(user.id),
+                })
+                const submit = useSubmitProposal({ studyId, form, yjsForm, tabSessionId })
+                return { form, ...submit }
+            },
+            { wrapper: createTestQueryWrapper() },
+        )
+
+        await act(async () => {
+            result.current.submitProposal()
+        })
+
+        await waitFor(() => expect(sendStateless).toHaveBeenCalledTimes(1), { timeout: 5000 })
+
+        const updatedStudy = await db
+            .selectFrom('study')
+            .select('status')
+            .where('id', '=', studyId)
+            .executeTakeFirstOrThrow()
+        expect(updatedStudy.status).toBe('PENDING-REVIEW')
+
+        const payload = JSON.parse(sendStateless.mock.calls[0][0] as string)
+        expect(payload.type).toBe('proposal-submitted')
+        expect(payload.studyId).toBe(studyId)
+        expect(payload.submittedByTabId).toBe(tabSessionId)
+        expect(typeof payload.submittedByName).toBe('string')
+        expect(payload.submittedByName.length).toBeGreaterThan(0)
+        expect(payload.orgName).toBe(enclave.name)
+
+        await waitFor(() => expect(memoryRouter.asPath).toBe(Routes.studySubmitted({ orgSlug: lab.slug, studyId })), {
+            timeout: 5000,
+        })
+    })
+
+    it('does not call the action or navigate when validation fails', async () => {
+        const { studyId } = await createTestProposalDraft({ enclaveSlug: 'submit-invalid' })
+        const { yjsForm, sendStateless } = buildStubYjsForm()
+
+        const { result } = renderHook(
+            () => {
+                const form = useForm<ProposalFormValues>({
+                    mode: 'controlled',
+                    initialValues: initialProposalValues,
+                    validate: zodResolver(proposalFormSchema),
+                })
+                const submit = useSubmitProposal({ studyId, form, yjsForm, tabSessionId })
+                return { form, ...submit }
+            },
+            { wrapper: createTestQueryWrapper() },
+        )
+
+        act(() => {
+            result.current.submitProposal()
+        })
+
+        const study = await db.selectFrom('study').select('status').where('id', '=', studyId).executeTakeFirstOrThrow()
+        expect(study.status).toBe('DRAFT')
+        expect(memoryRouter.asPath).toBe('/start')
+        expect(sendStateless).not.toHaveBeenCalled()
+    })
+
+    it('reports an error and does not broadcast when the proposal was already submitted', async () => {
+        const { studyId, user } = await createTestProposalDraft({ enclaveSlug: 'submit-concurrent' })
+
+        // First-submit-wins: pre-flip the study to PENDING-REVIEW.
+        actionResult(await finalizeStudySubmissionAction({ studyId }))
+
+        const { yjsForm, sendStateless } = buildStubYjsForm()
+
+        const { result } = renderHook(
+            () => {
+                const form = useForm<ProposalFormValues>({
+                    mode: 'controlled',
+                    initialValues: buildValidProposalValues(user.id),
+                })
+                const submit = useSubmitProposal({ studyId, form, yjsForm, tabSessionId })
+                return { form, ...submit }
+            },
+            { wrapper: createTestQueryWrapper() },
+        )
+
+        await act(async () => {
+            result.current.submitProposal()
+        })
+
+        await waitFor(() => expect(notifications.show).toHaveBeenCalled())
+        const errorCall = (notifications.show as Mock).mock.calls.find(
+            ([arg]) => arg && (arg as { title?: string }).title === 'Failed to submit proposal',
+        )
+        expect(errorCall).toBeDefined()
+        expect(sendStateless).not.toHaveBeenCalled()
+        // Navigation only happens onSuccess; ensure URL didn't change.
+        expect(memoryRouter.asPath).toBe('/start')
+    })
+})

--- a/src/hooks/query-wrappers.test.ts
+++ b/src/hooks/query-wrappers.test.ts
@@ -1,25 +1,6 @@
-import {
-    describe,
-    it,
-    expect,
-    vi,
-    beforeEach,
-    renderHook,
-    waitFor,
-    createTestQueryClient,
-    QueryClientProvider,
-} from '@/tests/unit.helpers'
+import { describe, it, expect, vi, beforeEach, renderHook, waitFor, createTestQueryWrapper } from '@/tests/unit.helpers'
 import { useQuery, useMutation } from './query-wrappers'
 import { type ActionResponse } from '@/lib/types'
-import React from 'react'
-
-const createWrapper = () => {
-    const queryClient = createTestQueryClient()
-    const Wrapper = ({ children }: { children: React.ReactNode }) =>
-        React.createElement(QueryClientProvider, { client: queryClient }, children)
-    Wrapper.displayName = 'QueryClientWrapper'
-    return Wrapper
-}
 
 describe('Query Wrappers', () => {
     beforeEach(() => {
@@ -37,7 +18,7 @@ describe('Query Wrappers', () => {
                         queryKey: ['test-error'],
                         queryFn: mockQueryFn,
                     }),
-                { wrapper: createWrapper() },
+                { wrapper: createTestQueryWrapper() },
             )
 
             await waitFor(() => expect(result.current.isError).toBe(true))
@@ -53,7 +34,7 @@ describe('Query Wrappers', () => {
                         queryKey: ['test-raw'],
                         queryFn: mockQueryFn,
                     }),
-                { wrapper: createWrapper() },
+                { wrapper: createTestQueryWrapper() },
             )
 
             await waitFor(() => expect(result.current.isSuccess).toBe(true))
@@ -75,7 +56,7 @@ describe('Query Wrappers', () => {
                         queryKey: ['test-complex'],
                         queryFn: mockQueryFn,
                     }),
-                { wrapper: createWrapper() },
+                { wrapper: createTestQueryWrapper() },
             )
 
             await waitFor(() => expect(result.current.isSuccess).toBe(true))
@@ -95,7 +76,7 @@ describe('Query Wrappers', () => {
                     useMutation({
                         mutationFn: mockMutationFn,
                     }),
-                { wrapper: createWrapper() },
+                { wrapper: createTestQueryWrapper() },
             )
 
             result.current.mutate('test-input')
@@ -112,7 +93,7 @@ describe('Query Wrappers', () => {
                     useMutation({
                         mutationFn: mockMutationFn,
                     }),
-                { wrapper: createWrapper() },
+                { wrapper: createTestQueryWrapper() },
             )
 
             result.current.mutate('test-input')

--- a/src/hooks/use-proposal-review-mutation.test.ts
+++ b/src/hooks/use-proposal-review-mutation.test.ts
@@ -1,0 +1,244 @@
+import { vi } from 'vitest'
+import {
+    act,
+    afterEach,
+    beforeEach,
+    buildFeedback,
+    createTestQueryWrapper,
+    db,
+    describe,
+    expect,
+    faker,
+    insertTestStudyJobData,
+    it,
+    mockSessionWithTestData,
+    renderHook,
+    resetSpyMode,
+    setSpyMode,
+    setTestStudyStatus,
+    spyModeState,
+    waitFor,
+    type Mock,
+} from '@/tests/unit.helpers'
+import { memoryRouter } from 'next-router-mock'
+import { notifications } from '@mantine/notifications'
+import { Routes } from '@/lib/routes'
+import { useProposalReviewMutation } from './use-proposal-review-mutation'
+
+vi.mock('@/components/spy-mode-context', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@/components/spy-mode-context')>()
+    return {
+        ...actual,
+        useSpyMode: () => ({ isSpyMode: spyModeState.isSpyMode, toggleSpyMode: vi.fn() }),
+    }
+})
+
+type Listener = (...args: unknown[]) => void
+
+type ProviderHandle = {
+    sendStateless: ReturnType<typeof vi.fn>
+}
+
+vi.mock('@hocuspocus/provider', () => {
+    const constructed: ProviderHandle[] = []
+
+    class HocuspocusProvider {
+        sendStateless = vi.fn()
+        private syncListeners: Listener[] = []
+
+        constructor() {
+            constructed.push({ sendStateless: this.sendStateless })
+        }
+        attach() {}
+        on(event: string, fn: Listener) {
+            if (event === 'synced') this.syncListeners.push(fn)
+        }
+        off(event: string, fn: Listener) {
+            if (event === 'synced') this.syncListeners = this.syncListeners.filter((l) => l !== fn)
+        }
+        destroy() {}
+    }
+
+    class HocuspocusProviderWebsocket {
+        constructor(_opts?: unknown) {}
+        destroy() {}
+    }
+
+    return {
+        HocuspocusProvider,
+        HocuspocusProviderWebsocket,
+        __constructed: constructed,
+    }
+})
+
+import * as HocuspocusModule from '@hocuspocus/provider'
+
+const constructed = (HocuspocusModule as unknown as { __constructed: ProviderHandle[] }).__constructed
+
+const validFeedback = buildFeedback(60)
+
+describe('useProposalReviewMutation', () => {
+    let tabSessionId: string
+
+    beforeEach(() => {
+        tabSessionId = faker.string.uuid()
+        constructed.length = 0
+        memoryRouter.setCurrentUrl('/start')
+        ;(notifications.show as Mock).mockClear()
+    })
+
+    afterEach(() => {
+        resetSpyMode()
+    })
+
+    it('approve decision broadcasts and navigates when the flag is ON', async () => {
+        const { user, org } = await mockSessionWithTestData({ orgSlug: 'openstax', orgType: 'enclave' })
+        const { study } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'PENDING-REVIEW',
+        })
+        setSpyMode(true)
+
+        const { result } = renderHook(
+            () => useProposalReviewMutation({ studyId: study.id, orgSlug: org.slug, tabSessionId }),
+            { wrapper: createTestQueryWrapper() },
+        )
+
+        await waitFor(() => expect(constructed).toHaveLength(1))
+        const handle = constructed[0]
+
+        await act(async () => {
+            result.current.submitReview({ decision: 'approve', feedback: validFeedback })
+        })
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+        const updated = await db
+            .selectFrom('study')
+            .select('status')
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+        expect(updated.status).toBe('APPROVED')
+
+        expect(handle.sendStateless).toHaveBeenCalledTimes(1)
+        const payload = JSON.parse(handle.sendStateless.mock.calls[0][0] as string)
+        expect(payload.type).toBe('proposal-review-submitted')
+        expect(payload.studyId).toBe(study.id)
+        expect(payload.submittedByTabId).toBe(tabSessionId)
+        expect(typeof payload.submittedByName).toBe('string')
+        expect(payload.submittedByName.length).toBeGreaterThan(0)
+
+        await waitFor(() =>
+            expect(memoryRouter.asPath).toBe(Routes.studyReview({ orgSlug: org.slug, studyId: study.id })),
+        )
+    })
+
+    it.each([
+        { decision: 'needs-clarification' as const, expectedStatus: 'CHANGE-REQUESTED' as const },
+        { decision: 'reject' as const, expectedStatus: 'REJECTED' as const },
+    ])('$decision decision broadcasts with the same wiring (flag ON)', async ({ decision, expectedStatus }) => {
+        const { user, org } = await mockSessionWithTestData({ orgSlug: 'openstax', orgType: 'enclave' })
+        const { study } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'PENDING-REVIEW',
+        })
+        setSpyMode(true)
+
+        const { result } = renderHook(
+            () => useProposalReviewMutation({ studyId: study.id, orgSlug: org.slug, tabSessionId }),
+            { wrapper: createTestQueryWrapper() },
+        )
+
+        await waitFor(() => expect(constructed).toHaveLength(1))
+        const handle = constructed[0]
+
+        await act(async () => {
+            result.current.submitReview({ decision, feedback: validFeedback })
+        })
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+        const updated = await db
+            .selectFrom('study')
+            .select('status')
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+        expect(updated.status).toBe(expectedStatus)
+
+        expect(handle.sendStateless).toHaveBeenCalledTimes(1)
+        const payload = JSON.parse(handle.sendStateless.mock.calls[0][0] as string)
+        expect(payload.type).toBe('proposal-review-submitted')
+        expect(payload.studyId).toBe(study.id)
+        expect(payload.submittedByTabId).toBe(tabSessionId)
+    })
+
+    it('flag OFF: navigates without broadcasting', async () => {
+        const { user, org } = await mockSessionWithTestData({ orgSlug: 'unrelated-enclave', orgType: 'enclave' })
+        const { study } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'PENDING-REVIEW',
+        })
+
+        const { result } = renderHook(
+            () => useProposalReviewMutation({ studyId: study.id, orgSlug: org.slug, tabSessionId }),
+            { wrapper: createTestQueryWrapper() },
+        )
+
+        // No provider constructed because the effect short-circuits when the flag is OFF.
+        expect(constructed).toHaveLength(0)
+
+        await act(async () => {
+            result.current.submitReview({ decision: 'approve', feedback: validFeedback })
+        })
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+        const updated = await db
+            .selectFrom('study')
+            .select('status')
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+        expect(updated.status).toBe('APPROVED')
+
+        expect(constructed).toHaveLength(0)
+        await waitFor(() =>
+            expect(memoryRouter.asPath).toBe(Routes.studyReview({ orgSlug: org.slug, studyId: study.id })),
+        )
+    })
+
+    it('action error: no navigation, no broadcast', async () => {
+        const { user, org } = await mockSessionWithTestData({ orgSlug: 'openstax', orgType: 'enclave' })
+        const { study } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'PENDING-REVIEW',
+        })
+        // Force the action's editable-status guard to reject by promoting the study
+        // out of PENDING-REVIEW after fixtures are inserted.
+        await setTestStudyStatus(study.id, 'APPROVED')
+        setSpyMode(true)
+
+        const { result } = renderHook(
+            () => useProposalReviewMutation({ studyId: study.id, orgSlug: org.slug, tabSessionId }),
+            { wrapper: createTestQueryWrapper() },
+        )
+
+        await waitFor(() => expect(constructed).toHaveLength(1))
+        const handle = constructed[0]
+
+        await act(async () => {
+            result.current.submitReview({ decision: 'approve', feedback: validFeedback })
+        })
+        await waitFor(() => expect(notifications.show).toHaveBeenCalled())
+
+        const errorCall = (notifications.show as Mock).mock.calls.find(
+            ([arg]) => arg && (arg as { title?: string }).title === 'Failed to submit review',
+        )
+        expect(errorCall).toBeDefined()
+        expect(handle.sendStateless).not.toHaveBeenCalled()
+        expect(memoryRouter.asPath).toBe('/start')
+
+        const after = await db.selectFrom('study').select('status').where('id', '=', study.id).executeTakeFirstOrThrow()
+        expect(after.status).toBe('APPROVED')
+    })
+})

--- a/src/hooks/use-proposal-review-mutation.test.ts
+++ b/src/hooks/use-proposal-review-mutation.test.ts
@@ -1,7 +1,6 @@
 import { vi } from 'vitest'
 import {
     act,
-    afterEach,
     beforeEach,
     buildFeedback,
     createTestQueryWrapper,
@@ -13,67 +12,31 @@ import {
     it,
     mockSessionWithTestData,
     renderHook,
-    resetSpyMode,
-    setSpyMode,
     setTestStudyStatus,
-    spyModeState,
     waitFor,
     type Mock,
 } from '@/tests/unit.helpers'
 import { memoryRouter } from 'next-router-mock'
 import { notifications } from '@mantine/notifications'
 import { Routes } from '@/lib/routes'
+import { createHocuspocusMock, type HocuspocusProviderHandle } from '@/tests/hocuspocus.mock'
 import { useProposalReviewMutation } from './use-proposal-review-mutation'
 
-vi.mock('@/components/spy-mode-context', async (importOriginal) => {
-    const actual = await importOriginal<typeof import('@/components/spy-mode-context')>()
+const featureFlagState = vi.hoisted(() => ({ enabled: false }))
+
+vi.mock('@/components/openstax-feature-flag', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@/components/openstax-feature-flag')>()
     return {
         ...actual,
-        useSpyMode: () => ({ isSpyMode: spyModeState.isSpyMode, toggleSpyMode: vi.fn() }),
+        useProposalCollaborationFeatureFlag: () => featureFlagState.enabled,
     }
 })
 
-type Listener = (...args: unknown[]) => void
-
-type ProviderHandle = {
-    sendStateless: ReturnType<typeof vi.fn>
-}
-
-vi.mock('@hocuspocus/provider', () => {
-    const constructed: ProviderHandle[] = []
-
-    class HocuspocusProvider {
-        sendStateless = vi.fn()
-        private syncListeners: Listener[] = []
-
-        constructor() {
-            constructed.push({ sendStateless: this.sendStateless })
-        }
-        attach() {}
-        on(event: string, fn: Listener) {
-            if (event === 'synced') this.syncListeners.push(fn)
-        }
-        off(event: string, fn: Listener) {
-            if (event === 'synced') this.syncListeners = this.syncListeners.filter((l) => l !== fn)
-        }
-        destroy() {}
-    }
-
-    class HocuspocusProviderWebsocket {
-        constructor(_opts?: unknown) {}
-        destroy() {}
-    }
-
-    return {
-        HocuspocusProvider,
-        HocuspocusProviderWebsocket,
-        __constructed: constructed,
-    }
-})
+vi.mock('@hocuspocus/provider', () => createHocuspocusMock())
 
 import * as HocuspocusModule from '@hocuspocus/provider'
 
-const constructed = (HocuspocusModule as unknown as { __constructed: ProviderHandle[] }).__constructed
+const constructed = (HocuspocusModule as unknown as { __constructed: HocuspocusProviderHandle[] }).__constructed
 
 const validFeedback = buildFeedback(60)
 
@@ -83,12 +46,9 @@ describe('useProposalReviewMutation', () => {
     beforeEach(() => {
         tabSessionId = faker.string.uuid()
         constructed.length = 0
+        featureFlagState.enabled = false
         memoryRouter.setCurrentUrl('/start')
         ;(notifications.show as Mock).mockClear()
-    })
-
-    afterEach(() => {
-        resetSpyMode()
     })
 
     it('approve decision broadcasts and navigates when the flag is ON', async () => {
@@ -98,7 +58,7 @@ describe('useProposalReviewMutation', () => {
             researcherId: user.id,
             studyStatus: 'PENDING-REVIEW',
         })
-        setSpyMode(true)
+        featureFlagState.enabled = true
 
         const { result } = renderHook(
             () => useProposalReviewMutation({ studyId: study.id, orgSlug: org.slug, tabSessionId }),
@@ -143,7 +103,7 @@ describe('useProposalReviewMutation', () => {
             researcherId: user.id,
             studyStatus: 'PENDING-REVIEW',
         })
-        setSpyMode(true)
+        featureFlagState.enabled = true
 
         const { result } = renderHook(
             () => useProposalReviewMutation({ studyId: study.id, orgSlug: org.slug, tabSessionId }),
@@ -216,7 +176,7 @@ describe('useProposalReviewMutation', () => {
         // Force the action's editable-status guard to reject by promoting the study
         // out of PENDING-REVIEW after fixtures are inserted.
         await setTestStudyStatus(study.id, 'APPROVED')
-        setSpyMode(true)
+        featureFlagState.enabled = true
 
         const { result } = renderHook(
             () => useProposalReviewMutation({ studyId: study.id, orgSlug: org.slug, tabSessionId }),

--- a/src/hooks/use-workspace-launcher.test.tsx
+++ b/src/hooks/use-workspace-launcher.test.tsx
@@ -8,11 +8,9 @@ import {
     waitFor,
     act,
     faker,
-    createTestQueryClient,
-    QueryClientProvider,
+    createTestQueryWrapper,
     type Mock,
 } from '@/tests/unit.helpers'
-import React from 'react'
 import { useWorkspaceLauncher } from './use-workspace-launcher'
 
 vi.mock('@/server/actions/workspaces.actions', () => ({
@@ -29,14 +27,6 @@ Object.defineProperty(window, 'open', {
 import { createUserAndWorkspaceAction, getWorkspaceUrlAction } from '@/server/actions/workspaces.actions'
 import { notifications } from '@mantine/notifications'
 
-const createWrapper = () => {
-    const queryClient = createTestQueryClient()
-    const Wrapper = ({ children }: { children: React.ReactNode }) =>
-        React.createElement(QueryClientProvider, { client: queryClient }, children)
-    Wrapper.displayName = 'QueryClientWrapper'
-    return Wrapper
-}
-
 const studyId = faker.string.uuid()
 
 describe('useWorkspaceLauncher', () => {
@@ -47,7 +37,7 @@ describe('useWorkspaceLauncher', () => {
     describe('initial state', () => {
         it('should return initial state correctly', () => {
             const { result } = renderHook(() => useWorkspaceLauncher({ studyId }), {
-                wrapper: createWrapper(),
+                wrapper: createTestQueryWrapper(),
             })
 
             expect(result.current.isLaunching).toBe(false)
@@ -65,7 +55,7 @@ describe('useWorkspaceLauncher', () => {
             )
 
             const { result } = renderHook(() => useWorkspaceLauncher({ studyId }), {
-                wrapper: createWrapper(),
+                wrapper: createTestQueryWrapper(),
             })
 
             act(() => {
@@ -82,7 +72,7 @@ describe('useWorkspaceLauncher', () => {
             ;(createUserAndWorkspaceAction as Mock).mockResolvedValue({ error: errorMessage })
 
             const { result } = renderHook(() => useWorkspaceLauncher({ studyId }), {
-                wrapper: createWrapper(),
+                wrapper: createTestQueryWrapper(),
             })
 
             act(() => {
@@ -100,7 +90,7 @@ describe('useWorkspaceLauncher', () => {
             ;(createUserAndWorkspaceAction as Mock).mockResolvedValue({ error: { code: 500 } })
 
             const { result } = renderHook(() => useWorkspaceLauncher({ studyId }), {
-                wrapper: createWrapper(),
+                wrapper: createTestQueryWrapper(),
             })
 
             act(() => {
@@ -121,7 +111,7 @@ describe('useWorkspaceLauncher', () => {
             ;(getWorkspaceUrlAction as Mock).mockResolvedValue('https://workspace.example.com')
 
             const { result } = renderHook(() => useWorkspaceLauncher({ studyId }), {
-                wrapper: createWrapper(),
+                wrapper: createTestQueryWrapper(),
             })
 
             act(() => {
@@ -144,7 +134,7 @@ describe('useWorkspaceLauncher', () => {
             ;(getWorkspaceUrlAction as Mock).mockResolvedValue(workspaceUrl)
 
             const { result } = renderHook(() => useWorkspaceLauncher({ studyId }), {
-                wrapper: createWrapper(),
+                wrapper: createTestQueryWrapper(),
             })
 
             act(() => {
@@ -166,7 +156,7 @@ describe('useWorkspaceLauncher', () => {
             ;(getWorkspaceUrlAction as Mock).mockResolvedValue(workspaceUrl)
 
             const { result } = renderHook(() => useWorkspaceLauncher({ studyId }), {
-                wrapper: createWrapper(),
+                wrapper: createTestQueryWrapper(),
             })
 
             act(() => {
@@ -193,7 +183,7 @@ describe('useWorkspaceLauncher', () => {
             ;(getWorkspaceUrlAction as Mock).mockResolvedValue('https://workspace.example.com')
 
             const { result } = renderHook(() => useWorkspaceLauncher({ studyId }), {
-                wrapper: createWrapper(),
+                wrapper: createTestQueryWrapper(),
             })
 
             act(() => {
@@ -215,7 +205,7 @@ describe('useWorkspaceLauncher', () => {
             ;(getWorkspaceUrlAction as Mock).mockResolvedValue({ error: queryError })
 
             const { result } = renderHook(() => useWorkspaceLauncher({ studyId }), {
-                wrapper: createWrapper(),
+                wrapper: createTestQueryWrapper(),
             })
 
             act(() => {
@@ -235,7 +225,7 @@ describe('useWorkspaceLauncher', () => {
             ;(getWorkspaceUrlAction as Mock).mockResolvedValue({ error: { code: 404 } })
 
             const { result } = renderHook(() => useWorkspaceLauncher({ studyId }), {
-                wrapper: createWrapper(),
+                wrapper: createTestQueryWrapper(),
             })
 
             act(() => {
@@ -253,7 +243,7 @@ describe('useWorkspaceLauncher', () => {
             ;(createUserAndWorkspaceAction as Mock).mockResolvedValue({ error: 'Some error' })
 
             const { result } = renderHook(() => useWorkspaceLauncher({ studyId }), {
-                wrapper: createWrapper(),
+                wrapper: createTestQueryWrapper(),
             })
 
             act(() => {
@@ -287,7 +277,7 @@ describe('useWorkspaceLauncher', () => {
             ;(getWorkspaceUrlAction as Mock).mockResolvedValue('https://workspace.example.com')
 
             const { result } = renderHook(() => useWorkspaceLauncher({ studyId }), {
-                wrapper: createWrapper(),
+                wrapper: createTestQueryWrapper(),
             })
 
             // First attempt - fails
@@ -314,7 +304,7 @@ describe('useWorkspaceLauncher', () => {
             ;(createUserAndWorkspaceAction as Mock).mockResolvedValue({ error: 'Some error' })
 
             const { result } = renderHook(() => useWorkspaceLauncher({ studyId }), {
-                wrapper: createWrapper(),
+                wrapper: createTestQueryWrapper(),
             })
 
             act(() => {

--- a/src/hooks/use-yjs-form-map.test.ts
+++ b/src/hooks/use-yjs-form-map.test.ts
@@ -14,7 +14,7 @@ import { useForm } from '@mantine/form'
 import * as Y from 'yjs'
 import { proposalFieldsDocName } from '@/lib/collaboration-documents'
 import { initialProposalValues, type ProposalFormValues } from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
-import { useYjsFormMap, type CollabFieldKey } from './use-yjs-form-map'
+import { useYjsFormMap } from './use-yjs-form-map'
 
 type Listener = (...args: unknown[]) => void
 
@@ -27,24 +27,28 @@ type Handle = {
 vi.mock('@hocuspocus/provider', () => {
     const constructed: Handle[] = []
 
-    class HocuspocusProvider {
-        document: Y.Doc
-        isSynced = false
-        sendStateless = vi.fn()
-        private syncListeners: Listener[] = []
+class HocuspocusProvider {
+    document: Y.Doc
+    isSynced = false
+    sendStateless = vi.fn()
+    private attached = false
+    private syncListeners: Listener[] = []
 
         constructor(opts: { document: Y.Doc }) {
             this.document = opts.document
             constructed.push({
                 document: opts.document,
                 triggerSync: () => {
+                    if (!this.attached) throw new Error('HocuspocusProvider must be attached before syncing')
                     this.isSynced = true
                     this.syncListeners.forEach((fn) => fn())
                 },
                 sendStateless: this.sendStateless,
             })
         }
-        attach() {}
+        attach() {
+            this.attached = true
+        }
         on(event: string, fn: Listener) {
             if (event === 'synced') this.syncListeners.push(fn)
         }
@@ -229,7 +233,7 @@ describe('useYjsFormMap', () => {
             Y.applyUpdate(peerB, update, origin)
         })
 
-        hookResult.result.current.pushField('datasets' as CollabFieldKey, ['ds-1', 'ds-2'])
+        hookResult.result.current.pushField('datasets', ['ds-1', 'ds-2'])
 
         // Confirm the local write committed before checking propagation.
         expect(handle.document.getMap('fields').get('datasets')).toEqual(['ds-1', 'ds-2'])

--- a/src/hooks/use-yjs-form-map.test.ts
+++ b/src/hooks/use-yjs-form-map.test.ts
@@ -27,12 +27,12 @@ type Handle = {
 vi.mock('@hocuspocus/provider', () => {
     const constructed: Handle[] = []
 
-class HocuspocusProvider {
-    document: Y.Doc
-    isSynced = false
-    sendStateless = vi.fn()
-    private attached = false
-    private syncListeners: Listener[] = []
+    class HocuspocusProvider {
+        document: Y.Doc
+        isSynced = false
+        sendStateless = vi.fn()
+        private attached = false
+        private syncListeners: Listener[] = []
 
         constructor(opts: { document: Y.Doc }) {
             this.document = opts.document

--- a/src/hooks/use-yjs-form-map.test.ts
+++ b/src/hooks/use-yjs-form-map.test.ts
@@ -1,0 +1,292 @@
+import { vi } from 'vitest'
+import {
+    beforeEach,
+    createTestProposalDraft,
+    db,
+    describe,
+    expect,
+    faker,
+    it,
+    renderHook,
+    waitFor,
+} from '@/tests/unit.helpers'
+import { useForm } from '@mantine/form'
+import * as Y from 'yjs'
+import { proposalFieldsDocName } from '@/lib/collaboration-documents'
+import { initialProposalValues, type ProposalFormValues } from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
+import { useYjsFormMap, type CollabFieldKey } from './use-yjs-form-map'
+
+type Listener = (...args: unknown[]) => void
+
+type Handle = {
+    document: Y.Doc
+    triggerSync: () => void
+    sendStateless: ReturnType<typeof vi.fn>
+}
+
+vi.mock('@hocuspocus/provider', () => {
+    const constructed: Handle[] = []
+
+    class HocuspocusProvider {
+        document: Y.Doc
+        isSynced = false
+        sendStateless = vi.fn()
+        private syncListeners: Listener[] = []
+
+        constructor(opts: { document: Y.Doc }) {
+            this.document = opts.document
+            constructed.push({
+                document: opts.document,
+                triggerSync: () => {
+                    this.isSynced = true
+                    this.syncListeners.forEach((fn) => fn())
+                },
+                sendStateless: this.sendStateless,
+            })
+        }
+        attach() {}
+        on(event: string, fn: Listener) {
+            if (event === 'synced') this.syncListeners.push(fn)
+        }
+        off(event: string, fn: Listener) {
+            if (event === 'synced') this.syncListeners = this.syncListeners.filter((l) => l !== fn)
+        }
+        destroy() {}
+    }
+
+    class HocuspocusProviderWebsocket {
+        constructor(_opts?: unknown) {}
+        destroy() {}
+    }
+
+    return {
+        HocuspocusProvider,
+        HocuspocusProviderWebsocket,
+        __constructed: constructed,
+    }
+})
+
+import * as HocuspocusModule from '@hocuspocus/provider'
+
+const constructed = (HocuspocusModule as unknown as { __constructed: Handle[] }).__constructed
+
+const buildProposalForm = (overrides: Partial<ProposalFormValues> = {}) => {
+    const initial = { ...initialProposalValues, ...overrides }
+    return renderHook(() => useForm<ProposalFormValues>({ mode: 'uncontrolled', initialValues: initial }))
+}
+
+const setupCollabHook = ({
+    studyId,
+    formInitial,
+    enabled = true,
+}: {
+    studyId: string
+    formInitial: Partial<ProposalFormValues>
+    enabled?: boolean
+}) => {
+    const { result: formResult } = buildProposalForm(formInitial)
+    const form = formResult.current
+    const websocketProvider = new (HocuspocusModule.HocuspocusProviderWebsocket as unknown as new () => InstanceType<
+        typeof HocuspocusModule.HocuspocusProviderWebsocket
+    >)()
+    const hookResult = renderHook(() =>
+        useYjsFormMap({
+            studyId,
+            form,
+            websocketProvider: enabled ? websocketProvider : null,
+            enabled,
+        }),
+    )
+    return { form, hookResult }
+}
+
+const createDraftStudy = (slugTag: string, formTitle = 'Original') =>
+    createTestProposalDraft({
+        enclaveSlug: `yjs-${slugTag}-enclave`,
+        studyInfo: { title: formTitle },
+    })
+
+describe('useYjsFormMap', () => {
+    beforeEach(() => {
+        constructed.length = 0
+    })
+
+    it('cold load: seeds the Y.Map from form initial values when no yjsDocument row exists', async () => {
+        const { studyId } = await createDraftStudy('cold')
+        const piUserId = faker.string.uuid()
+
+        const { hookResult } = setupCollabHook({
+            studyId,
+            formInitial: {
+                title: 'Original',
+                datasets: ['ds-1'],
+                piName: 'PI',
+                piUserId,
+            },
+        })
+
+        expect(constructed).toHaveLength(1)
+        constructed[0].triggerSync()
+
+        await waitFor(() => expect(hookResult.result.current.isSynced).toBe(true))
+
+        const fieldsMap = hookResult.result.current.fieldsMap
+        expect(fieldsMap).not.toBeNull()
+        expect(fieldsMap!.get('title')).toBe('Original')
+        expect(fieldsMap!.get('datasets')).toEqual(['ds-1'])
+        expect(fieldsMap!.get('piName')).toBe('PI')
+        expect(fieldsMap!.get('piUserId')).toBe(piUserId)
+    })
+
+    it('warm load: applies persisted CRDT state to the form when a yjsDocument row already exists', async () => {
+        const { studyId } = await createDraftStudy('warm', 'OriginalForm')
+
+        await db
+            .insertInto('yjsDocument')
+            .values({
+                name: proposalFieldsDocName(studyId),
+                studyId,
+                data: Buffer.from([0]),
+            })
+            .execute()
+
+        const { form, hookResult } = setupCollabHook({
+            studyId,
+            formInitial: { title: 'OriginalForm', datasets: [], piName: 'PI', piUserId: faker.string.uuid() },
+        })
+
+        expect(constructed).toHaveLength(1)
+        const handle = constructed[0]
+
+        // Simulate the Hocuspocus server pushing persisted CRDT state into the doc
+        // before the synced event fires.
+        const seedDoc = new Y.Doc()
+        seedDoc.getMap('fields').set('title', 'FromCRDT')
+        Y.applyUpdate(handle.document, Y.encodeStateAsUpdate(seedDoc))
+
+        handle.triggerSync()
+
+        await waitFor(() => expect(hookResult.result.current.isSynced).toBe(true))
+        await waitFor(() => expect(form.getValues().title).toBe('FromCRDT'))
+        expect(form.isDirty()).toBe(false)
+    })
+
+    it('remote update applies to local form mid-session', async () => {
+        const { studyId } = await createDraftStudy('remote')
+
+        const { form, hookResult } = setupCollabHook({
+            studyId,
+            formInitial: {
+                title: 'Original',
+                datasets: ['ds-1'],
+                piName: 'PI',
+                piUserId: faker.string.uuid(),
+            },
+        })
+
+        expect(constructed).toHaveLength(1)
+        const handle = constructed[0]
+        handle.triggerSync()
+        await waitFor(() => expect(hookResult.result.current.isSynced).toBe(true))
+
+        // Write to the captured Y.Doc with a non-LOCAL_ORIGIN origin so the hook's
+        // observe handler treats it as a remote update.
+        const remoteOrigin = Symbol('remote')
+        handle.document.transact(() => {
+            handle.document.getMap('fields').set('title', 'Remote')
+        }, remoteOrigin)
+
+        await waitFor(() => expect(form.getValues().title).toBe('Remote'))
+        expect(form.isDirty()).toBe(false)
+    })
+
+    it('local writes via pushField propagate to a remote peer with the LOCAL_ORIGIN tag', async () => {
+        const { studyId } = await createDraftStudy('local')
+
+        const { hookResult } = setupCollabHook({
+            studyId,
+            formInitial: {
+                title: 'Original',
+                datasets: ['ds-1'],
+                piName: 'PI',
+                piUserId: faker.string.uuid(),
+            },
+        })
+
+        expect(constructed).toHaveLength(1)
+        const handle = constructed[0]
+        handle.triggerSync()
+        await waitFor(() => expect(hookResult.result.current.isSynced).toBe(true))
+
+        const peerB = new Y.Doc()
+        // Pre-sync peerB with peerA's current state so the receiving peer has the
+        // baseline before applying incremental updates.
+        Y.applyUpdate(peerB, Y.encodeStateAsUpdate(handle.document))
+
+        const capturedOrigins: unknown[] = []
+        handle.document.on('update', (update: Uint8Array, origin: unknown) => {
+            capturedOrigins.push(origin)
+            Y.applyUpdate(peerB, update, origin)
+        })
+
+        hookResult.result.current.pushField('datasets' as CollabFieldKey, ['ds-1', 'ds-2'])
+
+        // Confirm the local write committed before checking propagation.
+        expect(handle.document.getMap('fields').get('datasets')).toEqual(['ds-1', 'ds-2'])
+
+        await waitFor(() => expect(peerB.getMap('fields').get('datasets')).toEqual(['ds-1', 'ds-2']))
+
+        const localOrigin = capturedOrigins.find(
+            (o): o is symbol => typeof o === 'symbol' && (o as symbol).description === 'use-yjs-form-map.local',
+        )
+        expect(localOrigin).toBeDefined()
+    })
+
+    it('pushPI writes both keys in a single transact', async () => {
+        const { studyId } = await createDraftStudy('pi')
+
+        const { hookResult } = setupCollabHook({
+            studyId,
+            formInitial: {
+                title: 'Original',
+                datasets: ['ds-1'],
+                piName: 'PI',
+                piUserId: faker.string.uuid(),
+            },
+        })
+
+        expect(constructed).toHaveLength(1)
+        constructed[0].triggerSync()
+        await waitFor(() => expect(hookResult.result.current.isSynced).toBe(true))
+
+        const fieldsMap = hookResult.result.current.fieldsMap!
+        const events: Y.YMapEvent<unknown>[] = []
+        const observer = (event: Y.YMapEvent<unknown>) => events.push(event)
+        fieldsMap.observe(observer)
+
+        const newPiId = faker.string.uuid()
+        hookResult.result.current.pushPI(newPiId, 'Dr. PI')
+
+        expect(events).toHaveLength(1)
+        expect(events[0].keysChanged).toEqual(new Set(['piName', 'piUserId']))
+        expect(fieldsMap.get('piName')).toBe('Dr. PI')
+        expect(fieldsMap.get('piUserId')).toBe(newPiId)
+
+        fieldsMap.unobserve(observer)
+    })
+
+    it('disabled hook is inert', () => {
+        const studyId = faker.string.uuid()
+        const { hookResult } = setupCollabHook({
+            studyId,
+            formInitial: { title: 'Original', datasets: ['ds-1'], piName: 'PI', piUserId: faker.string.uuid() },
+            enabled: false,
+        })
+
+        expect(constructed).toHaveLength(0)
+        expect(hookResult.result.current.provider).toBeNull()
+        expect(hookResult.result.current.fieldsMap).toBeNull()
+        expect(hookResult.result.current.isSynced).toBe(false)
+        expect(() => hookResult.result.current.pushField('title', 'X')).not.toThrow()
+    })
+})

--- a/src/hooks/use-yjs-form-map.test.ts
+++ b/src/hooks/use-yjs-form-map.test.ts
@@ -2,7 +2,6 @@ import { vi } from 'vitest'
 import {
     beforeEach,
     createTestProposalDraft,
-    db,
     describe,
     expect,
     faker,
@@ -12,67 +11,27 @@ import {
 } from '@/tests/unit.helpers'
 import { useForm } from '@mantine/form'
 import * as Y from 'yjs'
-import { proposalFieldsDocName } from '@/lib/collaboration-documents'
+import { createHocuspocusMock, type HocuspocusProviderHandle } from '@/tests/hocuspocus.mock'
 import { initialProposalValues, type ProposalFormValues } from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
 import { useYjsFormMap } from './use-yjs-form-map'
 
-type Listener = (...args: unknown[]) => void
+const yjsDocumentState = vi.hoisted(() => ({ updatedAt: null as Date | null }))
 
-type Handle = {
-    document: Y.Doc
-    triggerSync: () => void
-    sendStateless: ReturnType<typeof vi.fn>
-}
-
-vi.mock('@hocuspocus/provider', () => {
-    const constructed: Handle[] = []
-
-    class HocuspocusProvider {
-        document: Y.Doc
-        isSynced = false
-        sendStateless = vi.fn()
-        private attached = false
-        private syncListeners: Listener[] = []
-
-        constructor(opts: { document: Y.Doc }) {
-            this.document = opts.document
-            constructed.push({
-                document: opts.document,
-                triggerSync: () => {
-                    if (!this.attached) throw new Error('HocuspocusProvider must be attached before syncing')
-                    this.isSynced = true
-                    this.syncListeners.forEach((fn) => fn())
-                },
-                sendStateless: this.sendStateless,
-            })
-        }
-        attach() {
-            this.attached = true
-        }
-        on(event: string, fn: Listener) {
-            if (event === 'synced') this.syncListeners.push(fn)
-        }
-        off(event: string, fn: Listener) {
-            if (event === 'synced') this.syncListeners = this.syncListeners.filter((l) => l !== fn)
-        }
-        destroy() {}
-    }
-
-    class HocuspocusProviderWebsocket {
-        constructor(_opts?: unknown) {}
-        destroy() {}
-    }
-
+vi.mock('@/server/actions/editor.actions', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@/server/actions/editor.actions')>()
     return {
-        HocuspocusProvider,
-        HocuspocusProviderWebsocket,
-        __constructed: constructed,
+        ...actual,
+        getYjsDocumentUpdatedAtAction: () => yjsDocumentState.updatedAt,
     }
 })
 
+vi.mock('@hocuspocus/provider', () => createHocuspocusMock({ withYDoc: true }))
+
 import * as HocuspocusModule from '@hocuspocus/provider'
 
-const constructed = (HocuspocusModule as unknown as { __constructed: Handle[] }).__constructed
+const constructed = (HocuspocusModule as unknown as { __constructed: HocuspocusProviderHandle[] }).__constructed
+
+const newWebsocketProvider = () => new HocuspocusModule.HocuspocusProviderWebsocket(undefined as never)
 
 const buildProposalForm = (overrides: Partial<ProposalFormValues> = {}) => {
     const initial = { ...initialProposalValues, ...overrides }
@@ -90,9 +49,7 @@ const setupCollabHook = ({
 }) => {
     const { result: formResult } = buildProposalForm(formInitial)
     const form = formResult.current
-    const websocketProvider = new (HocuspocusModule.HocuspocusProviderWebsocket as unknown as new () => InstanceType<
-        typeof HocuspocusModule.HocuspocusProviderWebsocket
-    >)()
+    const websocketProvider = newWebsocketProvider()
     const hookResult = renderHook(() =>
         useYjsFormMap({
             studyId,
@@ -113,6 +70,7 @@ const createDraftStudy = (slugTag: string, formTitle = 'Original') =>
 describe('useYjsFormMap', () => {
     beforeEach(() => {
         constructed.length = 0
+        yjsDocumentState.updatedAt = null
     })
 
     it('cold load: seeds the Y.Map from form initial values when no yjsDocument row exists', async () => {
@@ -142,17 +100,9 @@ describe('useYjsFormMap', () => {
         expect(fieldsMap!.get('piUserId')).toBe(piUserId)
     })
 
-    it('warm load: applies persisted CRDT state to the form when a yjsDocument row already exists', async () => {
+    it('applies CRDT state pushed before sync to the form', async () => {
         const { studyId } = await createDraftStudy('warm', 'OriginalForm')
-
-        await db
-            .insertInto('yjsDocument')
-            .values({
-                name: proposalFieldsDocName(studyId),
-                studyId,
-                data: Buffer.from([0]),
-            })
-            .execute()
+        yjsDocumentState.updatedAt = new Date()
 
         const { form, hookResult } = setupCollabHook({
             studyId,
@@ -166,7 +116,7 @@ describe('useYjsFormMap', () => {
         // before the synced event fires.
         const seedDoc = new Y.Doc()
         seedDoc.getMap('fields').set('title', 'FromCRDT')
-        Y.applyUpdate(handle.document, Y.encodeStateAsUpdate(seedDoc))
+        Y.applyUpdate(handle.document!, Y.encodeStateAsUpdate(seedDoc))
 
         handle.triggerSync()
 
@@ -196,8 +146,9 @@ describe('useYjsFormMap', () => {
         // Write to the captured Y.Doc with a non-LOCAL_ORIGIN origin so the hook's
         // observe handler treats it as a remote update.
         const remoteOrigin = Symbol('remote')
-        handle.document.transact(() => {
-            handle.document.getMap('fields').set('title', 'Remote')
+        const document = handle.document!
+        document.transact(() => {
+            document.getMap('fields').set('title', 'Remote')
         }, remoteOrigin)
 
         await waitFor(() => expect(form.getValues().title).toBe('Remote'))
@@ -225,10 +176,10 @@ describe('useYjsFormMap', () => {
         const peerB = new Y.Doc()
         // Pre-sync peerB with peerA's current state so the receiving peer has the
         // baseline before applying incremental updates.
-        Y.applyUpdate(peerB, Y.encodeStateAsUpdate(handle.document))
+        Y.applyUpdate(peerB, Y.encodeStateAsUpdate(handle.document!))
 
         const capturedOrigins: unknown[] = []
-        handle.document.on('update', (update: Uint8Array, origin: unknown) => {
+        handle.document!.on('update', (update: Uint8Array, origin: unknown) => {
             capturedOrigins.push(origin)
             Y.applyUpdate(peerB, update, origin)
         })
@@ -236,7 +187,7 @@ describe('useYjsFormMap', () => {
         hookResult.result.current.pushField('datasets', ['ds-1', 'ds-2'])
 
         // Confirm the local write committed before checking propagation.
-        expect(handle.document.getMap('fields').get('datasets')).toEqual(['ds-1', 'ds-2'])
+        expect(handle.document!.getMap('fields').get('datasets')).toEqual(['ds-1', 'ds-2'])
 
         await waitFor(() => expect(peerB.getMap('fields').get('datasets')).toEqual(['ds-1', 'ds-2']))
 

--- a/src/hooks/use-yjs-form-map.test.ts
+++ b/src/hooks/use-yjs-form-map.test.ts
@@ -2,6 +2,7 @@ import { vi } from 'vitest'
 import {
     beforeEach,
     createTestProposalDraft,
+    db,
     describe,
     expect,
     faker,
@@ -12,18 +13,9 @@ import {
 import { useForm } from '@mantine/form'
 import * as Y from 'yjs'
 import { createHocuspocusMock, type HocuspocusProviderHandle } from '@/tests/hocuspocus.mock'
+import { proposalFieldsDocName } from '@/lib/collaboration-documents'
 import { initialProposalValues, type ProposalFormValues } from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
 import { useYjsFormMap } from './use-yjs-form-map'
-
-const yjsDocumentState = vi.hoisted(() => ({ updatedAt: null as Date | null }))
-
-vi.mock('@/server/actions/editor.actions', async (importOriginal) => {
-    const actual = await importOriginal<typeof import('@/server/actions/editor.actions')>()
-    return {
-        ...actual,
-        getYjsDocumentUpdatedAtAction: () => yjsDocumentState.updatedAt,
-    }
-})
 
 vi.mock('@hocuspocus/provider', () => createHocuspocusMock({ withYDoc: true }))
 
@@ -70,7 +62,6 @@ const createDraftStudy = (slugTag: string, formTitle = 'Original') =>
 describe('useYjsFormMap', () => {
     beforeEach(() => {
         constructed.length = 0
-        yjsDocumentState.updatedAt = null
     })
 
     it('cold load: seeds the Y.Map from form initial values when no yjsDocument row exists', async () => {
@@ -100,9 +91,20 @@ describe('useYjsFormMap', () => {
         expect(fieldsMap!.get('piUserId')).toBe(piUserId)
     })
 
-    it('applies CRDT state pushed before sync to the form', async () => {
+    it('warm load: applies CRDT state pushed before sync to the form when a yjsDocument row exists', async () => {
         const { studyId } = await createDraftStudy('warm', 'OriginalForm')
-        yjsDocumentState.updatedAt = new Date()
+
+        // The row gates `getYjsDocumentUpdatedAtAction` onto the warm-load branch (non-null
+        // updatedAt). The mocked Hocuspocus provider can't read it back as CRDT bytes, so
+        // the Y.applyUpdate below is what supplies the actual content the form will see.
+        await db
+            .insertInto('yjsDocument')
+            .values({
+                name: proposalFieldsDocName(studyId),
+                studyId,
+                data: Buffer.from([0]),
+            })
+            .execute()
 
         const { form, hookResult } = setupCollabHook({
             studyId,

--- a/src/server/actions/study-request.test.ts
+++ b/src/server/actions/study-request.test.ts
@@ -2,6 +2,7 @@ import * as aws from '@/server/aws'
 import {
     actionResult,
     cleanupWorkspaceDirs,
+    createTestProposalDraft,
     createWorkspaceDir,
     db,
     expectStudyJobRecords,
@@ -11,11 +12,13 @@ import {
     insertTestStudyJobData,
     insertTestStudyOnly,
     mockSessionWithTestData,
+    setTestStudyStatus,
     writeWorkspaceFiles,
 } from '@/tests/unit.helpers'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
     addJobToStudyAction,
+    getDraftStudyAction,
     onDeleteStudyAction,
     onSaveDraftStudyAction,
     onSubmitDraftStudyAction,
@@ -362,19 +365,12 @@ describe('Request Study Actions', () => {
 
     describe('Multi-user proposal collaboration (OTTER-497)', () => {
         it('finalizeStudySubmissionAction returns submitterFullName and DO orgName', async () => {
-            const enclave = await insertTestOrg({ type: 'enclave', slug: 'test-otter-497-meta' })
-            const lab = await insertTestOrg({ slug: `${enclave.slug}-lab`, type: 'lab' })
-            await mockSessionWithTestData({ orgSlug: lab.slug, orgType: 'lab' })
+            const { enclave, studyId } = await createTestProposalDraft({
+                enclaveSlug: 'test-otter-497-meta',
+                studyInfo: { title: 'Meta' },
+            })
 
-            const draftResult = actionResult(
-                await onSaveDraftStudyAction({
-                    orgSlug: enclave.slug,
-                    studyInfo: { title: 'Meta', piName: 'PI', language: 'R' as const },
-                    submittingOrgSlug: lab.slug,
-                }),
-            )
-
-            const result = actionResult(await finalizeStudySubmissionAction({ studyId: draftResult.studyId }))
+            const result = actionResult(await finalizeStudySubmissionAction({ studyId }))
 
             expect(typeof result.submitterFullName).toBe('string')
             expect(result.submitterFullName.length).toBeGreaterThan(0)
@@ -382,21 +378,14 @@ describe('Request Study Actions', () => {
         })
 
         it('finalizeStudySubmissionAction is first-submit-wins: second concurrent caller fails', async () => {
-            const enclave = await insertTestOrg({ type: 'enclave', slug: 'test-otter-497-race' })
-            const lab = await insertTestOrg({ slug: `${enclave.slug}-lab`, type: 'lab' })
-            await mockSessionWithTestData({ orgSlug: lab.slug, orgType: 'lab' })
-
-            const draftResult = actionResult(
-                await onSaveDraftStudyAction({
-                    orgSlug: enclave.slug,
-                    studyInfo: { title: 'Race', piName: 'PI', language: 'R' as const },
-                    submittingOrgSlug: lab.slug,
-                }),
-            )
+            const { studyId } = await createTestProposalDraft({
+                enclaveSlug: 'test-otter-497-race',
+                studyInfo: { title: 'Race' },
+            })
 
             const [first, second] = await Promise.all([
-                finalizeStudySubmissionAction({ studyId: draftResult.studyId }),
-                finalizeStudySubmissionAction({ studyId: draftResult.studyId }),
+                finalizeStudySubmissionAction({ studyId }),
+                finalizeStudySubmissionAction({ studyId }),
             ])
 
             const successes = [first, second].filter((r) => !('error' in r))
@@ -411,7 +400,7 @@ describe('Request Study Actions', () => {
             const study = await db
                 .selectFrom('study')
                 .selectAll('study')
-                .where('id', '=', draftResult.studyId)
+                .where('id', '=', studyId)
                 .executeTakeFirstOrThrow()
             expect(study.status).toBe('PENDING-REVIEW')
         })
@@ -421,7 +410,7 @@ describe('Request Study Actions', () => {
             const { study } = await insertTestStudyOnly({ org })
 
             // Force the test study into CHANGE-REQUESTED status (insertTestStudyOnly defaults to APPROVED)
-            await db.updateTable('study').set({ status: 'CHANGE-REQUESTED' }).where('id', '=', study.id).execute()
+            await setTestStudyStatus(study.id, 'CHANGE-REQUESTED')
 
             const result = actionResult(await finalizeStudySubmissionAction({ studyId: study.id }))
             expect(result.studyId).toBe(study.id)
@@ -465,7 +454,7 @@ describe('Request Study Actions', () => {
         it('finalizeStudySubmissionAction deletes proposal-* yjs_document rows so re-edit reseeds from study columns', async () => {
             const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
             const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
-            await db.updateTable('study').set({ status: 'DRAFT' }).where('id', '=', study.id).execute()
+            await setTestStudyStatus(study.id, 'DRAFT')
 
             // Simulate Hocuspocus-persisted Y.Doc rows accumulated during the editing session.
             await db
@@ -541,24 +530,12 @@ describe('Request Study Actions', () => {
         })
 
         it('onUpdateDraftStudyAction allows another lab member to edit a CHANGE-REQUESTED draft', async () => {
-            const enclave = await insertTestOrg({ type: 'enclave', slug: 'test-otter-497-coauthor' })
-            const lab = await insertTestOrg({ slug: `${enclave.slug}-lab`, type: 'lab' })
+            const { lab, studyId } = await createTestProposalDraft({
+                enclaveSlug: 'test-otter-497-coauthor',
+                studyInfo: { title: 'Original' },
+            })
 
-            // First user creates the draft.
-            await mockSessionWithTestData({ orgSlug: lab.slug, orgType: 'lab' })
-            const draftResult = actionResult(
-                await onSaveDraftStudyAction({
-                    orgSlug: enclave.slug,
-                    studyInfo: { title: 'Original', piName: 'PI', language: 'R' as const },
-                    submittingOrgSlug: lab.slug,
-                }),
-            )
-
-            await db
-                .updateTable('study')
-                .set({ status: 'CHANGE-REQUESTED' })
-                .where('id', '=', draftResult.studyId)
-                .execute()
+            await setTestStudyStatus(studyId, 'CHANGE-REQUESTED')
 
             // Second user in the same lab updates the draft. mockSessionWithTestData
             // creates a fresh user; the lab-membership middleware should allow the edit.
@@ -566,7 +543,7 @@ describe('Request Study Actions', () => {
 
             actionResult(
                 await onUpdateDraftStudyAction({
-                    studyId: draftResult.studyId,
+                    studyId,
                     studyInfo: { title: 'Coauthored', piName: 'PI', language: 'R' as const },
                 }),
             )
@@ -574,10 +551,150 @@ describe('Request Study Actions', () => {
             const updated = await db
                 .selectFrom('study')
                 .select(['title', 'status'])
-                .where('id', '=', draftResult.studyId)
+                .where('id', '=', studyId)
                 .executeTakeFirstOrThrow()
             expect(updated.title).toBe('Coauthored')
             expect(updated.status).toBe('CHANGE-REQUESTED')
+        })
+
+        it('onUpdateDraftStudyAction allows another lab member to edit a DRAFT', async () => {
+            const { lab, studyId } = await createTestProposalDraft({
+                enclaveSlug: 'test-otter-497-draft-coauthor',
+                studyInfo: { title: 'Original DRAFT' },
+            })
+
+            // Second user in the same lab.
+            await mockSessionWithTestData({ orgSlug: lab.slug, orgType: 'lab' })
+            actionResult(
+                await onUpdateDraftStudyAction({
+                    studyId,
+                    studyInfo: { title: 'Coauthored DRAFT', piName: 'PI', language: 'R' as const },
+                }),
+            )
+
+            const updated = await db
+                .selectFrom('study')
+                .select(['title', 'status'])
+                .where('id', '=', studyId)
+                .executeTakeFirstOrThrow()
+            expect(updated.title).toBe('Coauthored DRAFT')
+            expect(updated.status).toBe('DRAFT')
+        })
+
+        it('onUpdateDraftStudyAction rejects a cross-lab user on DRAFT', async () => {
+            const { enclave, studyId } = await createTestProposalDraft({
+                enclaveSlug: 'test-otter-497-update-cross-draft',
+                studyInfo: { title: 'LabA Draft' },
+            })
+            const labB = await insertTestOrg({ slug: `${enclave.slug}-lab-b`, type: 'lab' })
+
+            await mockSessionWithTestData({ orgSlug: labB.slug, orgType: 'lab' })
+            const result = await onUpdateDraftStudyAction({
+                studyId,
+                studyInfo: { title: 'Hijacked', piName: 'PI', language: 'R' as const },
+            })
+            expect(result).toHaveProperty('error')
+
+            const after = await db
+                .selectFrom('study')
+                .select(['title'])
+                .where('id', '=', studyId)
+                .executeTakeFirstOrThrow()
+            expect(after.title).toBe('LabA Draft')
+        })
+
+        it('onUpdateDraftStudyAction rejects a cross-lab user on CHANGE-REQUESTED', async () => {
+            const { enclave, studyId } = await createTestProposalDraft({
+                enclaveSlug: 'test-otter-497-update-cross-cr',
+                studyInfo: { title: 'LabA Draft' },
+            })
+            const labB = await insertTestOrg({ slug: `${enclave.slug}-lab-b`, type: 'lab' })
+            await setTestStudyStatus(studyId, 'CHANGE-REQUESTED')
+
+            await mockSessionWithTestData({ orgSlug: labB.slug, orgType: 'lab' })
+            const result = await onUpdateDraftStudyAction({
+                studyId,
+                studyInfo: { title: 'Hijacked', piName: 'PI', language: 'R' as const },
+            })
+            expect(result).toHaveProperty('error')
+
+            const after = await db
+                .selectFrom('study')
+                .select(['title', 'status'])
+                .where('id', '=', studyId)
+                .executeTakeFirstOrThrow()
+            expect(after.title).toBe('LabA Draft')
+            expect(after.status).toBe('CHANGE-REQUESTED')
+        })
+    })
+
+    describe('getDraftStudyAction (OTTER-497)', () => {
+        it('returns the draft for the original creator on DRAFT and CHANGE-REQUESTED', async () => {
+            const { lab, studyId } = await createTestProposalDraft({
+                enclaveSlug: 'getdraft-creator-enclave',
+                studyInfo: { title: 'Creator Draft', piName: 'Dr. PI' },
+            })
+
+            const onDraft = actionResult(await getDraftStudyAction({ studyId }))
+            expect(onDraft.id).toBe(studyId)
+            expect(onDraft.title).toBe('Creator Draft')
+            expect(onDraft.status).toBe('DRAFT')
+            expect(onDraft.submittedByOrgId).toBe(lab.id)
+            expect(typeof onDraft.researcherName).toBe('string')
+
+            await setTestStudyStatus(studyId, 'CHANGE-REQUESTED')
+
+            const onChangeRequested = actionResult(await getDraftStudyAction({ studyId }))
+            expect(onChangeRequested.id).toBe(studyId)
+            expect(onChangeRequested.status).toBe('CHANGE-REQUESTED')
+        })
+
+        it('returns the draft for a different lab teammate', async () => {
+            const { lab, studyId } = await createTestProposalDraft({
+                enclaveSlug: 'getdraft-teammate-enclave',
+                studyInfo: { title: 'Teammate Draft' },
+            })
+
+            // Switch to a different user in the same lab.
+            await mockSessionWithTestData({ orgSlug: lab.slug, orgType: 'lab' })
+            const onDraft = actionResult(await getDraftStudyAction({ studyId }))
+            expect(onDraft.id).toBe(studyId)
+            expect(onDraft.status).toBe('DRAFT')
+
+            await setTestStudyStatus(studyId, 'CHANGE-REQUESTED')
+
+            const onChangeRequested = actionResult(await getDraftStudyAction({ studyId }))
+            expect(onChangeRequested.id).toBe(studyId)
+            expect(onChangeRequested.status).toBe('CHANGE-REQUESTED')
+        })
+
+        it('rejects a user outside the submitting lab', async () => {
+            const { enclave, studyId } = await createTestProposalDraft({
+                enclaveSlug: 'getdraft-cross-enclave',
+                studyInfo: { title: 'LabA Draft' },
+            })
+            const labB = await insertTestOrg({ slug: `${enclave.slug}-lab-b`, type: 'lab' })
+
+            await mockSessionWithTestData({ orgSlug: labB.slug, orgType: 'lab' })
+            const result = await getDraftStudyAction({ studyId })
+            expect(result).toMatchObject({
+                error: expect.objectContaining({ permission_denied: expect.any(String) }),
+            })
+        })
+
+        it('rejects studies whose status is not in DRAFT/CHANGE-REQUESTED/APPROVED', async () => {
+            const { studyId } = await createTestProposalDraft({
+                enclaveSlug: 'getdraft-pending-enclave',
+                studyInfo: { title: 'Soon-PR' },
+            })
+
+            await setTestStudyStatus(studyId, 'PENDING-REVIEW')
+
+            const result = await getDraftStudyAction({ studyId })
+            // Middleware filters status before CASL check; falls into not-found.
+            expect(result).toMatchObject({
+                error: expect.objectContaining({ user: expect.stringMatching(/not found/i) }),
+            })
         })
     })
 

--- a/src/server/actions/study-request.test.ts
+++ b/src/server/actions/study-request.test.ts
@@ -677,9 +677,9 @@ describe('Request Study Actions', () => {
 
             await mockSessionWithTestData({ orgSlug: labB.slug, orgType: 'lab' })
             const result = await getDraftStudyAction({ studyId })
-            expect(result).toMatchObject({
-                error: expect.objectContaining({ permission_denied: expect.any(String) }),
-            })
+            const permissionDenied = (result as { error: { permission_denied: string } }).error.permission_denied
+            expect(permissionDenied).toContain('in getDraftStudyAction action; cannot view Study.')
+            expect(permissionDenied).toContain(`"studyId": "${studyId}"`)
         })
 
         it('rejects studies whose status is not in DRAFT/CHANGE-REQUESTED/APPROVED', async () => {
@@ -691,10 +691,7 @@ describe('Request Study Actions', () => {
             await setTestStudyStatus(studyId, 'PENDING-REVIEW')
 
             const result = await getDraftStudyAction({ studyId })
-            // Middleware filters status before CASL check; falls into not-found.
-            expect(result).toMatchObject({
-                error: expect.objectContaining({ user: expect.stringMatching(/not found/i) }),
-            })
+            expect(result).toEqual({ error: { user: 'Draft study was not found' } })
         })
     })
 

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -1,6 +1,9 @@
 import logger from '@/lib/logger'
 import { deliver } from '@/server/mailgun'
 import {
+    actionResult,
+    buildFeedback,
+    createTestProposalDraft,
     db,
     getAuditEntries,
     insertTestOrg,
@@ -9,6 +12,7 @@ import {
     insertTestUser,
     mockClerkSession,
     mockSessionWithTestData,
+    setTestStudyStatus,
     waitFor,
 } from '@/tests/unit.helpers'
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
@@ -458,6 +462,55 @@ describe('Study Actions', () => {
             error: expect.objectContaining({ permission_denied: expect.any(String) }),
         })
     })
+
+    describe('fetchStudiesForOrgAction lab-branch visibility (OTTER-497)', () => {
+        it('lab teammate sees a DRAFT created by another teammate', async () => {
+            const { lab, studyId } = await createTestProposalDraft({
+                enclaveSlug: 'fetch-lab-draft-enclave',
+                studyInfo: { title: 'Teammate DRAFT' },
+            })
+
+            // User B in the same lab.
+            await mockSessionWithTestData({ orgSlug: lab.slug, orgType: 'lab' })
+            const result = await fetchStudiesForOrgAction({ orgSlug: lab.slug })
+
+            expect(Array.isArray(result)).toBe(true)
+            expect(result).toEqual(expect.arrayContaining([expect.objectContaining({ id: studyId, status: 'DRAFT' })]))
+        })
+
+        it('lab teammate sees a CHANGE-REQUESTED study from another teammate', async () => {
+            const { lab, studyId } = await createTestProposalDraft({
+                enclaveSlug: 'fetch-lab-changereq-enclave',
+                studyInfo: { title: 'Teammate CHANGE-REQUESTED' },
+            })
+            await setTestStudyStatus(studyId, 'CHANGE-REQUESTED')
+
+            await mockSessionWithTestData({ orgSlug: lab.slug, orgType: 'lab' })
+            const result = await fetchStudiesForOrgAction({ orgSlug: lab.slug })
+
+            expect(Array.isArray(result)).toBe(true)
+            expect(result).toEqual(
+                expect.arrayContaining([expect.objectContaining({ id: studyId, status: 'CHANGE-REQUESTED' })]),
+            )
+        })
+
+        it("outside-lab user does not see another lab's draft", async () => {
+            const { enclave, lab: labA } = await createTestProposalDraft({
+                enclaveSlug: 'fetch-lab-cross-enclave',
+                studyInfo: { title: 'Cross-lab DRAFT' },
+            })
+            const labB = await insertTestOrg({ slug: `${enclave.slug}-lab-b`, type: 'lab' })
+
+            // User in labB tries to read labA's dashboard. CASL denies cross-org viewing.
+            await mockSessionWithTestData({ orgSlug: labB.slug, orgType: 'lab' })
+            vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+
+            const result = await fetchStudiesForOrgAction({ orgSlug: labA.slug })
+            expect(result).toMatchObject({
+                error: expect.objectContaining({ permission_denied: expect.any(String) }),
+            })
+        })
+    })
 })
 
 describe('ackAgreementsAction', () => {
@@ -546,7 +599,6 @@ describe('ackAgreementsAction', () => {
 })
 
 describe('submitProposalReviewAction', () => {
-    const buildFeedback = (wordCount: number) => Array.from({ length: wordCount }, (_, i) => `word${i + 1}`).join(' ')
     const validFeedback = buildFeedback(60)
 
     const loadCommentRows = (studyId: string) =>
@@ -560,12 +612,15 @@ describe('submitProposalReviewAction', () => {
         const { user, org } = await mockSessionWithTestData({ orgType: 'enclave' })
         const { study } = await insertTestStudyJobData({ org, researcherId: user.id, studyStatus: 'PENDING-REVIEW' })
 
-        await submitProposalReviewAction({
+        const result = await submitProposalReviewAction({
             studyId: study.id,
             orgSlug: org.slug,
             decision: 'approve',
             feedback: validFeedback,
         })
+        const value = actionResult(result)
+        expect(typeof value.submitterFullName).toBe('string')
+        expect(value.submitterFullName.length).toBeGreaterThan(0)
 
         const rows = await loadCommentRows(study.id)
         expect(rows).toHaveLength(1)

--- a/src/server/actions/user-keys.actions.test.ts
+++ b/src/server/actions/user-keys.actions.test.ts
@@ -8,7 +8,8 @@ import {
 import { db } from '@/database'
 import logger from '@/lib/logger'
 
-vi.mock('@/server/events', () => ({
+vi.mock('@/server/events', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@/server/events')>()),
     onUserPublicKeyCreated: vi.fn(),
     onUserPublicKeyUpdated: vi.fn(),
 }))

--- a/tests/hocuspocus.mock.ts
+++ b/tests/hocuspocus.mock.ts
@@ -1,0 +1,63 @@
+import { vi } from 'vitest'
+import * as Y from 'yjs'
+
+type Listener = (...args: unknown[]) => void
+
+type CreateHocuspocusMockOptions = {
+    withYDoc?: boolean
+}
+
+export type HocuspocusProviderHandle = {
+    document?: Y.Doc
+    triggerSync: () => void
+    sendStateless: ReturnType<typeof vi.fn>
+}
+
+export const createHocuspocusMock = ({ withYDoc = false }: CreateHocuspocusMockOptions = {}) => {
+    const constructed: HocuspocusProviderHandle[] = []
+
+    class HocuspocusProvider {
+        document?: Y.Doc
+        isSynced = false
+        synced = false
+        sendStateless = vi.fn()
+        private attached = false
+        private syncListeners: Listener[] = []
+
+        constructor(opts?: { document?: Y.Doc }) {
+            this.document = opts?.document ?? (withYDoc ? new Y.Doc() : undefined)
+            constructed.push({
+                document: this.document,
+                triggerSync: () => {
+                    if (withYDoc && !this.attached)
+                        throw new Error('HocuspocusProvider must be attached before syncing')
+                    this.isSynced = true
+                    this.synced = true
+                    this.syncListeners.forEach((fn) => fn())
+                },
+                sendStateless: this.sendStateless,
+            })
+        }
+        attach() {
+            this.attached = true
+        }
+        on(event: string, fn: Listener) {
+            if (event === 'synced') this.syncListeners.push(fn)
+        }
+        off(event: string, fn: Listener) {
+            if (event === 'synced') this.syncListeners = this.syncListeners.filter((l) => l !== fn)
+        }
+        destroy() {}
+    }
+
+    class HocuspocusProviderWebsocket {
+        constructor(_opts?: unknown) {}
+        destroy() {}
+    }
+
+    return {
+        HocuspocusProvider,
+        HocuspocusProviderWebsocket,
+        __constructed: constructed,
+    }
+}

--- a/tests/temp-dir.ts
+++ b/tests/temp-dir.ts
@@ -1,0 +1,9 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+export async function createTempDir() {
+    const ostmpdir = os.tmpdir()
+    const tmpdir = path.join(ostmpdir, 'unit-test-')
+    return await fs.promises.mkdtemp(tmpdir)
+}

--- a/tests/unit.helpers.tsx
+++ b/tests/unit.helpers.tsx
@@ -5,6 +5,7 @@ import { CLERK_ADMIN_ORG_SLUG, UserOrgRoles } from '@/lib/types'
 import { Org } from '@/schema/org'
 import { latestJobForStudy } from '@/server/db/queries'
 import { findOrCreateOrgMembership } from '@/server/mutations'
+import { actionResult } from '@/lib/utils'
 import { theme } from '@/theme'
 import { useAuth, useClerk, useSession, useUser } from '@clerk/nextjs'
 import { auth as clerkAuth, clerkClient, currentUser as currentClerkUser } from '@clerk/nextjs/server'
@@ -23,7 +24,7 @@ import os from 'os'
 import path from 'path'
 import type { StudyRow } from '@/components/dashboard/studies-table/types'
 
-import { ReactElement } from 'react'
+import { ReactElement, ReactNode } from 'react'
 import { expect, Mock, vi } from 'vitest'
 
 import userEvent from '@testing-library/user-event'
@@ -62,8 +63,23 @@ export const createTestQueryClient = () =>
             queries: {
                 retry: false,
             },
+            mutations: {
+                retry: false,
+            },
         },
     })
+
+// `renderHook(..., { wrapper: createTestQueryWrapper() })` for hooks that depend on
+// useMutation / useQuery. Each call gets a fresh QueryClient so cached state cannot
+// leak between tests.
+export const createTestQueryWrapper = () => {
+    const client = createTestQueryClient()
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+    Wrapper.displayName = 'QueryClientWrapper'
+    return Wrapper
+}
 
 export function renderWithProviders(ui: ReactElement, options?: Parameters<typeof render>[1]) {
     const testQueryClient = createTestQueryClient()
@@ -597,6 +613,49 @@ export async function mockSessionWithTestData(options: MockSessionWithTestDataOp
 
     return { session, org, user, orgUser, ...mocks }
 }
+
+type CreateTestProposalDraftOptions = {
+    /** Unique enclave slug for this test. The lab counterpart is derived as `${enclaveSlug}-lab`. */
+    enclaveSlug: string
+    studyInfo?: {
+        title?: string
+        piName?: string
+        language?: Language
+    }
+}
+
+// Builds the canonical OTTER-497 fixture shape: enclave + lab + lab-member session +
+// DRAFT study where `submittedByOrgId` is the lab and `orgId` is the enclave. Use this
+// instead of `insertTestStudyOnly` for collaboration tests, which collapse both ids to
+// the same org and do not match the production submitting-lab vs reviewing-enclave split.
+//
+// `onSaveDraftStudyAction` is lazy-imported because eagerly importing it from this
+// always-loaded helper file would pull `@/server/aws` into every test's module graph,
+// which races with module-level mocks like `aws.test.ts` does for `./config`.
+export async function createTestProposalDraft({ enclaveSlug, studyInfo = {} }: CreateTestProposalDraftOptions) {
+    const { onSaveDraftStudyAction } = await import('@/server/actions/study-request')
+    const enclave = await insertTestOrg({ type: 'enclave', slug: enclaveSlug })
+    const lab = await insertTestOrg({ slug: `${enclave.slug}-lab`, type: 'lab' })
+    const session = await mockSessionWithTestData({ orgSlug: lab.slug, orgType: 'lab' })
+
+    const draft = actionResult(
+        await onSaveDraftStudyAction({
+            orgSlug: enclave.slug,
+            studyInfo: { title: 'Test draft', piName: 'PI', language: 'R', ...studyInfo },
+            submittingOrgSlug: lab.slug,
+        }),
+    )
+
+    return { enclave, lab, studyId: draft.studyId, user: session.user }
+}
+
+export const setTestStudyStatus = (studyId: string, status: StudyStatus) =>
+    db.updateTable('study').set({ status }).where('id', '=', studyId).execute()
+
+// Generates a feedback string with `wordCount` whitespace-separated tokens. The
+// proposal-review action requires 50–500 words; default is 60 (a comfortable midpoint).
+// Pass smaller / larger counts to exercise the validation boundaries.
+export const buildFeedback = (wordCount = 60) => Array.from({ length: wordCount }, (_, i) => `word${i + 1}`).join(' ')
 
 export const createWorkspaceDir = async (prefix: string) => {
     const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), `${prefix}-`))

--- a/tests/unit.helpers.tsx
+++ b/tests/unit.helpers.tsx
@@ -628,11 +628,10 @@ type CreateTestProposalDraftOptions = {
 // DRAFT study where `submittedByOrgId` is the lab and `orgId` is the enclave. Use this
 // instead of `insertTestStudyOnly` for collaboration tests, which collapse both ids to
 // the same org and do not match the production submitting-lab vs reviewing-enclave split.
-//
-// `onSaveDraftStudyAction` is lazy-imported because eagerly importing it from this
-// always-loaded helper file would pull `@/server/aws` into every test's module graph,
-// which races with module-level mocks like `aws.test.ts` does for `./config`.
 export async function createTestProposalDraft({ enclaveSlug, studyInfo = {} }: CreateTestProposalDraftOptions) {
+    // `onSaveDraftStudyAction` is lazy-imported because eagerly importing it from this
+    // always-loaded helper file would pull `@/server/aws` into every test's module graph,
+    // which races with module-level mocks like `aws.test.ts` does for `./config`.
     const { onSaveDraftStudyAction } = await import('@/server/actions/study-request')
     const enclave = await insertTestOrg({ type: 'enclave', slug: enclaveSlug })
     const lab = await insertTestOrg({ slug: `${enclave.slug}-lab`, type: 'lab' })

--- a/tests/unit.helpers.tsx
+++ b/tests/unit.helpers.tsx
@@ -632,6 +632,7 @@ export async function createTestProposalDraft({ enclaveSlug, studyInfo = {} }: C
     // `onSaveDraftStudyAction` is lazy-imported because eagerly importing it from this
     // always-loaded helper file would pull `@/server/aws` into every test's module graph,
     // which races with module-level mocks like `aws.test.ts` does for `./config`.
+    // TODO: switch to a top-level import once @/server/aws no longer self-mocks at module scope.
     const { onSaveDraftStudyAction } = await import('@/server/actions/study-request')
     const enclave = await insertTestOrg({ type: 'enclave', slug: enclaveSlug })
     const lab = await insertTestOrg({ slug: `${enclave.slug}-lab`, type: 'lab' })
@@ -896,19 +897,6 @@ export const expectStudyJobRecords = async (
         .orderBy('createdAt', 'asc')
         .execute()
     expect(statuses.map((row) => row.status)).toEqual(['INITIATED', 'CODE-SUBMITTED', 'CODE-SCANNED'])
-}
-
-// Pair this with a `vi.mock('@/components/spy-mode-context', ...)` in your test file
-// whose factory reads from `spyModeState`. Drive it from tests with setSpyMode()/resetSpyMode().
-// See legacy-proposal-review-view.test.tsx for an example of the vi.mock factory wiring.
-export const spyModeState = { isSpyMode: false }
-
-export const setSpyMode = (value: boolean) => {
-    spyModeState.isSpyMode = value
-}
-
-export const resetSpyMode = () => {
-    spyModeState.isSpyMode = false
 }
 
 export const mockStudyRow = (overrides: Partial<StudyRow> = {}): StudyRow => ({

--- a/tests/unit.helpers.tsx
+++ b/tests/unit.helpers.tsx
@@ -5,6 +5,7 @@ import { CLERK_ADMIN_ORG_SLUG, UserOrgRoles } from '@/lib/types'
 import { Org } from '@/schema/org'
 import { latestJobForStudy } from '@/server/db/queries'
 import { findOrCreateOrgMembership } from '@/server/mutations'
+import { onSaveDraftStudyAction } from '@/server/actions/study-request'
 import { actionResult } from '@/lib/utils'
 import { theme } from '@/theme'
 import { useAuth, useClerk, useSession, useUser } from '@clerk/nextjs'
@@ -372,12 +373,6 @@ export const insertTestStudyJobUsers = async ({
     return { study, job, user1, user2, ...rest }
 }
 
-export async function createTempDir() {
-    const ostmpdir = os.tmpdir()
-    const tmpdir = path.join(ostmpdir, 'unit-test-')
-    return await fs.promises.mkdtemp(tmpdir)
-}
-
 export type InsertTestOrgOptions = {
     slug: string
     name?: string
@@ -629,11 +624,6 @@ type CreateTestProposalDraftOptions = {
 // instead of `insertTestStudyOnly` for collaboration tests, which collapse both ids to
 // the same org and do not match the production submitting-lab vs reviewing-enclave split.
 export async function createTestProposalDraft({ enclaveSlug, studyInfo = {} }: CreateTestProposalDraftOptions) {
-    // `onSaveDraftStudyAction` is lazy-imported because eagerly importing it from this
-    // always-loaded helper file would pull `@/server/aws` into every test's module graph,
-    // which races with module-level mocks like `aws.test.ts` does for `./config`.
-    // TODO: switch to a top-level import once @/server/aws no longer self-mocks at module scope.
-    const { onSaveDraftStudyAction } = await import('@/server/actions/study-request')
     const enclave = await insertTestOrg({ type: 'enclave', slug: enclaveSlug })
     const lab = await insertTestOrg({ slug: `${enclave.slug}-lab`, type: 'lab' })
     const session = await mockSessionWithTestData({ orgSlug: lab.slug, orgType: 'lab' })

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -2,7 +2,7 @@ import 'dotenv/config' // read .env file before other imports, to match Next.js 
 import { beforeAll, beforeEach, afterEach, afterAll, vi, Mock, expect } from 'vitest'
 import { testTransaction } from 'pg-transactional-tests'
 import { localStorageContext } from '@/server/actions/action'
-import { createTempDir } from '@/tests/unit.helpers'
+import { createTempDir } from '@/tests/temp-dir'
 import fs from 'fs'
 import { ClerkProvider, useAuth, useClerk, useUser } from '@clerk/nextjs'
 import { cleanup } from '@testing-library/react'


### PR DESCRIPTION
This PR increases test coverage of [OTTER-497](https://openstax.atlassian.net/browse/OTTER-497)

Only tests are modified and added here.



This PR tries to address these multi editor test gaps with unit tests (a real end to end test requires multiple clerk test users in same org which we don't have + Hocuspocus editor service running):

1. **Lab-collaboration visibility is locked in.** Tests prove that lab teammates can see and edit each other's DRAFT and CHANGE-REQUESTED studies, and that cross-lab access is denied. Today only the enclave branch is exercised, so the core OTTER-497 user claim ("my teammate can pick up where I left off") is unverified.
2. **The Y.js form bridge gets its first real coverage.** Two-peer round-trip, cold seed, warm load from persisted CRDT state, remote-vs-local origin tagging. This is the closest unit-level substitute for "user A types, user B sees", minus the WebSocket layer.
3. **Broadcast wiring on both sides is contract-tested.** `useSubmitProposal` (researcher submits) and `useProposalReviewMutation` (reviewer decides) both push stateless events; today nothing catches a silent rename like `submitterFullName -> submitter_name` that would break the redirect listener in prod.
4. **`getDraftStudyAction` goes from zero tests to four.** Original creator, lab teammate, cross-lab rejection, and non-editable status, all paths.


[OTTER-497]: https://openstax.atlassian.net/browse/OTTER-497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ