### PR TITLE
OTTER-519: Research Lab post-submission feedback view

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
@@ -2,13 +2,11 @@
 
 import { PageBreadcrumbs } from '@/components/page-breadcrumbs'
 import type { ReviewDecision } from '@/database/types'
+import { FeedbackAndNotesSection } from '@/components/study/feedback-and-notes'
 import { Routes } from '@/lib/routes'
-import { extractTextFromLexical } from '@/lib/word-count'
-import { Anchor, Box, Button, Collapse, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
-import { CaretDownIcon, CaretUpIcon } from '@phosphor-icons/react'
+import { Box, Button, Divider, Group, Stack, Text, Title } from '@mantine/core'
 import dayjs from 'dayjs'
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
 import type { ProposalFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
 import { ProposalSection } from './proposal-section'
 
@@ -57,16 +55,6 @@ function formatDate(date: Date | string): string {
     return dayjs(date).format('MMM DD, YYYY')
 }
 
-function entryTitle(entry: ProposalFeedbackEntry): string {
-    return entry.entryType === 'REVIEWER-FEEDBACK' ? 'Reviewer feedback' : 'Resubmission note'
-}
-
-// TODO(OTTER-491): swap plain-text rendering for a Lexical viewer once the editor
-// component lands; share node config with the textarea.
-function entryBodyText(entry: ProposalFeedbackEntry): string {
-    return extractTextFromLexical(JSON.stringify(entry.body))
-}
-
 function DecisionBanner({ decision }: { decision: ReviewDecision }) {
     const { banner } = DECISION_COPY[decision]
     return (
@@ -80,101 +68,6 @@ function DecisionBanner({ decision }: { decision: ReviewDecision }) {
 
 function FullProposalDropdown({ orgSlug, study }: { orgSlug: string; study: SelectedStudy }) {
     return <ProposalSection orgSlug={orgSlug} study={study} initialExpanded={false} />
-}
-
-function ToggleCaret({ isExpanded }: { isExpanded: boolean }) {
-    const Icon = isExpanded ? CaretUpIcon : CaretDownIcon
-    return <Icon size={14} />
-}
-
-type FeedbackEntryProps = {
-    entry: ProposalFeedbackEntry
-    isExpanded: boolean
-    onToggle: () => void
-}
-
-function FeedbackEntry({ entry, isExpanded, onToggle }: FeedbackEntryProps) {
-    const title = entryTitle(entry)
-    const body = entryBodyText(entry)
-    const date = formatDate(entry.createdAt)
-
-    return (
-        <Stack gap="sm" data-testid={`feedback-entry-${entry.id}`}>
-            <Group justify="space-between" align="center">
-                <Stack gap={2}>
-                    <Text fw={600}>{title}</Text>
-                    <Text size="sm" c="gray.7">
-                        {entry.authorName} · {date}
-                    </Text>
-                </Stack>
-                <Anchor
-                    component="button"
-                    onClick={onToggle}
-                    c="blue"
-                    size="sm"
-                    data-testid={`feedback-toggle-${entry.id}`}
-                    aria-expanded={isExpanded}
-                >
-                    <ToggleCaret isExpanded={isExpanded} />
-                </Anchor>
-            </Group>
-            <Collapse in={isExpanded}>
-                <Text size="sm" data-testid={`feedback-body-${entry.id}`} style={{ whiteSpace: 'pre-wrap' }}>
-                    {body}
-                </Text>
-            </Collapse>
-        </Stack>
-    )
-}
-
-function useExpandedEntries(entries: ProposalFeedbackEntry[]) {
-    const [expandedIds, setExpandedIds] = useState<Set<string>>(() => {
-        const latest = entries[0]?.id
-        return latest ? new Set([latest]) : new Set()
-    })
-
-    const toggle = (id: string) => {
-        setExpandedIds((prev) => {
-            const next = new Set(prev)
-            if (next.has(id)) {
-                next.delete(id)
-            } else {
-                next.add(id)
-            }
-            return next
-        })
-    }
-
-    const isExpanded = (id: string) => expandedIds.has(id)
-
-    return { isExpanded, toggle }
-}
-
-function FeedbackAndNotesSection({ entries }: { entries: ProposalFeedbackEntry[] }) {
-    const { isExpanded, toggle } = useExpandedEntries(entries)
-
-    return (
-        <Paper p="xl" data-testid="feedback-and-notes-section">
-            <Stack gap="md">
-                <Text fw={600} fz={20}>
-                    Feedback and notes
-                </Text>
-                <Divider />
-                <Stack gap="md" data-testid="feedback-entries">
-                    {entries.map((entry, idx) => (
-                        <Stack key={entry.id} gap="md">
-                            <FeedbackEntry
-                                entry={entry}
-                                isExpanded={isExpanded(entry.id)}
-                                onToggle={() => toggle(entry.id)}
-                            />
-                            {idx < entries.length - 1 && <Divider data-testid="entry-divider" />}
-                        </Stack>
-                    ))}
-                </Stack>
-            </Stack>
-        </Paper>
-    )
 }
 
 function GoToDashboardButton() {

--- a/src/app/[orgSlug]/study/[studyId]/submitted/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/page.tsx
@@ -1,4 +1,4 @@
-import { getStudyAction } from '@/server/actions/study.actions'
+import { getStudyAction, getProposalFeedbackForStudyAction } from '@/server/actions/study.actions'
 import { getOrgNameFromId } from '@/server/db/queries'
 import { isActionError } from '@/lib/errors'
 import { AlertNotFound } from '@/components/errors'
@@ -13,7 +13,12 @@ export default async function StudySubmittedRoute(props: { params: Promise<{ stu
         return <AlertNotFound title="Study was not found" message="no such study exists" />
     }
 
-    const orgName = await getOrgNameFromId(result.orgId)
+    const [orgName, feedbackResult] = await Promise.all([
+        getOrgNameFromId(result.orgId),
+        getProposalFeedbackForStudyAction({ studyId }),
+    ])
 
-    return <SubmittedView orgSlug={orgSlug} study={result} orgName={orgName} />
+    const entries = isActionError(feedbackResult) ? [] : feedbackResult
+
+    return <SubmittedView orgSlug={orgSlug} study={result} orgName={orgName} entries={entries} />
 }

--- a/src/app/[orgSlug]/study/[studyId]/submitted/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/page.tsx
@@ -1,3 +1,4 @@
+import { captureException } from '@sentry/nextjs'
 import { getStudyAction, getProposalFeedbackForStudyAction } from '@/server/actions/study.actions'
 import { getOrgNameFromId } from '@/server/db/queries'
 import { isActionError } from '@/lib/errors'
@@ -18,7 +19,13 @@ export default async function StudySubmittedRoute(props: { params: Promise<{ stu
         getProposalFeedbackForStudyAction({ studyId }),
     ])
 
-    const entries = isActionError(feedbackResult) ? [] : feedbackResult
+    const feedbackError = isActionError(feedbackResult)
 
-    return <SubmittedView orgSlug={orgSlug} study={result} orgName={orgName} entries={entries} />
+    if (feedbackError) {
+        captureException(new Error(`Failed to fetch proposal feedback for study ${studyId}: ${feedbackResult.error}`))
+    }
+
+    const entries = feedbackError ? [] : feedbackResult
+
+    return <SubmittedView orgSlug={orgSlug} study={result} orgName={orgName} entries={entries} feedbackError={feedbackError} />
 }

--- a/src/app/[orgSlug]/study/[studyId]/submitted/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/page.tsx
@@ -27,5 +27,13 @@ export default async function StudySubmittedRoute(props: { params: Promise<{ stu
 
     const entries = feedbackError ? [] : feedbackResult
 
-    return <SubmittedView orgSlug={orgSlug} study={result} orgName={orgName} entries={entries} feedbackError={feedbackError} />
+    return (
+        <SubmittedView
+            orgSlug={orgSlug}
+            study={result}
+            orgName={orgName}
+            entries={entries}
+            feedbackError={feedbackError}
+        />
+    )
 }

--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.test.tsx
@@ -215,6 +215,61 @@ describe('ProposalSubmitted', () => {
         })
     })
 
+    describe('navigation', () => {
+        it('shows a "Back" button linking to dashboard when status is APPROVED', () => {
+            const approvedStudy = { ...study, status: 'APPROVED' as const }
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={approvedStudy} orgName={ORG_NAME} entries={[]} />,
+            )
+
+            const backLink = screen.getByRole('link', { name: /back/i })
+            expect(backLink).toHaveAttribute('href', '/dashboard')
+        })
+
+        it('shows a "Proceed to step 3" button linking to agreements when status is APPROVED', () => {
+            const approvedStudy = { ...study, status: 'APPROVED' as const }
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={approvedStudy} orgName={ORG_NAME} entries={[]} />,
+            )
+
+            const proceedLink = screen.getByRole('link', { name: /proceed to step 3/i })
+            expect(proceedLink).toHaveAttribute(
+                'href',
+                expect.stringContaining(`/${ORG_SLUG}/study/${study.id}/agreements`),
+            )
+        })
+
+        it('shows a "Back" button linking to dashboard when status is CHANGE-REQUESTED', () => {
+            const clarificationStudy = { ...study, status: 'CHANGE-REQUESTED' as const }
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={clarificationStudy} orgName={ORG_NAME} entries={[]} />,
+            )
+
+            const backLink = screen.getByRole('link', { name: /back/i })
+            expect(backLink).toHaveAttribute('href', '/dashboard')
+        })
+
+        it('shows an "Edit and resubmit" button linking to edit page when status is CHANGE-REQUESTED', () => {
+            const clarificationStudy = { ...study, status: 'CHANGE-REQUESTED' as const }
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={clarificationStudy} orgName={ORG_NAME} entries={[]} />,
+            )
+
+            const editLink = screen.getByRole('link', { name: /edit and resubmit/i })
+            expect(editLink).toHaveAttribute('href', `/${ORG_SLUG}/study/${study.id}/edit`)
+        })
+
+        it('shows a "Go to dashboard" button linking to dashboard when status is REJECTED', () => {
+            const rejectedStudy = { ...study, status: 'REJECTED' as const }
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={rejectedStudy} orgName={ORG_NAME} entries={[]} />,
+            )
+
+            const dashboardLink = screen.getByRole('link', { name: /go to dashboard/i })
+            expect(dashboardLink).toHaveAttribute('href', '/dashboard')
+        })
+    })
+
     describe('feedback and notes', () => {
         const reviewerEntry = buildEntry({
             id: 'reviewer-1',

--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.test.tsx
@@ -1,0 +1,172 @@
+import { getStudyAction, type SelectedStudy } from '@/server/actions/study.actions'
+import {
+    actionResult,
+    insertTestStudyJobData,
+    mockSessionWithTestData,
+    renderWithProviders,
+    screen,
+    type Mock,
+} from '@/tests/unit.helpers'
+import { useParams } from 'next/navigation'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ProposalSubmitted } from './proposal-submitted'
+
+const ORG_SLUG = 'test-org'
+const ORG_NAME = 'Test Data Organization'
+
+describe('ProposalSubmitted', () => {
+    let study: SelectedStudy
+
+    beforeEach(async () => {
+        const { org, user } = await mockSessionWithTestData({ orgSlug: ORG_SLUG, orgType: 'enclave' })
+        const { study: dbStudy } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'APPROVED',
+            title: 'Effect of Reading Comprehension Tools',
+        })
+        study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+        ;(useParams as Mock).mockReturnValue({ orgSlug: ORG_SLUG, studyId: study.id })
+    })
+
+    describe('timestamp and decision label', () => {
+        it('displays "Approved on {date}" when status is APPROVED', () => {
+            const approvedStudy = {
+                ...study,
+                status: 'APPROVED' as const,
+                submittedAt: new Date('2025-04-16T10:00:00Z'),
+            }
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={approvedStudy} orgName={ORG_NAME} entries={[]} />,
+            )
+
+            expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent('Approved on Apr 16, 2025')
+        })
+
+        it('displays "Clarification requested on {date}" when status is CHANGE-REQUESTED', () => {
+            const clarificationStudy = {
+                ...study,
+                status: 'CHANGE-REQUESTED' as const,
+                submittedAt: new Date('2025-04-16T10:00:00Z'),
+            }
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={clarificationStudy} orgName={ORG_NAME} entries={[]} />,
+            )
+
+            expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent(
+                'Clarification requested on Apr 16, 2025',
+            )
+        })
+
+        it('displays "Rejected on {date}" when status is REJECTED', () => {
+            const rejectedStudy = {
+                ...study,
+                status: 'REJECTED' as const,
+                submittedAt: new Date('2025-04-16T10:00:00Z'),
+            }
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={rejectedStudy} orgName={ORG_NAME} entries={[]} />,
+            )
+
+            expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent('Rejected on Apr 16, 2025')
+        })
+
+        it('displays "Submitted on {date}" when status is PENDING-REVIEW', () => {
+            const pendingStudy = {
+                ...study,
+                status: 'PENDING-REVIEW' as const,
+                submittedAt: new Date('2025-04-16T10:00:00Z'),
+            }
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={pendingStudy} orgName={ORG_NAME} entries={[]} />,
+            )
+
+            expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent('Submitted on Apr 16, 2025')
+        })
+
+        it('formats the date as MMM DD, YYYY', () => {
+            const approvedStudy = {
+                ...study,
+                status: 'APPROVED' as const,
+                submittedAt: new Date('2025-12-01T10:00:00Z'),
+            }
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={approvedStudy} orgName={ORG_NAME} entries={[]} />,
+            )
+
+            expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent('Approved on Dec 01, 2025')
+        })
+
+        it('renders the timestamp above the divider', () => {
+            const approvedStudy = { ...study, status: 'APPROVED' as const, submittedAt: new Date('2025-04-16') }
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={approvedStudy} orgName={ORG_NAME} entries={[]} />,
+            )
+
+            const timestamp = screen.getByTestId('proposal-timestamp')
+            const divider = screen.getByTestId('proposal-header-divider')
+            expect(timestamp.compareDocumentPosition(divider) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+        })
+    })
+
+    describe('decision banner', () => {
+        it('renders a green banner with approved copy when status is APPROVED', () => {
+            const approvedStudy = { ...study, status: 'APPROVED' as const }
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={approvedStudy} orgName={ORG_NAME} entries={[]} />,
+            )
+
+            const banner = screen.getByTestId('status-banner-APPROVED')
+            expect(banner).toHaveTextContent(
+                `${ORG_NAME} has reviewed and approved your initial request. Review their feedback below, then proceed to Step 3 - Agreements to sign the required legal documents.`,
+            )
+        })
+
+        it('renders a blue banner with clarification copy when status is CHANGE-REQUESTED', () => {
+            const clarificationStudy = { ...study, status: 'CHANGE-REQUESTED' as const }
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={clarificationStudy} orgName={ORG_NAME} entries={[]} />,
+            )
+
+            const banner = screen.getByTestId('status-banner-CHANGE-REQUESTED')
+            expect(banner).toHaveTextContent(
+                `${ORG_NAME} has reviewed your initial request and has requested clarifications. Please review their feedback below. You can revise and resubmit your request to address their questions.`,
+            )
+        })
+
+        it('renders a red banner with rejected copy when status is REJECTED', () => {
+            const rejectedStudy = { ...study, status: 'REJECTED' as const }
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={rejectedStudy} orgName={ORG_NAME} entries={[]} />,
+            )
+
+            const banner = screen.getByTestId('status-banner-REJECTED')
+            expect(banner).toHaveTextContent(
+                `${ORG_NAME} has reviewed your initial request and is unable to support it at this time. Please review their feedback below for more details.`,
+            )
+        })
+
+        it('renders the banner below the divider', () => {
+            const approvedStudy = { ...study, status: 'APPROVED' as const }
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={approvedStudy} orgName={ORG_NAME} entries={[]} />,
+            )
+
+            const divider = screen.getByTestId('proposal-header-divider')
+            const banner = screen.getByTestId('status-banner-APPROVED')
+            expect(divider.compareDocumentPosition(banner) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+        })
+
+        it('renders only one banner at a time', () => {
+            const approvedStudy = { ...study, status: 'APPROVED' as const }
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={approvedStudy} orgName={ORG_NAME} entries={[]} />,
+            )
+
+            expect(screen.getByTestId('status-banner-APPROVED')).toBeInTheDocument()
+            expect(screen.queryByTestId('status-banner-REJECTED')).not.toBeInTheDocument()
+            expect(screen.queryByTestId('status-banner-CHANGE-REQUESTED')).not.toBeInTheDocument()
+            expect(screen.queryByTestId('status-banner-PENDING-REVIEW')).not.toBeInTheDocument()
+        })
+    })
+})

