### PR TITLE
OTTER 493: fix duplicated proposal prefix in change-requested status label

### DIFF
--- a/src/components/study/display-study-status.test.tsx
+++ b/src/components/study/display-study-status.test.tsx
@@ -25,7 +25,9 @@ describe('DisplayStudyStatus', () => {
         it.each(cases)('renders %s as "%s"', (statusKey, expectedText) => {
             const status = REVIEWER_STATUS_LABELS[statusKey]!
             renderWithProviders(<DisplayStudyStatus status={status} />)
-            expect(screen.getByText(expectedText)).toBeDefined()
+            const textEl = screen.getByText(expectedText)
+            expect(textEl).toBeDefined()
+            expect(textEl.parentElement?.textContent?.trim()).toBe(expectedText)
         })
     })
 
@@ -49,7 +51,9 @@ describe('DisplayStudyStatus', () => {
         it.each(cases)('renders %s as "%s"', (statusKey, expectedText) => {
             const status = RESEARCHER_STATUS_LABELS[statusKey]!
             renderWithProviders(<DisplayStudyStatus status={status} />)
-            expect(screen.getByText(expectedText)).toBeDefined()
+            const textEl = screen.getByText(expectedText)
+            expect(textEl).toBeDefined()
+            expect(textEl.parentElement?.textContent?.trim()).toBe(expectedText)
         })
     })
 })

--- a/src/components/study/display-study-status.test.tsx
+++ b/src/components/study/display-study-status.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { renderWithProviders } from '@/tests/unit.helpers'
+import { screen } from '@testing-library/react'
+import { DisplayStudyStatus } from '@/components/study/display-study-status'
+import { REVIEWER_STATUS_LABELS, RESEARCHER_STATUS_LABELS } from '@/lib/status-labels'
+import type { AllStatus } from '@/lib/types'
+
+describe('DisplayStudyStatus', () => {
+    describe('reviewer audience', () => {
+        const cases: Array<[AllStatus, string]> = [
+            ['PENDING-REVIEW', 'Proposal needs review'],
+            ['APPROVED', 'Proposal approved'],
+            ['REJECTED', 'Proposal rejected'],
+            ['CHANGE-REQUESTED', 'Proposal change requested'],
+            ['CODE-SUBMITTED', 'Code needs review'],
+            ['CODE-APPROVED', 'Code approved'],
+            ['CODE-REJECTED', 'Code rejected'],
+            ['JOB-RUNNING', 'Code processing'],
+            ['JOB-ERRORED', 'Code errored'],
+            ['RUN-COMPLETE', 'Result needs review'],
+            ['FILES-APPROVED', 'Result ready'],
+            ['FILES-REJECTED', 'Result rejected'],
+        ]
+
+        it.each(cases)('renders %s as "%s"', (statusKey, expectedText) => {
+            const status = REVIEWER_STATUS_LABELS[statusKey]!
+            renderWithProviders(<DisplayStudyStatus status={status} />)
+            expect(screen.getByText(expectedText)).toBeDefined()
+        })
+    })
+
+    describe('researcher audience', () => {
+        const cases: Array<[AllStatus, string]> = [
+            ['DRAFT', 'Proposal draft'],
+            ['PENDING-REVIEW', 'Proposal under review'],
+            ['APPROVED', 'Proposal approved'],
+            ['REJECTED', 'Proposal rejected'],
+            ['CHANGE-REQUESTED', 'Proposal change requested'],
+            ['INITIATED', 'Code draft'],
+            ['CODE-SUBMITTED', 'Code under review'],
+            ['CODE-APPROVED', 'Code approved'],
+            ['CODE-REJECTED', 'Code rejected'],
+            ['JOB-ERRORED', 'Code errored'],
+            ['RUN-COMPLETE', 'Result under review'],
+            ['FILES-APPROVED', 'Result ready'],
+            ['FILES-REJECTED', 'Result rejected'],
+        ]
+
+        it.each(cases)('renders %s as "%s"', (statusKey, expectedText) => {
+            const status = RESEARCHER_STATUS_LABELS[statusKey]!
+            renderWithProviders(<DisplayStudyStatus status={status} />)
+            expect(screen.getByText(expectedText)).toBeDefined()
+        })
+    })
+})

--- a/src/hooks/use-study-status.test.ts
+++ b/src/hooks/use-study-status.test.ts
@@ -63,13 +63,13 @@ describe('useStudyStatus', () => {
             expect(researcherResult).toEqual(
                 expect.objectContaining({
                     stage: 'Proposal',
-                    label: 'Proposal change requested',
+                    label: 'Change requested',
                 }),
             )
             expect(reviewerResult).toEqual(
                 expect.objectContaining({
                     stage: 'Proposal',
-                    label: 'Proposal change requested',
+                    label: 'Change requested',
                 }),
             )
         })

--- a/src/lib/status-labels.ts
+++ b/src/lib/status-labels.ts
@@ -56,7 +56,7 @@ export const REVIEWER_STATUS_LABELS: Partial<Record<AllStatus, StatusLabel>> = {
     },
     'CHANGE-REQUESTED': {
         stage: 'Proposal',
-        label: 'Proposal change requested',
+        label: 'Change requested',
         tooltip: "You've asked the Researcher to clarify or revise this proposal.",
         colors: COLORS.clarification,
     },
@@ -164,7 +164,7 @@ export const RESEARCHER_STATUS_LABELS: Partial<Record<AllStatus, StatusLabel>> =
     },
     'CHANGE-REQUESTED': {
         stage: 'Proposal',
-        label: 'Proposal change requested',
+        label: 'Change requested',
         tooltip: 'The reviewer has requested changes to your proposal. Open your study for more details.',
         colors: COLORS.underReview,
     },


### PR DESCRIPTION
fixes issue described [here](https://openstax.atlassian.net/browse/OTTER-492?focusedCommentId=41223)

- Fixed a bug where the change-requested status badge displayed the word "Proposal" twice and caused text to overlap neighboring content in the reviewer dashboard.
- Added a test suite that pins the exact rendered text for every status across both reviewer and researcher audiences to prevent regressions.