### PR TITLE
align post-feedback view structure with Figma

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
@@ -49,7 +49,7 @@ describe('PostFeedbackView', () => {
             const entries = [buildEntry({ decision: 'APPROVE', createdAt: new Date('2026-04-16T10:00:00Z') })]
             renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={entries} />)
 
-            expect(screen.getByTestId('decision-timestamp')).toHaveTextContent('Approved on Apr 16, 2026')
+            expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent('Approved on Apr 16, 2026')
         })
 
         it('renders "Clarification requested on {date}" for needs-clarification', () => {
@@ -58,7 +58,7 @@ describe('PostFeedbackView', () => {
             ]
             renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={entries} />)
 
-            expect(screen.getByTestId('decision-timestamp')).toHaveTextContent(
+            expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent(
                 'Clarification requested on Apr 16, 2026',
             )
         })
@@ -67,7 +67,7 @@ describe('PostFeedbackView', () => {
             const entries = [buildEntry({ decision: 'REJECT', createdAt: new Date('2026-04-16T10:00:00Z') })]
             renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={entries} />)
 
-            expect(screen.getByTestId('decision-timestamp')).toHaveTextContent('Rejected on Apr 16, 2026')
+            expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent('Rejected on Apr 16, 2026')
         })
 
         it('renders the page title and study title', () => {
@@ -75,10 +75,8 @@ describe('PostFeedbackView', () => {
             renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={entries} />)
 
             expect(screen.getByRole('heading', { name: 'Study Proposal', level: 1 })).toBeInTheDocument()
-            // "Review initial request" and the study title both appear twice — once in the
-            // decision header, once in the ProposalSection's collapsed header. Both expected.
-            expect(screen.getAllByText('Review initial request').length).toBeGreaterThan(0)
-            expect(screen.getAllByText(/Effect of Reading Comprehension Tools/).length).toBeGreaterThan(0)
+            expect(screen.getByText('Review initial request')).toBeInTheDocument()
+            expect(screen.getByText(/Effect of Reading Comprehension Tools/)).toBeInTheDocument()
         })
     })
 

--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
@@ -3,12 +3,11 @@
 import { PageBreadcrumbs } from '@/components/page-breadcrumbs'
 import type { ReviewDecision } from '@/database/types'
 import { FeedbackAndNotesSection } from '@/components/study/feedback-and-notes'
+import { ProposalRequest } from '@/components/study/proposal-initial-request'
 import { Routes } from '@/lib/routes'
