### PR TITLE
security: add baseline response security headers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,19 @@ import type { NextConfig } from 'next'
 
 const isDev = Boolean(process.env.CI || process.env.NODE_ENV === 'development')
 
+const securityHeaders = [
+    // Clickjacking protection (SIINFOSEC-470, ZAP-10020).
+    // We never want this app embedded in a frame; DENY is stricter than SAMEORIGIN
+    // and we have no in-app frame usage.
+    { key: 'X-Frame-Options', value: 'DENY' },
+    // Defense-in-depth equivalent of X-Frame-Options for modern browsers.
+    { key: 'Content-Security-Policy', value: "frame-ancestors 'none'" },
+    // Prevent MIME-sniffing-based content-type confusion.
+    { key: 'X-Content-Type-Options', value: 'nosniff' },
+    // Limit referrer leakage to cross-origin destinations.
+    { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+]
+
 const nextConfig: NextConfig = {
     cacheComponents: false,
     productionBrowserSourceMaps: true,
@@ -13,6 +26,9 @@ const nextConfig: NextConfig = {
     env: {
         // sets the DSN for Sentry in the client bundle at build time
         NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN || process.env.SENTRY_DSN || '',
+    },
+    async headers() {
+        return [{ source: '/:path*', headers: securityHeaders }]
     },
     experimental: {
         // https://github.com/phosphor-icons/react?tab=readme-ov-file#nextjs-specific-optimizations


### PR DESCRIPTION
## Summary
Adds four standard response headers to all routes:

- `X-Frame-Options: DENY` + `Content-Security-Policy: frame-ancestors 'none'` — clickjacking protection
- `X-Content-Type-Options: nosniff` — defeats MIME-sniffing-based content-type confusion
- `Referrer-Policy: strict-origin-when-cross-origin` — limits referrer leakage to other origins

## Jira
- https://openstax.atlassian.net/browse/SIINFOSEC-470 — missing X-Frame-Options / frame-ancestors (resolved)
- https://openstax.atlassian.net/browse/SIINFOSEC-468 — missing CSP header (partially resolved; full `default-src` / `script-src` enforcement is a larger follow-up since Clerk + Sentry + Mantine + Next inline scripts need nonce wiring and staging validation. This PR ships only the safe `frame-ancestors` directive.)

## Out of scope (separate work)
- SIINFOSEC-471 (proxy disclosure: TRACE/OPTIONS, Server header) — infrastructure / reverse proxy config, not application code
- SIINFOSEC-473 (web cache deception) — CDN / reverse proxy cache key config
- SIINFOSEC-472 (SRI integrity attribute) — affects Clerk-injected external scripts that we don't control via static markup
- SIINFOSEC-469 (integer overflow on `/login?__clerk_handshake=…`) — likely false positive; URL is a Clerk-issued JWT, not our backend code

## Test plan
- [x] `npm run lint` clean
- [x] `tsc --noEmit` clean
- [ ] Verify after deploy that the four headers appear on `/`, `/login`, and a protected route
- [ ] Confirm Clerk login flow still works (frame-ancestors should not affect it; Clerk does not iframe back into our origin)