### PR TITLE
fix: stop duplicating approved results in reviewer Study Status

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/study-results.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/study-results.test.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/tests/unit.helpers'
 import { fireEvent, waitFor, screen } from '@testing-library/react'
 import { StudyResults } from './study-results'
-import { fetchEncryptedJobFilesAction } from '@/server/actions/study-job.actions'
+import { fetchApprovedJobFilesAction, fetchEncryptedJobFilesAction } from '@/server/actions/study-job.actions'
 import { latestJobForStudy } from '@/server/db/queries'
 import { ResultsWriter } from 'si-encryption/job-results/writer'
 import { fingerprintKeyData, pemToArrayBuffer } from 'si-encryption/util'
@@ -57,10 +57,78 @@ describe('View Study Results', () => {
     })
 
     it('renders the results if the job has been approved', async () => {
-        await insertAndRender('APPROVED', 'FILES-APPROVED')
-        await waitFor(() => {
-            expect(screen.getByRole('link', { name: /Download/i })).toBeDefined()
+        const { study, latestJobWithStatus: rawJob } = await insertTestStudyJobData({
+            org,
+            studyStatus: 'APPROVED',
+            jobStatus: 'FILES-APPROVED',
         })
+
+        await db
+            .insertInto('studyJobFile')
+            .values({
+                studyJobId: rawJob.id,
+                name: 'approved.csv',
+                path: `test-org/${study.id}/${rawJob.id}/results/approved/approved.csv`,
+                fileType: 'APPROVED-RESULT',
+            })
+            .execute()
+
+        const job = await latestJobForStudy(study.id)
+        renderWithProviders(<StudyResults job={job} />)
+
+        await waitFor(() => {
+            expect(screen.getByTestId('download-link')).toBeDefined()
+        })
+        // approved files render once per file in the unified table — not duplicated by the legacy JobResults section
+        expect(screen.getAllByTestId('download-link')).toHaveLength(1)
+    })
+
+    it('does not duplicate rows when multiple APPROVED-RESULT files share a fileType', async () => {
+        const { study, latestJobWithStatus: rawJob } = await insertTestStudyJobData({
+            org,
+            studyStatus: 'APPROVED',
+            jobStatus: 'FILES-APPROVED',
+        })
+
+        await db
+            .insertInto('studyJobFile')
+            .values([
+                {
+                    studyJobId: rawJob.id,
+                    name: 'results.csv',
+                    path: `test-org/${study.id}/${rawJob.id}/results/approved/results.csv`,
+                    fileType: 'APPROVED-RESULT',
+                },
+                {
+                    studyJobId: rawJob.id,
+                    name: 'results2.csv',
+                    path: `test-org/${study.id}/${rawJob.id}/results/approved/results2.csv`,
+                    fileType: 'APPROVED-RESULT',
+                },
+            ])
+            .execute()
+
+        vi.mocked(fetchApprovedJobFilesAction).mockResolvedValue([
+            {
+                contents: new TextEncoder().encode('a').buffer as ArrayBuffer,
+                path: 'results.csv',
+                fileType: 'APPROVED-RESULT' as FileType,
+            },
+            {
+                contents: new TextEncoder().encode('b').buffer as ArrayBuffer,
+                path: 'results2.csv',
+                fileType: 'APPROVED-RESULT' as FileType,
+            },
+        ])
+
+        const job = await latestJobForStudy(study.id)
+        renderWithProviders(<StudyResults job={job} />)
+
+        await waitFor(() => {
+            expect(screen.getAllByTestId('download-link')).toHaveLength(2)
+        })
+        expect(screen.getAllByText('results.csv')).toHaveLength(1)
+        expect(screen.getAllByText('results2.csv')).toHaveLength(1)
     })
 
     it('renders the form to unlock results', async () => {

--- a/src/app/[orgSlug]/study/[studyId]/review/study-results.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/study-results.tsx
@@ -2,7 +2,6 @@
 
 import { CopyingInput } from '@/components/copying-input'
 import { EncryptedFilesPanel } from '@/components/encrypted-files-panel'
-import { JobResults } from '@/components/job-results'
 import { useJobStatus } from '@/hooks/use-job-results-status'
 import { isEncryptedLogType } from '@/lib/file-type-helpers'
 import { JobFileInfo } from '@/lib/types'
@@ -73,7 +72,6 @@ export const StudyResults: FC<{
                         onFilesApproved?.(files)
                     }}
                 />
-                <JobResults job={job} />
             </Stack>
         </Paper>
     )

--- a/src/hooks/use-encrypted-files-panel.ts
+++ b/src/hooks/use-encrypted-files-panel.ts
@@ -141,6 +141,7 @@ export function useEncryptedFilesPanel({ job, onFilesApproved }: Options) {
 
     const fileRows: UnifiedFileRow[] = useMemo(() => {
         const rows: UnifiedFileRow[] = []
+        const seenApprovedTypes = new Set<FileType>()
 
         for (const f of job.files ?? []) {
             const isEncrypted = isEncryptedLogType(f.fileType) || f.fileType === 'ENCRYPTED-RESULT'
@@ -152,6 +153,11 @@ export function useEncryptedFilesPanel({ job, onFilesApproved }: Options) {
 
             // skip if both encrypted and approved entries exist — we'll use the approved one
             if (isEncrypted && approvedFileTypes.has(approvedType)) continue
+
+            // an archive can yield multiple per-file APPROVED-RESULT rows in studyJobFile;
+            // process each fileType once so rows aren't multiplied by N×N
+            if (seenApprovedTypes.has(approvedType)) continue
+            seenApprovedTypes.add(approvedType)
 
             const approvedFilesForType = approvedFilesByType.get(approvedType) ?? []
             const decryptedFilesForType = decryptedFilesByType.get(approvedType) ?? []


### PR DESCRIPTION
## Summary

Testers reported approved study results appearing multiple times on the reviewer's Study Status panel ([OTTER-529](https://openstax.atlassian.net/browse/OTTER-529)). Two bugs combined to cause this:

- **`fileRows` in `use-encrypted-files-panel.ts` multiplied rows N×N.** When an encrypted archive contained N inner files, each `APPROVED-RESULT` row in `studyJobFile` re-emitted every approved file, so 2 results rendered as 4. Fixed by tracking `seenApprovedTypes` so each fileType is processed only once.
- **`<JobResults>` rendered a redundant legacy list below the unified table.** The new `EncryptedFilesPanel` table (PR #673) already shows approved files with View/Download per file; the older "Results: View | Download" block underneath was duplicating the same files. Removed it.

Repeat decrypt/view interactions are unaffected — the form is hidden after decryption (`shouldShowForm` flips false), and re-fetched approved files replace rather than append state.

## Test plan

- [x] Existing `EncryptedFilesPanel` and `StudyResults` unit tests pass (16 tests)
- [x] Related review-page tests pass (29 tests)
- [x] New regression test: approving a job with two `APPROVED-RESULT` files renders exactly one row per file
- [x] `tsc --noEmit` clean
- [ ] Manual: navigate to an approved study as a reviewer and confirm only one row per result file in the Study Status table, no list below

[OTTER-529]: https://openstax.atlassian.net/browse/OTTER-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