### PR TITLE
OTTER-522: Version proposal entries on the post-resubmission view

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
@@ -167,12 +167,17 @@ describe('PostFeedbackView', () => {
         })
 
         it('expands the latest entry by default and collapses older entries', () => {
-            renderWithProviders(
-                <PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[reviewerEntry, researcherEntry]} />,
-            )
+            const scrollHeightSpy = vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(1000)
+            try {
+                renderWithProviders(
+                    <PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[reviewerEntry, researcherEntry]} />,
+                )
 
-            expect(screen.getByTestId('feedback-entry-reviewer-1')).toHaveAttribute('aria-expanded', 'true')
-            expect(screen.getByTestId('feedback-entry-researcher-1')).toHaveAttribute('aria-expanded', 'false')
+                expect(screen.getByTestId('feedback-toggle-reviewer-1')).toHaveAttribute('aria-expanded', 'true')
+                expect(screen.getByTestId('feedback-toggle-researcher-1')).toHaveAttribute('aria-expanded', 'false')
+            } finally {
+                scrollHeightSpy.mockRestore()
+            }
         })
 
         it('titles entries with their stored version', () => {
@@ -209,24 +214,18 @@ describe('PostFeedbackView', () => {
         it('toggles entry expansion on click', async () => {
             // happy-dom doesn't compute real layout, so scrollHeight ≈ clientHeight and
             // isTruncated stays false. Mock a large scrollHeight so the toggle renders.
-            const scrollHeightSpy = vi
-                .spyOn(HTMLElement.prototype, 'scrollHeight', 'get')
-                .mockReturnValue(1000)
+            const scrollHeightSpy = vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(1000)
             try {
                 const user = userEvent.setup()
                 renderWithProviders(
-                    <PostFeedbackView
-                        orgSlug={ORG_SLUG}
-                        study={study}
-                        entries={[reviewerEntry, researcherEntry]}
-                    />,
+                    <PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[reviewerEntry, researcherEntry]} />,
                 )
 
-                const reviewerEntryEl = screen.getByTestId('feedback-entry-reviewer-1')
-                expect(reviewerEntryEl).toHaveAttribute('aria-expanded', 'true')
+                const toggle = screen.getByTestId('feedback-toggle-reviewer-1')
+                expect(toggle).toHaveAttribute('aria-expanded', 'true')
 
-                await user.click(screen.getByTestId('feedback-toggle-reviewer-1'))
-                expect(reviewerEntryEl).toHaveAttribute('aria-expanded', 'false')
+                await user.click(toggle)
+                expect(toggle).toHaveAttribute('aria-expanded', 'false')
             } finally {
                 scrollHeightSpy.mockRestore()
             }

--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
@@ -26,6 +26,7 @@ const buildEntry = (overrides: Partial<ProposalFeedbackEntry> = {}): ProposalFee
         decision: overrides.decision === undefined ? 'APPROVE' : overrides.decision,
         body: overrides.body ?? JSON.parse(lexicalJson('This is the reviewer feedback body.')),
         createdAt: overrides.createdAt ?? new Date('2026-04-16T10:00:00Z'),
+        version: overrides.version ?? null,
     }) as ProposalFeedbackEntry
 
 describe('PostFeedbackView', () => {
@@ -141,6 +142,7 @@ describe('PostFeedbackView', () => {
             decision: 'NEEDS-CLARIFICATION',
             createdAt: new Date('2026-04-20T12:00:00Z'),
             body: JSON.parse(lexicalJson('Latest reviewer note.')),
+            version: 2,
         })
 
         const researcherEntry = buildEntry({
@@ -151,6 +153,7 @@ describe('PostFeedbackView', () => {
             decision: null,
             createdAt: new Date('2026-04-18T08:00:00Z'),
             body: JSON.parse(lexicalJson('Original resubmission note.')),
+            version: 2,
         })
 
         it('orders entries from most recent to oldest', () => {
@@ -170,26 +173,17 @@ describe('PostFeedbackView', () => {
                 <PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[reviewerEntry, researcherEntry]} />,
             )
 
-            expect(screen.getByTestId('feedback-toggle-reviewer-1')).toHaveAttribute('aria-expanded', 'true')
-            expect(screen.getByTestId('feedback-toggle-researcher-1')).toHaveAttribute('aria-expanded', 'false')
+            expect(screen.getByTestId('feedback-entry-reviewer-1')).toHaveAttribute('aria-expanded', 'true')
+            expect(screen.getByTestId('feedback-entry-researcher-1')).toHaveAttribute('aria-expanded', 'false')
         })
 
-        it('titles reviewer entries "Reviewer feedback"', () => {
-            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[reviewerEntry]} />)
-
-            const entry = screen.getByTestId('feedback-entry-reviewer-1')
-            expect(entry).toHaveTextContent('Reviewer feedback')
-        })
-
-        it('titles researcher entries "Resubmission note"', () => {
-            // Include a reviewer entry first so the view's decision header can render —
-            // PostFeedbackView returns null when the latest entry has no decision.
+        it('titles entries with their stored version', () => {
             renderWithProviders(
                 <PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[reviewerEntry, researcherEntry]} />,
             )
 
-            const entry = screen.getByTestId('feedback-entry-researcher-1')
-            expect(entry).toHaveTextContent('Resubmission note')
+            expect(screen.getByTestId('feedback-entry-reviewer-1')).toHaveTextContent('Reviewer feedback (v2.0)')
+            expect(screen.getByTestId('feedback-entry-researcher-1')).toHaveTextContent('Resubmission note (v2.0)')
         })
 
         it('renders author name and date for each entry', () => {
@@ -214,16 +208,17 @@ describe('PostFeedbackView', () => {
             expect(screen.queryByTestId('entry-divider')).not.toBeInTheDocument()
         })
 
-        it('toggles entry expansion on caret click', async () => {
+        it('toggles entry expansion on click', async () => {
             const user = userEvent.setup()
             renderWithProviders(
                 <PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[reviewerEntry, researcherEntry]} />,
             )
 
-            const olderToggle = screen.getByTestId('feedback-toggle-researcher-1')
-            expect(olderToggle).toHaveAttribute('aria-expanded', 'false')
-            await user.click(olderToggle)
-            expect(olderToggle).toHaveAttribute('aria-expanded', 'true')
+            const reviewerEntryEl = screen.getByTestId('feedback-entry-reviewer-1')
+            expect(reviewerEntryEl).toHaveAttribute('aria-expanded', 'true')
+
+            await user.click(screen.getByTestId('feedback-toggle-reviewer-1'))
+            expect(reviewerEntryEl).toHaveAttribute('aria-expanded', 'false')
         })
     })
 

--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/tests/unit.helpers'
 import { useParams } from 'next/navigation'
 import { memoryRouter } from 'next-router-mock'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { PostFeedbackView } from './post-feedback-view'
 
 const ORG_SLUG = 'test-org'
@@ -207,16 +207,29 @@ describe('PostFeedbackView', () => {
         })
 
         it('toggles entry expansion on click', async () => {
-            const user = userEvent.setup()
-            renderWithProviders(
-                <PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[reviewerEntry, researcherEntry]} />,
-            )
+            // happy-dom doesn't compute real layout, so scrollHeight ≈ clientHeight and
+            // isTruncated stays false. Mock a large scrollHeight so the toggle renders.
+            const scrollHeightSpy = vi
+                .spyOn(HTMLElement.prototype, 'scrollHeight', 'get')
+                .mockReturnValue(1000)
+            try {
+                const user = userEvent.setup()
+                renderWithProviders(
+                    <PostFeedbackView
+                        orgSlug={ORG_SLUG}
+                        study={study}
+                        entries={[reviewerEntry, researcherEntry]}
+                    />,
+                )
 
-            const reviewerEntryEl = screen.getByTestId('feedback-entry-reviewer-1')
-            expect(reviewerEntryEl).toHaveAttribute('aria-expanded', 'true')
+                const reviewerEntryEl = screen.getByTestId('feedback-entry-reviewer-1')
+                expect(reviewerEntryEl).toHaveAttribute('aria-expanded', 'true')
 
-            await user.click(screen.getByTestId('feedback-toggle-reviewer-1'))
-            expect(reviewerEntryEl).toHaveAttribute('aria-expanded', 'false')
+                await user.click(screen.getByTestId('feedback-toggle-reviewer-1'))
+                expect(reviewerEntryEl).toHaveAttribute('aria-expanded', 'false')
+            } finally {
+                scrollHeightSpy.mockRestore()
+            }
         })
     })
 

--- a/src/app/[orgSlug]/study/[studyId]/submitted/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/page.tsx
@@ -1,6 +1,7 @@
 import { captureException } from '@sentry/nextjs'
 import { getStudyAction, getProposalFeedbackForStudyAction } from '@/server/actions/study.actions'
 import { getOrgNameFromId } from '@/server/db/queries'
+import { deriveStudyVersion } from '@/lib/studies'
 import { isActionError } from '@/lib/errors'
 import { AlertNotFound } from '@/components/errors'
 import { SubmittedView } from './submitted-view'
@@ -26,7 +27,7 @@ export default async function StudySubmittedRoute(props: { params: Promise<{ stu
     }
 
     const entries = feedbackError ? [] : feedbackResult
-    const studyVersion = entries.length > 0 ? Math.max(...entries.map((e) => e.version ?? 1)) : 1
+    const studyVersion = deriveStudyVersion(entries)
 
     return (
         <SubmittedView

--- a/src/app/[orgSlug]/study/[studyId]/submitted/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/page.tsx
@@ -26,6 +26,7 @@ export default async function StudySubmittedRoute(props: { params: Promise<{ stu
     }
 
     const entries = feedbackError ? [] : feedbackResult
+    const studyVersion = entries.length > 0 ? Math.max(...entries.map((e) => e.version ?? 1)) : 1
 
     return (
         <SubmittedView
@@ -33,6 +34,7 @@ export default async function StudySubmittedRoute(props: { params: Promise<{ stu
             study={result}
             orgName={orgName}
             entries={entries}
+            studyVersion={studyVersion}
             feedbackError={feedbackError}
         />
     )

--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.test.tsx
@@ -11,7 +11,7 @@ import {
     type Mock,
 } from '@/tests/unit.helpers'
 import { useParams } from 'next/navigation'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ProposalSubmitted } from './proposal-submitted'
 
 const ORG_SLUG = 'test-org'
@@ -567,45 +567,60 @@ describe('ProposalSubmitted', () => {
         })
 
         it('expands the latest entry by default', () => {
-            renderWithProviders(
-                <ProposalSubmitted
-                    orgSlug={ORG_SLUG}
-                    study={study}
-                    orgName={ORG_NAME}
-                    entries={[reviewerEntry, researcherEntry]}
-                    studyVersion={2}
-                />,
-            )
+            const scrollHeightSpy = vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(1000)
+            try {
+                renderWithProviders(
+                    <ProposalSubmitted
+                        orgSlug={ORG_SLUG}
+                        study={study}
+                        orgName={ORG_NAME}
+                        entries={[reviewerEntry, researcherEntry]}
+                        studyVersion={2}
+                    />,
+                )
 
-            expect(screen.getByTestId('feedback-entry-reviewer-1')).toHaveAttribute('aria-expanded', 'true')
+                expect(screen.getByTestId('feedback-toggle-reviewer-1')).toHaveAttribute('aria-expanded', 'true')
+            } finally {
+                scrollHeightSpy.mockRestore()
+            }
         })
 
         it('collapses older entries by default', () => {
-            renderWithProviders(
-                <ProposalSubmitted
-                    orgSlug={ORG_SLUG}
-                    study={study}
-                    orgName={ORG_NAME}
-                    entries={[reviewerEntry, researcherEntry]}
-                    studyVersion={2}
-                />,
-            )
+            const scrollHeightSpy = vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(1000)
+            try {
+                renderWithProviders(
+                    <ProposalSubmitted
+                        orgSlug={ORG_SLUG}
+                        study={study}
+                        orgName={ORG_NAME}
+                        entries={[reviewerEntry, researcherEntry]}
+                        studyVersion={2}
+                    />,
+                )
 
-            expect(screen.getByTestId('feedback-entry-researcher-1')).toHaveAttribute('aria-expanded', 'false')
+                expect(screen.getByTestId('feedback-toggle-researcher-1')).toHaveAttribute('aria-expanded', 'false')
+            } finally {
+                scrollHeightSpy.mockRestore()
+            }
         })
 
         it('collapses resubmission notes by default even when latest', () => {
-            renderWithProviders(
-                <ProposalSubmitted
-                    orgSlug={ORG_SLUG}
-                    study={study}
-                    orgName={ORG_NAME}
-                    entries={[researcherEntry, reviewerEntry]}
-                    studyVersion={2}
-                />,
-            )
+            const scrollHeightSpy = vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(1000)
+            try {
+                renderWithProviders(
+                    <ProposalSubmitted
+                        orgSlug={ORG_SLUG}
+                        study={study}
+                        orgName={ORG_NAME}
+                        entries={[researcherEntry, reviewerEntry]}
+                        studyVersion={2}
+                    />,
+                )
 
-            expect(screen.getByTestId('feedback-entry-researcher-1')).toHaveAttribute('aria-expanded', 'false')
+                expect(screen.getByTestId('feedback-toggle-researcher-1')).toHaveAttribute('aria-expanded', 'false')
+            } finally {
+                scrollHeightSpy.mockRestore()
+            }
         })
 
         it('labels multiple resubmission notes with ascending versions', () => {

--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.test.tsx
@@ -27,6 +27,7 @@ const buildEntry = (overrides: Partial<ProposalFeedbackEntry> = {}): ProposalFee
         decision: overrides.decision === undefined ? 'APPROVE' : overrides.decision,
         body: overrides.body ?? JSON.parse(lexicalJson('Feedback body text.')),
         createdAt: overrides.createdAt ?? new Date('2026-04-20T12:00:00Z'),
+        version: overrides.version ?? null,
     }) as ProposalFeedbackEntry
 
 describe('ProposalSubmitted', () => {
@@ -52,7 +53,13 @@ describe('ProposalSubmitted', () => {
                 submittedAt: new Date('2025-04-16T10:00:00Z'),
             }
             renderWithProviders(
-                <ProposalSubmitted orgSlug={ORG_SLUG} study={approvedStudy} orgName={ORG_NAME} entries={[]} />,
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={approvedStudy}
+                    orgName={ORG_NAME}
+                    entries={[]}
+                    studyVersion={1}
+                />,
             )
 
             expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent('Approved on Apr 16, 2025')
@@ -65,7 +72,13 @@ describe('ProposalSubmitted', () => {
                 submittedAt: new Date('2025-04-16T10:00:00Z'),
             }
             renderWithProviders(
-                <ProposalSubmitted orgSlug={ORG_SLUG} study={clarificationStudy} orgName={ORG_NAME} entries={[]} />,
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={clarificationStudy}
+                    orgName={ORG_NAME}
+                    entries={[]}
+                    studyVersion={1}
+                />,
             )
 
             expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent(
@@ -80,7 +93,13 @@ describe('ProposalSubmitted', () => {
                 submittedAt: new Date('2025-04-16T10:00:00Z'),
             }
             renderWithProviders(
-                <ProposalSubmitted orgSlug={ORG_SLUG} study={rejectedStudy} orgName={ORG_NAME} entries={[]} />,
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={rejectedStudy}
+                    orgName={ORG_NAME}
+                    entries={[]}
+                    studyVersion={1}
+                />,
             )
 
             expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent('Rejected on Apr 16, 2025')
@@ -93,10 +112,35 @@ describe('ProposalSubmitted', () => {
                 submittedAt: new Date('2025-04-16T10:00:00Z'),
             }
             renderWithProviders(
-                <ProposalSubmitted orgSlug={ORG_SLUG} study={pendingStudy} orgName={ORG_NAME} entries={[]} />,
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={pendingStudy}
+                    orgName={ORG_NAME}
+                    entries={[]}
+                    studyVersion={1}
+                />,
             )
 
             expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent('Submitted on Apr 16, 2025')
+        })
+
+        it('displays "Resubmitted on {date}" when status is PENDING-REVIEW after a resubmission', () => {
+            const pendingStudy = {
+                ...study,
+                status: 'PENDING-REVIEW' as const,
+                submittedAt: new Date('2025-04-16T10:00:00Z'),
+            }
+            renderWithProviders(
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={pendingStudy}
+                    orgName={ORG_NAME}
+                    entries={[]}
+                    studyVersion={2}
+                />,
+            )
+
+            expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent('Resubmitted on Apr 16, 2025')
         })
 
         it('formats the date as MMM DD, YYYY', () => {
@@ -106,7 +150,13 @@ describe('ProposalSubmitted', () => {
                 submittedAt: new Date('2025-12-01T10:00:00Z'),
             }
             renderWithProviders(
-                <ProposalSubmitted orgSlug={ORG_SLUG} study={approvedStudy} orgName={ORG_NAME} entries={[]} />,
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={approvedStudy}
+                    orgName={ORG_NAME}
+                    entries={[]}
+                    studyVersion={1}
+                />,
             )
 
             expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent('Approved on Dec 01, 2025')
@@ -115,7 +165,13 @@ describe('ProposalSubmitted', () => {
         it('renders the timestamp above the divider', () => {
             const approvedStudy = { ...study, status: 'APPROVED' as const, submittedAt: new Date('2025-04-16') }
             renderWithProviders(
-                <ProposalSubmitted orgSlug={ORG_SLUG} study={approvedStudy} orgName={ORG_NAME} entries={[]} />,
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={approvedStudy}
+                    orgName={ORG_NAME}
+                    entries={[]}
+                    studyVersion={1}
+                />,
             )
 
             const timestamp = screen.getByTestId('proposal-timestamp')
@@ -128,7 +184,13 @@ describe('ProposalSubmitted', () => {
         it('renders a green banner with approved copy when status is APPROVED', () => {
             const approvedStudy = { ...study, status: 'APPROVED' as const }
             renderWithProviders(
-                <ProposalSubmitted orgSlug={ORG_SLUG} study={approvedStudy} orgName={ORG_NAME} entries={[]} />,
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={approvedStudy}
+                    orgName={ORG_NAME}
+                    entries={[]}
+                    studyVersion={1}
+                />,
             )
 
             const banner = screen.getByTestId('status-banner-APPROVED')
@@ -140,7 +202,13 @@ describe('ProposalSubmitted', () => {
         it('renders a blue banner with clarification copy when status is CHANGE-REQUESTED', () => {
             const clarificationStudy = { ...study, status: 'CHANGE-REQUESTED' as const }
             renderWithProviders(
-                <ProposalSubmitted orgSlug={ORG_SLUG} study={clarificationStudy} orgName={ORG_NAME} entries={[]} />,
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={clarificationStudy}
+                    orgName={ORG_NAME}
+                    entries={[]}
+                    studyVersion={1}
+                />,
             )
 
             const banner = screen.getByTestId('status-banner-CHANGE-REQUESTED')
@@ -152,7 +220,13 @@ describe('ProposalSubmitted', () => {
         it('renders a red banner with rejected copy when status is REJECTED', () => {
             const rejectedStudy = { ...study, status: 'REJECTED' as const }
             renderWithProviders(
-                <ProposalSubmitted orgSlug={ORG_SLUG} study={rejectedStudy} orgName={ORG_NAME} entries={[]} />,
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={rejectedStudy}
+                    orgName={ORG_NAME}
+                    entries={[]}
+                    studyVersion={1}
+                />,
             )
 
             const banner = screen.getByTestId('status-banner-REJECTED')
@@ -164,7 +238,13 @@ describe('ProposalSubmitted', () => {
         it('renders the banner below the divider', () => {
             const approvedStudy = { ...study, status: 'APPROVED' as const }
             renderWithProviders(
-                <ProposalSubmitted orgSlug={ORG_SLUG} study={approvedStudy} orgName={ORG_NAME} entries={[]} />,
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={approvedStudy}
+                    orgName={ORG_NAME}
+                    entries={[]}
+                    studyVersion={1}
+                />,
             )
 
             const divider = screen.getByTestId('proposal-header-divider')
@@ -175,7 +255,13 @@ describe('ProposalSubmitted', () => {
         it('renders only one banner at a time', () => {
             const approvedStudy = { ...study, status: 'APPROVED' as const }
             renderWithProviders(
-                <ProposalSubmitted orgSlug={ORG_SLUG} study={approvedStudy} orgName={ORG_NAME} entries={[]} />,
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={approvedStudy}
+                    orgName={ORG_NAME}
+                    entries={[]}
+                    studyVersion={1}
+                />,
             )
 
             expect(screen.getByTestId('status-banner-APPROVED')).toBeInTheDocument()
@@ -183,11 +269,31 @@ describe('ProposalSubmitted', () => {
             expect(screen.queryByTestId('status-banner-CHANGE-REQUESTED')).not.toBeInTheDocument()
             expect(screen.queryByTestId('status-banner-PENDING-REVIEW')).not.toBeInTheDocument()
         })
+
+        it('renders resubmission copy when status is PENDING-REVIEW after a resubmission', () => {
+            const pendingStudy = { ...study, status: 'PENDING-REVIEW' as const }
+            renderWithProviders(
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={pendingStudy}
+                    orgName={ORG_NAME}
+                    entries={[]}
+                    studyVersion={2}
+                />,
+            )
+
+            const banner = screen.getByTestId('status-banner-PENDING-REVIEW')
+            expect(banner).toHaveTextContent(
+                `Your revised initial request has been resubmitted to ${ORG_NAME}. They will review your changes and respond with feedback or a decision. You'll receive email notifications as your request progresses through the review process.`,
+            )
+        })
     })
 
     describe('view full initial request dropdown', () => {
         it('is collapsed by default on page load', () => {
-            renderWithProviders(<ProposalSubmitted orgSlug={ORG_SLUG} study={study} orgName={ORG_NAME} entries={[]} />)
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={study} orgName={ORG_NAME} entries={[]} studyVersion={1} />,
+            )
 
             expect(screen.getByTestId('proposal-toggle-header')).toHaveTextContent('View full initial request')
             expect(screen.queryByTestId('proposal-body')).not.toBeVisible()
@@ -195,7 +301,9 @@ describe('ProposalSubmitted', () => {
 
         it('expands to display the study proposal when clicked', async () => {
             const user = userEvent.setup()
-            renderWithProviders(<ProposalSubmitted orgSlug={ORG_SLUG} study={study} orgName={ORG_NAME} entries={[]} />)
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={study} orgName={ORG_NAME} entries={[]} studyVersion={1} />,
+            )
 
             await user.click(screen.getByTestId('proposal-toggle-header'))
 
@@ -206,7 +314,9 @@ describe('ProposalSubmitted', () => {
 
         it('displays study proposal content as read-only with no editable fields', async () => {
             const user = userEvent.setup()
-            renderWithProviders(<ProposalSubmitted orgSlug={ORG_SLUG} study={study} orgName={ORG_NAME} entries={[]} />)
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={study} orgName={ORG_NAME} entries={[]} studyVersion={1} />,
+            )
 
             await user.click(screen.getByTestId('proposal-toggle-header'))
 
@@ -220,7 +330,13 @@ describe('ProposalSubmitted', () => {
         it('shows a "Back" button linking to dashboard when status is APPROVED', () => {
             const approvedStudy = { ...study, status: 'APPROVED' as const }
             renderWithProviders(
-                <ProposalSubmitted orgSlug={ORG_SLUG} study={approvedStudy} orgName={ORG_NAME} entries={[]} />,
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={approvedStudy}
+                    orgName={ORG_NAME}
+                    entries={[]}
+                    studyVersion={1}
+                />,
             )
 
             const backLink = screen.getByRole('link', { name: /back/i })
@@ -230,7 +346,13 @@ describe('ProposalSubmitted', () => {
         it('shows a "Proceed to step 3" button linking to agreements when status is APPROVED', () => {
             const approvedStudy = { ...study, status: 'APPROVED' as const }
             renderWithProviders(
-                <ProposalSubmitted orgSlug={ORG_SLUG} study={approvedStudy} orgName={ORG_NAME} entries={[]} />,
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={approvedStudy}
+                    orgName={ORG_NAME}
+                    entries={[]}
+                    studyVersion={1}
+                />,
             )
 
             const proceedLink = screen.getByRole('link', { name: /proceed to step 3/i })
@@ -243,17 +365,29 @@ describe('ProposalSubmitted', () => {
         it('shows a "Back" button linking to dashboard when status is CHANGE-REQUESTED', () => {
             const clarificationStudy = { ...study, status: 'CHANGE-REQUESTED' as const }
             renderWithProviders(
-                <ProposalSubmitted orgSlug={ORG_SLUG} study={clarificationStudy} orgName={ORG_NAME} entries={[]} />,
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={clarificationStudy}
+                    orgName={ORG_NAME}
+                    entries={[]}
+                    studyVersion={1}
+                />,
             )
 
             const backLink = screen.getByRole('link', { name: /back/i })
             expect(backLink).toHaveAttribute('href', '/dashboard')
         })
 
-        it('shows an "Edit and resubmit" button linking to edit page when status is CHANGE-REQUESTED', () => {
+        it('shows an "Edit and resubmit" button linking to edit and resubmit page when status is CHANGE-REQUESTED', () => {
             const clarificationStudy = { ...study, status: 'CHANGE-REQUESTED' as const }
             renderWithProviders(
-                <ProposalSubmitted orgSlug={ORG_SLUG} study={clarificationStudy} orgName={ORG_NAME} entries={[]} />,
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={clarificationStudy}
+                    orgName={ORG_NAME}
+                    entries={[]}
+                    studyVersion={1}
+                />,
             )
 
             const editLink = screen.getByRole('link', { name: /edit and resubmit/i })
@@ -263,11 +397,43 @@ describe('ProposalSubmitted', () => {
         it('shows a "Go to dashboard" button linking to dashboard when status is REJECTED', () => {
             const rejectedStudy = { ...study, status: 'REJECTED' as const }
             renderWithProviders(
-                <ProposalSubmitted orgSlug={ORG_SLUG} study={rejectedStudy} orgName={ORG_NAME} entries={[]} />,
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={rejectedStudy}
+                    orgName={ORG_NAME}
+                    entries={[]}
+                    studyVersion={1}
+                />,
             )
 
             const dashboardLink = screen.getByRole('link', { name: /go to dashboard/i })
             expect(dashboardLink).toHaveAttribute('href', '/dashboard')
+        })
+    })
+
+    describe('section heading iteration label', () => {
+        it('displays "Initial request" on first submission', () => {
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={study} orgName={ORG_NAME} entries={[]} studyVersion={1} />,
+            )
+
+            expect(screen.getByTestId('proposal-section-header')).toHaveTextContent('Initial request')
+        })
+
+        it('displays "Initial request 2.0" after the first resubmission', () => {
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={study} orgName={ORG_NAME} entries={[]} studyVersion={2} />,
+            )
+
+            expect(screen.getByTestId('proposal-section-header')).toHaveTextContent('Initial request 2.0')
+        })
+
+        it('displays "Initial request 3.0" after the second resubmission', () => {
+            renderWithProviders(
+                <ProposalSubmitted orgSlug={ORG_SLUG} study={study} orgName={ORG_NAME} entries={[]} studyVersion={3} />,
+            )
+
+            expect(screen.getByTestId('proposal-section-header')).toHaveTextContent('Initial request 3.0')
         })
     })
 
@@ -280,6 +446,7 @@ describe('ProposalSubmitted', () => {
             decision: 'NEEDS-CLARIFICATION',
             createdAt: new Date('2026-04-20T12:00:00Z'),
             body: JSON.parse(lexicalJson('Latest reviewer note.')),
+            version: 2,
         })
 
         const researcherEntry = buildEntry({
@@ -290,6 +457,7 @@ describe('ProposalSubmitted', () => {
             decision: null,
             createdAt: new Date('2026-04-18T08:00:00Z'),
             body: JSON.parse(lexicalJson('Original resubmission note.')),
+            version: 2,
         })
 
         it('displays entries from most recent to oldest', () => {
@@ -299,6 +467,7 @@ describe('ProposalSubmitted', () => {
                     study={study}
                     orgName={ORG_NAME}
                     entries={[reviewerEntry, researcherEntry]}
+                    studyVersion={2}
                 />,
             )
 
@@ -308,30 +477,48 @@ describe('ProposalSubmitted', () => {
             expect(rendered[1]).toHaveAttribute('data-testid', 'feedback-entry-researcher-1')
         })
 
-        it('titles reviewer entries "Reviewer feedback"', () => {
+        it('titles reviewer entries "Reviewer feedback (v1.0)" for first submission', () => {
+            const v1ReviewerEntry = buildEntry({
+                ...reviewerEntry,
+                version: 1,
+            })
             renderWithProviders(
-                <ProposalSubmitted orgSlug={ORG_SLUG} study={study} orgName={ORG_NAME} entries={[reviewerEntry]} />,
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={study}
+                    orgName={ORG_NAME}
+                    entries={[v1ReviewerEntry]}
+                    studyVersion={1}
+                />,
             )
 
-            expect(screen.getByTestId('feedback-entry-reviewer-1')).toHaveTextContent('Reviewer feedback')
+            expect(screen.getByTestId('feedback-entry-reviewer-1')).toHaveTextContent('Reviewer feedback (v1.0)')
         })
 
-        it('titles researcher entries "Resubmission note"', () => {
+        it('titles entries with their stored version', () => {
             renderWithProviders(
                 <ProposalSubmitted
                     orgSlug={ORG_SLUG}
                     study={study}
                     orgName={ORG_NAME}
                     entries={[reviewerEntry, researcherEntry]}
+                    studyVersion={2}
                 />,
             )
 
-            expect(screen.getByTestId('feedback-entry-researcher-1')).toHaveTextContent('Resubmission note')
+            expect(screen.getByTestId('feedback-entry-reviewer-1')).toHaveTextContent('Reviewer feedback (v2.0)')
+            expect(screen.getByTestId('feedback-entry-researcher-1')).toHaveTextContent('Resubmission note (v2.0)')
         })
 
         it('displays the reviewer name on reviewer feedback entries', () => {
             renderWithProviders(
-                <ProposalSubmitted orgSlug={ORG_SLUG} study={study} orgName={ORG_NAME} entries={[reviewerEntry]} />,
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={study}
+                    orgName={ORG_NAME}
+                    entries={[reviewerEntry]}
+                    studyVersion={1}
+                />,
             )
 
             expect(screen.getByTestId('feedback-entry-reviewer-1')).toHaveTextContent('Dr. Reviewer')
@@ -344,6 +531,7 @@ describe('ProposalSubmitted', () => {
                     study={study}
                     orgName={ORG_NAME}
                     entries={[reviewerEntry, researcherEntry]}
+                    studyVersion={2}
                 />,
             )
 
@@ -352,7 +540,13 @@ describe('ProposalSubmitted', () => {
 
         it('displays the date the reviewer submitted their decision', () => {
             renderWithProviders(
-                <ProposalSubmitted orgSlug={ORG_SLUG} study={study} orgName={ORG_NAME} entries={[reviewerEntry]} />,
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={study}
+                    orgName={ORG_NAME}
+                    entries={[reviewerEntry]}
+                    studyVersion={1}
+                />,
             )
 
             expect(screen.getByTestId('feedback-entry-reviewer-1')).toHaveTextContent('Apr 20, 2026')
@@ -365,6 +559,7 @@ describe('ProposalSubmitted', () => {
                     study={study}
                     orgName={ORG_NAME}
                     entries={[reviewerEntry, researcherEntry]}
+                    studyVersion={2}
                 />,
             )
 
@@ -378,10 +573,11 @@ describe('ProposalSubmitted', () => {
                     study={study}
                     orgName={ORG_NAME}
                     entries={[reviewerEntry, researcherEntry]}
+                    studyVersion={2}
                 />,
             )
 
-            expect(screen.getByTestId('feedback-toggle-reviewer-1')).toHaveAttribute('aria-expanded', 'true')
+            expect(screen.getByTestId('feedback-entry-reviewer-1')).toHaveAttribute('aria-expanded', 'true')
         })
 
         it('collapses older entries by default', () => {
@@ -391,10 +587,51 @@ describe('ProposalSubmitted', () => {
                     study={study}
                     orgName={ORG_NAME}
                     entries={[reviewerEntry, researcherEntry]}
+                    studyVersion={2}
                 />,
             )
 
-            expect(screen.getByTestId('feedback-toggle-researcher-1')).toHaveAttribute('aria-expanded', 'false')
+            expect(screen.getByTestId('feedback-entry-researcher-1')).toHaveAttribute('aria-expanded', 'false')
+        })
+
+        it('collapses resubmission notes by default even when latest', () => {
+            renderWithProviders(
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={study}
+                    orgName={ORG_NAME}
+                    entries={[researcherEntry, reviewerEntry]}
+                    studyVersion={2}
+                />,
+            )
+
+            expect(screen.getByTestId('feedback-entry-researcher-1')).toHaveAttribute('aria-expanded', 'false')
+        })
+
+        it('labels multiple resubmission notes with ascending versions', () => {
+            const secondResub = buildEntry({
+                id: 'researcher-2',
+                authorRole: 'RESEARCHER',
+                entryType: 'RESUBMISSION-NOTE',
+                authorName: 'Dr. Researcher',
+                decision: null,
+                createdAt: new Date('2026-04-25T08:00:00Z'),
+                body: JSON.parse(lexicalJson('Second resubmission note.')),
+                version: 3,
+            })
+
+            renderWithProviders(
+                <ProposalSubmitted
+                    orgSlug={ORG_SLUG}
+                    study={study}
+                    orgName={ORG_NAME}
+                    entries={[secondResub, reviewerEntry, researcherEntry]}
+                    studyVersion={3}
+                />,
+            )
+
+            expect(screen.getByTestId('feedback-entry-researcher-2')).toHaveTextContent('Resubmission note (v3.0)')
+            expect(screen.getByTestId('feedback-entry-researcher-1')).toHaveTextContent('Resubmission note (v2.0)')
         })
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
@@ -18,7 +18,13 @@ interface ProposalSubmittedProps {
     study: SelectedStudy
     orgName: string
     entries: ProposalFeedbackEntry[]
+    studyVersion: number
     feedbackError?: boolean
+}
+
+function proposalHeading(studyVersion: number): string {
+    if (studyVersion <= 1) return 'Initial request'
+    return `Initial request ${studyVersion}.0`
 }
 
 type ProposalBannerConfig = {
@@ -53,13 +59,26 @@ const PROPOSAL_BANNERS: Partial<Record<StudyStatus, ProposalBannerConfig>> = {
     },
 }
 
-function StatusBanner({ orgName, status }: { orgName: string; status: StudyStatus }) {
+function StatusBanner({
+    orgName,
+    status,
+    studyVersion,
+}: {
+    orgName: string
+    status: StudyStatus
+    studyVersion: number
+}) {
     const config = PROPOSAL_BANNERS[status]
     if (!config) return null
 
+    const isResubmission = status === 'PENDING-REVIEW' && studyVersion > 1
+    const message = isResubmission
+        ? `Your revised initial request has been resubmitted to ${displayOrgName(orgName)}. They will review your changes and respond with feedback or a decision. You'll receive email notifications as your request progresses through the review process.`
+        : config.message(orgName)
+
     return (
         <Alert color={config.color} mb="md" data-testid={`status-banner-${status}`}>
-            {config.message(orgName)}
+            {message}
         </Alert>
     )
 }
@@ -126,8 +145,16 @@ function FeedbackErrorAlert({ status, feedbackError }: { status: StudyStatus; fe
     )
 }
 
-export function ProposalSubmitted({ orgSlug, study, orgName, entries, feedbackError }: ProposalSubmittedProps) {
+export function ProposalSubmitted({
+    orgSlug,
+    study,
+    orgName,
+    entries,
+    studyVersion,
+    feedbackError,
+}: ProposalSubmittedProps) {
     const bannerConfig = PROPOSAL_BANNERS[study.status]
+    const statusBadge = bannerConfig?.statusBadge ?? (studyVersion > 1 ? 'Resubmitted on' : undefined)
 
     return (
         <Stack p="xl" gap="xl">
@@ -137,9 +164,9 @@ export function ProposalSubmitted({ orgSlug, study, orgName, entries, feedbackEr
                     study={study}
                     orgSlug={orgSlug}
                     stepLabel="STEP 2"
-                    heading="Initial request"
-                    banner={<StatusBanner orgName={orgName} status={study.status} />}
-                    statusBadge={bannerConfig?.statusBadge}
+                    heading={proposalHeading(studyVersion)}
+                    banner={<StatusBanner orgName={orgName} status={study.status} studyVersion={studyVersion} />}
+                    statusBadge={statusBadge}
                     initialExpanded={false}
                 />
                 <FeedbackErrorAlert status={study.status} feedbackError={feedbackError} />

--- a/src/app/[orgSlug]/study/[studyId]/submitted/submitted-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/submitted-view.tsx
@@ -14,10 +14,11 @@ interface SubmittedViewProps {
     study: SelectedStudy
     orgName: string
     entries: ProposalFeedbackEntry[]
+    studyVersion: number
     feedbackError?: boolean
 }
 
-export function SubmittedView({ orgSlug, study, orgName, entries, feedbackError }: SubmittedViewProps) {
+export function SubmittedView({ orgSlug, study, orgName, entries, studyVersion, feedbackError }: SubmittedViewProps) {
     const existingView = (
         <Stack p="xl" gap="xl">
             <StudyRequestPageHeader orgSlug={orgSlug} studyId={study.id} studyTitle={study.title} />
@@ -51,6 +52,7 @@ export function SubmittedView({ orgSlug, study, orgName, entries, feedbackError 
                     study={study}
                     orgName={orgName}
                     entries={entries}
+                    studyVersion={studyVersion}
                     feedbackError={feedbackError}
                 />
             }

--- a/src/components/study/feedback-and-notes.tsx
+++ b/src/components/study/feedback-and-notes.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Anchor, Box, Divider, Paper, Stack, Text, Title } from '@mantine/core'
 import { CaretRightIcon } from '@phosphor-icons/react'
 import dayjs from 'dayjs'
@@ -28,11 +28,13 @@ type FeedbackEntryProps = {
 function FeedbackEntry({ entry, isExpanded, onToggle }: FeedbackEntryProps) {
     const title = entryTitle(entry)
     const date = formatDate(entry.createdAt)
+    const bodyRef = useRef<HTMLDivElement>(null)
     const [isTruncated, setIsTruncated] = useState(false)
 
-    const bodyRef = useCallback((node: HTMLDivElement | null) => {
+    useEffect(() => {
+        const node = bodyRef.current
         if (node) setIsTruncated(node.scrollHeight > node.clientHeight)
-    }, [])
+    }, [isExpanded])
 
     const showToggle = isExpanded || isTruncated
 

--- a/src/components/study/feedback-and-notes.tsx
+++ b/src/components/study/feedback-and-notes.tsx
@@ -31,12 +31,28 @@ function FeedbackEntry({ entry, isExpanded, onToggle }: FeedbackEntryProps) {
     const bodyRef = useRef<HTMLDivElement>(null)
     const [isTruncated, setIsTruncated] = useState(false)
 
+    // scrollHeight vs clientHeight only reflects overflow while line-clamp is on; once expanded,
+    // that comparison stays stale — measure against a fixed collapsed height (lineHeight × clamp) instead.
     useEffect(() => {
         const node = bodyRef.current
-        if (node) setIsTruncated(node.scrollHeight > node.clientHeight)
+        if (!node) return
+
+        const check = () => {
+            const lineHeight = parseFloat(getComputedStyle(node).lineHeight)
+            if (Number.isFinite(lineHeight) && lineHeight > 0) {
+                setIsTruncated(node.scrollHeight > lineHeight * COLLAPSED_LINE_CLAMP + 1)
+                return
+            }
+            setIsTruncated(node.scrollHeight > node.clientHeight)
+        }
+
+        check()
+        const observer = new ResizeObserver(check)
+        observer.observe(node)
+        return () => observer.disconnect()
     }, [isExpanded])
 
-    const showToggle = isExpanded || isTruncated
+    const showToggle = isTruncated
 
     return (
         <Stack gap="sm" data-testid={`feedback-entry-${entry.id}`} aria-expanded={isExpanded}>

--- a/src/components/study/feedback-and-notes.tsx
+++ b/src/components/study/feedback-and-notes.tsx
@@ -55,7 +55,7 @@ function FeedbackEntry({ entry, isExpanded, onToggle }: FeedbackEntryProps) {
     const showToggle = isTruncated
 
     return (
-        <Stack gap="sm" data-testid={`feedback-entry-${entry.id}`} aria-expanded={isExpanded}>
+        <Stack gap="sm" data-testid={`feedback-entry-${entry.id}`}>
             <Text fw={700} fz={14}>
                 {title}
             </Text>
@@ -88,6 +88,7 @@ function FeedbackEntry({ entry, isExpanded, onToggle }: FeedbackEntryProps) {
                         mt="xs"
                         display="inline-flex"
                         style={{ alignItems: 'center', gap: 4 }}
+                        aria-expanded={isExpanded}
                         data-testid={`feedback-toggle-${entry.id}`}
                     >
                         {isExpanded ? 'View less' : 'View more'}

--- a/src/components/study/feedback-and-notes.tsx
+++ b/src/components/study/feedback-and-notes.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useState } from 'react'
-import { Anchor, Box, Collapse, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
-import { CaretDownIcon, CaretUpIcon } from '@phosphor-icons/react'
+import { useCallback, useState } from 'react'
+import { Anchor, Box, Divider, Paper, Stack, Text, Title } from '@mantine/core'
+import { CaretRightIcon } from '@phosphor-icons/react'
 import dayjs from 'dayjs'
 import { ReadOnlyLexicalContent } from '@/components/readonly-lexical-content'
 import type { ProposalFeedbackEntry } from '@/server/actions/study.actions'
@@ -12,13 +12,12 @@ function formatDate(date: Date | string): string {
 }
 
 function entryTitle(entry: ProposalFeedbackEntry): string {
-    return entry.entryType === 'REVIEWER-FEEDBACK' ? 'Reviewer feedback' : 'Resubmission note'
+    const label = entry.entryType === 'REVIEWER-FEEDBACK' ? 'Reviewer feedback' : 'Resubmission note'
+    if (entry.version) return `${label} (v${entry.version}.0)`
+    return label
 }
 
-function ToggleCaret({ isExpanded }: { isExpanded: boolean }) {
-    const Icon = isExpanded ? CaretUpIcon : CaretDownIcon
-    return <Icon size={14} />
-}
+const COLLAPSED_LINE_CLAMP = 3
 
 type FeedbackEntryProps = {
     entry: ProposalFeedbackEntry
@@ -29,24 +28,19 @@ type FeedbackEntryProps = {
 function FeedbackEntry({ entry, isExpanded, onToggle }: FeedbackEntryProps) {
     const title = entryTitle(entry)
     const date = formatDate(entry.createdAt)
+    const [isTruncated, setIsTruncated] = useState(false)
+
+    const bodyRef = useCallback((node: HTMLDivElement | null) => {
+        if (node) setIsTruncated(node.scrollHeight > node.clientHeight)
+    }, [])
+
+    const showToggle = isExpanded || isTruncated
 
     return (
-        <Stack gap="sm" data-testid={`feedback-entry-${entry.id}`}>
-            <Group justify="space-between" align="center">
-                <Text fw={700} fz={14}>
-                    {title}
-                </Text>
-                <Anchor
-                    component="button"
-                    onClick={onToggle}
-                    c="blue"
-                    size="sm"
-                    data-testid={`feedback-toggle-${entry.id}`}
-                    aria-expanded={isExpanded}
-                >
-                    <ToggleCaret isExpanded={isExpanded} />
-                </Anchor>
-            </Group>
+        <Stack gap="sm" data-testid={`feedback-entry-${entry.id}`} aria-expanded={isExpanded}>
+            <Text fw={700} fz={14}>
+                {title}
+            </Text>
             <Box bg="gray.0" p="lg">
                 <Stack gap="xs">
                     <Text size="sm" fw={600}>
@@ -56,12 +50,39 @@ function FeedbackEntry({ entry, isExpanded, onToggle }: FeedbackEntryProps) {
                         {date}
                     </Text>
                 </Stack>
-                <Collapse in={isExpanded}>
-                    {/* component="div" because Lexical renders block-level elements that can't nest inside <p> */}
-                    <Text size="sm" component="div" mt="sm" data-testid={`feedback-body-${entry.id}`}>
-                        <ReadOnlyLexicalContent value={entry.body} />
-                    </Text>
-                </Collapse>
+                {/* component="div" because Lexical renders block-level elements that can't nest inside <p> */}
+                <Text
+                    ref={bodyRef}
+                    size="sm"
+                    component="div"
+                    mt="sm"
+                    lineClamp={isExpanded ? undefined : COLLAPSED_LINE_CLAMP}
+                    data-testid={`feedback-body-${entry.id}`}
+                >
+                    <ReadOnlyLexicalContent value={entry.body} />
+                </Text>
+                {showToggle && (
+                    <Anchor
+                        component="button"
+                        onClick={onToggle}
+                        size="sm"
+                        fw={700}
+                        mt="xs"
+                        display="inline-flex"
+                        style={{ alignItems: 'center', gap: 4 }}
+                        data-testid={`feedback-toggle-${entry.id}`}
+                    >
+                        {isExpanded ? 'View less' : 'View more'}
+                        <CaretRightIcon
+                            size={12}
+                            weight="bold"
+                            style={{
+                                transform: isExpanded ? 'rotate(-90deg)' : 'rotate(0deg)',
+                                transition: 'transform 200ms ease',
+                            }}
+                        />
+                    </Anchor>
+                )}
             </Box>
         </Stack>
     )
@@ -69,8 +90,11 @@ function FeedbackEntry({ entry, isExpanded, onToggle }: FeedbackEntryProps) {
 
 function useExpandedEntries(entries: ProposalFeedbackEntry[]) {
     const [expandedIds, setExpandedIds] = useState<Set<string>>(() => {
-        const latest = entries[0]?.id
-        return latest ? new Set([latest]) : new Set()
+        // Resubmission notes must be collapsed by default per spec,
+        // so only auto-expand the latest entry when it's reviewer feedback.
+        const latest = entries[0]
+        if (!latest || latest.entryType === 'RESUBMISSION-NOTE') return new Set()
+        return new Set([latest.id])
     })
 
     const toggle = (id: string) => {

--- a/src/database/migrations/1776400000000_add_version_to_study_proposal_comment.ts
+++ b/src/database/migrations/1776400000000_add_version_to_study_proposal_comment.ts
@@ -1,0 +1,28 @@
+import { type Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+    await db.schema.alterTable('study_proposal_comment').addColumn('version', 'integer').execute()
+
+    // Backfill: walk each study's entries in chronological order.
+    // Reviewer feedback gets the current version; resubmission notes
+    // increment the version first, then receive the new value.
+    await sql`
+        WITH versioned AS (
+            SELECT id,
+                   entry_type,
+                   SUM(CASE WHEN entry_type = 'RESUBMISSION-NOTE' THEN 1 ELSE 0 END)
+                       OVER (PARTITION BY study_id ORDER BY created_at, id
+                             ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+                   + 1 AS computed_version
+            FROM study_proposal_comment
+        )
+        UPDATE study_proposal_comment
+        SET version = versioned.computed_version
+        FROM versioned
+        WHERE study_proposal_comment.id = versioned.id
+    `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+    await db.schema.alterTable('study_proposal_comment').dropColumn('version').execute()
+}

--- a/src/database/migrations/1776400000000_add_version_to_study_proposal_comment.ts
+++ b/src/database/migrations/1776400000000_add_version_to_study_proposal_comment.ts
@@ -21,6 +21,11 @@ export async function up(db: Kysely<unknown>): Promise<void> {
         FROM versioned
         WHERE study_proposal_comment.id = versioned.id
     `.execute(db)
+
+    await db.schema
+        .alterTable('study_proposal_comment')
+        .alterColumn('version', (col) => col.setNotNull())
+        .execute()
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -252,7 +252,7 @@ export interface StudyProposalComment {
     entryType: StudyProposalCommentEntryType
     id: Generated<string>
     studyId: string
-    version: number | null
+    version: number
 }
 
 export interface StudyReview {

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -252,6 +252,7 @@ export interface StudyProposalComment {
     entryType: StudyProposalCommentEntryType
     id: Generated<string>
     studyId: string
+    version: number | null
 }
 
 export interface StudyReview {

--- a/src/lib/studies.ts
+++ b/src/lib/studies.ts
@@ -8,7 +8,7 @@ export function studyHasJobStatus(study: StudyWithJobStatuses, status: StudyJobS
     return study.jobStatusChanges.some((s) => s.status === status)
 }
 
-export function deriveStudyVersion(entries: { version: number | null }[]): number {
+export function deriveStudyVersion(entries: { version: number }[]): number {
     if (entries.length === 0) return 1
-    return Math.max(...entries.map((e) => e.version ?? 1))
+    return Math.max(...entries.map((e) => e.version))
 }

--- a/src/lib/studies.ts
+++ b/src/lib/studies.ts
@@ -7,3 +7,8 @@ type StudyWithJobStatuses = {
 export function studyHasJobStatus(study: StudyWithJobStatuses, status: StudyJobStatus): boolean {
     return study.jobStatusChanges.some((s) => s.status === status)
 }
+
+export function deriveStudyVersion(entries: { version: number | null }[]): number {
+    if (entries.length === 0) return 1
+    return Math.max(...entries.map((e) => e.version ?? 1))
+}

--- a/src/server/actions/resubmit-proposal.test.ts
+++ b/src/server/actions/resubmit-proposal.test.ts
@@ -50,7 +50,7 @@ describe('resubmitProposalAction', () => {
 
         const comments = await db
             .selectFrom('studyProposalComment')
-            .select(['authorRole', 'entryType', 'authorId', 'body'])
+            .select(['authorRole', 'entryType', 'authorId', 'body', 'version'])
             .where('studyId', '=', study.id)
             .execute()
 
@@ -60,6 +60,7 @@ describe('resubmitProposalAction', () => {
                 authorRole: 'RESEARCHER',
                 entryType: 'RESUBMISSION-NOTE',
                 authorId: user.id,
+                version: 2,
             }),
         )
         // body is stored as Lexical JSON; the note words should round-trip

--- a/src/server/actions/study-request.ts
+++ b/src/server/actions/study-request.ts
@@ -21,7 +21,7 @@ import { db as database } from '@/database'
 import { deferred, onStudyReviewRequested, onStudyCodeSubmitted, onStudyCreated } from '@/server/events'
 import { purgeProposalYjsDocsBeforeAt } from '@/server/db/yjs-cleanup'
 import logger from '@/lib/logger'
-import { Kysely } from 'kysely'
+import { Kysely, sql } from 'kysely'
 import { revalidatePath } from 'next/cache'
 import { v7 as uuidv7 } from 'uuid'
 import { draftStudyApiSchema } from '@/app/[orgSlug]/study/request/form-schemas'
@@ -721,14 +721,6 @@ export const resubmitProposalAction = new Action('resubmitProposalAction', { per
             .where('researcherId', '=', userId)
             .execute()
 
-        const latest = await db
-            .selectFrom('studyProposalComment')
-            .select('version')
-            .where('studyId', '=', studyId)
-            .orderBy('createdAt', 'desc')
-            .limit(1)
-            .executeTakeFirst()
-
         await db
             .insertInto('studyProposalComment')
             .values({
@@ -737,7 +729,10 @@ export const resubmitProposalAction = new Action('resubmitProposalAction', { per
                 authorRole: 'RESEARCHER',
                 entryType: 'RESUBMISSION-NOTE',
                 body: JSON.parse(lexicalJson(resubmissionNote)),
-                version: (latest?.version ?? 1) + 1,
+                version: sql<number>`coalesce((
+                    select max(version) from study_proposal_comment
+                    where study_id = ${studyId}
+                ), 1) + 1`,
             })
             .execute()
 

--- a/src/server/actions/study-request.ts
+++ b/src/server/actions/study-request.ts
@@ -721,6 +721,14 @@ export const resubmitProposalAction = new Action('resubmitProposalAction', { per
             .where('researcherId', '=', userId)
             .execute()
 
+        const latest = await db
+            .selectFrom('studyProposalComment')
+            .select('version')
+            .where('studyId', '=', studyId)
+            .orderBy('createdAt', 'desc')
+            .limit(1)
+            .executeTakeFirst()
+
         await db
             .insertInto('studyProposalComment')
             .values({
@@ -729,6 +737,7 @@ export const resubmitProposalAction = new Action('resubmitProposalAction', { per
                 authorRole: 'RESEARCHER',
                 entryType: 'RESUBMISSION-NOTE',
                 body: JSON.parse(lexicalJson(resubmissionNote)),
+                version: (latest?.version ?? 1) + 1,
             })
             .execute()
 

--- a/src/server/actions/study-request.ts
+++ b/src/server/actions/study-request.ts
@@ -678,6 +678,9 @@ export const onUpdateClarifiedProposalAction = new Action('onUpdateClarifiedProp
 // Final resubmission: writes the latest proposal edits, records the
 // resubmission note as a study_proposal_comment row, and transitions
 // CHANGE-REQUESTED -> PENDING-REVIEW.
+//
+// `performsMutations: true` runs this handler inside db.transaction().
+// Do not drop it: the study updates/inserts must commit or roll back together.
 export const resubmitProposalAction = new Action('resubmitProposalAction', { performsMutations: true })
     .params(
         z.object({

--- a/src/server/actions/study-request.ts
+++ b/src/server/actions/study-request.ts
@@ -16,12 +16,13 @@ import {
     triggerScanForStudyJob,
 } from '@/server/aws'
 import { CODER_DISABLED, getConfigValue, SIMULATE_CODE_BUILD } from '@/server/config'
+import { nextVersionForStudyComment } from '@/server/db/mutations'
 import { getInfoForStudyId, getInfoForStudyJobId, getOrgIdFromSlug } from '@/server/db/queries'
 import { db as database } from '@/database'
 import { deferred, onStudyReviewRequested, onStudyCodeSubmitted, onStudyCreated } from '@/server/events'
 import { purgeProposalYjsDocsBeforeAt } from '@/server/db/yjs-cleanup'
 import logger from '@/lib/logger'
-import { Kysely, sql } from 'kysely'
+import { Kysely } from 'kysely'
 import { revalidatePath } from 'next/cache'
 import { v7 as uuidv7 } from 'uuid'
 import { draftStudyApiSchema } from '@/app/[orgSlug]/study/request/form-schemas'
@@ -729,10 +730,7 @@ export const resubmitProposalAction = new Action('resubmitProposalAction', { per
                 authorRole: 'RESEARCHER',
                 entryType: 'RESUBMISSION-NOTE',
                 body: JSON.parse(lexicalJson(resubmissionNote)),
-                version: sql<number>`coalesce((
-                    select max(version) from study_proposal_comment
-                    where study_id = ${studyId}
-                ), 1) + 1`,
+                version: nextVersionForStudyComment({ studyId, increment: true }),
             })
             .execute()
 

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -604,7 +604,7 @@ describe('submitProposalReviewAction', () => {
     const loadCommentRows = (studyId: string) =>
         db
             .selectFrom('studyProposalComment')
-            .select(['authorId', 'authorRole', 'body', 'decision', 'entryType'])
+            .select(['authorId', 'authorRole', 'body', 'decision', 'entryType', 'version'])
             .where('studyId', '=', studyId)
             .execute()
 
@@ -628,6 +628,7 @@ describe('submitProposalReviewAction', () => {
         expect(rows[0].authorId).toBe(user.id)
         expect(rows[0].authorRole).toBe('REVIEWER')
         expect(rows[0].entryType).toBe('REVIEWER-FEEDBACK')
+        expect(rows[0].version).toBe(1)
 
         const updatedStudy = await db
             .selectFrom('study')
@@ -675,6 +676,7 @@ describe('submitProposalReviewAction', () => {
         expect(rows[0].authorId).toBe(user.id)
         expect(rows[0].authorRole).toBe('REVIEWER')
         expect(rows[0].entryType).toBe('REVIEWER-FEEDBACK')
+        expect(rows[0].version).toBe(1)
 
         const updatedStudy = await db
             .selectFrom('study')
@@ -724,6 +726,7 @@ describe('submitProposalReviewAction', () => {
         expect(rows[0].authorId).toBe(user.id)
         expect(rows[0].authorRole).toBe('REVIEWER')
         expect(rows[0].entryType).toBe('REVIEWER-FEEDBACK')
+        expect(rows[0].version).toBe(1)
 
         const updatedStudy = await db
             .selectFrom('study')

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -501,6 +501,14 @@ async function insertReviewerProposalComment({
     decision: Decision
     body: string
 }) {
+    const latest = await db
+        .selectFrom('studyProposalComment')
+        .select('version')
+        .where('studyId', '=', studyId)
+        .orderBy('createdAt', 'desc')
+        .limit(1)
+        .executeTakeFirst()
+
     await db
         .insertInto('studyProposalComment')
         .values({
@@ -510,6 +518,7 @@ async function insertReviewerProposalComment({
             entryType: 'REVIEWER-FEEDBACK',
             decision: toReviewDecision(decision),
             body: JSON.parse(body),
+            version: latest?.version ?? 1,
         })
         .executeTakeFirstOrThrow()
 }

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -15,6 +15,7 @@ import {
     latestJobForStudy,
     type LatestJobForStudy,
 } from '@/server/db/queries'
+import { nextVersionForStudyComment } from '@/server/db/mutations'
 import { purgeReviewFeedbackYjsDocBeforeAt } from '@/server/db/yjs-cleanup'
 import {
     deferred,
@@ -510,10 +511,7 @@ async function insertReviewerProposalComment({
             entryType: 'REVIEWER-FEEDBACK',
             decision: toReviewDecision(decision),
             body: JSON.parse(body),
-            version: sql<number>`coalesce((
-                select max(version) from study_proposal_comment
-                where study_id = ${studyId}
-            ), 1)`,
+            version: nextVersionForStudyComment({ studyId, increment: false }),
         })
         .executeTakeFirstOrThrow()
 }

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -501,14 +501,6 @@ async function insertReviewerProposalComment({
     decision: Decision
     body: string
 }) {
-    const latest = await db
-        .selectFrom('studyProposalComment')
-        .select('version')
-        .where('studyId', '=', studyId)
-        .orderBy('createdAt', 'desc')
-        .limit(1)
-        .executeTakeFirst()
-
     await db
         .insertInto('studyProposalComment')
         .values({
@@ -518,7 +510,10 @@ async function insertReviewerProposalComment({
             entryType: 'REVIEWER-FEEDBACK',
             decision: toReviewDecision(decision),
             body: JSON.parse(body),
-            version: latest?.version ?? 1,
+            version: sql<number>`coalesce((
+                select max(version) from study_proposal_comment
+                where study_id = ${studyId}
+            ), 1)`,
         })
         .executeTakeFirstOrThrow()
 }

--- a/src/server/db/mutations.ts
+++ b/src/server/db/mutations.ts
@@ -1,6 +1,6 @@
 import { Action } from '../actions/action'
 import type { DB } from '@/database/types'
-import type { Kysely } from 'kysely'
+import { sql, type Kysely } from 'kysely'
 
 type SiUserOptionalAttrs = {
     firstName?: string | null
@@ -54,4 +54,14 @@ export async function ensureBaselineJob(db: Kysely<DB>, studyId: string) {
 /** Always creates a fresh job for IDE launch. Starter files should have their mtime backdated. */
 export async function resetBaselineJob(db: Kysely<DB>, studyId: string) {
     return createBaselineJob(db, studyId, new Date())
+}
+
+// Reviewer feedback shares the version of the proposal it reviews (increment=false)
+// Researcher resubmission opens a new version (increment=true)
+export function nextVersionForStudyComment({ studyId, increment }: { studyId: string; increment: boolean }) {
+    const current = sql<number>`coalesce((
+        select max(version) from study_proposal_comment
+        where study_id = ${studyId}
+    ), 1)`
+    return increment ? sql<number>`${current} + 1` : current
 }

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -171,6 +171,7 @@ export const getProposalFeedbackForStudy = async (studyId: string) => {
                 'studyProposalComment.decision',
                 'studyProposalComment.body',
                 'studyProposalComment.createdAt',
+                'studyProposalComment.version',
                 'author.fullName as authorName',
             ])
             .where('studyProposalComment.studyId', '=', studyId)


### PR DESCRIPTION
## Summary                                                                      
- Add a nullable `version` column to `study_proposal_comment`, backfill existing rows in chronological order (resubmission notes increment, reviewer feedback inherits the current version), and populate it on every insert from `resubmitProposalAction` and `insertReviewerProposalComment`.                   
- Derive `studyVersion` for the submitted page from the max entry version, and use it to drive:                                                                
    - the section heading (`Initial request` → `Initial request 2.0`, `3.0`, … on each resubmission),                                                             
    - the timestamp label (`Submitted on …` → `Resubmitted on …` once `studyVersion > 1`),                                                            
    - the yellow `PENDING-REVIEW` banner copy (revised-resubmission copy when `studyVersion > 1`),                                                            
    - per-entry titles (`Reviewer feedback (vN.0)` / `Resubmission note (vN.0)`). 
- Rework the Feedback & Notes entries: replace the Collapse/caret toggle with a `lineClamp`-driven `View more` / `View less` anchor in line with the design, and collapse resubmission notes by default even when they're the latest entry.