### PR TITLE
OTTER-521: fix View as reviewer crash on edit-and-resubmit page

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.tsx
@@ -91,6 +91,8 @@ export const EditResubmitFooter: FC<EditResubmitFooterProps> = ({ researcherName
 
             <AppModal size="xl" isOpen={isReviewerOpen} onClose={() => setReviewerOpen(false)} title="View as reviewer">
                 <ReviewerPreview
+                    studyId={studyId}
+                    values={form.getValues()}
                     researcherName={researcherName}
                     researcherId={researcherId}
                     piUserId={form.values.piUserId}

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.tsx
@@ -92,10 +92,9 @@ export const EditResubmitFooter: FC<EditResubmitFooterProps> = ({ researcherName
             <AppModal size="xl" isOpen={isReviewerOpen} onClose={() => setReviewerOpen(false)} title="View as reviewer">
                 <ReviewerPreview
                     studyId={studyId}
-                    values={form.getValues()}
+                    values={form.values}
                     researcherName={researcherName}
                     researcherId={researcherId}
-                    piUserId={form.values.piUserId}
                     enclaveOrgSlug={enclaveOrgSlug}
                 />
             </AppModal>

--- a/src/app/[orgSlug]/study/[studyId]/proposal/footer.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/footer.tsx
@@ -87,6 +87,8 @@ export const ProposalFooter: FC<ProposalFooterProps> = ({ researcherName, resear
                 title="View as reviewer"
             >
                 <ReviewerPreview
+                    studyId={studyId}
+                    values={form.getValues()}
                     researcherName={researcherName}
                     researcherId={researcherId}
                     piUserId={piUserId}

--- a/src/app/[orgSlug]/study/[studyId]/proposal/footer.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/footer.tsx
@@ -13,11 +13,10 @@ import { ReviewerPreview } from './reviewer-preview'
 interface ProposalFooterProps {
     researcherName: string
     researcherId: string
-    piUserId: string
     enclaveOrgSlug?: string
 }
 
-export const ProposalFooter: FC<ProposalFooterProps> = ({ researcherName, researcherId, piUserId, enclaveOrgSlug }) => {
+export const ProposalFooter: FC<ProposalFooterProps> = ({ researcherName, researcherId, enclaveOrgSlug }) => {
     const router = useRouter()
     const { orgSlug } = useParams<{ orgSlug: string }>()
     const { studyId, form, saveDraft, submitProposal, isSaving, isSubmitting } = useProposal()
@@ -88,10 +87,9 @@ export const ProposalFooter: FC<ProposalFooterProps> = ({ researcherName, resear
             >
                 <ReviewerPreview
                     studyId={studyId}
-                    values={form.getValues()}
+                    values={form.values}
                     researcherName={researcherName}
                     researcherId={researcherId}
-                    piUserId={piUserId}
                     enclaveOrgSlug={enclaveOrgSlug}
                 />
             </AppModal>

--- a/src/app/[orgSlug]/study/[studyId]/proposal/form.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/form.tsx
@@ -291,7 +291,6 @@ export const ProposalForm: FC<ProposalFormProps> = ({
                     <ProposalFooter
                         researcherName={researcherName}
                         researcherId={researcherId}
-                        piUserId={form.values.piUserId}
                         enclaveOrgSlug={enclaveOrgSlug}
                     />
                 </Stack>

--- a/src/app/[orgSlug]/study/[studyId]/proposal/reviewer-preview.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/reviewer-preview.tsx
@@ -6,29 +6,32 @@ import { useParams } from 'next/navigation'
 import { EditableText } from '@/components/editable-text'
 import { ResearcherProfilePopover } from '@/components/researcher-profile-popover'
 import { extractTextFromLexical } from '@/lib/word-count'
-import { useProposal } from '@/contexts/proposal'
 import { useOrgDataSources } from '@/hooks/use-org-data-sources'
 import { usePopover } from '@/hooks/use-popover'
-import { DEFAULT_DRAFT_TITLE } from './schema'
+import { DEFAULT_DRAFT_TITLE, type ProposalFormValues } from './schema'
 import { editableTextFields } from './field-config'
 
 interface ReviewerPreviewProps {
+    studyId: string
+    values: ProposalFormValues
     researcherName: string
     researcherId: string
     piUserId: string
     enclaveOrgSlug?: string
 }
 
+// Pure presentation — accepts form values + studyId as props so it can be
+// rendered from any context (ProposalProvider, EditResubmitProvider, ...).
 export const ReviewerPreview: FC<ReviewerPreviewProps> = ({
+    studyId,
+    values,
     researcherName,
     researcherId,
     piUserId,
     enclaveOrgSlug,
 }) => {
-    const { form, studyId } = useProposal()
     const { orgSlug } = useParams<{ orgSlug: string }>()
     const { options: datasetOptions } = useOrgDataSources(enclaveOrgSlug)
-    const values = form.getValues()
     const { getPopoverProps } = usePopover()
 
     return (

--- a/src/app/[orgSlug]/study/[studyId]/proposal/reviewer-preview.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/reviewer-preview.tsx
@@ -16,7 +16,6 @@ interface ReviewerPreviewProps {
     values: ProposalFormValues
     researcherName: string
     researcherId: string
-    piUserId: string
     enclaveOrgSlug?: string
 }
 
@@ -27,7 +26,6 @@ export const ReviewerPreview: FC<ReviewerPreviewProps> = ({
     values,
     researcherName,
     researcherId,
-    piUserId,
     enclaveOrgSlug,
 }) => {
     const { orgSlug } = useParams<{ orgSlug: string }>()
@@ -86,9 +84,9 @@ export const ReviewerPreview: FC<ReviewerPreviewProps> = ({
                 <Text size="sm" fw={600} mb="xs">
                     Principal Investigator
                 </Text>
-                {piUserId ? (
+                {values.piUserId ? (
                     <ResearcherProfilePopover
-                        userId={piUserId}
+                        userId={values.piUserId}
                         studyId={studyId}
                         orgSlug={orgSlug}
                         name={values.piName}


### PR DESCRIPTION
Fixes:
"View as reviewer" crash on /edit-and-resubmit. 
ReviewerPreview was using useProposal() but the page is inside EditResubmitProvider. 
Refactored to take values + studyId as props; both callers updated.