### PR TITLE
security: harden @claude trigger and document SONAR_TOKEN scope (OTTER-545)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# Dependabot config — keeps SHA-pinned actions current.
+#
+# Per OTTER-545, every third-party action in .github/workflows/ is pinned to a
+# commit SHA (with the version tag in a trailing comment). Without Dependabot
+# updates we'd silently drift behind upstream security fixes. This config
+# tracks updates for the github-actions ecosystem and groups them so we don't
+# get a separate PR per action per week.
+#
+# Add npm tracking later if/when we want it; for now the existing manual
+# update cadence + `npm audit fix` covers the npm side.
+
+version: 2
+updates:
+    - package-ecosystem: 'github-actions'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+          day: 'monday'
+      open-pull-requests-limit: 5
+      groups:
+          actions-minor-and-patch:
+              update-types:
+                  - 'minor'
+                  - 'patch'
+      labels:
+          - 'dependencies'
+          - 'github-actions'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,6 +25,15 @@ jobs:
             - name: validate actions
               run: npm run validate-actions
 
+    # SECURITY (OTTER-545): SONAR_TOKEN grants write access to SonarCloud and is
+    # exposed to PR-controlled code. This job is safe ONLY because it does not run
+    # `npm ci`, build scripts, or any other PR-supplied code before the Sonar step.
+    # Do NOT:
+    #   - add `npm ci` / `npm install` / build / test steps to this job
+    #   - move SONAR_TOKEN to a job-level or workflow-level `env`
+    #   - reorder steps so PR code executes before the SonarQube scan
+    # If you need to run PR code alongside Sonar, split it into a separate job
+    # that does not have access to SONAR_TOKEN.
     infosec:
         timeout-minutes: 5
         runs-on: ubuntu-latest
@@ -39,6 +48,8 @@ jobs:
                   scan-ref: '.'
                   trivy-config: trivy.yaml
             - name: Run SonarQube SAST Scan
+              # SONAR_TOKEN is scoped to this single step (not the job env) so that
+              # any future steps added above cannot accidentally read it. Keep it here.
               uses: SonarSource/sonarqube-scan-action@v7
               env:
                   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,3 +1,18 @@
+# SECURITY (OTTER-545): this workflow runs on `pull_request` and therefore
+# executes PR-controlled code (npm install scripts, build, tests). Two threat
+# model rules apply across every job here:
+#
+#   1. Every `actions/checkout` MUST set `persist-credentials: false` so the
+#      runner does not leave a usable GITHUB_TOKEN on disk that a malicious
+#      preinstall / postinstall / test fixture could read.
+#   2. Every job's `permissions:` block MUST be the minimum required for that
+#      job. The `GITHUB_TOKEN` is still passed via env to actions that ask for
+#      it (e.g. coverage-diff-action), but its blast radius is bounded by the
+#      job's permissions even if it leaks.
+#
+# Third-party actions are pinned to commit SHAs (with the version tag in a
+# trailing comment) so a compromised upstream tag cannot silently change what
+# runs here. Use Dependabot to update the SHAs.
 name: Checks
 on:
     push:
@@ -11,8 +26,10 @@ jobs:
         runs-on: ubuntu-latest
         permissions: {}
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              with:
+                  persist-credentials: false
+            - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
               with:
                   node-version: 22
                   cache: 'npm'
@@ -40,7 +57,9 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              with:
+                  persist-credentials: false
             - name: Run Trivy vulnerability scanner in fs mode
               uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
               with:
@@ -50,7 +69,7 @@ jobs:
             - name: Run SonarQube SAST Scan
               # SONAR_TOKEN is scoped to this single step (not the job env) so that
               # any future steps added above cannot accidentally read it. Keep it here.
-              uses: SonarSource/sonarqube-scan-action@v7
+              uses: SonarSource/sonarqube-scan-action@c7ee0f9df90b7aa20e8dcf9695dcfe2e7da5b4f2 # v7
               env:
                   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
                   SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
@@ -68,10 +87,15 @@ jobs:
                     POSTGRES_DB: si_test
                     POSTGRES_PASSWORD: si
                 options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        # SECURITY (OTTER-545): minimum permissions for this job.