--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.test.tsx
@@ -1,10 +1,12 @@
-import { getStudyAction, type SelectedStudy } from '@/server/actions/study.actions'
+import { lexicalJson } from '@/lib/word-count'
+import { getStudyAction, type ProposalFeedbackEntry, type SelectedStudy } from '@/server/actions/study.actions'
 import {
     actionResult,
     insertTestStudyJobData,
     mockSessionWithTestData,
     renderWithProviders,
     screen,
+    userEvent,
     type Mock,
 } from '@/tests/unit.helpers'
 import { useParams } from 'next/navigation'
@@ -13,6 +15,18 @@ import { ProposalSubmitted } from './proposal-submitted'
 
 const ORG_SLUG = 'test-org'
 const ORG_NAME = 'Test Data Organization'
+
+const buildEntry = (overrides: Partial<ProposalFeedbackEntry> = {}): ProposalFeedbackEntry =>
+    ({
+        id: overrides.id ?? 'entry-1',
+        authorId: overrides.authorId ?? 'author-1',
+        authorName: overrides.authorName ?? 'Reviewer One',
+        authorRole: overrides.authorRole ?? 'REVIEWER',
+        entryType: overrides.entryType ?? 'REVIEWER-FEEDBACK',
+        decision: overrides.decision === undefined ? 'APPROVE' : overrides.decision,
+        body: overrides.body ?? JSON.parse(lexicalJson('Feedback body text.')),
+        createdAt: overrides.createdAt ?? new Date('2026-04-20T12:00:00Z'),
+    }) as ProposalFeedbackEntry
 
 describe('ProposalSubmitted', () => {
     let study: SelectedStudy
@@ -167,6 +181,164 @@ describe('ProposalSubmitted', () => {
             expect(screen.queryByTestId('status-banner-REJECTED')).not.toBeInTheDocument()
             expect(screen.queryByTestId('status-banner-CHANGE-REQUESTED')).not.toBeInTheDocument()
             expect(screen.queryByTestId('status-banner-PENDING-REVIEW')).not.toBeInTheDocument()
+        })
+    })
+
+    describe('view full initial request dropdown', () => {
+        it('is collapsed by default on page load', () => {
+            renderWithProviders(<ProposalSubmitted orgSlug={ORG_SLUG} study={study} orgName={ORG_NAME} entries={[]} />)
+
+            expect(screen.getByTestId('proposal-toggle-header')).toHaveTextContent('View full initial request')
+            expect(screen.queryByTestId('proposal-body')).not.toBeVisible()
+        })
+
+        it('expands to display the study proposal when clicked', async () => {
+            const user = userEvent.setup()
+            renderWithProviders(<ProposalSubmitted orgSlug={ORG_SLUG} study={study} orgName={ORG_NAME} entries={[]} />)
+
+            await user.click(screen.getByTestId('proposal-toggle-header'))
+
+            expect(screen.getByTestId('proposal-toggle-header')).toHaveTextContent('Hide full initial request')
+            expect(screen.getByTestId('proposal-body')).toBeVisible()
+            expect(screen.getByText(`Title: ${study.title}`)).toBeInTheDocument()
+        })
+
+        it('displays study proposal content as read-only with no editable fields', async () => {
+            const user = userEvent.setup()
+            renderWithProviders(<ProposalSubmitted orgSlug={ORG_SLUG} study={study} orgName={ORG_NAME} entries={[]} />)
+
+            await user.click(screen.getByTestId('proposal-toggle-header'))
+
+            const body = screen.getByTestId('proposal-body')
+            const inputs = body.querySelectorAll('input, textarea, select, [contenteditable="true"]')
+            expect(inputs).toHaveLength(0)
+        })
+    })
+
+    describe('feedback and notes', () => {
+        const reviewerEntry = buildEntry({
+            id: 'reviewer-1',
+            authorRole: 'REVIEWER',
+            entryType: 'REVIEWER-FEEDBACK',
+            authorName: 'Dr. Reviewer',
+            decision: 'NEEDS-CLARIFICATION',
+            createdAt: new Date('2026-04-20T12:00:00Z'),
+            body: JSON.parse(lexicalJson('Latest reviewer note.')),
+        })
+
+        const researcherEntry = buildEntry({
+            id: 'researcher-1',
+            authorRole: 'RESEARCHER',
+            entryType: 'RESUBMISSION-NOTE',
+            authorName: 'Dr. Researcher',
+            decision: null,
+            createdAt: new Date('2026-04-18T08:00:00Z'),
+            body: JSON.parse(lexicalJson('Original resubmission note.')),
+        })
+
+        it('displays entries from most recent to oldest', () => {
+            renderWithProviders(
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={study}
+                    orgName={ORG_NAME}
+                    entries={[reviewerEntry, researcherEntry]}
+                />,
+            )
+
+            const entries = screen.getByTestId('feedback-entries')
+            const rendered = entries.querySelectorAll('[data-testid^="feedback-entry-"]')
+            expect(rendered[0]).toHaveAttribute('data-testid', 'feedback-entry-reviewer-1')
+            expect(rendered[1]).toHaveAttribute('data-testid', 'feedback-entry-researcher-1')
+        })
+
+        it('titles reviewer entries "Reviewer feedback"', () => {
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={study} orgName={ORG_NAME} entries={[reviewerEntry]} />,
+            )
+
+            expect(screen.getByTestId('feedback-entry-reviewer-1')).toHaveTextContent('Reviewer feedback')
+        })
+
+        it('titles researcher entries "Resubmission note"', () => {
+            renderWithProviders(
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={study}
+                    orgName={ORG_NAME}
+                    entries={[reviewerEntry, researcherEntry]}
+                />,
+            )
+
+            expect(screen.getByTestId('feedback-entry-researcher-1')).toHaveTextContent('Resubmission note')
+        })
+
+        it('displays the reviewer name on reviewer feedback entries', () => {
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={study} orgName={ORG_NAME} entries={[reviewerEntry]} />,
+            )
+
+            expect(screen.getByTestId('feedback-entry-reviewer-1')).toHaveTextContent('Dr. Reviewer')
+        })
+
+        it('displays the researcher name on resubmission note entries', () => {
+            renderWithProviders(
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={study}
+                    orgName={ORG_NAME}
+                    entries={[reviewerEntry, researcherEntry]}
+                />,
+            )
+
+            expect(screen.getByTestId('feedback-entry-researcher-1')).toHaveTextContent('Dr. Researcher')
+        })
+
+        it('displays the date the reviewer submitted their decision', () => {
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={study} orgName={ORG_NAME} entries={[reviewerEntry]} />,
+            )
+
+            expect(screen.getByTestId('feedback-entry-reviewer-1')).toHaveTextContent('Apr 20, 2026')
+        })
+
+        it('displays the date the researcher submitted proposal changes', () => {
+            renderWithProviders(
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={study}
+                    orgName={ORG_NAME}
+                    entries={[reviewerEntry, researcherEntry]}
+                />,
+            )
+
+            expect(screen.getByTestId('feedback-entry-researcher-1')).toHaveTextContent('Apr 18, 2026')
+        })
+
+        it('expands the latest entry by default', () => {
+            renderWithProviders(
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={study}
+                    orgName={ORG_NAME}
+                    entries={[reviewerEntry, researcherEntry]}
+                />,
+            )
+
+            expect(screen.getByTestId('feedback-toggle-reviewer-1')).toHaveAttribute('aria-expanded', 'true')
+        })
+
+        it('collapses older entries by default', () => {
+            renderWithProviders(
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={study}
+                    orgName={ORG_NAME}
+                    entries={[reviewerEntry, researcherEntry]}
+                />,
+            )
+
+            expect(screen.getByTestId('feedback-toggle-researcher-1')).toHaveAttribute('aria-expanded', 'false')
         })
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.test.tsx
@@ -1,4 +1,5 @@
 import { lexicalJson } from '@/lib/word-count'
