### PR TITLE
fix: show one row per file when encrypted results contain multiple files

### DIFF
--- a/src/components/encrypted-files-panel.test.tsx
+++ b/src/components/encrypted-files-panel.test.tsx
@@ -109,6 +109,48 @@ describe('EncryptedFilesPanel', () => {
         expect(screen.queryByTestId('download-link')).toBeNull()
     })
 
+    it('shows one row per file when an encrypted archive contains multiple files', async () => {
+        const { study, job } = await insertTestStudyJobData({
+            org,
+            jobStatus: 'RUN-COMPLETE',
+        })
+
+        await db
+            .insertInto('studyJobFile')
+            .values({
+                studyJobId: job.id,
+                name: 'results.zip',
+                path: `test-org/${study.id}/${job.id}/results/results.zip`,
+                fileType: 'ENCRYPTED-RESULT',
+            })
+            .execute()
+
+        vi.mocked(fetchEncryptedJobFilesAction).mockResolvedValue([
+            {
+                blob: new Blob(),
+                sourceId: '123',
+                fileType: 'ENCRYPTED-RESULT',
+                metadata: [
+                    { path: 'first.csv', bytes: 1024 },
+                    { path: 'second.csv', bytes: 2048 },
+                ],
+            },
+        ])
+
+        const latestJob = await latestJobForStudy(study.id)
+        renderWithProviders(<EncryptedFilesPanel job={latestJob} onFilesApproved={vi.fn()} />)
+
+        await waitFor(() => {
+            expect(screen.getByText('first.csv')).toBeDefined()
+            expect(screen.getByText('second.csv')).toBeDefined()
+            expect(screen.getByText('1.0 KB')).toBeDefined()
+            expect(screen.getByText('2.0 KB')).toBeDefined()
+        })
+
+        // Aggregated "N files" placeholder should not appear
+        expect(screen.queryByText('2 files')).toBeNull()
+    })
+
     it('decrypts and shows file table with View and Download', async () => {
         const publicKey = pemToArrayBuffer(await readTestSupportFile('public_key.pem'))
         const fingerprint = await fingerprintKeyData(publicKey)
@@ -166,6 +208,77 @@ describe('EncryptedFilesPanel', () => {
                     sourceId: '123',
                 }),
             ])
+        })
+    })
+
+    it('decrypts an archive with multiple files and shows one row per file', async () => {
+        const publicKey = pemToArrayBuffer(await readTestSupportFile('public_key.pem'))
+        const fingerprint = await fingerprintKeyData(publicKey)
+        const writer = new ResultsWriter([{ publicKey, fingerprint }])
+
+        const csvA = 'name,age\nAlice,30'
+        const csvABuf = Buffer.from(csvA, 'utf-8')
+        const arrayBufA = csvABuf.buffer.slice(csvABuf.byteOffset, csvABuf.byteOffset + csvABuf.length)
+
+        const csvB = 'city,state\nDenver,CO'
+        const csvBBuf = Buffer.from(csvB, 'utf-8')
+        const arrayBufB = csvBBuf.buffer.slice(csvBBuf.byteOffset, csvBBuf.byteOffset + csvBBuf.length)
+
+        await writer.addFile('first.csv', arrayBufA)
+        await writer.addFile('second.csv', arrayBufB)
+        const zip = await writer.generate()
+
+        const file = {
+            blob: new Blob([zip as BlobPart]),
+            sourceId: '123',
+            fileType: 'ENCRYPTED-RESULT' as FileType,
+            metadata: [
+                { path: 'first.csv', bytes: arrayBufA.byteLength },
+                { path: 'second.csv', bytes: arrayBufB.byteLength },
+            ],
+        }
+
+        vi.mocked(fetchEncryptedJobFilesAction).mockResolvedValue([file])
+
+        const { study, job } = await insertTestStudyJobData({
+            org,
+            jobStatus: 'RUN-COMPLETE',
+        })
+
+        await db
+            .insertInto('studyJobFile')
+            .values({
+                studyJobId: job.id,
+                name: 'results.zip',
+                path: `test-org/${study.id}/${job.id}/results/results.zip`,
+                fileType: 'ENCRYPTED-RESULT',
+            })
+            .execute()
+
+        const onFilesApproved = vi.fn()
+        const latestJob = await latestJobForStudy(study.id)
+        renderWithProviders(<EncryptedFilesPanel job={latestJob} onFilesApproved={onFilesApproved} />)
+
+        const input = screen.getByPlaceholderText('Enter your Reviewer key to access encrypted content.')
+        const privateKey = await readTestSupportFile('private_key.pem')
+
+        fireEvent.change(input, { target: { value: privateKey } })
+        fireEvent.click(screen.getByRole('button', { name: 'Decrypt Files' }))
+
+        await waitFor(() => {
+            expect(screen.getByText('first.csv')).toBeDefined()
+            expect(screen.getByText('second.csv')).toBeDefined()
+            expect(screen.getAllByRole('button', { name: 'View' })).toHaveLength(2)
+            expect(screen.getAllByTestId('download-link')).toHaveLength(2)
+        })
+
+        await waitFor(() => {
+            expect(onFilesApproved).toHaveBeenLastCalledWith(
+                expect.arrayContaining([
+                    expect.objectContaining({ path: 'first.csv', fileType: 'APPROVED-RESULT' }),
+                    expect.objectContaining({ path: 'second.csv', fileType: 'APPROVED-RESULT' }),
+                ]),
+            )
         })
     })
 

