### PR TITLE
Share ProposalStepHeader + ReviewCriteriaBanner across Step 1 / Step 3

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.test.tsx
@@ -60,7 +60,7 @@ describe('CodeReviewRedesignView', () => {
         renderWithProviders(await CodeReviewRedesignView({ orgSlug: ORG_SLUG, study }))
 
         expect(screen.getByText('STEP 3')).toBeInTheDocument()
-        expect(screen.getByRole('heading', { name: 'Review study code', level: 2 })).toBeInTheDocument()
+        expect(screen.getByRole('heading', { name: 'Review study code', level: 4 })).toBeInTheDocument()
     })
 
     it('renders the study title in the section header', async () => {
@@ -73,7 +73,7 @@ describe('CodeReviewRedesignView', () => {
         renderWithProviders(await CodeReviewRedesignView({ orgSlug: ORG_SLUG, study }))
 
         const formatted = dayjs(jobCreatedAt).format('MMM DD, YYYY')
-        expect(screen.getByTestId('code-review-submitted-on')).toHaveTextContent(`Submitted on ${formatted}`)
+        expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent(`Submitted on ${formatted}`)
     })
 
     it('renders the status banner with the submitting lab name in bold', async () => {

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.tsx
@@ -1,8 +1,9 @@
 import { PageBreadcrumbs } from '@/components/page-breadcrumbs'
+import { ProposalStepHeader } from '@/components/study/proposal-step-header'
+import { ReviewCriteriaBanner } from '@/components/study/review-criteria-banner'
 import { Routes } from '@/lib/routes'
 import { latestJobForStudy } from '@/server/db/queries'
-import { Box, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
-import dayjs from 'dayjs'
+import { Box, Stack, Title } from '@mantine/core'
 import type { SelectedStudy } from '@/server/actions/study.actions'
 
 type CodeReviewRedesignViewProps = {
@@ -29,38 +30,19 @@ const CODE_REVIEW_CRITERIA = [
     },
 ]
 
-function formatDate(date: Date | string): string {
-    return dayjs(date).format('MMM DD, YYYY')
-}
-
-function CodeReviewCriteriaList() {
-    return (
-        <Stack gap={4} data-testid="code-review-criteria">
-            {CODE_REVIEW_CRITERIA.map(({ label, description }) => (
-                <Text size="sm" key={label}>
-                    <strong>{label}:</strong> {description}
-                </Text>
-            ))}
-        </Stack>
-    )
-}
-
 function CodeReviewStatusBanner({ labName }: { labName: string }) {
     return (
-        <Box
-            bg="purple.0"
-            p="md"
-            style={{ borderRadius: 'var(--mantine-radius-sm)' }}
-            data-testid="code-review-status-banner"
-        >
-            <Stack gap="xs">
-                <Text size="sm">
+        <ReviewCriteriaBanner
+            testId="code-review-status-banner"
+            criteriaTestId="code-review-criteria"
+            intro={
+                <>
                     <strong>{labName}</strong> has submitted their study code for review. Below, you will review their
                     code and an AI-generated summary of its behavior, then share your feedback and decision.
-                </Text>
-                <CodeReviewCriteriaList />
-            </Stack>
-        </Box>
+                </>
+            }
+            criteria={CODE_REVIEW_CRITERIA}
+        />
     )
 }
 
@@ -73,31 +55,13 @@ function CodeReviewSection({ study, submittedAt }: CodeReviewSectionProps) {
     const labName = study.submittingLabName ?? study.submittedByOrgSlug
 
     return (
-        <Paper p="xxl" data-testid="code-review-section-header">
-            <Stack gap="md">
-                <Group justify="space-between" align="flex-start" wrap="nowrap">
-                    <Stack gap={4}>
-                        <Text fz="xs" fw={700} c="charcoal.7">
-                            STEP 3
-                        </Text>
-                        <Title order={2} fz={20} fw={700}>
-                            Review study code
-                        </Title>
-                        <Text size="sm">Title: {study.title}</Text>
-                    </Stack>
-                    <Text
-                        fz={12}
-                        c="charcoal.7"
-                        style={{ whiteSpace: 'nowrap' }}
-                        data-testid="code-review-submitted-on"
-                    >
-                        Submitted on {formatDate(submittedAt)}
-                    </Text>
-                </Group>
-                <Divider />
-                <CodeReviewStatusBanner labName={labName} />
-            </Stack>
-        </Paper>
+        <ProposalStepHeader
+            stepLabel="STEP 3"
+            heading="Review study code"
+            studyTitle={study.title}
+            timestampDate={submittedAt}
+            banner={<CodeReviewStatusBanner labName={labName} />}
+        />
     )
 }
 

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-section.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ProposalRequest } from '@/components/study/proposal-initial-request'
-import { Box, Stack, Text } from '@mantine/core'
+import { ReviewCriteriaBanner } from '@/components/study/review-criteria-banner'
 import type { StudyForReview } from './review-types'
 
 type ProposalSectionProps = {
@@ -26,36 +26,21 @@ const EVALUATION_CRITERIA = [
     },
 ]
 
-function CriteriaList() {
-    return (
-        <Stack gap={4} data-testid="evaluation-criteria">
-            {EVALUATION_CRITERIA.map(({ label, description }) => (
-                <Text size="sm" key={label}>
-                    <strong>{label}:</strong> {description}
-                </Text>
-            ))}
-        </Stack>
-    )
-}
-
 function StatusBanner({ labName }: { labName: string }) {
     return (
-        <Box
-            bg="purple.0"
-            p="md"
+        <ReviewCriteriaBanner
             mb="md"
-            style={{ borderRadius: 'var(--mantine-radius-sm)' }}
-            data-testid="status-banner"
-        >
-            <Stack gap="xs">
-                <Text size="sm">
+            testId="status-banner"
+            criteriaTestId="evaluation-criteria"
+            intro={
+                <>
                     <strong>{labName}</strong> has submitted an initial request requesting permission to use your data.
                     Please review it and share your feedback and decision. Consider evaluating the initial request on
                     these criteria:
-                </Text>
-                <CriteriaList />
-            </Stack>
-        </Box>
+                </>
+            }
+            criteria={EVALUATION_CRITERIA}
+        />
     )
 }
 

--- a/src/components/study/proposal-initial-request.tsx
+++ b/src/components/study/proposal-initial-request.tsx
@@ -1,13 +1,13 @@
 'use client'
 
 import { useState, type ReactNode } from 'react'
-import { Anchor, Collapse, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
+import { Anchor, Collapse, Divider, Paper, Stack } from '@mantine/core'
 import { CaretRightIcon } from '@phosphor-icons/react/dist/ssr'
-import dayjs from 'dayjs'
 import { stringifyJson } from '@/lib/string'
 import { usePopover } from '@/hooks/use-popover'
 import type { SelectedStudy } from '@/server/actions/study.actions'
 import { DatasetsField, LexicalProposalField, PIField, ResearcherField } from './proposal-fields'
+import { ProposalStepHeader } from './proposal-step-header'
 
 type ProposalRequestProps = {
     study: SelectedStudy
@@ -68,27 +68,16 @@ export function ProposalRequest({
 
     return (
         <Stack gap="md" data-testid="proposal-section">
-            <Paper p="xxl" data-testid="proposal-section-header">
-                <Text fz={10} fw={700} c="charcoal.7" pb={4}>
-                    {stepLabel}
-                </Text>
-                <Title order={4} fz={20} c="charcoal.9" pb={4}>
-                    {heading}
-                </Title>
-                <Group justify="space-between" align="center" wrap="nowrap">
-                    <Text c="charcoal.9" style={{ maxWidth: '105ch', wordBreak: 'break-word' }}>
-                        Title: {study.title}
-                    </Text>
-                    {renderedTimestamp && (
-                        <Text fz={12} c="charcoal.7" style={{ whiteSpace: 'nowrap' }} data-testid="proposal-timestamp">
-                            {statusBadge} {dayjs(renderedTimestamp).format('MMM DD, YYYY')}
-                        </Text>
-                    )}
-                </Group>
-                <Divider my="md" data-testid="proposal-header-divider" />
-                {banner}
+            <ProposalStepHeader
+                stepLabel={stepLabel}
+                heading={heading}
+                studyTitle={study.title}
+                timestampDate={renderedTimestamp}
+                timestampLabel={statusBadge}
+                banner={banner}
+            >
                 <ToggleLink isExpanded={expanded} onClick={toggle} testId="proposal-toggle-header" />
-            </Paper>
+            </ProposalStepHeader>
 
             <Collapse in={expanded}>
                 <Paper p="xxl" data-testid="proposal-body">

--- a/src/components/study/proposal-step-header.tsx
+++ b/src/components/study/proposal-step-header.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from 'react'
+import { Divider, Group, Paper, Text, Title } from '@mantine/core'
+import dayjs from 'dayjs'
+
+type ProposalStepHeaderProps = {
+    stepLabel: string
+    heading: string
+    studyTitle: string
+    timestampDate?: Date | string | null
+    timestampLabel?: string
+    banner?: ReactNode
+    children?: ReactNode
+}
+
+export function ProposalStepHeader({
+    stepLabel,
+    heading,
+    studyTitle,
+    timestampDate,
+    timestampLabel = 'Submitted on',
+    banner,
+    children,
+}: ProposalStepHeaderProps) {
+    return (
+        <Paper p="xxl" data-testid="proposal-section-header">
+            <Text fz={10} fw={700} c="charcoal.7" pb={4}>
+                {stepLabel}
+            </Text>
+            <Title order={4} fz={20} c="charcoal.9" pb={4}>
+                {heading}
+            </Title>
+            <Group justify="space-between" align="center" wrap="nowrap">
+                <Text c="charcoal.9" style={{ maxWidth: '105ch', wordBreak: 'break-word' }}>
+                    Title: {studyTitle}
+                </Text>
+                {timestampDate && (
+                    <Text fz={12} c="charcoal.7" style={{ whiteSpace: 'nowrap' }} data-testid="proposal-timestamp">
+                        {timestampLabel} {dayjs(timestampDate).format('MMM DD, YYYY')}
+                    </Text>
+                )}
+            </Group>
+            <Divider my="md" data-testid="proposal-header-divider" />
+            {banner}
+            {children}
+        </Paper>
+    )
+}

--- a/src/components/study/review-criteria-banner.tsx
+++ b/src/components/study/review-criteria-banner.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from 'react'
+import { Box, Stack, Text } from '@mantine/core'
+import type { MantineSpacing } from '@mantine/core'
+
+type Criterion = {
+    label: string
+    description: string
+}
+
+type ReviewCriteriaBannerProps = {
+    intro: ReactNode
+    criteria: Criterion[]
+    mb?: MantineSpacing
+    testId?: string
+    criteriaTestId?: string
+}
+
+export function ReviewCriteriaBanner({
+    intro,
+    criteria,
+    mb,
+    testId = 'review-criteria-banner',
+    criteriaTestId = 'review-criteria',
+}: ReviewCriteriaBannerProps) {
+    return (
+        <Box bg="purple.0" p="md" mb={mb} style={{ borderRadius: 'var(--mantine-radius-sm)' }} data-testid={testId}>
+            <Stack gap="xs">
+                <Text size="sm">{intro}</Text>
+                <Stack gap={4} data-testid={criteriaTestId}>
+                    {criteria.map(({ label, description }) => (
+                        <Text size="sm" key={label}>
+                            <strong>{label}:</strong> {description}
+                        </Text>
+                    ))}
+                </Stack>
+            </Stack>
+        </Box>
+    )
+}


### PR DESCRIPTION
## Summary
Follow-up to PR #695 [review comment](https://github.com/safeinsights/management-app/pull/695#discussion_r3228417086) from @nathanstitt.

`CodeReviewSection` (Step 3, added in #695) duplicated the header structure already in `ProposalRequest` (Step 1) — step label / heading / "Title: …" / right-aligned timestamp / divider / banner. The purple `bg="purple.0"` "criteria + status copy" banner was also duplicated.

This PR extracts:

- **`ProposalStepHeader`** (`src/components/study/proposal-step-header.tsx`) — the header block. Server-component-safe (no `'use client'`); accepts `stepLabel`, `heading`, `studyTitle`, optional `timestampDate` / `timestampLabel`, a `banner` slot, and `children` (used for `ToggleLink` on the collapsible Step 1).
- **`ReviewCriteriaBanner`** (`src/components/study/review-criteria-banner.tsx`) — the purple intro-+-criteria-list banner, parameterized by `intro`, `criteria`, optional `mb`, and stable testId props.

Refactored callers:
- `ProposalRequest` now composes `ProposalStepHeader`.
- `proposal-section.tsx` (Step 1) `StatusBanner` now composes `ReviewCriteriaBanner`.
- `code-review-redesign-view.tsx` (Step 3) `CodeReviewSection` is ~10 lines and `CodeReviewStatusBanner` is now a thin wrapper around `ReviewCriteriaBanner`.

Net effect across the four touched files: **-104 / +42** lines, plus the two new shared components.

## Notes for reviewers
- Preserved existing testIds: `proposal-section-header`, `proposal-timestamp`, `proposal-header-divider`, `status-banner`, `evaluation-criteria`, `code-review-status-banner`, `code-review-criteria`.
- Unified the Step 3 timestamp testId from `code-review-submitted-on` → `proposal-timestamp` (it's the same DOM element semantically; one test assertion updated).
- **Heading semantic level** — kept `Title order={4}` to preserve Step 1's existing behavior. Step 3 was previously `order={2}` in PR #695; this PR drops it to `order={4}` to unify. Both pages still have an `h1` page title above. Happy to revisit if design wants the section heading bumped to `h2` consistently — would be a follow-up.

## Test plan
- [x] `pnpm test:unit --run` on the four affected test files — 65/65 pass
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [ ] Spot-check Step 1 (proposal review) and Step 3 (code review) pages render visually unchanged
- [ ] Spot-check `PostFeedbackView` and `ProposalSubmitted` (also consume `ProposalRequest`) — pixels should be identical