### PR TITLE
Fix/simplify study review malformed report

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-view.tsx
@@ -1,9 +1,7 @@
 import { OrgBreadcrumbs } from '@/components/page-breadcrumbs'
 import { StudyCodeDetails } from '@/components/study/study-code-details'
 import { AlertNotFound } from '@/components/errors'
-import { latestSubmittedJobForStudy } from '@/server/db/queries'
-import { getStudyReviewAction } from '@/server/actions/study-job.actions'
-import { isActionError } from '@/lib/errors'
+import { getStudyReviewForJob, latestSubmittedJobForStudy } from '@/server/db/queries'
 import { ButtonLink } from '@/components/links'
 import { Routes } from '@/lib/routes'
 import { Divider, Group, Paper, Stack, Title } from '@mantine/core'
@@ -23,10 +21,7 @@ export async function CodeReviewView({ orgSlug, study }: CodeReviewViewProps) {
         return <AlertNotFound title="No submission found" message="This study has no submitted code to review." />
     }
 
-    // Soft-fail seed: an action error here surfaces as "in progress"; the client
-    // poller will request again and show a real error on its next failed refetch.
-    const result = await getStudyReviewAction({ studyJobId: job.id })
-    const initialReview = isActionError(result) ? null : result
+    const initialReview = await getStudyReviewForJob(job.id)
 
     return (
         <Stack px="xl" gap="xl">

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-view.tsx
@@ -1,13 +1,16 @@
 import { OrgBreadcrumbs } from '@/components/page-breadcrumbs'
 import { StudyCodeDetails } from '@/components/study/study-code-details'
 import { AlertNotFound } from '@/components/errors'
-import { getStudyReviewForJob, latestSubmittedJobForStudy } from '@/server/db/queries'
+import { latestSubmittedJobForStudy } from '@/server/db/queries'
+import { getStudyReviewAction } from '@/server/actions/study-job.actions'
+import { isActionError } from '@/lib/errors'
 import { ButtonLink } from '@/components/links'
 import { Routes } from '@/lib/routes'
 import { Divider, Group, Paper, Stack, Title } from '@mantine/core'
 import { CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
 import { StudyResultsWithReview } from './study-results-with-review'
 import type { SelectedStudy } from '@/server/actions/study.actions'
+import type { StudyReviewResult } from './study-review-types'
 import { StudyReviewSection } from './study-review-section'
 
 type CodeReviewViewProps = {
@@ -20,7 +23,10 @@ export async function CodeReviewView({ orgSlug, study }: CodeReviewViewProps) {
     if (!job) {
         return <AlertNotFound title="No submission found" message="This study has no submitted code to review." />
     }
-    const review = await getStudyReviewForJob(job.id)
+    const reviewResult = await getStudyReviewAction({ studyJobId: job.id })
+    // Soft-fail the seed: if the action errored, render the in-progress state and
+    // let the client poller surface a real error on its next refetch.
+    const initialReview: StudyReviewResult = isActionError(reviewResult) ? { kind: 'missing' } : reviewResult
 
     return (
         <Stack px="xl" gap="xl">
@@ -46,7 +52,7 @@ export async function CodeReviewView({ orgSlug, study }: CodeReviewViewProps) {
                 </Stack>
             </Paper>
             <Paper bg="white" p="xxl">
-                <StudyReviewSection studyJobId={job.id} initialReview={review} />
+                <StudyReviewSection studyJobId={job.id} initialReview={initialReview} />
             </Paper>
             <StudyResultsWithReview job={job} study={study} />
             <Group>

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-view.tsx
@@ -1,16 +1,16 @@
 import { OrgBreadcrumbs } from '@/components/page-breadcrumbs'
 import { StudyCodeDetails } from '@/components/study/study-code-details'
 import { AlertNotFound } from '@/components/errors'
-import { latestSubmittedJobForStudy } from '@/server/db/queries'
+import { latestSubmittedJobForStudy, type StudyReviewLookup } from '@/server/db/queries'
 import { getStudyReviewAction } from '@/server/actions/study-job.actions'
+import { getConfigValue } from '@/server/config'
 import { isActionError } from '@/lib/errors'
 import { ButtonLink } from '@/components/links'
 import { Routes } from '@/lib/routes'
-import { Divider, Group, Paper, Stack, Title } from '@mantine/core'
+import { Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
 import { CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
 import { StudyResultsWithReview } from './study-results-with-review'
 import type { SelectedStudy } from '@/server/actions/study.actions'
-import type { StudyReviewResult } from './study-review-types'
 import { StudyReviewSection } from './study-review-section'
 
 type CodeReviewViewProps = {
@@ -23,10 +23,13 @@ export async function CodeReviewView({ orgSlug, study }: CodeReviewViewProps) {
     if (!job) {
         return <AlertNotFound title="No submission found" message="This study has no submitted code to review." />
     }
-    const reviewResult = await getStudyReviewAction({ studyJobId: job.id })
-    // Soft-fail the seed: if the action errored, render the in-progress state and
-    // let the client poller surface a real error on its next refetch.
-    const initialReview: StudyReviewResult = isActionError(reviewResult) ? { kind: 'missing' } : reviewResult
+
+    const apiKey = await getConfigValue('CLAUDE_API_KEY', false)
+    const reviewPanel = apiKey ? (
+        <StudyReviewSection studyJobId={job.id} initialReview={await seedInitialReview(job.id)} />
+    ) : (
+        <ReviewDisabled />
+    )
 
     return (
         <Stack px="xl" gap="xl">
@@ -52,7 +55,7 @@ export async function CodeReviewView({ orgSlug, study }: CodeReviewViewProps) {
                 </Stack>
             </Paper>
             <Paper bg="white" p="xxl">
-                <StudyReviewSection studyJobId={job.id} initialReview={initialReview} />
+                {reviewPanel}
             </Paper>
             <StudyResultsWithReview job={job} study={study} />
             <Group>
@@ -64,6 +67,27 @@ export async function CodeReviewView({ orgSlug, study }: CodeReviewViewProps) {
                     Previous
                 </ButtonLink>
             </Group>
+        </Stack>
+    )
+}
+
+// Soft-fail seed: an action error here surfaces as "in progress"; the client
+// poller will request again and show a real error on its next failed refetch.
+async function seedInitialReview(studyJobId: string): Promise<StudyReviewLookup> {
+    const result = await getStudyReviewAction({ studyJobId })
+    return isActionError(result) ? null : result
+}
+
+function ReviewDisabled() {
+    return (
+        <Stack>
+            <Title order={4} size="xl">
+                Study Review
+            </Title>
+            <Divider c="dimmed" />
+            <Text c="dimmed" size="sm" data-testid="study-review-disabled">
+                AI review is not enabled for this environment.
+            </Text>
         </Stack>
     )
 }

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-view.tsx
@@ -1,13 +1,12 @@
 import { OrgBreadcrumbs } from '@/components/page-breadcrumbs'
 import { StudyCodeDetails } from '@/components/study/study-code-details'
 import { AlertNotFound } from '@/components/errors'
-import { latestSubmittedJobForStudy, type StudyReviewLookup } from '@/server/db/queries'
+import { latestSubmittedJobForStudy } from '@/server/db/queries'
 import { getStudyReviewAction } from '@/server/actions/study-job.actions'
-import { getConfigValue } from '@/server/config'
 import { isActionError } from '@/lib/errors'
 import { ButtonLink } from '@/components/links'
 import { Routes } from '@/lib/routes'
-import { Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
+import { Divider, Group, Paper, Stack, Title } from '@mantine/core'
 import { CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
 import { StudyResultsWithReview } from './study-results-with-review'
 import type { SelectedStudy } from '@/server/actions/study.actions'
@@ -24,12 +23,10 @@ export async function CodeReviewView({ orgSlug, study }: CodeReviewViewProps) {
         return <AlertNotFound title="No submission found" message="This study has no submitted code to review." />
     }
 
-    const apiKey = await getConfigValue('CLAUDE_API_KEY', false)
-    const reviewPanel = apiKey ? (
-        <StudyReviewSection studyJobId={job.id} initialReview={await seedInitialReview(job.id)} />
-    ) : (
-        <ReviewDisabled />
-    )
+    // Soft-fail seed: an action error here surfaces as "in progress"; the client
+    // poller will request again and show a real error on its next failed refetch.
+    const result = await getStudyReviewAction({ studyJobId: job.id })
+    const initialReview = isActionError(result) ? null : result
 
     return (
         <Stack px="xl" gap="xl">
@@ -55,7 +52,7 @@ export async function CodeReviewView({ orgSlug, study }: CodeReviewViewProps) {
                 </Stack>
             </Paper>
             <Paper bg="white" p="xxl">
-                {reviewPanel}
+                <StudyReviewSection studyJobId={job.id} initialReview={initialReview} />
             </Paper>
             <StudyResultsWithReview job={job} study={study} />
             <Group>
@@ -67,27 +64,6 @@ export async function CodeReviewView({ orgSlug, study }: CodeReviewViewProps) {
                     Previous
                 </ButtonLink>
             </Group>
-        </Stack>
-    )
-}
-
-// Soft-fail seed: an action error here surfaces as "in progress"; the client
-// poller will request again and show a real error on its next failed refetch.
-async function seedInitialReview(studyJobId: string): Promise<StudyReviewLookup> {
-    const result = await getStudyReviewAction({ studyJobId })
-    return isActionError(result) ? null : result
-}
-
-function ReviewDisabled() {
-    return (
-        <Stack>
-            <Title order={4} size="xl">
-                Study Review
-            </Title>
-            <Divider c="dimmed" />
-            <Text c="dimmed" size="sm" data-testid="study-review-disabled">
-                AI review is not enabled for this environment.
-            </Text>
         </Stack>
     )
 }

--- a/src/app/[orgSlug]/study/[studyId]/review/study-review-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/study-review-section.test.tsx
@@ -59,12 +59,16 @@ describe('StudyReviewSection', () => {
         expect(screen.getByText('Review in progress…')).toBeInTheDocument()
     })
 
-    it('renders a non-crashing error state when the stored report is malformed', () => {
-        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview="malformed" />)
+    it('renders "No findings" when a failing check has an empty findings array', () => {
+        const report: AnalysisReport = {
+            ...baseReport,
+            alignmentCheck: { isAligned: false, findings: [] },
+        }
 
-        expect(screen.getByTestId('study-review-malformed')).toHaveTextContent(
-            'AI review for this submission could not be displayed',
-        )
+        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={buildReview(report)} />)
+
+        expect(screen.getByText('Misaligned')).toBeInTheDocument()
+        expect(screen.getAllByText('No findings').length).toBeGreaterThan(0)
     })
 
     it('lists the files the review was generated against', () => {
@@ -87,5 +91,18 @@ describe('StudyReviewSection', () => {
         renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={buildReview(report)} />)
 
         expect(screen.getByText('Median score 82, no anomalies.')).toBeInTheDocument()
+    })
+
+    it('renders the disabled-key placeholder report like any other review', () => {
+        const disabledReport: AnalysisReport = {
+            proposalSummary: 'AI code review is disabled for this environment — CLAUDE_API_KEY is not configured.',
+            codeExplanation: 'No automated review was generated.',
+            alignmentCheck: { isAligned: true, findings: [] },
+            complianceCheck: { isCompliant: true, findings: [] },
+        }
+
+        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={buildReview(disabledReport, [])} />)
+
+        expect(screen.getByText(/AI code review is disabled/)).toBeInTheDocument()
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/review/study-review-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/study-review-section.test.tsx
@@ -93,16 +93,25 @@ describe('StudyReviewSection', () => {
         expect(screen.getByText('Median score 82, no anomalies.')).toBeInTheDocument()
     })
 
-    it('renders the disabled-key placeholder report like any other review', () => {
+    it('renders the disabled-key placeholder with red badges so a missing review does not look like a pass', () => {
         const disabledReport: AnalysisReport = {
-            proposalSummary: 'AI code review is disabled for this environment — CLAUDE_API_KEY is not configured.',
-            codeExplanation: 'No automated review was generated.',
-            alignmentCheck: { isAligned: true, findings: [] },
-            complianceCheck: { isCompliant: true, findings: [] },
+            proposalSummary: 'Automated AI review did not run — CLAUDE_API_KEY is not configured for this environment.',
+            codeExplanation: 'Manual review required.',
+            alignmentCheck: {
+                isAligned: false,
+                findings: ['Automated review did not run for this submission.'],
+            },
+            complianceCheck: {
+                isCompliant: false,
+                findings: ['Automated review did not run for this submission.'],
+            },
         }
 
         renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={buildReview(disabledReport, [])} />)
 
-        expect(screen.getByText(/AI code review is disabled/)).toBeInTheDocument()
+        expect(screen.getByText(/Automated AI review did not run/)).toBeInTheDocument()
+        expect(screen.getByText('Misaligned')).toBeInTheDocument()
+        expect(screen.getByText('Non-compliant')).toBeInTheDocument()
+        expect(screen.getAllByText(/Automated review did not run/).length).toBeGreaterThan(1)
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/review/study-review-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/study-review-section.test.tsx
@@ -3,14 +3,14 @@ import { renderWithProviders, screen } from '@/tests/unit.helpers'
 import { StudyReviewSection } from './study-review-section'
 import { getStudyReviewAction } from '@/server/actions/study-job.actions'
 import type { AnalysisReport } from '@/server/agents/review-agent/types'
-import type { StudyReviewResult } from './study-review-types'
+import type { StudyReviewWithMeta } from '@/server/db/queries'
 
 vi.mock('@/server/actions/study-job.actions', () => ({
     getStudyReviewAction: vi.fn(),
 }))
 
 beforeEach(() => {
-    vi.mocked(getStudyReviewAction).mockResolvedValue({ kind: 'missing' })
+    vi.mocked(getStudyReviewAction).mockResolvedValue(null)
 })
 
 const baseReport: AnalysisReport = {
@@ -20,20 +20,17 @@ const baseReport: AnalysisReport = {
     complianceCheck: { isCompliant: true, findings: [] },
 }
 
-function okResult(report: AnalysisReport, files: string[] = ['main.r']): StudyReviewResult {
+function buildReview(report: AnalysisReport, files: string[] = ['main.r']): StudyReviewWithMeta {
     return {
-        kind: 'ok',
-        review: {
-            report,
-            createdAt: new Date('2026-04-28T12:00:00Z'),
-            files: files.map((name) => ({ name, fileType: 'MAIN-CODE' as const })),
-        },
+        report,
+        createdAt: new Date('2026-04-28T12:00:00Z'),
+        files: files.map((name) => ({ name, fileType: 'MAIN-CODE' as const })),
     }
 }
 
 describe('StudyReviewSection', () => {
     it('renders summaries and check badges when a review is provided', () => {
-        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={okResult(baseReport)} />)
+        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={buildReview(baseReport)} />)
 
         expect(screen.getByText('Studying student performance trends.')).toBeInTheDocument()
         expect(screen.getByText('Aggregates scores grouped by school.')).toBeInTheDocument()
@@ -48,7 +45,7 @@ describe('StudyReviewSection', () => {
             complianceCheck: { isCompliant: false, findings: ['Logs raw student IDs'] },
         }
 
-        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={okResult(report)} />)
+        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={buildReview(report)} />)
 
         expect(screen.getByText('Misaligned')).toBeInTheDocument()
         expect(screen.getByText('Code skips step 3 from proposal')).toBeInTheDocument()
@@ -57,24 +54,13 @@ describe('StudyReviewSection', () => {
     })
 
     it('renders the in-progress state when the runner has not yet produced a row', () => {
-        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={{ kind: 'missing' }} />)
+        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={null} />)
 
         expect(screen.getByText('Review in progress…')).toBeInTheDocument()
     })
 
-    it('renders the disabled state when the feature is off in this environment', () => {
-        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={{ kind: 'disabled' }} />)
-
-        expect(screen.getByTestId('study-review-disabled')).toHaveTextContent('AI review is not enabled')
-    })
-
     it('renders a non-crashing error state when the stored report is malformed', () => {
-        renderWithProviders(
-            <StudyReviewSection
-                studyJobId="job-1"
-                initialReview={{ kind: 'malformed', createdAt: new Date('2026-04-28T12:00:00Z') }}
-            />,
-        )
+        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview="malformed" />)
 
         expect(screen.getByTestId('study-review-malformed')).toHaveTextContent(
             'AI review for this submission could not be displayed',
@@ -83,7 +69,10 @@ describe('StudyReviewSection', () => {
 
     it('lists the files the review was generated against', () => {
         renderWithProviders(
-            <StudyReviewSection studyJobId="job-1" initialReview={okResult(baseReport, ['main.r', 'dragon_art.R'])} />,
+            <StudyReviewSection
+                studyJobId="job-1"
+                initialReview={buildReview(baseReport, ['main.r', 'dragon_art.R'])}
+            />,
         )
 
         expect(screen.getByText('Files reviewed: main.r, dragon_art.R')).toBeInTheDocument()
@@ -95,7 +84,7 @@ describe('StudyReviewSection', () => {
             resultsSummary: 'Median score 82, no anomalies.',
         }
 
-        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={okResult(report)} />)
+        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={buildReview(report)} />)
 
         expect(screen.getByText('Median score 82, no anomalies.')).toBeInTheDocument()
     })

--- a/src/app/[orgSlug]/study/[studyId]/review/study-review-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/study-review-section.test.tsx
@@ -3,14 +3,14 @@ import { renderWithProviders, screen } from '@/tests/unit.helpers'
 import { StudyReviewSection } from './study-review-section'
 import { getStudyReviewAction } from '@/server/actions/study-job.actions'
 import type { AnalysisReport } from '@/server/agents/review-agent/types'
-import type { StudyReviewWithMeta } from '@/server/db/queries'
+import type { StudyReviewResult } from './study-review-types'
 
 vi.mock('@/server/actions/study-job.actions', () => ({
     getStudyReviewAction: vi.fn(),
 }))
 
 beforeEach(() => {
-    vi.mocked(getStudyReviewAction).mockResolvedValue(null)
+    vi.mocked(getStudyReviewAction).mockResolvedValue({ kind: 'missing' })
 })
 
 const baseReport: AnalysisReport = {
@@ -20,17 +20,20 @@ const baseReport: AnalysisReport = {
     complianceCheck: { isCompliant: true, findings: [] },
 }
 
-function withMeta(report: AnalysisReport, files: string[] = ['main.r']): StudyReviewWithMeta {
+function okResult(report: AnalysisReport, files: string[] = ['main.r']): StudyReviewResult {
     return {
-        report,
-        createdAt: new Date('2026-04-28T12:00:00Z'),
-        files: files.map((name) => ({ name, fileType: 'MAIN-CODE' as const })),
+        kind: 'ok',
+        review: {
+            report,
+            createdAt: new Date('2026-04-28T12:00:00Z'),
+            files: files.map((name) => ({ name, fileType: 'MAIN-CODE' as const })),
+        },
     }
 }
 
 describe('StudyReviewSection', () => {
     it('renders summaries and check badges when a review is provided', () => {
-        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={withMeta(baseReport)} />)
+        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={okResult(baseReport)} />)
 
         expect(screen.getByText('Studying student performance trends.')).toBeInTheDocument()
         expect(screen.getByText('Aggregates scores grouped by school.')).toBeInTheDocument()
@@ -45,7 +48,7 @@ describe('StudyReviewSection', () => {
             complianceCheck: { isCompliant: false, findings: ['Logs raw student IDs'] },
         }
 
-        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={withMeta(report)} />)
+        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={okResult(report)} />)
 
         expect(screen.getByText('Misaligned')).toBeInTheDocument()
         expect(screen.getByText('Code skips step 3 from proposal')).toBeInTheDocument()
@@ -53,15 +56,34 @@ describe('StudyReviewSection', () => {
         expect(screen.getByText('Logs raw student IDs')).toBeInTheDocument()
     })
 
-    it('renders the in-progress state when initialReview is null', () => {
-        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={null} />)
+    it('renders the in-progress state when the runner has not yet produced a row', () => {
+        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={{ kind: 'missing' }} />)
 
         expect(screen.getByText('Review in progress…')).toBeInTheDocument()
     })
 
+    it('renders the disabled state when the feature is off in this environment', () => {
+        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={{ kind: 'disabled' }} />)
+
+        expect(screen.getByTestId('study-review-disabled')).toHaveTextContent('AI review is not enabled')
+    })
+
+    it('renders a non-crashing error state when the stored report is malformed', () => {
+        renderWithProviders(
+            <StudyReviewSection
+                studyJobId="job-1"
+                initialReview={{ kind: 'malformed', createdAt: new Date('2026-04-28T12:00:00Z') }}
+            />,
+        )
+
+        expect(screen.getByTestId('study-review-malformed')).toHaveTextContent(
+            'AI review for this submission could not be displayed',
+        )
+    })
+
     it('lists the files the review was generated against', () => {
         renderWithProviders(
-            <StudyReviewSection studyJobId="job-1" initialReview={withMeta(baseReport, ['main.r', 'dragon_art.R'])} />,
+            <StudyReviewSection studyJobId="job-1" initialReview={okResult(baseReport, ['main.r', 'dragon_art.R'])} />,
         )
 
         expect(screen.getByText('Files reviewed: main.r, dragon_art.R')).toBeInTheDocument()
@@ -73,7 +95,7 @@ describe('StudyReviewSection', () => {
             resultsSummary: 'Median score 82, no anomalies.',
         }
 
-        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={withMeta(report)} />)
+        renderWithProviders(<StudyReviewSection studyJobId="job-1" initialReview={okResult(report)} />)
 
         expect(screen.getByText('Median score 82, no anomalies.')).toBeInTheDocument()
     })

--- a/src/app/[orgSlug]/study/[studyId]/review/study-review-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/study-review-section.tsx
@@ -2,16 +2,14 @@
 
 import { useQuery } from '@/common'
 import { getStudyReviewAction } from '@/server/actions/study-job.actions'
-import type { StudyReviewWithMeta } from '@/server/db/queries'
-import type { StudyReviewResult } from './study-review-types'
-import type { AnalysisReport } from '@/server/agents/review-agent/types'
+import type { StudyReviewLookup, StudyReviewWithMeta } from '@/server/db/queries'
 import { Badge, Divider, Group, List, ListItem, Loader, Stack, Text, Title } from '@mantine/core'
 
 const POLL_INTERVAL_MS = 5_000
 
 type StudyReviewSectionProps = {
     studyJobId: string
-    initialReview: StudyReviewResult
+    initialReview: StudyReviewLookup
 }
 
 export function StudyReviewSection({ studyJobId, initialReview }: StudyReviewSectionProps) {
@@ -19,21 +17,14 @@ export function StudyReviewSection({ studyJobId, initialReview }: StudyReviewSec
         queryKey: ['study-review', studyJobId],
         queryFn: () => getStudyReviewAction({ studyJobId }),
         initialData: initialReview,
-        // Only poll while we have no resolved state yet (i.e. waiting on the runner).
-        // `disabled`, `malformed`, and `ok` are terminal; `missing` keeps polling.
-        refetchInterval: (query) => {
-            if (query.state.error) return false
-            const data = query.state.data
-            if (!data || data.kind === 'missing') return POLL_INTERVAL_MS
-            return false
-        },
+        // Poll only while no row exists yet; 'malformed' and a real review are terminal.
+        refetchInterval: (query) => (query.state.data === null && !query.state.error ? POLL_INTERVAL_MS : false),
     })
 
     if (error) return <ReviewError />
-    if (!result || result.kind === 'missing') return <ReviewInProgress />
-    if (result.kind === 'disabled') return <ReviewDisabled />
-    if (result.kind === 'malformed') return <ReviewMalformed />
-    return <ReviewReport review={result.review} />
+    if (result == null) return <ReviewInProgress />
+    if (result === 'malformed') return <ReviewMalformed />
+    return <ReviewReport review={result} />
 }
 
 function ReviewInProgress() {
@@ -56,17 +47,6 @@ function ReviewError() {
             <ReviewHeader />
             <Text c="red" size="sm" data-testid="study-review-error">
                 Failed to load study review. Please refresh to try again.
-            </Text>
-        </Stack>
-    )
-}
-
-function ReviewDisabled() {
-    return (
-        <Stack>
-            <ReviewHeader />
-            <Text c="dimmed" size="sm" data-testid="study-review-disabled">
-                AI review is not enabled for this environment.
             </Text>
         </Stack>
     )
@@ -164,7 +144,7 @@ type CheckSectionProps = {
     isPositive: boolean
     positiveLabel: string
     negativeLabel: string
-    findings: AnalysisReport['alignmentCheck']['findings']
+    findings: string[]
 }
 
 function CheckSection({ title, isPositive, positiveLabel, negativeLabel, findings }: CheckSectionProps) {

--- a/src/app/[orgSlug]/study/[studyId]/review/study-review-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/study-review-section.tsx
@@ -2,14 +2,14 @@
 
 import { useQuery } from '@/common'
 import { getStudyReviewAction } from '@/server/actions/study-job.actions'
-import type { StudyReviewLookup, StudyReviewWithMeta } from '@/server/db/queries'
+import type { StudyReviewWithMeta } from '@/server/db/queries'
 import { Badge, Divider, Group, List, ListItem, Loader, Stack, Text, Title } from '@mantine/core'
 
 const POLL_INTERVAL_MS = 5_000
 
 type StudyReviewSectionProps = {
     studyJobId: string
-    initialReview: StudyReviewLookup
+    initialReview: StudyReviewWithMeta | null
 }
 
 export function StudyReviewSection({ studyJobId, initialReview }: StudyReviewSectionProps) {
@@ -17,13 +17,17 @@ export function StudyReviewSection({ studyJobId, initialReview }: StudyReviewSec
         queryKey: ['study-review', studyJobId],
         queryFn: () => getStudyReviewAction({ studyJobId }),
         initialData: initialReview,
-        // Poll only while no row exists yet; 'malformed' and a real review are terminal.
-        refetchInterval: (query) => (query.state.data === null && !query.state.error ? POLL_INTERVAL_MS : false),
+        // Poll until the runner writes a row. A row — including the disabled-key
+        // placeholder — is terminal.
+        refetchInterval: (query) => {
+            if (query.state.error) return false
+            if (query.state.data != null) return false
+            return POLL_INTERVAL_MS
+        },
     })
 
     if (error) return <ReviewError />
     if (result == null) return <ReviewInProgress />
-    if (result === 'malformed') return <ReviewMalformed />
     return <ReviewReport review={result} />
 }
 
@@ -31,7 +35,7 @@ function ReviewInProgress() {
     return (
         <Stack>
             <ReviewHeader />
-            <Group gap="xs" data-testid="study-review-in-progress">
+            <Group gap="xs">
                 <Loader size="sm" />
                 <Text c="dimmed" size="sm">
                     Review in progress…
@@ -45,19 +49,8 @@ function ReviewError() {
     return (
         <Stack>
             <ReviewHeader />
-            <Text c="red" size="sm" data-testid="study-review-error">
+            <Text c="red" size="sm">
                 Failed to load study review. Please refresh to try again.
-            </Text>
-        </Stack>
-    )
-}
-
-function ReviewMalformed() {
-    return (
-        <Stack>
-            <ReviewHeader />
-            <Text c="red" size="sm" data-testid="study-review-malformed">
-                The AI review for this submission could not be displayed. Please contact support.
             </Text>
         </Stack>
     )

--- a/src/app/[orgSlug]/study/[studyId]/review/study-review-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/study-review-section.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from '@/common'
 import { getStudyReviewAction } from '@/server/actions/study-job.actions'
 import type { StudyReviewWithMeta } from '@/server/db/queries'
+import type { StudyReviewResult } from './study-review-types'
 import type { AnalysisReport } from '@/server/agents/review-agent/types'
 import { Badge, Divider, Group, List, ListItem, Loader, Stack, Text, Title } from '@mantine/core'
 
@@ -10,34 +11,36 @@ const POLL_INTERVAL_MS = 5_000
 
 type StudyReviewSectionProps = {
     studyJobId: string
-    initialReview: StudyReviewWithMeta | null
+    initialReview: StudyReviewResult
 }
 
 export function StudyReviewSection({ studyJobId, initialReview }: StudyReviewSectionProps) {
-    const { data: review, error } = useQuery({
+    const { data: result, error } = useQuery({
         queryKey: ['study-review', studyJobId],
         queryFn: () => getStudyReviewAction({ studyJobId }),
         initialData: initialReview,
-        // Review job runs async for unknown duration; poll until row arrives or query errors.
-        refetchInterval: (query) => (query.state.data || query.state.error ? false : POLL_INTERVAL_MS),
+        // Only poll while we have no resolved state yet (i.e. waiting on the runner).
+        // `disabled`, `malformed`, and `ok` are terminal; `missing` keeps polling.
+        refetchInterval: (query) => {
+            if (query.state.error) return false
+            const data = query.state.data
+            if (!data || data.kind === 'missing') return POLL_INTERVAL_MS
+            return false
+        },
     })
 
-    if (error) {
-        return <ReviewError />
-    }
-
-    if (!review) {
-        return <ReviewInProgress />
-    }
-
-    return <ReviewReport review={review} />
+    if (error) return <ReviewError />
+    if (!result || result.kind === 'missing') return <ReviewInProgress />
+    if (result.kind === 'disabled') return <ReviewDisabled />
+    if (result.kind === 'malformed') return <ReviewMalformed />
+    return <ReviewReport review={result.review} />
 }
 
 function ReviewInProgress() {
     return (
         <Stack>
             <ReviewHeader />
-            <Group gap="xs">
+            <Group gap="xs" data-testid="study-review-in-progress">
                 <Loader size="sm" />
                 <Text c="dimmed" size="sm">
                     Review in progress…
@@ -51,8 +54,30 @@ function ReviewError() {
     return (
         <Stack>
             <ReviewHeader />
-            <Text c="red" size="sm">
+            <Text c="red" size="sm" data-testid="study-review-error">
                 Failed to load study review. Please refresh to try again.
+            </Text>
+        </Stack>
+    )
+}
+
+function ReviewDisabled() {
+    return (
+        <Stack>
+            <ReviewHeader />
+            <Text c="dimmed" size="sm" data-testid="study-review-disabled">
+                AI review is not enabled for this environment.
+            </Text>
+        </Stack>
+    )
+}
+
+function ReviewMalformed() {
+    return (
+        <Stack>
+            <ReviewHeader />
+            <Text c="red" size="sm" data-testid="study-review-malformed">
+                The AI review for this submission could not be displayed. Please contact support.
             </Text>
         </Stack>
     )

--- a/src/app/[orgSlug]/study/[studyId]/review/study-review-types.ts
+++ b/src/app/[orgSlug]/study/[studyId]/review/study-review-types.ts
@@ -1,3 +1,0 @@
-import type { StudyReviewLookup } from '@/server/db/queries'
-
-export type StudyReviewResult = { kind: 'disabled' } | StudyReviewLookup

--- a/src/app/[orgSlug]/study/[studyId]/review/study-review-types.ts
+++ b/src/app/[orgSlug]/study/[studyId]/review/study-review-types.ts
@@ -1,0 +1,3 @@
+import type { StudyReviewLookup } from '@/server/db/queries'
+
+export type StudyReviewResult = { kind: 'disabled' } | StudyReviewLookup

--- a/src/server/actions/study-job.actions.ts
+++ b/src/server/actions/study-job.actions.ts
@@ -5,22 +5,9 @@ import { isApprovedLogType, isEncryptedLogType } from '@/lib/file-type-helpers'
 import { JobFile, jobFileSchema, minimalJobInfoSchema } from '@/lib/types'
 import { getStudyJobInfo, getStudyReviewForJob, latestJobForStudy } from '@/server/db/queries'
 import { onStudyResultsApproved, onStudyResultsRejected } from '@/server/events'
-import { getConfigValue } from '@/server/config'
 import { fetchFileContents, storeApprovedJobFile } from '@/server/storage'
 import { ResultsReader } from 'si-encryption/job-results/reader'
-import type { StudyReviewResult } from '@/app/[orgSlug]/study/[studyId]/review/study-review-types'
 import { Action, z } from './action'
-
-/**
- * Returns the AI study review state for a job, including the `disabled` case
- * when CLAUDE_API_KEY is not configured. Shared by the server page that seeds
- * `initialReview` and the action's handler.
- */
-async function loadStudyReview(studyJobId: string): Promise<StudyReviewResult> {
-    const apiKey = await getConfigValue('CLAUDE_API_KEY', false)
-    if (!apiKey) return { kind: 'disabled' }
-    return await getStudyReviewForJob(studyJobId)
-}
 
 export const approveStudyJobFilesAction = new Action('approveStudyJobFilesAction')
     .params(
@@ -111,8 +98,8 @@ export const getStudyReviewAction = new Action('getStudyReviewAction')
         return { studyJob, orgId: studyJob.orgId, submittedByOrgId: studyJob.submittedByOrgId }
     })
     .requireAbilityTo('view', 'StudyJob')
-    .handler(async ({ params: { studyJobId } }): Promise<StudyReviewResult> => {
-        return await loadStudyReview(studyJobId)
+    .handler(async ({ params: { studyJobId } }) => {
+        return await getStudyReviewForJob(studyJobId)
     })
 
 export const fetchApprovedJobFilesAction = new Action('fetchApprovedJobFilesAction')

--- a/src/server/actions/study-job.actions.ts
+++ b/src/server/actions/study-job.actions.ts
@@ -4,11 +4,23 @@ import { ActionFailure } from '@/lib/errors'
 import { isApprovedLogType, isEncryptedLogType } from '@/lib/file-type-helpers'
 import { JobFile, jobFileSchema, minimalJobInfoSchema } from '@/lib/types'
 import { getStudyJobInfo, getStudyReviewForJob, latestJobForStudy } from '@/server/db/queries'
-import type { StudyReviewWithMeta } from '@/server/db/queries'
 import { onStudyResultsApproved, onStudyResultsRejected } from '@/server/events'
+import { getConfigValue } from '@/server/config'
 import { fetchFileContents, storeApprovedJobFile } from '@/server/storage'
 import { ResultsReader } from 'si-encryption/job-results/reader'
+import type { StudyReviewResult } from '@/app/[orgSlug]/study/[studyId]/review/study-review-types'
 import { Action, z } from './action'
+
+/**
+ * Returns the AI study review state for a job, including the `disabled` case
+ * when CLAUDE_API_KEY is not configured. Shared by the server page that seeds
+ * `initialReview` and the action's handler.
+ */
+async function loadStudyReview(studyJobId: string): Promise<StudyReviewResult> {
+    const apiKey = await getConfigValue('CLAUDE_API_KEY', false)
+    if (!apiKey) return { kind: 'disabled' }
+    return await getStudyReviewForJob(studyJobId)
+}
 
 export const approveStudyJobFilesAction = new Action('approveStudyJobFilesAction')
     .params(
@@ -99,8 +111,8 @@ export const getStudyReviewAction = new Action('getStudyReviewAction')
         return { studyJob, orgId: studyJob.orgId, submittedByOrgId: studyJob.submittedByOrgId }
     })
     .requireAbilityTo('view', 'StudyJob')
-    .handler(async ({ params: { studyJobId } }): Promise<StudyReviewWithMeta | null> => {
-        return await getStudyReviewForJob(studyJobId)
+    .handler(async ({ params: { studyJobId } }): Promise<StudyReviewResult> => {
+        return await loadStudyReview(studyJobId)
     })
 
 export const fetchApprovedJobFilesAction = new Action('fetchApprovedJobFilesAction')

--- a/src/server/agents/review-agent/agent.test.ts
+++ b/src/server/agents/review-agent/agent.test.ts
@@ -21,7 +21,31 @@ function makeClient(content: unknown) {
     return { client: { messages: { create } } as unknown as Anthropic, create }
 }
 
+function makeClientWithSequence(responses: unknown[]) {
+    const create = vi.fn()
+    for (const r of responses) {
+        create.mockResolvedValueOnce({ content: r })
+    }
+    return { client: { messages: { create } } as unknown as Anthropic, create }
+}
+
 const toolUseBlock = [{ type: 'tool_use', name: 'submit_analysis', id: '1', input: baseReport }]
+
+const malformedToolUseBlock = [
+    {
+        type: 'tool_use',
+        name: 'submit_analysis',
+        id: '1',
+        input: {
+            proposalSummary: 'summary',
+            codeExplanation: 'explanation',
+            // Malformed: alignmentCheck/complianceCheck are strings, findings at top level.
+            findings: ['top-level finding'],
+            alignmentCheck: '\n<parameter name="isAligned">false',
+            complianceCheck: '\n<parameter name="isCompliant">false',
+        },
+    },
+]
 
 describe('generateAnalysis', () => {
     it('returns the structured report from a tool_use block', async () => {
@@ -89,5 +113,29 @@ describe('generateAnalysis', () => {
 
     it('throws when neither apiKey nor client is provided', async () => {
         await expect(generateAnalysis({}, baseContent)).rejects.toThrow(/apiKey or client/)
+    })
+
+    it('retries once with a stricter nudge when the first response fails validation', async () => {
+        const { client, create } = makeClientWithSequence([malformedToolUseBlock, toolUseBlock])
+
+        const result = await generateAnalysis({ client }, baseContent)
+
+        expect(result.report).toEqual(baseReport)
+        expect(create).toHaveBeenCalledTimes(2)
+
+        const retryArgs = create.mock.calls[1][0]
+        const retryMessages = retryArgs.messages as Array<{ role: string; content: string }>
+        expect(retryMessages).toHaveLength(3)
+        expect(retryMessages[1].role).toBe('assistant')
+        expect(retryMessages[2].role).toBe('user')
+        expect(retryMessages[2].content).toMatch(/submit_analysis/)
+        expect(retryMessages[2].content).toMatch(/findings/)
+    })
+
+    it('throws when both the initial and retry responses fail validation', async () => {
+        const { client, create } = makeClientWithSequence([malformedToolUseBlock, malformedToolUseBlock])
+
+        await expect(generateAnalysis({ client }, baseContent)).rejects.toThrow()
+        expect(create).toHaveBeenCalledTimes(2)
     })
 })

--- a/src/server/agents/review-agent/agent.test.ts
+++ b/src/server/agents/review-agent/agent.test.ts
@@ -21,31 +21,7 @@ function makeClient(content: unknown) {
     return { client: { messages: { create } } as unknown as Anthropic, create }
 }
 
-function makeClientWithSequence(responses: unknown[]) {
-    const create = vi.fn()
-    for (const r of responses) {
-        create.mockResolvedValueOnce({ content: r })
-    }
-    return { client: { messages: { create } } as unknown as Anthropic, create }
-}
-
 const toolUseBlock = [{ type: 'tool_use', name: 'submit_analysis', id: '1', input: baseReport }]
-
-const malformedToolUseBlock = [
-    {
-        type: 'tool_use',
-        name: 'submit_analysis',
-        id: '1',
-        input: {
-            proposalSummary: 'summary',
-            codeExplanation: 'explanation',
-            // Malformed: alignmentCheck/complianceCheck are strings, findings at top level.
-            findings: ['top-level finding'],
-            alignmentCheck: '\n<parameter name="isAligned">false',
-            complianceCheck: '\n<parameter name="isCompliant">false',
-        },
-    },
-]
 
 describe('generateAnalysis', () => {
     it('returns the structured report from a tool_use block', async () => {
@@ -115,27 +91,23 @@ describe('generateAnalysis', () => {
         await expect(generateAnalysis({}, baseContent)).rejects.toThrow(/apiKey or client/)
     })
 
-    it('retries once with a stricter nudge when the first response fails validation', async () => {
-        const { client, create } = makeClientWithSequence([malformedToolUseBlock, toolUseBlock])
-
-        const result = await generateAnalysis({ client }, baseContent)
-
-        expect(result.report).toEqual(baseReport)
-        expect(create).toHaveBeenCalledTimes(2)
-
-        const retryArgs = create.mock.calls[1][0]
-        const retryMessages = retryArgs.messages as Array<{ role: string; content: string }>
-        expect(retryMessages).toHaveLength(3)
-        expect(retryMessages[1].role).toBe('assistant')
-        expect(retryMessages[2].role).toBe('user')
-        expect(retryMessages[2].content).toMatch(/submit_analysis/)
-        expect(retryMessages[2].content).toMatch(/findings/)
-    })
-
-    it('throws when both the initial and retry responses fail validation', async () => {
-        const { client, create } = makeClientWithSequence([malformedToolUseBlock, malformedToolUseBlock])
+    it('throws when the tool_use payload fails schema validation', async () => {
+        const malformedToolUseBlock = [
+            {
+                type: 'tool_use',
+                name: 'submit_analysis',
+                id: '1',
+                input: {
+                    proposalSummary: 'summary',
+                    codeExplanation: 'explanation',
+                    findings: ['top-level finding'],
+                    alignmentCheck: '\n<parameter name="isAligned">false',
+                    complianceCheck: '\n<parameter name="isCompliant">false',
+                },
+            },
+        ]
+        const { client } = makeClient(malformedToolUseBlock)
 
         await expect(generateAnalysis({ client }, baseContent)).rejects.toThrow()
-        expect(create).toHaveBeenCalledTimes(2)
     })
 })

--- a/src/server/agents/review-agent/agent.test.ts
+++ b/src/server/agents/review-agent/agent.test.ts
@@ -16,8 +16,8 @@ const baseContent: ReviewContent = {
     referenceDocs: { requirements: 'r', brcDocs: 'b', dataDocs: 'd', otherDocs: 'o' },
 }
 
-function makeClient(content: unknown) {
-    const create = vi.fn().mockResolvedValue({ content })
+function makeClient(content: unknown, extra: Record<string, unknown> = {}) {
+    const create = vi.fn().mockResolvedValue({ content, ...extra })
     return { client: { messages: { create } } as unknown as Anthropic, create }
 }
 
@@ -89,6 +89,20 @@ describe('generateAnalysis', () => {
 
     it('throws when neither apiKey nor client is provided', async () => {
         await expect(generateAnalysis({}, baseContent)).rejects.toThrow(/apiKey or client/)
+    })
+
+    it('throws a specific error when the model refuses (stop_reason: refusal)', async () => {
+        const { client } = makeClient([{ type: 'text', text: 'I cannot help with that.', citations: null }], {
+            stop_reason: 'refusal',
+        })
+
+        await expect(generateAnalysis({ client }, baseContent)).rejects.toThrow(/refused/i)
+    })
+
+    it('throws a specific error when the response is truncated (stop_reason: max_tokens)', async () => {
+        const { client } = makeClient(toolUseBlock, { stop_reason: 'max_tokens' })
+
+        await expect(generateAnalysis({ client }, baseContent)).rejects.toThrow(/max_tokens/)
     })
 
     it('throws when the tool_use payload fails schema validation', async () => {

--- a/src/server/agents/review-agent/agent.ts
+++ b/src/server/agents/review-agent/agent.ts
@@ -4,10 +4,10 @@ import { analysisReportSchema } from './types'
 import type { AnalysisReport, AnalysisResult, ReviewAgentConfig, ReviewContent, ReviewMessage } from './types'
 
 const DEFAULT_MODEL = process.env.ANTHROPIC_MODEL ?? 'claude-sonnet-4-6'
-// Sized for ~3× the realistic worst-case review (2 narrative fields + ~10
-// findings per check at ~50 tokens each ≈ 4-5K tokens). The schema property
-// `description` strings below carry the actual length guidance to the model;
-// this cap exists only to bound runaway output if the model ignores them.
+// Realistic worst case is ~1.5K tokens (2 narrative fields × ~150 words ≈
+// 400 tokens, plus ~10 findings per check × 2 checks × ~50 tokens). 16K
+// gives ~10× headroom — schema property `description` strings carry the
+// actual length guidance to the model; this cap is just a runaway bound.
 const DEFAULT_MAX_TOKENS = 16_000
 const DEFAULT_MAX_RETRIES = 3
 

--- a/src/server/agents/review-agent/agent.ts
+++ b/src/server/agents/review-agent/agent.ts
@@ -40,13 +40,6 @@ const ANALYSIS_TOOL: Anthropic.Messages.Tool = {
     },
 }
 
-const RETRY_NUDGE =
-    'Your previous response did not call the `submit_analysis` tool with the exact required shape. ' +
-    'You MUST call `submit_analysis` exactly once. Every required field must be a real value of the ' +
-    'correct type — `alignmentCheck` and `complianceCheck` must each be objects with `isAligned`/' +
-    '`isCompliant` (boolean) and `findings` (array of strings). Do not return XML, parameter tags, ' +
-    'or string fragments — only the structured tool call.'
-
 function resolveClient(config: ReviewAgentConfig): Anthropic {
     if (config.client) return config.client
     if (config.apiKey) {
@@ -80,7 +73,7 @@ function buildPromptForContent(content: ReviewContent, templateOverride?: string
     )
 }
 
-function extractToolInput(response: Anthropic.Messages.Message): unknown {
+function extractReport(response: Anthropic.Messages.Message): AnalysisReport {
     const toolUse = response.content.find(
         (block): block is Anthropic.Messages.ToolUseBlock =>
             block.type === 'tool_use' && block.name === ANALYSIS_TOOL_NAME,
@@ -90,79 +83,23 @@ function extractToolInput(response: Anthropic.Messages.Message): unknown {
         throw new Error('The model did not return a structured analysis.')
     }
 
-    return toolUse.input
+    return analysisReportSchema.parse(toolUse.input)
 }
 
-function parseReport(input: unknown): AnalysisReport {
-    return analysisReportSchema.parse(input)
-}
-
-/**
- * Run a one-shot structured review. Returns the parsed report plus the
- * conversation seed (`messages`) — persist `messages` to enable chat follow-up.
- *
- * If the first response fails schema validation, retries once with a stricter
- * nudge appended to the conversation. The retry path was added after a
- * Sonnet response was observed putting findings at the top level and writing
- * XML-parameter fragments into the alignmentCheck/complianceCheck slots; the
- * persisted row then crashed the UI when reading `findings.length`.
- *
- * Future chat extension (target: before Oct 2026) — add alongside this fn:
- *
- *     export async function continueChat(
- *         config: ReviewAgentConfig,
- *         messages: ReviewMessage[],
- *         userMessage: string,
- *     ): Promise<{ reply: string; messages: ReviewMessage[] }>
- *
- * Caller (server action) loads `messages` from the studyReview row, appends
- * the user's question, calls `continueChat`, persists the new `messages`
- * back. Stateless — survives process restarts and queue retries.
- */
 export async function generateAnalysis(config: ReviewAgentConfig, content: ReviewContent): Promise<AnalysisResult> {
     const client = resolveClient(config)
     const prompt = buildPromptForContent(content, config.analysisPromptTemplate)
-    const model = config.model ?? DEFAULT_MODEL
-    const maxTokens = config.maxTokens ?? DEFAULT_MAX_TOKENS
-    const system = config.systemPrompt ?? DEFAULT_SYSTEM_INSTRUCTION
 
-    const initialMessages: Anthropic.Messages.MessageParam[] = [{ role: 'user', content: prompt }]
-
-    const firstResponse = await client.messages.create({
-        model,
-        max_tokens: maxTokens,
-        system,
+    const response = await client.messages.create({
+        model: config.model ?? DEFAULT_MODEL,
+        max_tokens: config.maxTokens ?? DEFAULT_MAX_TOKENS,
+        system: config.systemPrompt ?? DEFAULT_SYSTEM_INSTRUCTION,
         tools: [ANALYSIS_TOOL],
         tool_choice: { type: 'tool', name: ANALYSIS_TOOL_NAME },
-        messages: initialMessages,
+        messages: [{ role: 'user', content: prompt }],
     })
 
-    const firstInput = extractToolInput(firstResponse)
-    const firstParse = analysisReportSchema.safeParse(firstInput)
-    if (firstParse.success) {
-        return buildResult(firstParse.data, prompt)
-    }
-
-    const retryMessages: Anthropic.Messages.MessageParam[] = [
-        ...initialMessages,
-        { role: 'assistant', content: JSON.stringify(firstInput) },
-        { role: 'user', content: RETRY_NUDGE },
-    ]
-
-    const retryResponse = await client.messages.create({
-        model,
-        max_tokens: maxTokens,
-        system,
-        tools: [ANALYSIS_TOOL],
-        tool_choice: { type: 'tool', name: ANALYSIS_TOOL_NAME },
-        messages: retryMessages,
-    })
-
-    const report = parseReport(extractToolInput(retryResponse))
-    return buildResult(report, prompt)
-}
-
-function buildResult(report: AnalysisReport, prompt: string): AnalysisResult {
+    const report = extractReport(response)
     const messages: ReviewMessage[] = [
         { role: 'user', content: prompt },
         { role: 'assistant', content: JSON.stringify(report) },

--- a/src/server/agents/review-agent/agent.ts
+++ b/src/server/agents/review-agent/agent.ts
@@ -4,10 +4,11 @@ import { analysisReportSchema } from './types'
 import type { AnalysisReport, AnalysisResult, ReviewAgentConfig, ReviewContent, ReviewMessage } from './types'
 
 const DEFAULT_MODEL = process.env.ANTHROPIC_MODEL ?? 'claude-sonnet-4-6'
-// Sonnet 4.6 supports up to 64K output tokens. The review can contain many
-// long `findings` strings under each check, so we leave headroom rather than
-// risking a `stop_reason: 'max_tokens'` truncation mid-tool-call.
-const DEFAULT_MAX_TOKENS = 64_000
+// Sized for ~3× the realistic worst-case review (2 narrative fields + ~10
+// findings per check at ~50 tokens each ≈ 4-5K tokens). The schema property
+// `description` strings below carry the actual length guidance to the model;
+// this cap exists only to bound runaway output if the model ignores them.
+const DEFAULT_MAX_TOKENS = 16_000
 const DEFAULT_MAX_RETRIES = 3
 
 const ANALYSIS_TOOL_NAME = 'submit_analysis'
@@ -27,15 +28,31 @@ const ANALYSIS_TOOL: Anthropic.Messages.Tool = {
         type: 'object',
         additionalProperties: false,
         properties: {
-            proposalSummary: { type: 'string' },
-            codeExplanation: { type: 'string' },
-            resultsSummary: { type: 'string' },
+            proposalSummary: {
+                type: 'string',
+                description: 'Concise summary of the proposal goals. 2-3 sentences, ~80 words max.',
+            },
+            codeExplanation: {
+                type: 'string',
+                description:
+                    'What the code does, referencing file paths. One paragraph, ~150 words max. Use numbered steps if helpful.',
+            },
+            resultsSummary: {
+                type: 'string',
+                description:
+                    'Summary of researcher test results if provided. One paragraph, ~150 words max. Omit this field entirely when no results are provided.',
+            },
             alignmentCheck: {
                 type: 'object',
                 additionalProperties: false,
                 properties: {
                     isAligned: { type: 'boolean' },
-                    findings: { type: 'array', items: { type: 'string' } },
+                    findings: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description:
+                            'Specific discrepancies between proposal and code. At most 10 items, ordered by severity. Each finding 1-2 sentences. Empty array when fully aligned.',
+                    },
                 },
                 required: ['isAligned', 'findings'],
             },
@@ -44,7 +61,12 @@ const ANALYSIS_TOOL: Anthropic.Messages.Tool = {
                 additionalProperties: false,
                 properties: {
                     isCompliant: { type: 'boolean' },
-                    findings: { type: 'array', items: { type: 'string' } },
+                    findings: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description:
+                            'Specific violations of the reference documents or org requirements. At most 10 items, ordered by severity. Each finding 1-2 sentences. Empty array when fully compliant.',
+                    },
                 },
                 required: ['isCompliant', 'findings'],
             },

--- a/src/server/agents/review-agent/agent.ts
+++ b/src/server/agents/review-agent/agent.ts
@@ -9,18 +9,27 @@ const DEFAULT_MAX_RETRIES = 3
 
 const ANALYSIS_TOOL_NAME = 'submit_analysis'
 
+// `strict: true` opts into Anthropic's constrained-decoding tool mode. The
+// model can no longer emit a shape that violates `input_schema` — the class of
+// "alignmentCheck came back as an XML-tag string fragment" prod bug is fixed
+// at the API boundary, not in our app. Requires `additionalProperties: false`
+// at every object level. Docs:
+//   https://platform.claude.com/docs/en/build-with-claude/structured-outputs
 const ANALYSIS_TOOL: Anthropic.Messages.Tool = {
     name: ANALYSIS_TOOL_NAME,
     description:
         'Submit the structured review of the research proposal. Always call this tool exactly once with the full report.',
+    strict: true,
     input_schema: {
         type: 'object',
+        additionalProperties: false,
         properties: {
             proposalSummary: { type: 'string' },
             codeExplanation: { type: 'string' },
             resultsSummary: { type: 'string' },
             alignmentCheck: {
                 type: 'object',
+                additionalProperties: false,
                 properties: {
                     isAligned: { type: 'boolean' },
                     findings: { type: 'array', items: { type: 'string' } },
@@ -29,6 +38,7 @@ const ANALYSIS_TOOL: Anthropic.Messages.Tool = {
             },
             complianceCheck: {
                 type: 'object',
+                additionalProperties: false,
                 properties: {
                     isCompliant: { type: 'boolean' },
                     findings: { type: 'array', items: { type: 'string' } },

--- a/src/server/agents/review-agent/agent.ts
+++ b/src/server/agents/review-agent/agent.ts
@@ -1,5 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk'
 import { buildAnalysisPrompt, DEFAULT_SYSTEM_INSTRUCTION } from './prompts'
+import { analysisReportSchema } from './types'
 import type { AnalysisReport, AnalysisResult, ReviewAgentConfig, ReviewContent, ReviewMessage } from './types'
 
 const DEFAULT_MODEL = process.env.ANTHROPIC_MODEL ?? 'claude-sonnet-4-6'
@@ -39,6 +40,13 @@ const ANALYSIS_TOOL: Anthropic.Messages.Tool = {
     },
 }
 
+const RETRY_NUDGE =
+    'Your previous response did not call the `submit_analysis` tool with the exact required shape. ' +
+    'You MUST call `submit_analysis` exactly once. Every required field must be a real value of the ' +
+    'correct type — `alignmentCheck` and `complianceCheck` must each be objects with `isAligned`/' +
+    '`isCompliant` (boolean) and `findings` (array of strings). Do not return XML, parameter tags, ' +
+    'or string fragments — only the structured tool call.'
+
 function resolveClient(config: ReviewAgentConfig): Anthropic {
     if (config.client) return config.client
     if (config.apiKey) {
@@ -72,7 +80,7 @@ function buildPromptForContent(content: ReviewContent, templateOverride?: string
     )
 }
 
-function extractReport(response: Anthropic.Messages.Message): AnalysisReport {
+function extractToolInput(response: Anthropic.Messages.Message): unknown {
     const toolUse = response.content.find(
         (block): block is Anthropic.Messages.ToolUseBlock =>
             block.type === 'tool_use' && block.name === ANALYSIS_TOOL_NAME,
@@ -82,12 +90,22 @@ function extractReport(response: Anthropic.Messages.Message): AnalysisReport {
         throw new Error('The model did not return a structured analysis.')
     }
 
-    return toolUse.input as AnalysisReport
+    return toolUse.input
+}
+
+function parseReport(input: unknown): AnalysisReport {
+    return analysisReportSchema.parse(input)
 }
 
 /**
  * Run a one-shot structured review. Returns the parsed report plus the
  * conversation seed (`messages`) — persist `messages` to enable chat follow-up.
+ *
+ * If the first response fails schema validation, retries once with a stricter
+ * nudge appended to the conversation. The retry path was added after a
+ * Sonnet response was observed putting findings at the top level and writing
+ * XML-parameter fragments into the alignmentCheck/complianceCheck slots; the
+ * persisted row then crashed the UI when reading `findings.length`.
  *
  * Future chat extension (target: before Oct 2026) — add alongside this fn:
  *
@@ -104,22 +122,50 @@ function extractReport(response: Anthropic.Messages.Message): AnalysisReport {
 export async function generateAnalysis(config: ReviewAgentConfig, content: ReviewContent): Promise<AnalysisResult> {
     const client = resolveClient(config)
     const prompt = buildPromptForContent(content, config.analysisPromptTemplate)
+    const model = config.model ?? DEFAULT_MODEL
+    const maxTokens = config.maxTokens ?? DEFAULT_MAX_TOKENS
+    const system = config.systemPrompt ?? DEFAULT_SYSTEM_INSTRUCTION
 
-    const response = await client.messages.create({
-        model: config.model ?? DEFAULT_MODEL,
-        max_tokens: config.maxTokens ?? DEFAULT_MAX_TOKENS,
-        system: config.systemPrompt ?? DEFAULT_SYSTEM_INSTRUCTION,
+    const initialMessages: Anthropic.Messages.MessageParam[] = [{ role: 'user', content: prompt }]
+
+    const firstResponse = await client.messages.create({
+        model,
+        max_tokens: maxTokens,
+        system,
         tools: [ANALYSIS_TOOL],
         tool_choice: { type: 'tool', name: ANALYSIS_TOOL_NAME },
-        messages: [{ role: 'user', content: prompt }],
+        messages: initialMessages,
     })
 
-    const report = extractReport(response)
+    const firstInput = extractToolInput(firstResponse)
+    const firstParse = analysisReportSchema.safeParse(firstInput)
+    if (firstParse.success) {
+        return buildResult(firstParse.data, prompt)
+    }
 
+    const retryMessages: Anthropic.Messages.MessageParam[] = [
+        ...initialMessages,
+        { role: 'assistant', content: JSON.stringify(firstInput) },
+        { role: 'user', content: RETRY_NUDGE },
+    ]
+
+    const retryResponse = await client.messages.create({
+        model,
+        max_tokens: maxTokens,
+        system,
+        tools: [ANALYSIS_TOOL],
+        tool_choice: { type: 'tool', name: ANALYSIS_TOOL_NAME },
+        messages: retryMessages,
+    })
+
+    const report = parseReport(extractToolInput(retryResponse))
+    return buildResult(report, prompt)
+}
+
+function buildResult(report: AnalysisReport, prompt: string): AnalysisResult {
     const messages: ReviewMessage[] = [
         { role: 'user', content: prompt },
         { role: 'assistant', content: JSON.stringify(report) },
     ]
-
     return { report, messages }
 }

--- a/src/server/agents/review-agent/agent.ts
+++ b/src/server/agents/review-agent/agent.ts
@@ -4,7 +4,10 @@ import { analysisReportSchema } from './types'
 import type { AnalysisReport, AnalysisResult, ReviewAgentConfig, ReviewContent, ReviewMessage } from './types'
 
 const DEFAULT_MODEL = process.env.ANTHROPIC_MODEL ?? 'claude-sonnet-4-6'
-const DEFAULT_MAX_TOKENS = 4096
+// Sonnet 4.6 supports up to 64K output tokens. The review can contain many
+// long `findings` strings under each check, so we leave headroom rather than
+// risking a `stop_reason: 'max_tokens'` truncation mid-tool-call.
+const DEFAULT_MAX_TOKENS = 64_000
 const DEFAULT_MAX_RETRIES = 3
 
 const ANALYSIS_TOOL_NAME = 'submit_analysis'
@@ -84,6 +87,18 @@ function buildPromptForContent(content: ReviewContent, templateOverride?: string
 }
 
 function extractReport(response: Anthropic.Messages.Message): AnalysisReport {
+    // Structured-outputs doc explicitly calls out two degenerate paths where the
+    // response can be 200 OK but the tool_use block is missing or partial:
+    //   - `stop_reason: 'refusal'` — safety refusal takes precedence over schema
+    //   - `stop_reason: 'max_tokens'` — output truncated mid-tool-call
+    // Surface both with specific messages so Sentry alerts are actionable.
+    if (response.stop_reason === 'refusal') {
+        throw new Error('The model refused to generate an analysis.')
+    }
+    if (response.stop_reason === 'max_tokens') {
+        throw new Error('The model response was truncated by max_tokens — raise the limit.')
+    }
+
     const toolUse = response.content.find(
         (block): block is Anthropic.Messages.ToolUseBlock =>
             block.type === 'tool_use' && block.name === ANALYSIS_TOOL_NAME,

--- a/src/server/agents/review-agent/runner.test.ts
+++ b/src/server/agents/review-agent/runner.test.ts
@@ -179,4 +179,25 @@ describe('generateAndStoreStudyReview', () => {
 
         expect(generateAnalysisMock).not.toHaveBeenCalled()
     })
+
+    it('writes the disabled-review placeholder and skips the agent when CLAUDE_API_KEY is unset', async () => {
+        getConfigValueMock.mockResolvedValue(undefined)
+        const org = await insertTestOrg()
+        const { job } = await insertTestStudyJobData({ org })
+
+        await generateAndStoreStudyReview(job.id)
+
+        expect(generateAnalysisMock).not.toHaveBeenCalled()
+
+        const stored = await db
+            .selectFrom('studyReview')
+            .select('report')
+            .where('studyJobId', '=', job.id)
+            .executeTakeFirst()
+        expect(stored).toBeDefined()
+        const report = JSON.parse(stored!.report as unknown as string)
+        expect(report.proposalSummary).toMatch(/disabled/i)
+        expect(report.alignmentCheck.findings).toEqual([])
+        expect(report.complianceCheck.findings).toEqual([])
+    })
 })

--- a/src/server/agents/review-agent/runner.test.ts
+++ b/src/server/agents/review-agent/runner.test.ts
@@ -196,8 +196,11 @@ describe('generateAndStoreStudyReview', () => {
             .executeTakeFirst()
         expect(stored).toBeDefined()
         const report = stored!.report
-        expect(report.proposalSummary).toMatch(/disabled/i)
-        expect(report.alignmentCheck.findings).toEqual([])
-        expect(report.complianceCheck.findings).toEqual([])
+        expect(report.proposalSummary).toMatch(/did not run|disabled/i)
+        // Booleans must be false so the UI doesn't render a missing review as passing.
+        expect(report.alignmentCheck.isAligned).toBe(false)
+        expect(report.complianceCheck.isCompliant).toBe(false)
+        expect(report.alignmentCheck.findings.length).toBeGreaterThan(0)
+        expect(report.complianceCheck.findings.length).toBeGreaterThan(0)
     })
 })

--- a/src/server/agents/review-agent/runner.test.ts
+++ b/src/server/agents/review-agent/runner.test.ts
@@ -191,11 +191,11 @@ describe('generateAndStoreStudyReview', () => {
 
         const stored = await db
             .selectFrom('studyReview')
-            .select('report')
+            .select((eb) => eb.ref('report').$castTo<AnalysisReport>().as('report'))
             .where('studyJobId', '=', job.id)
             .executeTakeFirst()
         expect(stored).toBeDefined()
-        const report = JSON.parse(stored!.report as unknown as string)
+        const report = stored!.report
         expect(report.proposalSummary).toMatch(/disabled/i)
         expect(report.alignmentCheck.findings).toEqual([])
         expect(report.complianceCheck.findings).toEqual([])

--- a/src/server/agents/review-agent/runner.ts
+++ b/src/server/agents/review-agent/runner.ts
@@ -6,11 +6,23 @@ import type { AnalysisReport, ReviewContent } from './types'
 import { getConfigValue } from '@/server/config'
 import { fetchFileContents } from '@/server/storage'
 
+// Written when the API key is missing, before content assembly. This means a
+// no-code-files study with a missing key gets the placeholder too — fine, since
+// either condition prevents a real review. Sentinel is "automated review didn't
+// run," not strictly "key missing." Booleans are intentionally `false` so the
+// UI renders red Misaligned / Non-compliant badges — a missing review must NOT
+// look like a passing review to a reviewer.
 const DISABLED_REPORT: AnalysisReport = {
-    proposalSummary: 'AI code review is disabled for this environment — CLAUDE_API_KEY is not configured.',
-    codeExplanation: 'No automated review was generated.',
-    alignmentCheck: { isAligned: true, findings: [] },
-    complianceCheck: { isCompliant: true, findings: [] },
+    proposalSummary: 'Automated AI review did not run — CLAUDE_API_KEY is not configured for this environment.',
+    codeExplanation: 'Manual review required.',
+    alignmentCheck: {
+        isAligned: false,
+        findings: ['Automated review did not run for this submission.'],
+    },
+    complianceCheck: {
+        isCompliant: false,
+        findings: ['Automated review did not run for this submission.'],
+    },
 }
 
 const MAX_FILE_SIZE_BYTES = 100_000

--- a/src/server/agents/review-agent/runner.ts
+++ b/src/server/agents/review-agent/runner.ts
@@ -2,9 +2,16 @@ import { db, jsonArrayFrom } from '@/database'
 import logger from '@/lib/logger'
 import { extractTextFromLexical } from '@/lib/word-count'
 import { generateAnalysis } from './agent'
-import type { ReviewContent } from './types'
+import type { AnalysisReport, ReviewContent } from './types'
 import { getConfigValue } from '@/server/config'
 import { fetchFileContents } from '@/server/storage'
+
+const DISABLED_REPORT: AnalysisReport = {
+    proposalSummary: 'AI code review is disabled for this environment — CLAUDE_API_KEY is not configured.',
+    codeExplanation: 'No automated review was generated.',
+    alignmentCheck: { isAligned: true, findings: [] },
+    complianceCheck: { isCompliant: true, findings: [] },
+}
 
 const MAX_FILE_SIZE_BYTES = 100_000
 const MAX_FILE_COUNT = 10
@@ -138,10 +145,15 @@ export async function generateAndStoreStudyReview(studyJobId: string): Promise<v
         return
     }
 
+    const apiKey = await getConfigValue('CLAUDE_API_KEY', false)
+    if (!apiKey) {
+        logger.warn('CLAUDE_API_KEY not configured — writing disabled-review placeholder', { studyJobId })
+        await persistReport(studyJobId, DISABLED_REPORT)
+        return
+    }
+
     const content = await assembleReviewContent(studyJobId)
     if (!content) return
-
-    const apiKey = await getConfigValue('CLAUDE_API_KEY')
 
     // TODO(SI-Admin): once the SI Admin org-level config schema lands, fetch
     // `systemPrompt` and `analysisPromptTemplate` overrides for `job.orgId`
@@ -152,14 +164,14 @@ export async function generateAndStoreStudyReview(studyJobId: string): Promise<v
     // (target: before Oct 2026). Seed for `continueChat`.
     const { report } = await generateAnalysis({ apiKey }, content)
 
+    await persistReport(studyJobId, report)
+    logger.info(`Study review generated and stored`, { studyJobId })
+}
+
+async function persistReport(studyJobId: string, report: AnalysisReport): Promise<void> {
     await db
         .insertInto('studyReview')
-        .values({
-            studyJobId,
-            report: JSON.stringify(report),
-        })
+        .values({ studyJobId, report: JSON.stringify(report) })
         .onConflict((oc) => oc.column('studyJobId').doNothing())
         .execute()
-
-    logger.info(`Study review generated and stored`, { studyJobId })
 }

--- a/src/server/agents/review-agent/types.ts
+++ b/src/server/agents/review-agent/types.ts
@@ -55,11 +55,11 @@ export const analysisReportSchema = z.object({
     resultsSummary: z.string().optional(),
     alignmentCheck: z.object({
         isAligned: z.boolean(),
-        findings: z.array(z.string()),
+        findings: z.array(z.string()).default([]),
     }),
     complianceCheck: z.object({
         isCompliant: z.boolean(),
-        findings: z.array(z.string()),
+        findings: z.array(z.string()).default([]),
     }),
 })
 

--- a/src/server/agents/review-agent/types.ts
+++ b/src/server/agents/review-agent/types.ts
@@ -46,13 +46,9 @@ export interface ReviewAgentConfig {
     maxRetries?: number
 }
 
-/**
- * Runtime validator for AnalysisReport. The Anthropic tool-use JSON-schema is
- * advisory — Claude has been observed returning malformed shapes (e.g. string
- * fragments where objects are required). Use this schema to validate both the
- * model's response in the agent AND any persisted row before passing it to
- * the UI, since older rows pre-date the agent-side validation.
- */
+// Validates both the model's tool-use payload and any persisted row before
+// rendering — Anthropic's JSON-schema for tools is advisory, so the boundary
+// check is what actually guarantees shape.
 export const analysisReportSchema = z.object({
     proposalSummary: z.string(),
     codeExplanation: z.string(),

--- a/src/server/agents/review-agent/types.ts
+++ b/src/server/agents/review-agent/types.ts
@@ -1,4 +1,5 @@
 import type Anthropic from '@anthropic-ai/sdk'
+import { z } from 'zod'
 
 /**
  * Reference documents provided by the reviewing organization.
@@ -46,21 +47,30 @@ export interface ReviewAgentConfig {
 }
 
 /**
+ * Runtime validator for AnalysisReport. The Anthropic tool-use JSON-schema is
+ * advisory — Claude has been observed returning malformed shapes (e.g. string
+ * fragments where objects are required). Use this schema to validate both the
+ * model's response in the agent AND any persisted row before passing it to
+ * the UI, since older rows pre-date the agent-side validation.
+ */
+export const analysisReportSchema = z.object({
+    proposalSummary: z.string(),
+    codeExplanation: z.string(),
+    resultsSummary: z.string().optional(),
+    alignmentCheck: z.object({
+        isAligned: z.boolean(),
+        findings: z.array(z.string()),
+    }),
+    complianceCheck: z.object({
+        isCompliant: z.boolean(),
+        findings: z.array(z.string()),
+    }),
+})
+
+/**
  * Structured analysis output from the ReviewAgent.
  */
-export interface AnalysisReport {
-    proposalSummary: string
-    codeExplanation: string
-    resultsSummary?: string
-    alignmentCheck: {
-        isAligned: boolean
-        findings: string[]
-    }
-    complianceCheck: {
-        isCompliant: boolean
-        findings: string[]
-    }
-}
+export type AnalysisReport = z.infer<typeof analysisReportSchema>
 
 /**
  * Single message in a review conversation. Stored alongside the report so

--- a/src/server/agents/review-agent/types.ts
+++ b/src/server/agents/review-agent/types.ts
@@ -46,20 +46,22 @@ export interface ReviewAgentConfig {
     maxRetries?: number
 }
 
-// Validates both the model's tool-use payload and any persisted row before
-// rendering — Anthropic's JSON-schema for tools is advisory, so the boundary
-// check is what actually guarantees shape.
+// Shape is guaranteed at decode time by Anthropic's `strict: true` tool mode
+// (see ANALYSIS_TOOL in agent.ts). This schema mirrors that contract for two
+// reasons: (1) deriving `AnalysisReport` from one source so the TS type and
+// the API contract can't drift; (2) belt-and-suspenders runtime check at the
+// write boundary in case of SDK/model regression.
 export const analysisReportSchema = z.object({
     proposalSummary: z.string(),
     codeExplanation: z.string(),
     resultsSummary: z.string().optional(),
     alignmentCheck: z.object({
         isAligned: z.boolean(),
-        findings: z.array(z.string()).default([]),
+        findings: z.array(z.string()),
     }),
     complianceCheck: z.object({
         isCompliant: z.boolean(),
-        findings: z.array(z.string()).default([]),
+        findings: z.array(z.string()),
     }),
 })
 

--- a/src/server/db/queries.test.ts
+++ b/src/server/db/queries.test.ts
@@ -193,7 +193,7 @@ describe('getStudyReviewForJob', () => {
         expect(result).toBeNull()
     })
 
-    it('returns the review with meta when the stored row validates', async () => {
+    it('returns the review with meta when a row exists', async () => {
         const { job } = await insertTestStudyJobData()
         const report = {
             proposalSummary: 'Studying student outcomes.',
@@ -207,29 +207,9 @@ describe('getStudyReviewForJob', () => {
             .execute()
 
         const result = await getStudyReviewForJob(job.id)
-        if (result === null || result === 'malformed') throw new Error('expected review')
+        if (!result) throw new Error('expected review')
         expect(result.report).toEqual(report)
         expect(result.createdAt).toBeInstanceOf(Date)
         expect(result.files).toEqual([])
-    })
-
-    it('returns "malformed" when the stored report fails schema validation', async () => {
-        const { job } = await insertTestStudyJobData()
-        // Reproduces the prod bug: findings at the top level, alignmentCheck/complianceCheck
-        // are string fragments instead of objects.
-        const malformed = {
-            proposalSummary: 'summary',
-            codeExplanation: 'explanation',
-            findings: ['top-level finding'],
-            alignmentCheck: '\n<parameter name="isAligned">false',
-            complianceCheck: '\n<parameter name="isCompliant">false',
-        }
-        await db
-            .insertInto('studyReview')
-            .values({ studyJobId: job.id, report: JSON.stringify(malformed) })
-            .execute()
-
-        const result = await getStudyReviewForJob(job.id)
-        expect(result).toBe('malformed')
     })
 })

--- a/src/server/db/queries.test.ts
+++ b/src/server/db/queries.test.ts
@@ -187,13 +187,13 @@ describe('getOrgPublicKeys', () => {
 })
 
 describe('getStudyReviewForJob', () => {
-    it('returns null when no review exists for the job', async () => {
+    it('returns kind="missing" when no review exists for the job', async () => {
         const { job } = await insertTestStudyJobData()
         const result = await getStudyReviewForJob(job.id)
-        expect(result).toBeNull()
+        expect(result).toEqual({ kind: 'missing' })
     })
 
-    it('returns the stored report along with createdAt and files for the job', async () => {
+    it('returns kind="ok" with the stored report when the row validates', async () => {
         const { job } = await insertTestStudyJobData()
         const report = {
             proposalSummary: 'Studying student outcomes.',
@@ -207,9 +207,32 @@ describe('getStudyReviewForJob', () => {
             .execute()
 
         const result = await getStudyReviewForJob(job.id)
-        expect(result).not.toBeNull()
-        expect(result?.report).toEqual(report)
-        expect(result?.createdAt).toBeInstanceOf(Date)
-        expect(result?.files).toEqual([])
+        expect(result.kind).toBe('ok')
+        if (result.kind !== 'ok') return
+        expect(result.review.report).toEqual(report)
+        expect(result.review.createdAt).toBeInstanceOf(Date)
+        expect(result.review.files).toEqual([])
+    })
+
+    it('returns kind="malformed" when the stored report fails schema validation', async () => {
+        const { job } = await insertTestStudyJobData()
+        // Reproduces the prod bug: findings at the top level, alignmentCheck/complianceCheck
+        // are string fragments instead of objects.
+        const malformed = {
+            proposalSummary: 'summary',
+            codeExplanation: 'explanation',
+            findings: ['top-level finding'],
+            alignmentCheck: '\n<parameter name="isAligned">false',
+            complianceCheck: '\n<parameter name="isCompliant">false',
+        }
+        await db
+            .insertInto('studyReview')
+            .values({ studyJobId: job.id, report: JSON.stringify(malformed) })
+            .execute()
+
+        const result = await getStudyReviewForJob(job.id)
+        expect(result.kind).toBe('malformed')
+        if (result.kind !== 'malformed') return
+        expect(result.createdAt).toBeInstanceOf(Date)
     })
 })

--- a/src/server/db/queries.test.ts
+++ b/src/server/db/queries.test.ts
@@ -187,13 +187,13 @@ describe('getOrgPublicKeys', () => {
 })
 
 describe('getStudyReviewForJob', () => {
-    it('returns kind="missing" when no review exists for the job', async () => {
+    it('returns null when no review exists for the job', async () => {
         const { job } = await insertTestStudyJobData()
         const result = await getStudyReviewForJob(job.id)
-        expect(result).toEqual({ kind: 'missing' })
+        expect(result).toBeNull()
     })
 
-    it('returns kind="ok" with the stored report when the row validates', async () => {
+    it('returns the review with meta when the stored row validates', async () => {
         const { job } = await insertTestStudyJobData()
         const report = {
             proposalSummary: 'Studying student outcomes.',
@@ -207,14 +207,13 @@ describe('getStudyReviewForJob', () => {
             .execute()
 
         const result = await getStudyReviewForJob(job.id)
-        expect(result.kind).toBe('ok')
-        if (result.kind !== 'ok') return
-        expect(result.review.report).toEqual(report)
-        expect(result.review.createdAt).toBeInstanceOf(Date)
-        expect(result.review.files).toEqual([])
+        if (result === null || result === 'malformed') throw new Error('expected review')
+        expect(result.report).toEqual(report)
+        expect(result.createdAt).toBeInstanceOf(Date)
+        expect(result.files).toEqual([])
     })
 
-    it('returns kind="malformed" when the stored report fails schema validation', async () => {
+    it('returns "malformed" when the stored report fails schema validation', async () => {
         const { job } = await insertTestStudyJobData()
         // Reproduces the prod bug: findings at the top level, alignmentCheck/complianceCheck
         // are string fragments instead of objects.
@@ -231,8 +230,6 @@ describe('getStudyReviewForJob', () => {
             .execute()
 
         const result = await getStudyReviewForJob(job.id)
-        expect(result.kind).toBe('malformed')
-        if (result.kind !== 'malformed') return
-        expect(result.createdAt).toBeInstanceOf(Date)
+        expect(result).toBe('malformed')
     })
 })

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -397,10 +397,7 @@ export type StudyReviewWithMeta = {
     files: { name: string; fileType: FileType }[]
 }
 
-export type StudyReviewLookup =
-    | { kind: 'missing' }
-    | { kind: 'malformed'; createdAt: Date }
-    | { kind: 'ok'; review: StudyReviewWithMeta }
+export type StudyReviewLookup = StudyReviewWithMeta | 'malformed' | null
 
 export async function getStudyReviewForJob(studyJobId: string): Promise<StudyReviewLookup> {
     const row = await Action.db
@@ -423,7 +420,7 @@ export async function getStudyReviewForJob(studyJobId: string): Promise<StudyRev
         .limit(1)
         .executeTakeFirst()
 
-    if (!row) return { kind: 'missing' }
+    if (!row) return null
 
     const parsed = analysisReportSchema.safeParse(row.report)
     if (!parsed.success) {
@@ -432,8 +429,8 @@ export async function getStudyReviewForJob(studyJobId: string): Promise<StudyRev
             createdAt: row.createdAt,
             issues: parsed.error.issues,
         })
-        return { kind: 'malformed', createdAt: row.createdAt }
+        return 'malformed'
     }
 
-    return { kind: 'ok', review: { report: parsed.data, createdAt: row.createdAt, files: row.files } }
+    return { report: parsed.data, createdAt: row.createdAt, files: row.files }
 }

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -8,7 +8,8 @@ import { FileType } from '@/database/types'
 import { Selectable } from 'kysely'
 import { Action } from '../actions/action'
 import type { PublicKey } from 'si-encryption/job-results/types'
-import type { AnalysisReport } from '@/server/agents/review-agent/types'
+import { analysisReportSchema, type AnalysisReport } from '@/server/agents/review-agent/types'
+import logger from '@/lib/logger'
 
 export type SiUser = ClerkUser & {
     id: string
@@ -396,11 +397,16 @@ export type StudyReviewWithMeta = {
     files: { name: string; fileType: FileType }[]
 }
 
-export async function getStudyReviewForJob(studyJobId: string): Promise<StudyReviewWithMeta | null> {
+export type StudyReviewLookup =
+    | { kind: 'missing' }
+    | { kind: 'malformed'; createdAt: Date }
+    | { kind: 'ok'; review: StudyReviewWithMeta }
+
+export async function getStudyReviewForJob(studyJobId: string): Promise<StudyReviewLookup> {
     const row = await Action.db
         .selectFrom('studyReview')
         .select((eb) => [
-            eb.ref('report').$castTo<AnalysisReport>().as('report'),
+            eb.ref('report').$castTo<unknown>().as('report'),
             'createdAt',
             jsonArrayFrom(
                 eb
@@ -416,5 +422,18 @@ export async function getStudyReviewForJob(studyJobId: string): Promise<StudyRev
         .orderBy('createdAt', 'desc')
         .limit(1)
         .executeTakeFirst()
-    return row ?? null
+
+    if (!row) return { kind: 'missing' }
+
+    const parsed = analysisReportSchema.safeParse(row.report)
+    if (!parsed.success) {
+        logger.warn('study_review row failed schema validation', {
+            studyJobId,
+            createdAt: row.createdAt,
+            issues: parsed.error.issues,
+        })
+        return { kind: 'malformed', createdAt: row.createdAt }
+    }
+
+    return { kind: 'ok', review: { report: parsed.data, createdAt: row.createdAt, files: row.files } }
 }

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -8,8 +8,7 @@ import { FileType } from '@/database/types'
 import { Selectable } from 'kysely'
 import { Action } from '../actions/action'
 import type { PublicKey } from 'si-encryption/job-results/types'
-import { analysisReportSchema, type AnalysisReport } from '@/server/agents/review-agent/types'
-import logger from '@/lib/logger'
+import type { AnalysisReport } from '@/server/agents/review-agent/types'
 
 export type SiUser = ClerkUser & {
     id: string
@@ -397,13 +396,11 @@ export type StudyReviewWithMeta = {
     files: { name: string; fileType: FileType }[]
 }
 
-export type StudyReviewLookup = StudyReviewWithMeta | 'malformed' | null
-
-export async function getStudyReviewForJob(studyJobId: string): Promise<StudyReviewLookup> {
+export async function getStudyReviewForJob(studyJobId: string): Promise<StudyReviewWithMeta | null> {
     const row = await Action.db
         .selectFrom('studyReview')
         .select((eb) => [
-            eb.ref('report').$castTo<unknown>().as('report'),
+            eb.ref('report').$castTo<AnalysisReport>().as('report'),
             'createdAt',
             jsonArrayFrom(
                 eb
@@ -420,17 +417,5 @@ export async function getStudyReviewForJob(studyJobId: string): Promise<StudyRev
         .limit(1)
         .executeTakeFirst()
 
-    if (!row) return null
-
-    const parsed = analysisReportSchema.safeParse(row.report)
-    if (!parsed.success) {
-        logger.warn('study_review row failed schema validation', {
-            studyJobId,
-            createdAt: row.createdAt,
-            issues: parsed.error.issues,
-        })
-        return 'malformed'
-    }
-
-    return { report: parsed.data, createdAt: row.createdAt, files: row.files }
+    return row ?? null
 }


### PR DESCRIPTION
@nathanstitt I piggy-backed on your PR and tried to simplify a bit - I think the direction you went with the auto-retries + status tracking of the review (error/pending/malformed/finished/etc) might be better solved by implementing a more robust queue/job feature like we talked about in the dev roundtable - I think we should probably decide on something (SQS? Needs to support serverless right?) and this would be a great first candidate to implement/prove that out with


For now, dealing with those small drift/json output errors - i ended up learning about [structured outputs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs) - you can see in `agent.ts` how its working. That should get us the hardening we need for now without implementing a full job/queue for this iteration (hopefully 🤞)

Let me know what you think about all this, super open to ideas too but I wanted to keep the fix/implementation a bit smaller/simpler until the architecture change can do the heavy lifting