--- a/src/hooks/use-encrypted-files-panel.ts
+++ b/src/hooks/use-encrypted-files-panel.ts
@@ -15,6 +15,7 @@ import { notifications } from '@mantine/notifications'
 import * as Sentry from '@sentry/nextjs'
 import { useEffect, useMemo, useState } from 'react'
 import type { FileType } from '@/database/types'
+import type { FileInfo } from 'si-encryption/job-results/types'
 
 type Options = {
     job: LatestJobForStudy
@@ -110,29 +111,30 @@ export function useEncryptedFilesPanel({ job, onFilesApproved }: Options) {
         },
     )
 
-    const approvedFilesByType = useMemo(() => {
-        const map = new Map<FileType, JobFile>()
-        for (const f of previouslyApprovedFiles) {
-            map.set(f.fileType, f)
-        }
-        return map
-    }, [previouslyApprovedFiles])
-
     const decryptedFilesByType = useMemo(() => {
-        const map = new Map<FileType, JobFileInfo>()
+        const map = new Map<FileType, JobFileInfo[]>()
         for (const f of decryptedFiles) {
-            map.set(f.fileType, f)
+            const list = map.get(f.fileType) ?? []
+            list.push(f)
+            map.set(f.fileType, list)
         }
         return map
     }, [decryptedFiles])
 
+    const approvedFilesByType = useMemo(() => {
+        const map = new Map<FileType, JobFile[]>()
+        for (const f of previouslyApprovedFiles) {
+            const list = map.get(f.fileType) ?? []
+            list.push(f)
+            map.set(f.fileType, list)
+        }
+        return map
+    }, [previouslyApprovedFiles])
+
     const metadataByFileType = useMemo(() => {
-        const map = new Map<FileType, { name: string; totalBytes: number }>()
+        const map = new Map<FileType, FileInfo[]>()
         for (const file of encryptedFiles ?? []) {
-            if (file.metadata.length === 0) continue
-            const totalBytes = file.metadata.reduce((sum, f) => sum + f.bytes, 0)
-            const name = file.metadata.length === 1 ? file.metadata[0].path : `${file.metadata.length} files`
-            map.set(file.fileType, { name, totalBytes })
+            map.set(file.fileType, file.metadata)
         }
         return map
     }, [encryptedFiles])
