### PR TITLE
Configure hot reloading editor for development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,11 @@ services:
             - CLERK_JWT_KEY=$CLERK_JWT_KEY
             - CLERK_SECRET_KEY=$CLERK_SECRET_KEY
             - CLERK_AUTHORIZED_PARTIES=$CLERK_AUTHORIZED_PARTIES
+        volumes:
+            - ./services/editor:/app/services/editor
+            - editor_node_modules:/app/services/editor/node_modules
+            - ./src/lib/collaboration-documents.ts:/app/src/lib/collaboration-documents.ts
+        command: ['node', '--watch', 'server.ts']
         networks:
             - mgmnt-app
         ports:
@@ -134,5 +139,6 @@ networks:
 volumes:
     pgdata:
     node_modules:
+    editor_node_modules:
     dbgate-data:
     seaweedfs-data:


### PR DESCRIPTION
This resolves an issue with the editor image staying stale until manual `--build`.

**Development Environment Improvements:**

* Added volume mounts for `./services/editor` and `./src/lib/collaboration-documents.ts` to the `editor` service, enabling live code updates without rebuilding the container.
* Added a dedicated `editor_node_modules` volume to isolate `node_modules` for the `editor` service, preventing conflicts.

**Developer Experience Enhancement:**

* Updated the `editor` service command to use `node --watch server.ts`, allowing the server to automatically restart when code changes are detected.