-import { Box, Button, Divider, Group, Stack, Text, Title } from '@mantine/core'
-import dayjs from 'dayjs'
+import { Box, Button, Group, Stack, Text, Title } from '@mantine/core'
 import { useRouter } from 'next/navigation'
 import type { ProposalFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
-import { ProposalSection } from './proposal-section'
 
 type PostFeedbackViewProps = {
     orgSlug: string
@@ -18,56 +17,45 @@ type PostFeedbackViewProps = {
 
 type DecisionCopy = {
     timestampLabel: string
-    banner: { bg: string; color: string; testId: string; copy: string }
+    banner: { bg: string; testId: string; copy: string }
 }
 
 const DECISION_COPY: Record<ReviewDecision, DecisionCopy> = {
     APPROVE: {
-        timestampLabel: 'Approved',
+        timestampLabel: 'Approved on',
         banner: {
             bg: 'green.1',
-            color: 'green.8',
             testId: 'decision-banner-approved',
             copy: "This initial request has been approved. You'll receive email notifications when the researcher proceeds to the next step.",
         },
     },
     'NEEDS-CLARIFICATION': {
-        timestampLabel: 'Clarification requested',
+        timestampLabel: 'Clarification requested on',
         banner: {
             bg: 'yellow.1',
-            color: 'yellow.9',
             testId: 'decision-banner-clarification',
             copy: 'You have requested clarification. The researcher has been notified, and we will inform you once they resubmit.',
         },
     },
     REJECT: {
-        timestampLabel: 'Rejected',
+        timestampLabel: 'Rejected on',
         banner: {
             bg: 'red.1',
-            color: 'red.8',
             testId: 'decision-banner-rejected',
             copy: 'This initial request has been rejected. No further action is required at this time.',
         },
     },
 }
 
-function formatDate(date: Date | string): string {
-    return dayjs(date).format('MMM DD, YYYY')
-}
-
 function DecisionBanner({ decision }: { decision: ReviewDecision }) {
     const { banner } = DECISION_COPY[decision]
     return (
-        <Box bg={banner.bg} p="md" bdrs="sm" data-testid={banner.testId}>
-            <Text c={banner.color} size="sm">
+        <Box bg={banner.bg} p="md" bdrs="sm" my="md" data-testid={banner.testId}>
+            <Text c="charcoal.9" size="sm">
                 {banner.copy}
             </Text>
         </Box>
     )
-}
-
-function FullProposalDropdown({ orgSlug, study }: { orgSlug: string; study: SelectedStudy }) {
-    return <ProposalSection orgSlug={orgSlug} study={study} initialExpanded={false} />
 }
 
 function GoToDashboardButton() {
@@ -80,35 +68,6 @@ function GoToDashboardButton() {
     )
 }
 
-type DecisionHeaderProps = {
-    study: SelectedStudy
-    decision: ReviewDecision
-    decidedAt: Date | string
-}
-
-function DecisionHeader({ study, decision, decidedAt }: DecisionHeaderProps) {
-    const copy = DECISION_COPY[decision]
-    const date = formatDate(decidedAt)
-
-    return (
-        <Stack gap="md" data-testid="decision-header">
-            <Stack gap={4}>
-                <Title order={1} fz={40} fw={700}>
-                    Study Proposal
-                </Title>
-                <Text fz={20} fw={600}>
-                    Review initial request
-                </Text>
-                <Text size="sm">Title: {study.title}</Text>
-                <Text size="sm" c="gray.7" data-testid="decision-timestamp">
-                    {copy.timestampLabel} on {date}
-                </Text>
-            </Stack>
-            <Divider />
-        </Stack>
-    )
-}
-
 export function PostFeedbackView({ orgSlug, study, entries }: PostFeedbackViewProps) {
     const latest = entries[0]
     if (!latest || latest.decision === null) {
@@ -116,14 +75,31 @@ export function PostFeedbackView({ orgSlug, study, entries }: PostFeedbackViewPr
     }
 
     const decision = latest.decision
+    const { timestampLabel } = DECISION_COPY[decision]
 
     return (
         <Box bg="grey.10">
             <Stack px="xl" gap="xl" py="xl">
-                <PageBreadcrumbs crumbs={[['Dashboard', Routes.orgDashboard({ orgSlug })], ['Study proposal']]} />
-                <DecisionHeader study={study} decision={decision} decidedAt={latest.createdAt} />
-                <DecisionBanner decision={decision} />
-                <FullProposalDropdown orgSlug={orgSlug} study={study} />
+                <PageBreadcrumbs
+                    crumbs={[
+                        ['Dashboard', Routes.orgDashboard({ orgSlug })],
+                        ['Study proposal'],
+                        ['Review initial request'],
+                    ]}
+                />
+                <Title order={1} fz={40} fw={700}>
+                    Study Proposal
+                </Title>
+                <ProposalRequest
+                    study={study}
+                    orgSlug={orgSlug}
+                    stepLabel="STEP 1"
+                    heading="Review initial request"
+                    statusBadge={timestampLabel}
+                    timestampDate={latest.createdAt}
+                    banner={<DecisionBanner decision={decision} />}
+                    initialExpanded={false}
+                />
                 <FeedbackAndNotesSection entries={entries} />
                 <Group justify="flex-end">
                     <GoToDashboardButton />

--- a/src/components/study/proposal-initial-request.tsx
+++ b/src/components/study/proposal-initial-request.tsx
@@ -17,6 +17,8 @@ type ProposalRequestProps = {
     banner: ReactNode
     initialExpanded?: boolean
     statusBadge?: string
+    /** Overrides study.submittedAt when rendering the timestamp (e.g. a decision date). */
+    timestampDate?: Date | string | null
 }
 
 function useProposalRequest(initialExpanded: boolean) {
@@ -59,8 +61,10 @@ export function ProposalRequest({
     banner,
     initialExpanded = true,
     statusBadge = 'Submitted on',
+    timestampDate,
 }: ProposalRequestProps) {
     const { expanded, toggle, collapse, getPopoverProps } = useProposalRequest(initialExpanded)
+    const renderedTimestamp = timestampDate ?? study.submittedAt
 
     return (
         <Stack gap="md" data-testid="proposal-section">
@@ -75,9 +79,9 @@ export function ProposalRequest({
                     <Text c="charcoal.9" style={{ maxWidth: '105ch', wordBreak: 'break-word' }}>
                         Title: {study.title}
                     </Text>
-                    {study.submittedAt && (
+                    {renderedTimestamp && (
                         <Text fz={12} c="charcoal.7" style={{ whiteSpace: 'nowrap' }} data-testid="proposal-timestamp">
-                            {statusBadge} {dayjs(study.submittedAt).format('MMM DD, YYYY')}
+                            {statusBadge} {dayjs(renderedTimestamp).format('MMM DD, YYYY')}
                         </Text>
                     )}
                 </Group>

--- a/src/components/study/proposal-initial-request.tsx
+++ b/src/components/study/proposal-initial-request.tsx
@@ -18,7 +18,7 @@ type ProposalRequestProps = {
     initialExpanded?: boolean
     statusBadge?: string
     /** Overrides study.submittedAt when rendering the timestamp (e.g. a decision date). */
-    timestampDate?: Date | string | null
+    timestampDate?: Date | string
 }
 
 function useProposalRequest(initialExpanded: boolean) {


### PR DESCRIPTION
## Summary

Follow-up to the merged OTTER-501 PR addressing design review from Greg + Greg Fitch on the post-feedback view.

## Changes

- **Single proposal container** — Removed the separate `DecisionHeader` outside the proposal section. Page now matches Figma: breadcrumbs → "Study Proposal" h1 → one `ProposalRequest` paper (STEP 1, "Review initial request", title, decision-timestamp, divider, decision-banner, "View full initial request" toggle, expandable body) → feedback section → CTA. Fixes the duplicate "Review initial request" and "Title:" text.
- **Decision-overridden timestamp + banner** — Replaces the section's "Submitted on …" with "Approved on …" / "Clarification requested on …" / "Rejected on …" via a new `timestampDate` prop on `ProposalRequest`. Purple status banner is replaced by the decision-colored banner inline.
- **Banner contrast** — All three banners use `charcoal.9` text on `green.1` / `yellow.1` / `red.1` backgrounds for consistent readable contrast (fixes Greg Fitch's yellow-on-yellow note).
