### PR TITLE
Harden study review: validate report shape, retry malformed, surface disabled

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-view.tsx
@@ -1,13 +1,16 @@
 import { OrgBreadcrumbs } from '@/components/page-breadcrumbs'
 import { StudyCodeDetails } from '@/components/study/study-code-details'
 import { AlertNotFound } from '@/components/errors'
-import { getStudyReviewForJob, latestSubmittedJobForStudy } from '@/server/db/queries'
+import { latestSubmittedJobForStudy } from '@/server/db/queries'
+import { getStudyReviewAction } from '@/server/actions/study-job.actions'
+import { isActionError } from '@/lib/errors'
 import { ButtonLink } from '@/components/links'
 import { Routes } from '@/lib/routes'
 import { Divider, Group, Paper, Stack, Title } from '@mantine/core'
 import { CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
 import { StudyResultsWithReview } from './study-results-with-review'
 import type { SelectedStudy } from '@/server/actions/study.actions'
+import type { StudyReviewResult } from './study-review-types'
 import { StudyReviewSection } from './study-review-section'
 
 type CodeReviewViewProps = {
@@ -20,7 +23,10 @@ export async function CodeReviewView({ orgSlug, study }: CodeReviewViewProps) {
     if (!job) {
         return <AlertNotFound title="No submission found" message="This study has no submitted code to review." />
     }
-    const review = await getStudyReviewForJob(job.id)
+    const reviewResult = await getStudyReviewAction({ studyJobId: job.id })
+    // Soft-fail the seed: if the action errored, render the in-progress state and
+    // let the client poller surface a real error on its next refetch.
+    const initialReview: StudyReviewResult = isActionError(reviewResult) ? { kind: 'missing' } : reviewResult
 
     return (
         <Stack px="xl" gap="xl">
@@ -46,7 +52,7 @@ export async function CodeReviewView({ orgSlug, study }: CodeReviewViewProps) {
                 </Stack>
             </Paper>
             <Paper bg="white" p="xxl">
-                <StudyReviewSection studyJobId={job.id} initialReview={review} />
+                <StudyReviewSection studyJobId={job.id} initialReview={initialReview} />
             </Paper>
             <StudyResultsWithReview job={job} study={study} />
             <Group>

--- a/src/app/[orgSlug]/study/[studyId]/review/study-review-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/study-review-section.test.tsx
@@ -3,14 +3,14 @@ import { renderWithProviders, screen } from '@/tests/unit.helpers'
 import { StudyReviewSection } from './study-review-section'
 import { getStudyReviewAction } from '@/server/actions/study-job.actions'
 import type { AnalysisReport } from '@/server/agents/review-agent/types'
-import type { StudyReviewWithMeta } from '@/server/db/queries'
+import type { StudyReviewResult } from './study-review-types'
 
 vi.mock('@/server/actions/study-job.actions', () => ({
     getStudyReviewAction: vi.fn(),
 }))
 
 beforeEach(() => {
-    vi.mocked(getStudyReviewAction).mockResolvedValue(null)
+    vi.mocked(getStudyReviewAction).mockResolvedValue({ kind: 'missing' })
 })
 
 const baseReport: AnalysisReport = {
@@ -20,17 +20,20 @@ const baseReport: AnalysisReport = {
     complianceCheck: { isCompliant: true, findings: [] },
 }
 
-function withMeta(report: AnalysisReport, files: string[] = ['main.r']): StudyReviewWithMeta {
+function okResult(report: AnalysisReport, files: string[] = ['main.r']): StudyReviewResult {
     return {
-        report,
-        createdAt: new Date('2026-04-28T12:00:00Z'),
-        files: files.map((name) => ({ name, fileType: 'MAIN-CODE' as const })),
+        kind: 'ok',
+        review: {
+            report,
+            createdAt: new Date('2026-04-28T12:00:00Z'),
+            files: files.map((name) => ({ name, fileType: 'MAIN-CODE' as const })),
+        },
     }
 }
 
 describe('StudyReviewSection', () => {
     it('renders summaries and check badges when a review is provided', () => {
-        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={withMeta(baseReport)} />)
+        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={okResult(baseReport)} />)
 
         expect(screen.getByText('Studying student performance trends.')).toBeInTheDocument()
         expect(screen.getByText('Aggregates scores grouped by school.')).toBeInTheDocument()
@@ -45,7 +48,7 @@ describe('StudyReviewSection', () => {
             complianceCheck: { isCompliant: false, findings: ['Logs raw student IDs'] },
         }
 
-        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={withMeta(report)} />)
+        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={okResult(report)} />)
 
         expect(screen.getByText('Misaligned')).toBeInTheDocument()
         expect(screen.getByText('Code skips step 3 from proposal')).toBeInTheDocument()
@@ -53,15 +56,34 @@ describe('StudyReviewSection', () => {
         expect(screen.getByText('Logs raw student IDs')).toBeInTheDocument()
     })
 
-    it('renders the in-progress state when initialReview is null', () => {
-        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={null} />)
+    it('renders the in-progress state when the runner has not yet produced a row', () => {
+        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={{ kind: 'missing' }} />)
 
         expect(screen.getByText('Review in progress…')).toBeInTheDocument()
     })
 
+    it('renders the disabled state when the feature is off in this environment', () => {
+        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={{ kind: 'disabled' }} />)
+
+        expect(screen.getByTestId('study-review-disabled')).toHaveTextContent('AI review is not enabled')
+    })
+
+    it('renders a non-crashing error state when the stored report is malformed', () => {
+        renderWithProviders(
+            <StudyReviewSection
+                studyJobId="job-1"
+                initialReview={{ kind: 'malformed', createdAt: new Date('2026-04-28T12:00:00Z') }}
+            />,
+        )
+
+        expect(screen.getByTestId('study-review-malformed')).toHaveTextContent(
+            'AI review for this submission could not be displayed',
+        )
+    })
+
     it('lists the files the review was generated against', () => {
         renderWithProviders(
-            <StudyReviewSection studyJobId="job-1" initialReview={withMeta(baseReport, ['main.r', 'dragon_art.R'])} />,
+            <StudyReviewSection studyJobId="job-1" initialReview={okResult(baseReport, ['main.r', 'dragon_art.R'])} />,
         )
 
         expect(screen.getByText('Files reviewed: main.r, dragon_art.R')).toBeInTheDocument()
@@ -73,7 +95,7 @@ describe('StudyReviewSection', () => {
             resultsSummary: 'Median score 82, no anomalies.',
         }
 
-        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={withMeta(report)} />)
+        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={okResult(report)} />)
 
         expect(screen.getByText('Median score 82, no anomalies.')).toBeInTheDocument()
     })

--- a/src/app/[orgSlug]/study/[studyId]/review/study-review-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/study-review-section.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from '@/common'
 import { getStudyReviewAction } from '@/server/actions/study-job.actions'
 import type { StudyReviewWithMeta } from '@/server/db/queries'
+import type { StudyReviewResult } from './study-review-types'
 import type { AnalysisReport } from '@/server/agents/review-agent/types'
 import { Badge, Divider, Group, List, ListItem, Loader, Stack, Text, Title } from '@mantine/core'
 
@@ -10,34 +11,36 @@ const POLL_INTERVAL_MS = 5_000
 
 type StudyReviewSectionProps = {
     studyJobId: string
-    initialReview: StudyReviewWithMeta | null
+    initialReview: StudyReviewResult
 }
 
 export function StudyReviewSection({ studyJobId, initialReview }: StudyReviewSectionProps) {
-    const { data: review, error } = useQuery({
+    const { data: result, error } = useQuery({
         queryKey: ['study-review', studyJobId],
         queryFn: () => getStudyReviewAction({ studyJobId }),
         initialData: initialReview,
-        // Review job runs async for unknown duration; poll until row arrives or query errors.
-        refetchInterval: (query) => (query.state.data || query.state.error ? false : POLL_INTERVAL_MS),
+        // Only poll while we have no resolved state yet (i.e. waiting on the runner).
+        // `disabled`, `malformed`, and `ok` are terminal; `missing` keeps polling.
+        refetchInterval: (query) => {
+            if (query.state.error) return false
+            const data = query.state.data
+            if (!data || data.kind === 'missing') return POLL_INTERVAL_MS
+            return false
+        },
     })
 
-    if (error) {
-        return <ReviewError />
-    }
-
-    if (!review) {
-        return <ReviewInProgress />
-    }
-
-    return <ReviewReport review={review} />
+    if (error) return <ReviewError />
+    if (!result || result.kind === 'missing') return <ReviewInProgress />
+    if (result.kind === 'disabled') return <ReviewDisabled />
+    if (result.kind === 'malformed') return <ReviewMalformed />
+    return <ReviewReport review={result.review} />
 }
 
 function ReviewInProgress() {
     return (
         <Stack>
             <ReviewHeader />
-            <Group gap="xs">
+            <Group gap="xs" data-testid="study-review-in-progress">
                 <Loader size="sm" />
                 <Text c="dimmed" size="sm">
                     Review in progress…
@@ -51,8 +54,30 @@ function ReviewError() {
     return (
         <Stack>
             <ReviewHeader />
-            <Text c="red" size="sm">
+            <Text c="red" size="sm" data-testid="study-review-error">
                 Failed to load study review. Please refresh to try again.
+            </Text>
+        </Stack>
+    )
+}
+
+function ReviewDisabled() {
+    return (
+        <Stack>
+            <ReviewHeader />
+            <Text c="dimmed" size="sm" data-testid="study-review-disabled">
+                AI review is not enabled for this environment.
+            </Text>
+        </Stack>
+    )
+}
+
+function ReviewMalformed() {
+    return (
+        <Stack>
+            <ReviewHeader />
+            <Text c="red" size="sm" data-testid="study-review-malformed">
+                The AI review for this submission could not be displayed. Please contact support.
             </Text>
         </Stack>
     )

--- a/src/app/[orgSlug]/study/[studyId]/review/study-review-types.ts
+++ b/src/app/[orgSlug]/study/[studyId]/review/study-review-types.ts
@@ -1,0 +1,3 @@
+import type { StudyReviewLookup } from '@/server/db/queries'
+
+export type StudyReviewResult = { kind: 'disabled' } | StudyReviewLookup

--- a/src/server/actions/study-job.actions.ts
+++ b/src/server/actions/study-job.actions.ts
@@ -4,11 +4,23 @@ import { ActionFailure } from '@/lib/errors'
 import { isApprovedLogType, isEncryptedLogType } from '@/lib/file-type-helpers'
 import { JobFile, jobFileSchema, minimalJobInfoSchema } from '@/lib/types'
 import { getStudyJobInfo, getStudyReviewForJob, latestJobForStudy } from '@/server/db/queries'
-import type { StudyReviewWithMeta } from '@/server/db/queries'
 import { onStudyResultsApproved, onStudyResultsRejected } from '@/server/events'
+import { getConfigValue } from '@/server/config'
 import { fetchFileContents, storeApprovedJobFile } from '@/server/storage'
 import { ResultsReader } from 'si-encryption/job-results/reader'
+import type { StudyReviewResult } from '@/app/[orgSlug]/study/[studyId]/review/study-review-types'
 import { Action, z } from './action'
+
+/**
+ * Returns the AI study review state for a job, including the `disabled` case
+ * when CLAUDE_API_KEY is not configured. Shared by the server page that seeds
+ * `initialReview` and the action's handler.
+ */
+async function loadStudyReview(studyJobId: string): Promise<StudyReviewResult> {
+    const apiKey = await getConfigValue('CLAUDE_API_KEY', false)
+    if (!apiKey) return { kind: 'disabled' }
+    return await getStudyReviewForJob(studyJobId)
+}
 
 export const approveStudyJobFilesAction = new Action('approveStudyJobFilesAction')
     .params(
@@ -99,8 +111,8 @@ export const getStudyReviewAction = new Action('getStudyReviewAction')
         return { studyJob, orgId: studyJob.orgId, submittedByOrgId: studyJob.submittedByOrgId }
     })
     .requireAbilityTo('view', 'StudyJob')
-    .handler(async ({ params: { studyJobId } }): Promise<StudyReviewWithMeta | null> => {
-        return await getStudyReviewForJob(studyJobId)
+    .handler(async ({ params: { studyJobId } }): Promise<StudyReviewResult> => {
+        return await loadStudyReview(studyJobId)
     })
 
 export const fetchApprovedJobFilesAction = new Action('fetchApprovedJobFilesAction')

--- a/src/server/agents/review-agent/agent.test.ts
+++ b/src/server/agents/review-agent/agent.test.ts
@@ -21,7 +21,31 @@ function makeClient(content: unknown) {
     return { client: { messages: { create } } as unknown as Anthropic, create }
 }
 
+function makeClientWithSequence(responses: unknown[]) {
+    const create = vi.fn()
+    for (const r of responses) {
+        create.mockResolvedValueOnce({ content: r })
+    }
+    return { client: { messages: { create } } as unknown as Anthropic, create }
+}
+
 const toolUseBlock = [{ type: 'tool_use', name: 'submit_analysis', id: '1', input: baseReport }]
+
+const malformedToolUseBlock = [
+    {
+        type: 'tool_use',
+        name: 'submit_analysis',
+        id: '1',
+        input: {
+            proposalSummary: 'summary',
+            codeExplanation: 'explanation',
+            // Malformed: alignmentCheck/complianceCheck are strings, findings at top level.
+            findings: ['top-level finding'],
+            alignmentCheck: '\n<parameter name="isAligned">false',
+            complianceCheck: '\n<parameter name="isCompliant">false',
+        },
+    },
+]
 
 describe('generateAnalysis', () => {
     it('returns the structured report from a tool_use block', async () => {
@@ -89,5 +113,29 @@ describe('generateAnalysis', () => {
 
     it('throws when neither apiKey nor client is provided', async () => {
         await expect(generateAnalysis({}, baseContent)).rejects.toThrow(/apiKey or client/)
+    })
+
+    it('retries once with a stricter nudge when the first response fails validation', async () => {
+        const { client, create } = makeClientWithSequence([malformedToolUseBlock, toolUseBlock])
+
+        const result = await generateAnalysis({ client }, baseContent)
+
+        expect(result.report).toEqual(baseReport)
+        expect(create).toHaveBeenCalledTimes(2)
+
+        const retryArgs = create.mock.calls[1][0]
+        const retryMessages = retryArgs.messages as Array<{ role: string; content: string }>
+        expect(retryMessages).toHaveLength(3)
+        expect(retryMessages[1].role).toBe('assistant')
+        expect(retryMessages[2].role).toBe('user')
+        expect(retryMessages[2].content).toMatch(/submit_analysis/)
+        expect(retryMessages[2].content).toMatch(/findings/)
+    })
+
+    it('throws when both the initial and retry responses fail validation', async () => {
+        const { client, create } = makeClientWithSequence([malformedToolUseBlock, malformedToolUseBlock])
+
+        await expect(generateAnalysis({ client }, baseContent)).rejects.toThrow()
+        expect(create).toHaveBeenCalledTimes(2)
     })
 })

--- a/src/server/agents/review-agent/agent.ts
+++ b/src/server/agents/review-agent/agent.ts
@@ -1,5 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk'
 import { buildAnalysisPrompt, DEFAULT_SYSTEM_INSTRUCTION } from './prompts'
+import { analysisReportSchema } from './types'
 import type { AnalysisReport, AnalysisResult, ReviewAgentConfig, ReviewContent, ReviewMessage } from './types'
 
 const DEFAULT_MODEL = process.env.ANTHROPIC_MODEL ?? 'claude-sonnet-4-6'
@@ -39,6 +40,13 @@ const ANALYSIS_TOOL: Anthropic.Messages.Tool = {
     },
 }
 
+const RETRY_NUDGE =
+    'Your previous response did not call the `submit_analysis` tool with the exact required shape. ' +
+    'You MUST call `submit_analysis` exactly once. Every required field must be a real value of the ' +
+    'correct type — `alignmentCheck` and `complianceCheck` must each be objects with `isAligned`/' +
+    '`isCompliant` (boolean) and `findings` (array of strings). Do not return XML, parameter tags, ' +
+    'or string fragments — only the structured tool call.'
+
 function resolveClient(config: ReviewAgentConfig): Anthropic {
     if (config.client) return config.client
     if (config.apiKey) {
@@ -72,7 +80,7 @@ function buildPromptForContent(content: ReviewContent, templateOverride?: string
     )
 }
 
-function extractReport(response: Anthropic.Messages.Message): AnalysisReport {
+function extractToolInput(response: Anthropic.Messages.Message): unknown {
     const toolUse = response.content.find(
         (block): block is Anthropic.Messages.ToolUseBlock =>
             block.type === 'tool_use' && block.name === ANALYSIS_TOOL_NAME,
@@ -82,12 +90,22 @@ function extractReport(response: Anthropic.Messages.Message): AnalysisReport {
         throw new Error('The model did not return a structured analysis.')
     }
 
-    return toolUse.input as AnalysisReport
+    return toolUse.input
+}
+
+function parseReport(input: unknown): AnalysisReport {
+    return analysisReportSchema.parse(input)
 }
 
 /**
  * Run a one-shot structured review. Returns the parsed report plus the
  * conversation seed (`messages`) — persist `messages` to enable chat follow-up.
+ *
+ * If the first response fails schema validation, retries once with a stricter
+ * nudge appended to the conversation. The retry path was added after a
+ * Sonnet response was observed putting findings at the top level and writing
+ * XML-parameter fragments into the alignmentCheck/complianceCheck slots; the
+ * persisted row then crashed the UI when reading `findings.length`.
  *
  * Future chat extension (target: before Oct 2026) — add alongside this fn:
  *
@@ -104,22 +122,50 @@ function extractReport(response: Anthropic.Messages.Message): AnalysisReport {
 export async function generateAnalysis(config: ReviewAgentConfig, content: ReviewContent): Promise<AnalysisResult> {
     const client = resolveClient(config)
     const prompt = buildPromptForContent(content, config.analysisPromptTemplate)
+    const model = config.model ?? DEFAULT_MODEL
+    const maxTokens = config.maxTokens ?? DEFAULT_MAX_TOKENS
+    const system = config.systemPrompt ?? DEFAULT_SYSTEM_INSTRUCTION
 
-    const response = await client.messages.create({
-        model: config.model ?? DEFAULT_MODEL,
-        max_tokens: config.maxTokens ?? DEFAULT_MAX_TOKENS,
-        system: config.systemPrompt ?? DEFAULT_SYSTEM_INSTRUCTION,
+    const initialMessages: Anthropic.Messages.MessageParam[] = [{ role: 'user', content: prompt }]
+
+    const firstResponse = await client.messages.create({
+        model,
+        max_tokens: maxTokens,
+        system,
         tools: [ANALYSIS_TOOL],
         tool_choice: { type: 'tool', name: ANALYSIS_TOOL_NAME },
-        messages: [{ role: 'user', content: prompt }],
+        messages: initialMessages,
     })
 
-    const report = extractReport(response)
+    const firstInput = extractToolInput(firstResponse)
+    const firstParse = analysisReportSchema.safeParse(firstInput)
+    if (firstParse.success) {
+        return buildResult(firstParse.data, prompt)
+    }
 
+    const retryMessages: Anthropic.Messages.MessageParam[] = [
+        ...initialMessages,
+        { role: 'assistant', content: JSON.stringify(firstInput) },
+        { role: 'user', content: RETRY_NUDGE },
+    ]
+
+    const retryResponse = await client.messages.create({
+        model,
+        max_tokens: maxTokens,
+        system,
+        tools: [ANALYSIS_TOOL],
+        tool_choice: { type: 'tool', name: ANALYSIS_TOOL_NAME },
+        messages: retryMessages,
+    })
+
+    const report = parseReport(extractToolInput(retryResponse))
+    return buildResult(report, prompt)
+}
+
+function buildResult(report: AnalysisReport, prompt: string): AnalysisResult {
     const messages: ReviewMessage[] = [
         { role: 'user', content: prompt },
         { role: 'assistant', content: JSON.stringify(report) },
     ]
-
     return { report, messages }
 }

--- a/src/server/agents/review-agent/types.ts
+++ b/src/server/agents/review-agent/types.ts
@@ -1,4 +1,5 @@
 import type Anthropic from '@anthropic-ai/sdk'
+import { z } from 'zod'
 
 /**
  * Reference documents provided by the reviewing organization.
@@ -46,21 +47,30 @@ export interface ReviewAgentConfig {
 }
 
 /**
+ * Runtime validator for AnalysisReport. The Anthropic tool-use JSON-schema is
+ * advisory — Claude has been observed returning malformed shapes (e.g. string
+ * fragments where objects are required). Use this schema to validate both the
+ * model's response in the agent AND any persisted row before passing it to
+ * the UI, since older rows pre-date the agent-side validation.
+ */
+export const analysisReportSchema = z.object({
+    proposalSummary: z.string(),
+    codeExplanation: z.string(),
+    resultsSummary: z.string().optional(),
+    alignmentCheck: z.object({
+        isAligned: z.boolean(),
+        findings: z.array(z.string()),
+    }),
+    complianceCheck: z.object({
+        isCompliant: z.boolean(),
+        findings: z.array(z.string()),
+    }),
+})
+
+/**
  * Structured analysis output from the ReviewAgent.
  */
-export interface AnalysisReport {
-    proposalSummary: string
-    codeExplanation: string
-    resultsSummary?: string
-    alignmentCheck: {
-        isAligned: boolean
-        findings: string[]
-    }
-    complianceCheck: {
-        isCompliant: boolean
-        findings: string[]
-    }
-}
+export type AnalysisReport = z.infer<typeof analysisReportSchema>
 
 /**
  * Single message in a review conversation. Stored alongside the report so

--- a/src/server/db/queries.test.ts
+++ b/src/server/db/queries.test.ts
@@ -187,13 +187,13 @@ describe('getOrgPublicKeys', () => {
 })
 
 describe('getStudyReviewForJob', () => {
-    it('returns null when no review exists for the job', async () => {
+    it('returns kind="missing" when no review exists for the job', async () => {
         const { job } = await insertTestStudyJobData()
         const result = await getStudyReviewForJob(job.id)
-        expect(result).toBeNull()
+        expect(result).toEqual({ kind: 'missing' })
     })
 
-    it('returns the stored report along with createdAt and files for the job', async () => {
+    it('returns kind="ok" with the stored report when the row validates', async () => {
         const { job } = await insertTestStudyJobData()
         const report = {
             proposalSummary: 'Studying student outcomes.',
@@ -207,9 +207,32 @@ describe('getStudyReviewForJob', () => {
             .execute()
 
         const result = await getStudyReviewForJob(job.id)
-        expect(result).not.toBeNull()
-        expect(result?.report).toEqual(report)
-        expect(result?.createdAt).toBeInstanceOf(Date)
-        expect(result?.files).toEqual([])
+        expect(result.kind).toBe('ok')
+        if (result.kind !== 'ok') return
+        expect(result.review.report).toEqual(report)
+        expect(result.review.createdAt).toBeInstanceOf(Date)
+        expect(result.review.files).toEqual([])
+    })
+
+    it('returns kind="malformed" when the stored report fails schema validation', async () => {
+        const { job } = await insertTestStudyJobData()
+        // Reproduces the prod bug: findings at the top level, alignmentCheck/complianceCheck
+        // are string fragments instead of objects.
+        const malformed = {
+            proposalSummary: 'summary',
+            codeExplanation: 'explanation',
+            findings: ['top-level finding'],
+            alignmentCheck: '\n<parameter name="isAligned">false',
+            complianceCheck: '\n<parameter name="isCompliant">false',
+        }
+        await db
+            .insertInto('studyReview')
+            .values({ studyJobId: job.id, report: JSON.stringify(malformed) })
+            .execute()
+
+        const result = await getStudyReviewForJob(job.id)
+        expect(result.kind).toBe('malformed')
+        if (result.kind !== 'malformed') return
+        expect(result.createdAt).toBeInstanceOf(Date)
     })
 })

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -8,7 +8,8 @@ import { FileType } from '@/database/types'
 import { Selectable } from 'kysely'
 import { Action } from '../actions/action'
 import type { PublicKey } from 'si-encryption/job-results/types'
-import type { AnalysisReport } from '@/server/agents/review-agent/types'
+import { analysisReportSchema, type AnalysisReport } from '@/server/agents/review-agent/types'
+import logger from '@/lib/logger'
 
 export type SiUser = ClerkUser & {
     id: string
@@ -396,11 +397,16 @@ export type StudyReviewWithMeta = {
     files: { name: string; fileType: FileType }[]
 }
 
-export async function getStudyReviewForJob(studyJobId: string): Promise<StudyReviewWithMeta | null> {
+export type StudyReviewLookup =
+    | { kind: 'missing' }
+    | { kind: 'malformed'; createdAt: Date }
+    | { kind: 'ok'; review: StudyReviewWithMeta }
+
+export async function getStudyReviewForJob(studyJobId: string): Promise<StudyReviewLookup> {
     const row = await Action.db
         .selectFrom('studyReview')
         .select((eb) => [
-            eb.ref('report').$castTo<AnalysisReport>().as('report'),
+            eb.ref('report').$castTo<unknown>().as('report'),
             'createdAt',
             jsonArrayFrom(
                 eb
@@ -416,5 +422,18 @@ export async function getStudyReviewForJob(studyJobId: string): Promise<StudyRev
         .orderBy('createdAt', 'desc')
         .limit(1)
         .executeTakeFirst()
-    return row ?? null
+
+    if (!row) return { kind: 'missing' }
+
+    const parsed = analysisReportSchema.safeParse(row.report)
+    if (!parsed.success) {
+        logger.warn('study_review row failed schema validation', {
+            studyJobId,
+            createdAt: row.createdAt,
+            issues: parsed.error.issues,
+        })
+        return { kind: 'malformed', createdAt: row.createdAt }
+    }
+
+    return { kind: 'ok', review: { report: parsed.data, createdAt: row.createdAt, files: row.files } }
 }


### PR DESCRIPTION
## Summary
Three related fixes for the AI study review panel.

**Sentry incident:** [`TypeError: Cannot read properties of undefined (reading 'length')`](https://app.qa.safeinsights.org/openstax/study/019e1d37-0fe3-71fd-8c46-c0e437da183b/review) at `study-review-section.tsx:163` (the `findings.length` line in `FindingsList`).

### Diagnosis
Used `scripts/query-db.ts review <studyId>` against QA to inspect the malformed row directly. The persisted `report` had:

- `findings` as a **top-level** key (instead of nested inside the checks)
- `alignmentCheck` / `complianceCheck` as **string fragments** — literally `"\n<parameter name=\"isAligned\">false"` — instead of objects

So `report.alignmentCheck.findings` was `undefined`, crashing the React tree. The Anthropic tool-use schema requires the proper shape, but Claude didn't honor it, and `extractReport` blindly cast `toolUse.input as AnalysisReport`. The `$castTo<AnalysisReport>()` at read time also lied.

(The original suspicion — missing `CLAUDE_API_KEY` — turned out to be unrelated. With the key missing, `getConfigValue` throws in the deferred runner, no row is written, and the panel sits on "Review in progress…" forever. That's the third fix below.)

### Fixes

1. **Validate the agent's tool-use payload before persisting.** Added `analysisReportSchema` (Zod) as the single source of truth, co-located with the `AnalysisReport` type. On first validation failure the agent retries once with a stricter nudge appended to the conversation, recovering transparently when the model glitches. On second failure, the runner's `deferred()` wrapper logs + Sentry-captures and no malformed row gets written.
2. **Validate persisted rows at read time.** `getStudyReviewForJob` now returns a discriminated `StudyReviewLookup` (`missing` / `malformed` / `ok`). Existing bad rows in the DB will show a non-crashing error state ("The AI review for this submission could not be displayed. Please contact support.") instead of crashing.
3. **Surface "AI review is not enabled."** `getStudyReviewAction` now checks `CLAUDE_API_KEY` non-throwingly. When the key is unset, the action returns `{ kind: 'disabled' }` and the client renders a dedicated terminal state instead of spinning forever.

### Action contract
`getStudyReviewAction` and the seeded `initialReview` now return a discriminated `StudyReviewResult`:

```ts
type StudyReviewResult =
    | { kind: 'disabled' }                                 // CLAUDE_API_KEY not set
    | { kind: 'missing' }                                  // runner hasn't produced a row yet
    | { kind: 'malformed'; createdAt: Date }               // row exists but failed validation
    | { kind: 'ok'; review: StudyReviewWithMeta }          // ready to render
```

The client polls only while `kind === 'missing'`; the other three are terminal.

## Test plan
- [x] `pnpm test:unit --run` — 1108/1108 pass (38 across the directly-affected test files: agent, runner, queries, study-review-section)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm validate-actions` clean
- [x] New agent tests: malformed-then-valid-on-retry, malformed-twice-throws
- [x] New query test: `kind: 'malformed'` is returned for the exact bad shape we saw in prod (reproduces the prod payload verbatim)
- [x] New section tests: `disabled` and `malformed` render the dedicated copy without crashing
- [ ] Manual: confirm in QA after deploy — the existing malformed row should now render the "could not be displayed" message instead of crashing
- [ ] One-off cleanup: delete the bad `study_review` row for `019e1d54-98a7-7e10-bae0-542b086880e9` so the next runner pass produces a fresh (validated) review

## Notes for reviewers
- The retry path is bounded to one extra Anthropic call per request. The retry sends the malformed prior assistant turn back to the model, which is the conventional shape for tool-use recovery — Claude sees its own output and the corrective user message.
- The Zod schema lives in `src/server/agents/review-agent/types.ts` so both `agent.ts` and `queries.ts` validate against the same definition. `AnalysisReport` is now derived via `z.infer<typeof analysisReportSchema>` — no drift possible.
- `getStudyReviewForJob` switched from `$castTo<AnalysisReport>()` (a lie) to `$castTo<unknown>()` followed by `analysisReportSchema.safeParse(...)` — typed strictly + validated at the boundary.
- `code-review-view.tsx` (server component) now awaits the action instead of calling the query directly, so the `CLAUDE_API_KEY` disabled check runs for the seeded `initialReview` too.

Follow-up to investigate (out of scope for this PR): why Sonnet returned the malformed shape in the first place. The prompt and tool schema look correct; this may be a model-quality issue worth opening a ticket on with Anthropic if it recurs.