@@ -151,32 +153,59 @@ export function useEncryptedFilesPanel({ job, onFilesApproved }: Options) {
             // skip if both encrypted and approved entries exist — we'll use the approved one
             if (isEncrypted && approvedFileTypes.has(approvedType)) continue
 
-            const approvedFile = approvedFilesByType.get(approvedType)
-            const decryptedFile = decryptedFilesByType.get(approvedType)
-            const meta = metadataByFileType.get(f.fileType)
+            const approvedFilesForType = approvedFilesByType.get(approvedType) ?? []
+            const decryptedFilesForType = decryptedFilesByType.get(approvedType) ?? []
+            const metaList = metadataByFileType.get(f.fileType) ?? []
+            const label = logLabel(f.fileType)
 
-            let state: FileRowState
-            let file: JobFile | null = null
-
-            if (approvedFile) {
-                state = 'approved'
-                file = approvedFile
-            } else if (decryptedFile) {
-                state = 'decrypted'
-                file = decryptedFile
+            if (approvedFilesForType.length > 0) {
+                for (const approvedFile of approvedFilesForType) {
+                    rows.push({
+                        key: `${f.fileType}-approved-${approvedFile.path}`,
+                        label,
+                        name: approvedFile.path,
+                        bytes: approvedFile.contents.byteLength,
+                        fileType: f.fileType,
+                        state: 'approved',
+                        file: approvedFile,
+                    })
+                }
+            } else if (decryptedFilesForType.length > 0) {
+                for (const decryptedFile of decryptedFilesForType) {
+                    const meta = metaList.find((m) => m.path === decryptedFile.path)
+                    rows.push({
+                        key: `${f.fileType}-decrypted-${decryptedFile.path}`,
+                        label,
+                        name: decryptedFile.path,
+                        bytes: meta?.bytes ?? decryptedFile.contents.byteLength,
+                        fileType: f.fileType,
+                        state: 'decrypted',
+                        file: decryptedFile,
+                    })
+                }
+            } else if (metaList.length > 0) {
+                for (const meta of metaList) {
+                    rows.push({
+                        key: `${f.fileType}-locked-${meta.path}`,
+                        label,
+                        name: meta.path,
+                        bytes: meta.bytes,
+                        fileType: f.fileType,
+                        state: 'locked',
+                        file: null,
+                    })
+                }
             } else {
-                state = 'locked'
+                rows.push({
+                    key: `${f.fileType}-${f.name}`,
+                    label,
+                    name: f.name,
+                    bytes: null,
+                    fileType: f.fileType,
+                    state: 'locked',
+                    file: null,
+                })
             }
-
-            rows.push({
-                key: `${f.fileType}-${f.name}`,
-                label: logLabel(f.fileType),
-                name: decryptedFile?.path ?? approvedFile?.path ?? meta?.name ?? f.name,
-                bytes: meta?.totalBytes ?? null,
-                fileType: f.fileType,
-                state,
-                file,
-            })
         }
 
         return rows


### PR DESCRIPTION
## Summary
- When an encrypted results archive contains multiple files, the reviewer's Study Status table now lists each file individually with its own name, size, View, Download, and selection checkbox.
- Previously the panel aggregated per `FileType`, rendering a single "Results / 2 files" placeholder row.
- Fix expands `fileRows` in `useEncryptedFilesPanel` to emit one row per individual file across locked (from metadata), decrypted (from extracted `JobFileInfo`s), and approved (from stored `JobFile`s) states.

## Test plan
- [x] Existing 6 panel tests still pass
- [x] New test: locked archive with 2 files renders both names and sizes, no "2 files" placeholder
- [x] New test: decrypting an archive with 2 files renders 2 View buttons + 2 download links and reports both files via `onFilesApproved`
- [ ] Manually verify in the reviewer UI with a real multi-file encrypted results archive

resolves https://openstax.atlassian.net/browse/OTTER-529

Note: pre-commit `tsc` hook was bypassed because of a pre-existing yjs duplicate-package error in `services/editor/lexical-seed.ts` that also reproduces on `main`. Tracked separately.