### PR TITLE
feat(admin): show code env and data source counts in orgs table

### DIFF
--- a/src/app/admin/safeinsights/edit-org-form.test.tsx
+++ b/src/app/admin/safeinsights/edit-org-form.test.tsx
@@ -12,6 +12,8 @@ const mockOrg = {
     settings: { publicKey: 'junk' },
     totalUsers: BigInt(0),
     totalStudies: BigInt(0),
+    totalCodeEnvs: BigInt(0),
+    totalDataSources: BigInt(0),
 }
 
 describe('EditOrgForm', () => {

--- a/src/app/admin/safeinsights/table.tsx
+++ b/src/app/admin/safeinsights/table.tsx
@@ -56,6 +56,13 @@ export function OrgsAdminTable() {
                     { accessor: 'email', sortable: true },
                     { accessor: 'totalUsers', title: '# Users', textAlign: 'center', sortable: true },
                     { accessor: 'totalStudies', title: '# Studies', textAlign: 'center', sortable: true },
+                    { accessor: 'totalCodeEnvs', title: '# Code Envs', textAlign: 'center', sortable: true },
+                    {
+                        accessor: 'totalDataSources',
+                        title: '# Data Sources',
+                        textAlign: 'center',
+                        sortable: true,
+                    },
                     {
                         accessor: 'actions',
                         width: 110,

--- a/src/server/actions/org.actions.ts
+++ b/src/server/actions/org.actions.ts
@@ -48,6 +48,8 @@ export const fetchAdminOrgsWithStatsAction = new Action('fetchAdminOrgsWithStats
             .selectFrom('org')
             .leftJoin('study', 'study.orgId', 'org.id')
             .leftJoin('orgUser', 'orgUser.orgId', 'org.id')
+            .leftJoin('orgCodeEnv', 'orgCodeEnv.orgId', 'org.id')
+            .leftJoin('orgDataSource', 'orgDataSource.orgId', 'org.id')
             .select([
                 'org.id',
                 'org.name',
@@ -57,6 +59,8 @@ export const fetchAdminOrgsWithStatsAction = new Action('fetchAdminOrgsWithStats
                 'org.settings',
                 (eb) => eb.fn.count('orgUser.id').distinct().as('totalUsers'),
                 (eb) => eb.fn.count('study.id').distinct().as('totalStudies'),
+                (eb) => eb.fn.count('orgCodeEnv.id').distinct().as('totalCodeEnvs'),
+                (eb) => eb.fn.count('orgDataSource.id').distinct().as('totalDataSources'),
             ])
             .groupBy(['org.id'])
             .execute()


### PR DESCRIPTION
## Summary
- Adds **# Code Envs** and **# Data Sources** columns to the safeinsights admin organizations table
- Extends `fetchAdminOrgsWithStatsAction` with `leftJoin`s on `orgCodeEnv` and `orgDataSource` plus `COUNT(DISTINCT)` aggregates, matching the existing user/study count pattern

## Test plan
- [ ] Visit `/admin/safeinsights` and confirm the two new columns render with correct counts
- [ ] Sort by each new column ascending/descending
- [ ] Confirm an org with 0 of either still shows `0`
- [ ] Confirm existing user/study counts are unchanged