+        #   - pull-requests: write — required by coverage-diff-action to post a
+        #     PR comment with the coverage delta.
+        # Anything else (contents: write, pages: write, etc.) MUST NOT be added
+        # without re-evaluating the threat model: this job runs PR-controlled
+        # code, so any permission granted here is a permission a malicious PR
+        # could exercise via a stolen GITHUB_TOKEN.
         permissions:
             pull-requests: write
-            contents: write
-            pages: write
         env:
             DATABASE_URL: 'postgres://si:si@localhost:5432/si_test'
             SIMULATE_CODE_BUILD: 't'
@@ -80,8 +104,16 @@ jobs:
             # three Playwright test accounts (researcher, reviewer, admin), is
             # not connected to any production data, and the credentials are not
             # shared with any other environment, repo, or developer machine.
-            # If this changes (real users added, instance reused elsewhere), the
-            # exposure model in OTTER-545 needs to be re-evaluated.
+            #
+            # The load-bearing mitigation here is the CI-only Clerk instance,
+            # NOT step- or job-level scoping. Every step that needs Clerk creds
+            # (npm ci, unit tests, e2e tests, coverage) also runs PR-controlled
+            # code, so moving these to step-level env would not reduce exposure
+            # — a malicious PR can put exfil code in any of those steps.
+            #
+            # If the CI Clerk instance ever stops being throwaway-isolated
+            # (real users added, instance reused elsewhere), the exposure model
+            # in OTTER-545 needs to be re-evaluated.
             NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
             CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
             CLERK_RESEARCHER_EMAIL: ${{ secrets.CLERK_RESEARCHER_EMAIL }}
@@ -99,12 +131,14 @@ jobs:
             PORT: '4000'
             NEXT_PUBLIC_CLERK_DOMAIN: 'localhost:4000'
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              with:
+                  persist-credentials: false
+            - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
               with:
                   node-version: 22
                   cache: 'npm'
-            - uses: actions/cache@v4
+            - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
               id: cache-all-the-things
               with:  # https://nextjs.org/docs/pages/guides/ci-build-caching
                   key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
@@ -160,7 +194,7 @@ jobs:
                   cat test-results/coverage/coverage-summary.md >> $GITHUB_STEP_SUMMARY
                   cat test-results/coverage/coverage-details.md >> $GITHUB_STEP_SUMMARY
             - name: Coverage Diff
-              uses: bultkrantz/coverage-diff-action@v5.0.1
+              uses: bultkrantz/coverage-diff-action@4b5175f210f33024e9725a59f6be6ba407bec8cd # v5.0.1
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   base-summary-filename: base-summary.json
@@ -175,7 +209,7 @@ jobs:
             - name: Delete any test users created
               run: npx tsx ./bin/delete-clerk-test-users.ts
               if: always()
-            - uses: actions/upload-artifact@v4
+            - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               if: failure()
               with:
                   name: playwright-report

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -75,6 +75,13 @@ jobs:
         env:
             DATABASE_URL: 'postgres://si:si@localhost:5432/si_test'
             SIMULATE_CODE_BUILD: 't'
+            # SECURITY (OTTER-545): the CLERK_* secrets below belong to a Clerk
+            # instance dedicated to GitHub CI. That instance contains ONLY the
+            # three Playwright test accounts (researcher, reviewer, admin), is
+            # not connected to any production data, and the credentials are not
+            # shared with any other environment, repo, or developer machine.
+            # If this changes (real users added, instance reused elsewhere), the
+            # exposure model in OTTER-545 needs to be re-evaluated.
             NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
             CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
             CLERK_RESEARCHER_EMAIL: ${{ secrets.CLERK_RESEARCHER_EMAIL }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -86,7 +86,6 @@ jobs:
             CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
             CLERK_RESEARCHER_EMAIL: ${{ secrets.CLERK_RESEARCHER_EMAIL }}
             CLERK_RESEARCHER_PASSWORD: ${{ secrets.CLERK_RESEARCHER_PASSWORD }}
-            AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
             CLERK_REVIEWER_EMAIL: ${{ secrets.CLERK_REVIEWER_EMAIL }}
             CLERK_REVIEWER_PASSWORD: ${{ secrets.CLERK_REVIEWER_PASSWORD }}
             CLERK_ADMIN_EMAIL: ${{ secrets.CLERK_ADMIN_EMAIL }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,12 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        # SECURITY (OTTER-545): pinned to commit SHA so a re-tag of v2.6.1
+        # cannot silently change what runs here. This workflow uses
+        # `pull_request_target` and runs with `contents: write` /
+        # `pull-requests: write`, so an upstream compromise would be
+        # significant. Update via Dependabot.
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,6 +15,9 @@ permissions:
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
+    # SECURITY (OTTER-545): cap the job lifetime so a stolen GITHUB_TOKEN's
+    # validity window — which equals the job's actual runtime — is bounded.
+    timeout-minutes: 10
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,6 +38,9 @@ jobs:
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && (github.event.issue.author_association == 'OWNER' || github.event.issue.author_association == 'MEMBER' || github.event.issue.author_association == 'COLLABORATOR'))
       )
     runs-on: ubuntu-latest