+import { Routes } from '@/lib/routes'
 import { getStudyAction, type ProposalFeedbackEntry, type SelectedStudy } from '@/server/actions/study.actions'
 import {
     actionResult,
@@ -235,7 +236,7 @@ describe('ProposalSubmitted', () => {
             const proceedLink = screen.getByRole('link', { name: /proceed to step 3/i })
             expect(proceedLink).toHaveAttribute(
                 'href',
-                expect.stringContaining(`/${ORG_SLUG}/study/${study.id}/agreements`),
+                Routes.studyAgreements({ orgSlug: ORG_SLUG, studyId: study.id }),
             )
         })
 

--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
@@ -78,7 +78,7 @@ const ProposalNavigation: FC<{ orgSlug: string; study: SelectedStudy }> = ({ org
                     >
                         Back
                     </Button>
-                    {/* TODO: Add a link to the study resubmit page */}
+                    {/* TODO: Add a link to the study resubmit page when ready */}
                     <Button component={Link} href={Routes.studyEdit(studyParams)} size="md">
                         Edit and resubmit
                     </Button>

--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
@@ -1,6 +1,8 @@
 'use client'
 
-import { Alert, Button, Stack } from '@mantine/core'
+import type { FC } from 'react'
+import { Alert, Button, Group, Stack } from '@mantine/core'
+import { CaretLeftIcon } from '@phosphor-icons/react'
 import { displayOrgName } from '@/lib/string'
 import { ProposalRequest } from '@/components/study/proposal-initial-request'
 import type { SelectedStudy } from '@/server/actions/study.actions'
@@ -58,6 +60,56 @@ function StatusBanner({ orgName, status }: { orgName: string; status: StudyStatu
     )
 }
 
+const ProposalNavigation: FC<{ orgSlug: string; study: SelectedStudy }> = ({ orgSlug, study }) => {
+    const studyParams = { orgSlug, studyId: study.id }
+
+    switch (study.status) {
+        case 'CHANGE-REQUESTED':
+            return (
+                <Group justify="space-between">
+                    <Button
+                        component={Link}
+                        href={Routes.dashboard}
+                        variant="subtle"
+                        size="md"
+                        leftSection={<CaretLeftIcon />}
+                    >
+                        Back
+                    </Button>
+                    {/* TODO: Add a link to the study resubmit page */}
+                    <Button component={Link} href={Routes.studyEdit(studyParams)} size="md">
+                        Edit and resubmit
+                    </Button>
+                </Group>
+            )
+        case 'APPROVED':
+            return (
+                <Group justify="space-between">
+                    <Button
+                        component={Link}
+                        href={Routes.dashboard}
+                        variant="subtle"
+                        size="md"
+                        leftSection={<CaretLeftIcon />}
+                    >
+                        Back
+                    </Button>
+                    <Button component={Link} href={Routes.studyAgreements(studyParams)} size="md">
+                        Proceed to step 3
+                    </Button>
+                </Group>
+            )
+        default:
+            return (
+                <Group justify="flex-end">
+                    <Button component={Link} href={Routes.dashboard} size="md">
+                        Go to dashboard
+                    </Button>
+                </Group>
+            )
+    }
+}
+
 export function ProposalSubmitted({ orgSlug, study, orgName }: ProposalSubmittedProps) {
     const bannerConfig = PROPOSAL_BANNERS[study.status]
 
@@ -74,11 +126,7 @@ export function ProposalSubmitted({ orgSlug, study, orgName }: ProposalSubmitted
                     statusBadge={bannerConfig?.statusBadge}
                     initialExpanded={false}
                 />
-                <Stack gap="sm" align="flex-end">
-                    <Button component={Link} href={Routes.dashboard} size="md">
-                        Go to dashboard
-                    </Button>
-                </Stack>
+                <ProposalNavigation orgSlug={orgSlug} study={study} />
             </Stack>
         </Stack>
     )

--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
@@ -4,6 +4,7 @@ import { Alert, Button, Stack } from '@mantine/core'
 import { displayOrgName } from '@/lib/string'
 import { ProposalRequest } from '@/components/study/proposal-initial-request'
 import type { SelectedStudy } from '@/server/actions/study.actions'
+import type { StudyStatus } from '@/database/types'
 import { ProposalHeader } from '../../request/page-header'
 import { Routes } from '@/lib/routes'
 import { Link } from '@/components/links'
@@ -14,17 +15,52 @@ interface ProposalSubmittedProps {
     orgName: string
 }
 
-function SubmissionAlert({ orgName }: { orgName: string }) {
+type ProposalBannerConfig = {
+    color: string
+    message: (orgName: string) => string
+    statusBadge?: string
+}
+
+const PROPOSAL_BANNERS: Partial<Record<StudyStatus, ProposalBannerConfig>> = {
+    'PENDING-REVIEW': {
+        color: 'yellow',
+        message: (orgName) =>
+            `Your initial request has been successfully submitted to ${displayOrgName(orgName)}. They will review it and respond with feedback or a decision. You'll receive email notifications as your request progresses through the review process. Please allow an estimated 7 to 10 days for a complete review.`,
+    },
+    APPROVED: {
+        color: 'green',
+        statusBadge: 'Approved on',
+        message: (orgName) =>
+            `${displayOrgName(orgName)} has reviewed and approved your initial request. Review their feedback below, then proceed to Step 3 - Agreements to sign the required legal documents.`,
+    },
+    REJECTED: {
+        color: 'red',
+        statusBadge: 'Rejected on',
+        message: (orgName) =>
+            `${displayOrgName(orgName)} has reviewed your initial request and is unable to support it at this time. Please review their feedback below for more details.`,
+    },
+    'CHANGE-REQUESTED': {
+        color: 'blue',
+        statusBadge: 'Clarification requested on',
+        message: (orgName) =>
+            `${displayOrgName(orgName)} has reviewed your initial request and has requested clarifications. Please review their feedback below. You can revise and resubmit your request to address their questions.`,
+    },
+}
+
+function StatusBanner({ orgName, status }: { orgName: string; status: StudyStatus }) {
+    const config = PROPOSAL_BANNERS[status]
+    if (!config) return null
+
     return (
-        <Alert color="yellow" mb="md">
-            Your initial request has been successfully submitted to {displayOrgName(orgName)}. They will review it and
-            respond with feedback or a decision. You&apos;ll receive email notifications as your request progresses
-            through the review process. Please allow an estimated 7 to 10 days for a complete review.
+        <Alert color={config.color} mb="md">
+            {config.message(orgName)}
         </Alert>
     )
 }
 
 export function ProposalSubmitted({ orgSlug, study, orgName }: ProposalSubmittedProps) {
+    const bannerConfig = PROPOSAL_BANNERS[study.status]
+
     return (
         <Stack p="xl" gap="xl">
             <ProposalHeader orgSlug={orgSlug} title="Study proposal" studyId={study.id} studyTitle={study.title} />
@@ -34,7 +70,8 @@ export function ProposalSubmitted({ orgSlug, study, orgName }: ProposalSubmitted
                     orgSlug={orgSlug}
                     stepLabel="STEP 2"
                     heading="Initial request"
-                    banner={<SubmissionAlert orgName={orgName} />}
+                    banner={<StatusBanner orgName={orgName} status={study.status} />}
+                    statusBadge={bannerConfig?.statusBadge}
                     initialExpanded={false}
                 />
                 <Stack gap="sm" align="flex-end">

--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
@@ -5,7 +5,8 @@ import { Alert, Button, Group, Stack } from '@mantine/core'
 import { CaretLeftIcon } from '@phosphor-icons/react'
 import { displayOrgName } from '@/lib/string'
 import { ProposalRequest } from '@/components/study/proposal-initial-request'
-import type { SelectedStudy } from '@/server/actions/study.actions'
+import { FeedbackAndNotesSection } from '@/components/study/feedback-and-notes'
+import type { ProposalFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
 import type { StudyStatus } from '@/database/types'
 import { ProposalHeader } from '../../request/page-header'
 import { Routes } from '@/lib/routes'
@@ -15,6 +16,7 @@ interface ProposalSubmittedProps {
     orgSlug: string
     study: SelectedStudy
     orgName: string
+    entries: ProposalFeedbackEntry[]
 }
 
 type ProposalBannerConfig = {
@@ -110,7 +112,7 @@ const ProposalNavigation: FC<{ orgSlug: string; study: SelectedStudy }> = ({ org
     }
 }
 
-export function ProposalSubmitted({ orgSlug, study, orgName }: ProposalSubmittedProps) {
+export function ProposalSubmitted({ orgSlug, study, orgName, entries }: ProposalSubmittedProps) {
     const bannerConfig = PROPOSAL_BANNERS[study.status]
 
     return (
@@ -126,6 +128,7 @@ export function ProposalSubmitted({ orgSlug, study, orgName }: ProposalSubmitted
                     statusBadge={bannerConfig?.statusBadge}
                     initialExpanded={false}
                 />
+                <FeedbackAndNotesSection entries={entries} />
                 <ProposalNavigation orgSlug={orgSlug} study={study} />
             </Stack>
         </Stack>

--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
@@ -56,7 +56,7 @@ function StatusBanner({ orgName, status }: { orgName: string; status: StudyStatu
     if (!config) return null
 
     return (
-        <Alert color={config.color} mb="md">
+        <Alert color={config.color} mb="md" data-testid={`status-banner-${status}`}>
             {config.message(orgName)}
         </Alert>
     )

--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
@@ -4,6 +4,7 @@ import type { FC } from 'react'
 import { Alert, Button, Group, Stack } from '@mantine/core'
 import { CaretLeftIcon } from '@phosphor-icons/react'
 import { displayOrgName } from '@/lib/string'
+import { ErrorAlert } from '@/components/errors'
 import { ProposalRequest } from '@/components/study/proposal-initial-request'
 import { FeedbackAndNotesSection } from '@/components/study/feedback-and-notes'
 import type { ProposalFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
@@ -17,6 +18,7 @@ interface ProposalSubmittedProps {
     study: SelectedStudy
     orgName: string
     entries: ProposalFeedbackEntry[]
+    feedbackError?: boolean
 }
 
 type ProposalBannerConfig = {
@@ -112,7 +114,20 @@ const ProposalNavigation: FC<{ orgSlug: string; study: SelectedStudy }> = ({ org
     }
 }
 
-export function ProposalSubmitted({ orgSlug, study, orgName, entries }: ProposalSubmittedProps) {
+const STATUSES_EXPECTING_FEEDBACK: StudyStatus[] = ['APPROVED', 'REJECTED', 'CHANGE-REQUESTED']
+
+function FeedbackErrorAlert({ status, feedbackError }: { status: StudyStatus; feedbackError?: boolean }) {
+    if (!feedbackError || !STATUSES_EXPECTING_FEEDBACK.includes(status)) return null
+
+    return (
+        <ErrorAlert
+            error="Unable to load feedback and notes. Please try refreshing the page."
+            data-testid="feedback-error-alert"
+        />
+    )
+}
+
+export function ProposalSubmitted({ orgSlug, study, orgName, entries, feedbackError }: ProposalSubmittedProps) {
     const bannerConfig = PROPOSAL_BANNERS[study.status]
 
     return (
@@ -128,6 +143,7 @@ export function ProposalSubmitted({ orgSlug, study, orgName, entries }: Proposal
                     statusBadge={bannerConfig?.statusBadge}
                     initialExpanded={false}
                 />
+                <FeedbackErrorAlert status={study.status} feedbackError={feedbackError} />
                 <FeedbackAndNotesSection entries={entries} />
                 <ProposalNavigation orgSlug={orgSlug} study={study} />
             </Stack>

--- a/src/app/[orgSlug]/study/[studyId]/submitted/submitted-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/submitted-view.tsx
@@ -4,7 +4,7 @@ import { Link } from '@/components/links'
 import { Routes } from '@/lib/routes'
 import { displayOrgName } from '@/lib/string'
 import { PostSubmissionFeatureFlag } from '@/components/openstax-feature-flag'
-import type { SelectedStudy } from '@/server/actions/study.actions'
+import type { ProposalFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
 import { StudyRequestPageHeader } from '../../request/page-header'
 import { SubmittedProposalPreview } from './submitted-proposal-preview'
 import { ProposalSubmitted } from './proposal-submitted'
@@ -13,9 +13,10 @@ interface SubmittedViewProps {
     orgSlug: string
     study: SelectedStudy
     orgName: string
+    entries: ProposalFeedbackEntry[]
 }
 
-export function SubmittedView({ orgSlug, study, orgName }: SubmittedViewProps) {
+export function SubmittedView({ orgSlug, study, orgName, entries }: SubmittedViewProps) {
     const existingView = (
         <Stack p="xl" gap="xl">
             <StudyRequestPageHeader orgSlug={orgSlug} studyId={study.id} studyTitle={study.title} />
@@ -43,7 +44,7 @@ export function SubmittedView({ orgSlug, study, orgName }: SubmittedViewProps) {
     return (
         <PostSubmissionFeatureFlag
             defaultContent={existingView}
-            optInContent={<ProposalSubmitted orgSlug={orgSlug} study={study} orgName={orgName} />}
+            optInContent={<ProposalSubmitted orgSlug={orgSlug} study={study} orgName={orgName} entries={entries} />}
         />
     )
 }

--- a/src/app/[orgSlug]/study/[studyId]/submitted/submitted-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/submitted-view.tsx
@@ -45,7 +45,15 @@ export function SubmittedView({ orgSlug, study, orgName, entries, feedbackError 
     return (
         <PostSubmissionFeatureFlag
             defaultContent={existingView}
-            optInContent={<ProposalSubmitted orgSlug={orgSlug} study={study} orgName={orgName} entries={entries} feedbackError={feedbackError} />}
+            optInContent={
+                <ProposalSubmitted
+                    orgSlug={orgSlug}
+                    study={study}
+                    orgName={orgName}
+                    entries={entries}
+                    feedbackError={feedbackError}
+                />
+            }
         />
     )
 }

--- a/src/app/[orgSlug]/study/[studyId]/submitted/submitted-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/submitted-view.tsx
@@ -14,9 +14,10 @@ interface SubmittedViewProps {
     study: SelectedStudy
     orgName: string
     entries: ProposalFeedbackEntry[]
+    feedbackError?: boolean
 }
 
-export function SubmittedView({ orgSlug, study, orgName, entries }: SubmittedViewProps) {
+export function SubmittedView({ orgSlug, study, orgName, entries, feedbackError }: SubmittedViewProps) {
     const existingView = (
         <Stack p="xl" gap="xl">
             <StudyRequestPageHeader orgSlug={orgSlug} studyId={study.id} studyTitle={study.title} />
@@ -44,7 +45,7 @@ export function SubmittedView({ orgSlug, study, orgName, entries }: SubmittedVie
     return (
         <PostSubmissionFeatureFlag
             defaultContent={existingView}
-            optInContent={<ProposalSubmitted orgSlug={orgSlug} study={study} orgName={orgName} entries={entries} />}
+            optInContent={<ProposalSubmitted orgSlug={orgSlug} study={study} orgName={orgName} entries={entries} feedbackError={feedbackError} />}
         />
     )
 }

--- a/src/components/dashboard/studies-table/study-action-link.tsx
+++ b/src/components/dashboard/studies-table/study-action-link.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@/components/links'
 import { Routes } from '@/lib/routes'
+import { usePostSubmissionFeatureFlag } from '@/components/openstax-feature-flag'
 import { Audience, Scope, StudyRow } from './types'
 import { useStudyHref } from '@/hooks/use-study-href'
 
@@ -22,11 +23,12 @@ function ResearcherLink({
     scope: Scope
     isHighlighted: boolean
 }) {
+    const isPostSubmissionFlow = usePostSubmissionFeatureFlag()
     const labSlug = study.submittedByOrgSlug || orgSlug
     const hasJobActivity = study.jobStatusChanges.length > 0
     const studyParams = { orgSlug: labSlug, studyId: study.id }
     const jobStatuses = study.jobStatusChanges.map((c) => c.status)
-    const baseHref = useStudyHref(study.status, hasJobActivity, studyParams, jobStatuses)
+    const baseHref = useStudyHref(study.status, hasJobActivity, studyParams, jobStatuses, isPostSubmissionFlow)
     const href = scope === 'org' ? (`${baseHref}?returnTo=org` as typeof baseHref) : baseHref
 
     if (study.status === 'DRAFT') {

--- a/src/components/openstax-feature-flag.tsx
+++ b/src/components/openstax-feature-flag.tsx
@@ -56,7 +56,8 @@ export {
     // Card 64: DO Proposal Review redesign
     useOpenStaxFeatureFlag as useProposalReviewFeatureFlag,
     OpenStaxFeatureFlag as ProposalReviewFeatureFlag,
-    // OTTER-495: Post-submission page
+    // OTTER-495 & 519: Post-submission page
+    useOpenStaxFeatureFlag as usePostSubmissionFeatureFlag,
     OpenStaxFeatureFlag as PostSubmissionFeatureFlag,
     // OTTER-497: Multi-user proposal collaboration
     useOpenStaxFeatureFlag as useProposalCollaborationFeatureFlag,

--- a/src/components/readonly-lexical-content.tsx
+++ b/src/components/readonly-lexical-content.tsx
@@ -5,15 +5,18 @@ import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin'
 import { ContentEditable } from '@lexical/react/LexicalContentEditable'
 import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary'
 import { lexicalTheme, lexicalNodes } from '@/components/editable-text/config'
+import type { JsonValue } from '@/database/types'
 import logger from '@/lib/logger'
 
-export function ReadOnlyLexicalContent({ value }: { value: string }) {
+export function ReadOnlyLexicalContent({ value }: { value: string | JsonValue }) {
+    if (value == null) return null
+    const editorState = typeof value === 'string' ? value : JSON.stringify(value)
     const initialConfig = {
         namespace: 'ReadOnlyLexicalContent',
         theme: lexicalTheme,
         nodes: lexicalNodes,
         editable: false,
-        editorState: value,
+        editorState,
         onError: (error: Error) => {
             logger.error('Lexical read-only error:', error)
         },

--- a/src/components/study/feedback-and-notes.tsx
+++ b/src/components/study/feedback-and-notes.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { useState } from 'react'
+import { Anchor, Collapse, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
+import { CaretDownIcon, CaretUpIcon } from '@phosphor-icons/react'
+import dayjs from 'dayjs'
+import { ReadOnlyLexicalContent } from '@/components/readonly-lexical-content'
+import type { ProposalFeedbackEntry } from '@/server/actions/study.actions'
+
+function formatDate(date: Date | string): string {
+    return dayjs(date).format('MMM DD, YYYY')
+}
+
+function entryTitle(entry: ProposalFeedbackEntry): string {
+    return entry.entryType === 'REVIEWER-FEEDBACK' ? 'Reviewer feedback' : 'Resubmission note'
+}
+
+function ToggleCaret({ isExpanded }: { isExpanded: boolean }) {
+    const Icon = isExpanded ? CaretUpIcon : CaretDownIcon
+    return <Icon size={14} />
+}
+
+type FeedbackEntryProps = {
+    entry: ProposalFeedbackEntry
+    isExpanded: boolean
+    onToggle: () => void
+}
+
+function FeedbackEntry({ entry, isExpanded, onToggle }: FeedbackEntryProps) {
+    const title = entryTitle(entry)
+    const date = formatDate(entry.createdAt)
+
+    return (
+        <Stack gap="sm" data-testid={`feedback-entry-${entry.id}`}>
+            <Group justify="space-between" align="center">
+                <Stack gap={2}>
+                    <Text fw={600}>{title}</Text>
+                    <Text size="sm" c="gray.7">
+                        {entry.authorName} · {date}
+                    </Text>
+                </Stack>
+                <Anchor
+                    component="button"
+                    onClick={onToggle}
+                    c="blue"
+                    size="sm"
+                    data-testid={`feedback-toggle-${entry.id}`}
+                    aria-expanded={isExpanded}
+                >
+                    <ToggleCaret isExpanded={isExpanded} />
+                </Anchor>
+            </Group>
+            <Collapse in={isExpanded}>
+                <Text size="sm" component="div" data-testid={`feedback-body-${entry.id}`}>
+                    <ReadOnlyLexicalContent value={JSON.stringify(entry.body)} />
+                </Text>
+            </Collapse>
+        </Stack>
+    )
+}
+
+function useExpandedEntries(entries: ProposalFeedbackEntry[]) {
+    const [expandedIds, setExpandedIds] = useState<Set<string>>(() => {
+        const latest = entries[0]?.id
+        return latest ? new Set([latest]) : new Set()
+    })
+
+    const toggle = (id: string) => {
+        setExpandedIds((prev) => {
+            const next = new Set(prev)
+            if (next.has(id)) {
+                next.delete(id)
+            } else {
+                next.add(id)
+            }
+            return next
+        })
+    }
+
+    const isExpanded = (id: string) => expandedIds.has(id)
+
+    return { isExpanded, toggle }
+}
+
+export function FeedbackAndNotesSection({ entries }: { entries: ProposalFeedbackEntry[] }) {
+    const { isExpanded, toggle } = useExpandedEntries(entries)
+
+    if (entries.length === 0) return null
+
+    return (
+        <Paper p="xl" data-testid="feedback-and-notes-section">
+            <Stack gap="md">
+                <Title order={4} fz={20} c="charcoal.9" pb={4}>
+                    Feedback and notes
+                </Title>
+                <Divider />
+                <Stack gap="md" data-testid="feedback-entries">
+                    {entries.map((entry, idx) => (
+                        <Stack key={entry.id} gap="md">
+                            <FeedbackEntry
+                                entry={entry}
+                                isExpanded={isExpanded(entry.id)}
+                                onToggle={() => toggle(entry.id)}
+                            />
+                            {idx < entries.length - 1 && <Divider data-testid="entry-divider" />}
+                        </Stack>
+                    ))}
+                </Stack>
+            </Stack>
+        </Paper>
+    )
+}

--- a/src/components/study/feedback-and-notes.tsx
+++ b/src/components/study/feedback-and-notes.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Anchor, Collapse, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
+import { Anchor, Box, Collapse, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
 import { CaretDownIcon, CaretUpIcon } from '@phosphor-icons/react'
 import dayjs from 'dayjs'
 import { ReadOnlyLexicalContent } from '@/components/readonly-lexical-content'
@@ -33,12 +33,9 @@ function FeedbackEntry({ entry, isExpanded, onToggle }: FeedbackEntryProps) {
     return (
         <Stack gap="sm" data-testid={`feedback-entry-${entry.id}`}>
             <Group justify="space-between" align="center">
-                <Stack gap={2}>
-                    <Text fw={600}>{title}</Text>
-                    <Text size="sm" c="gray.7">
-                        {entry.authorName} · {date}
-                    </Text>
-                </Stack>
+                <Text fw={700} fz={14}>
+                    {title}
+                </Text>
                 <Anchor
                     component="button"
                     onClick={onToggle}
@@ -50,11 +47,21 @@ function FeedbackEntry({ entry, isExpanded, onToggle }: FeedbackEntryProps) {
                     <ToggleCaret isExpanded={isExpanded} />
                 </Anchor>
             </Group>
-            <Collapse in={isExpanded}>
-                <Text size="sm" component="div" data-testid={`feedback-body-${entry.id}`}>
-                    <ReadOnlyLexicalContent value={JSON.stringify(entry.body)} />
-                </Text>
-            </Collapse>
+            <Box bg="gray.0" p="lg">
+                <Stack gap="xs">
+                    <Text size="sm" fw={600}>
+                        {entry.authorName}
+                    </Text>
+                    <Text size="sm" c="gray.7">
+                        {date}
+                    </Text>
+                </Stack>
+                <Collapse in={isExpanded}>
+                    <Text size="sm" component="div" mt="sm" data-testid={`feedback-body-${entry.id}`}>
+                        <ReadOnlyLexicalContent value={JSON.stringify(entry.body)} />
+                    </Text>
+                </Collapse>
+            </Box>
         </Stack>
     )
 }
@@ -88,7 +95,7 @@ export function FeedbackAndNotesSection({ entries }: { entries: ProposalFeedback
     if (entries.length === 0) return null
 
     return (
-        <Paper p="xl" data-testid="feedback-and-notes-section">
+        <Paper p="xxl" data-testid="feedback-and-notes-section">
             <Stack gap="md">
                 <Title order={4} fz={20} c="charcoal.9" pb={4}>
                     Feedback and notes

--- a/src/components/study/feedback-and-notes.tsx
+++ b/src/components/study/feedback-and-notes.tsx
@@ -57,8 +57,9 @@ function FeedbackEntry({ entry, isExpanded, onToggle }: FeedbackEntryProps) {
                     </Text>
                 </Stack>
                 <Collapse in={isExpanded}>
+                    {/* component="div" because Lexical renders block-level elements that can't nest inside <p> */}
                     <Text size="sm" component="div" mt="sm" data-testid={`feedback-body-${entry.id}`}>
-                        <ReadOnlyLexicalContent value={JSON.stringify(entry.body)} />
+                        <ReadOnlyLexicalContent value={entry.body} />
                     </Text>
                 </Collapse>
             </Box>

--- a/src/components/study/proposal-initial-request.tsx
+++ b/src/components/study/proposal-initial-request.tsx
@@ -76,12 +76,12 @@ export function ProposalRequest({
                         Title: {study.title}
                     </Text>
                     {study.submittedAt && (
-                        <Text fz={12} c="charcoal.7" style={{ whiteSpace: 'nowrap' }}>
+                        <Text fz={12} c="charcoal.7" style={{ whiteSpace: 'nowrap' }} data-testid="proposal-timestamp">
                             {statusBadge ?? 'Submitted on'} {dayjs(study.submittedAt).format('MMM DD, YYYY')}
                         </Text>
                     )}
                 </Group>
-                <Divider my="md" />
+                <Divider my="md" data-testid="proposal-header-divider" />
                 {banner}
                 <ToggleLink isExpanded={expanded} onClick={toggle} testId="proposal-toggle-header" />
             </Paper>

--- a/src/components/study/proposal-initial-request.tsx
+++ b/src/components/study/proposal-initial-request.tsx
@@ -16,6 +16,7 @@ type ProposalRequestProps = {
     heading: string
     banner: ReactNode
     initialExpanded?: boolean
+    statusBadge?: string
 }
 
 function useProposalRequest(initialExpanded: boolean) {
@@ -57,6 +58,7 @@ export function ProposalRequest({
     heading,
     banner,
     initialExpanded = true,
+    statusBadge,
 }: ProposalRequestProps) {
     const { expanded, toggle, collapse, getPopoverProps } = useProposalRequest(initialExpanded)
 
@@ -75,7 +77,7 @@ export function ProposalRequest({
                     </Text>
                     {study.submittedAt && (
                         <Text fz={12} c="charcoal.7" style={{ whiteSpace: 'nowrap' }}>
-                            Submitted on {dayjs(study.submittedAt).format('MMM DD, YYYY')}
+                            {statusBadge ?? 'Submitted on'} {dayjs(study.submittedAt).format('MMM DD, YYYY')}
                         </Text>
                     )}
                 </Group>

--- a/src/components/study/proposal-initial-request.tsx
+++ b/src/components/study/proposal-initial-request.tsx
@@ -58,7 +58,7 @@ export function ProposalRequest({
     heading,
     banner,
     initialExpanded = true,
-    statusBadge,
+    statusBadge = 'Submitted on',
 }: ProposalRequestProps) {
     const { expanded, toggle, collapse, getPopoverProps } = useProposalRequest(initialExpanded)
 
@@ -77,7 +77,7 @@ export function ProposalRequest({
                     </Text>
                     {study.submittedAt && (
                         <Text fz={12} c="charcoal.7" style={{ whiteSpace: 'nowrap' }} data-testid="proposal-timestamp">
-                            {statusBadge ?? 'Submitted on'} {dayjs(study.submittedAt).format('MMM DD, YYYY')}
+                            {statusBadge} {dayjs(study.submittedAt).format('MMM DD, YYYY')}
                         </Text>
                     )}
                 </Group>

--- a/src/hooks/use-study-href.test.ts
+++ b/src/hooks/use-study-href.test.ts
@@ -34,4 +34,18 @@ describe('useStudyHref', () => {
     it('routes to /view for DRAFT without job activity', () => {
         expect(useStudyHref('DRAFT', false, PARAMS)).toBe(`${BASE}/view`)
     })
+
+    describe('post-submission flow', () => {
+        it('routes to /submitted for APPROVED without job activity', () => {
+            expect(useStudyHref('APPROVED', false, PARAMS, undefined, true)).toBe(`${BASE}/submitted`)
+        })
+
+        it('routes to /submitted for REJECTED without job activity', () => {
+            expect(useStudyHref('REJECTED', false, PARAMS, undefined, true)).toBe(`${BASE}/submitted`)
+        })
+
+        it('routes to /submitted for CHANGE-REQUESTED without job activity', () => {
+            expect(useStudyHref('CHANGE-REQUESTED', false, PARAMS, undefined, true)).toBe(`${BASE}/submitted`)
+        })
+    })
 })

--- a/src/hooks/use-study-href.ts
+++ b/src/hooks/use-study-href.ts
@@ -3,17 +3,23 @@ import { StudyJobStatus, StudyStatus } from '@/database/types'
 
 type StudyParams = { orgSlug: string; studyId: string }
 
+const POST_SUBMISSION_STATUSES: StudyStatus[] = ['PENDING-REVIEW', 'APPROVED', 'REJECTED', 'CHANGE-REQUESTED']
+
 export function useStudyHref(
     status: StudyStatus,
     hasJobActivity: boolean,
     studyParams: StudyParams,
     jobStatuses?: StudyJobStatus[],
+    isPostSubmissionFlow = false,
 ) {
     // APPROVED with only a baseline job (no code submitted yet) → continue uploading
     const hasCodeSubmitted = jobStatuses?.some((s) => s === 'CODE-SUBMITTED')
     if (status === 'APPROVED' && hasJobActivity && !hasCodeSubmitted) return Routes.studyCode(studyParams)
 
     if (hasJobActivity) return Routes.studyView(studyParams)
+
+    if (isPostSubmissionFlow && POST_SUBMISSION_STATUSES.includes(status)) return Routes.studySubmitted(studyParams)
+
     if (status === 'PENDING-REVIEW') return Routes.studySubmitted(studyParams)
     if (status === 'APPROVED') return Routes.studyAgreements(studyParams)
     return Routes.studyView(studyParams)


### PR DESCRIPTION
### Summary

Adds a status-aware `/submitted` view for research labs (behind the OpenStax spy mode feature flag) that dynamically displays content based on the study's proposal decision status.

**Status-dependent banners and badges:**
- `PENDING-REVIEW` — yellow banner, "Submitted on" badge
- `APPROVED` — green banner, "Approved on" badge
- `REJECTED` — red banner, "Rejected on" badge
- `CHANGE-REQUESTED` — blue banner, "Clarification requested on" badge

**Status-dependent navigation:**
- `APPROVED` — "Back" (dashboard) + "Proceed to step 3" (agreements)
- `CHANGE-REQUESTED` — "Back" (dashboard) + "Edit and resubmit" (edit page)
- `REJECTED` / `PENDING-REVIEW` — "Go to dashboard"

**Feedback and notes section:**
- Displays reviewer feedback and researcher resubmission notes in reverse chronological order
- Latest entry expanded by default, older entries collapsed
- Entries render rich text (Lexical) with author name, date, and a subtle `gray.0` background container

**Routing fix:**
- When spy mode is active, `APPROVED`, `REJECTED`, and `CHANGE-REQUESTED` statuses now correctly route to `/submitted` instead of `/agreements` or other pages

**Refactoring:**
- Extracted `FeedbackAndNotesSection` into a shared component (`src/components/study/feedback-and-notes.tsx`), reused by both the research lab submitted view and the data organization post-feedback view

### Files changed

| File | Change |
|------|--------|
| `proposal-submitted.tsx` | Status banners, badges, and navigation |
| `feedback-and-notes.tsx` | New shared feedback section component |
| `post-feedback-view.tsx` | Refactored to use shared feedback component |
| `page.tsx` (submitted) | Parallel fetch of feedback entries |
| `submitted-view.tsx` | Passes feedback entries through to component |
| `use-study-href.ts` | Post-submission routing for spy mode |
| `study-action-link.tsx` | Integrates post-submission feature flag |
| `openstax-feature-flag.tsx` | Exports `usePostSubmissionFeatureFlag` |
| `proposal-initial-request.tsx` | Smooth caret rotation, `statusBadge` prop |
| `proposal-submitted.test.tsx` | 28 unit tests (new file) |
| `use-study-href.test.ts` | Post-submission routing tests |