+    # SECURITY (OTTER-545): cap the job lifetime so a stolen GITHUB_TOKEN's
+    # validity window — which equals the job's actual runtime — is bounded.
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,3 +1,21 @@
+# SECURITY (OTTER-545): threat model for this workflow.
+#
+# Trigger gating: every job-level `if:` requires the @claude trigger PLUS an
+# OWNER / MEMBER / COLLABORATOR author_association. CONTRIBUTOR is intentionally
+# excluded — anyone with a single merged typo PR would otherwise become a
+# permanent CONTRIBUTOR and could trigger Claude with their own prompts.
+#
+# Runtime trust (audited from anthropics/claude-code-action@v1 source, 2026-05):
+#   - The action's own `bun install` runs inside ${GITHUB_ACTION_PATH}, NOT the
+#     user's workspace. It does not execute the repo's package.json scripts.
+#   - With `actions/checkout` invoked without a `ref:`, the base ref is checked
+#     out — not the PR head. So even if a PR is open, this workflow does not
+#     execute PR-controlled code.
+#   - The action revokes its own app token at the end of the run.
+# These properties make ANTHROPIC_API_KEY exposure low-risk under default
+# settings. If we ever set `ref: ${{ github.event.pull_request.head.sha }}` on
+# the checkout, or pass `--add-dir` to claude_args pointing at PR code, the
+# threat model changes and this comment block needs to be revisited.
 name: Claude Code
 
 on:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,12 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && (github.event.review.author_association == 'OWNER' || github.event.review.author_association == 'MEMBER' || github.event.review.author_association == 'COLLABORATOR')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && (github.event.issue.author_association == 'OWNER' || github.event.issue.author_association == 'MEMBER' || github.event.issue.author_association == 'COLLABORATOR'))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,13 +28,18 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          # SECURITY (OTTER-545): the claude-code-action runs `npm install`
+          # and other PR-controlled tooling against the checked-out tree, so
+          # we must not leave a usable GITHUB_TOKEN on disk for a malicious
+          # install script to read.
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@2cc1ac1331eac7a6a96d716dd204dd2888d0fcd2 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 


### PR DESCRIPTION
## Summary
- Gate the `@claude` workflow trigger on `author_association` (OWNER/MEMBER/COLLABORATOR) so arbitrary fork PR authors and drive-by commenters cannot invoke runs that have `ANTHROPIC_API_KEY` in scope.
- Document the constraints that keep the `infosec` job safe to use `SONAR_TOKEN`: no PR-controlled code (`npm ci`, build, tests) runs before the Sonar step, and the token is step-scoped rather than job- or workflow-scoped.

## Context
Jira: https://openstax.atlassian.net/browse/OTTER-545

The ticket flags secret-exposure paths in CI. Audit of this repo's workflows found two relevant items:
1. `claude.yml` had no actor gating — any GitHub user commenting `@claude` on a public-repo issue or PR (including from a fork) could trigger a run with `ANTHROPIC_API_KEY` available, and the action checks out the PR's HEAD.
2. `checks.yml` `infosec` job uses `SONAR_TOKEN` correctly today (step-scoped, no PR code executes before it), but nothing in the file made that constraint explicit, so a future edit could easily regress it.

The Clerk credentials in the `test` job remain a separate, larger concern and are out of scope for this PR.

## Test plan
- [ ] `npm run validate-actions` passes locally (verified)
- [ ] After merge, confirm `@claude` still works when triggered by a repo collaborator
- [ ] Confirm `@claude` from a non-collaborator account is ignored (workflow does not run)
- [ ] SonarCloud scan still publishes results on the next push to main