### PR TITLE
Add code review feedback + decision section with auto-save

### DIFF
--- a/services/editor/auth.test.ts
+++ b/services/editor/auth.test.ts
@@ -25,6 +25,13 @@ describe('parseDocumentName', () => {
         })
     })
 
+    it('parses code-review-feedback documents', () => {
+        expect(parseDocumentName(`code-review-feedback-${STUDY_ID}`)).toEqual({
+            kind: 'code-review-feedback',
+            studyId: STUDY_ID,
+        })
+    })
+
     it('parses proposal-fields documents', () => {
         expect(parseDocumentName(`proposal-${STUDY_ID}-fields`)).toEqual({
             kind: 'proposal-fields',
@@ -61,6 +68,10 @@ describe('requiredOrgIdForDocument', () => {
 
     it('returns DO org for review-feedback', () => {
         expect(requiredOrgIdForDocument({ kind: 'review-feedback', studyId: STUDY_ID }, study)).toBe('do-org')
+    })
+
+    it('returns DO org for code-review-feedback', () => {
+        expect(requiredOrgIdForDocument({ kind: 'code-review-feedback', studyId: STUDY_ID }, study)).toBe('do-org')
     })
 
     it('returns lab org for proposal-fields', () => {
@@ -429,6 +440,9 @@ describe('editableStatusForKind', () => {
     })
     it('returns PENDING-REVIEW for review-feedback', () => {
         expect(editableStatusForKind('review-feedback')).toEqual(['PENDING-REVIEW'])
+    })
+    it('returns APPROVED for code-review-feedback', () => {
+        expect(editableStatusForKind('code-review-feedback')).toEqual(['APPROVED'])
     })
 })
 

--- a/services/editor/auth.ts
+++ b/services/editor/auth.ts
@@ -4,6 +4,7 @@
 // network keys. `services/editor/server.ts` wires these into the runtime.
 
 import {
+    CODE_REVIEW_FEEDBACK_PREFIX,
     PROPOSAL_PREFIX,
     PROPOSAL_TEXT_SLUGS,
     REVIEW_FEEDBACK_PREFIX,
@@ -28,10 +29,17 @@ const SUBMITTED_REVIEW_STATUSES: readonly StudyStatus[] = ['APPROVED', 'CHANGE-R
 
 export type ParsedDocumentName =
     | { kind: 'review-feedback'; studyId: string }
+    | { kind: 'code-review-feedback'; studyId: string }
     | { kind: 'proposal-fields'; studyId: string }
     | { kind: 'proposal-text'; studyId: string; slug: ProposalTextSlug }
 
 export function parseDocumentName(name: string): ParsedDocumentName | null {
+    // Check the longer 'code-review-feedback-' prefix before 'review-feedback-'.
+    if (name.startsWith(CODE_REVIEW_FEEDBACK_PREFIX)) {
+        const studyId = name.slice(CODE_REVIEW_FEEDBACK_PREFIX.length)
+        return UUID_RE.test(studyId) ? { kind: 'code-review-feedback', studyId } : null
+    }
+
     if (name.startsWith(REVIEW_FEEDBACK_PREFIX)) {
         const studyId = name.slice(REVIEW_FEEDBACK_PREFIX.length)
         return UUID_RE.test(studyId) ? { kind: 'review-feedback', studyId } : null
@@ -54,13 +62,14 @@ export function parseDocumentName(name: string): ParsedDocumentName | null {
     return null
 }
 
-// review-feedback-* documents are owned by the reviewing org (DO).
+// review-feedback-* and code-review-feedback-* documents are owned by the reviewing org (DO).
 // proposal-* documents are owned by the submitting lab.
 export function requiredOrgIdForDocument(
     parsed: ParsedDocumentName,
     study: { org_id: string; submitted_by_org_id: string },
 ): string {
-    return parsed.kind === 'review-feedback' ? study.org_id : study.submitted_by_org_id
+    if (parsed.kind === 'review-feedback' || parsed.kind === 'code-review-feedback') return study.org_id
+    return study.submitted_by_org_id
 }
 
 // Allowed study statuses for editing each document kind. Authentication
@@ -69,6 +78,7 @@ export function requiredOrgIdForDocument(
 // persisted Yjs state after submission.
 export function editableStatusForKind(kind: ParsedDocumentName['kind']): readonly StudyStatus[] {
     if (kind === 'review-feedback') return ['PENDING-REVIEW']
+    if (kind === 'code-review-feedback') return ['APPROVED']
     return ['DRAFT', 'CHANGE-REQUESTED']
 }
 

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-decision-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-decision-section.test.tsx
@@ -31,8 +31,11 @@ describe('CodeReviewDecisionSection', () => {
 
     it('splices the lab name into each description', () => {
         renderWithProviders(<Harness labName="Bayes Lab" />)
-        // Lab name appears in the section intro plus in the approve + request-revision + reject descriptions.
-        expect(screen.getAllByText('Bayes Lab').length).toBeGreaterThanOrEqual(3)
+        expect(
+            screen.getByText(/The code will proceed to run in your secure enclave\. Bayes Lab will be notified/),
+        ).toBeInTheDocument()
+        expect(screen.getByText(/Return this code submission to Bayes Lab/)).toBeInTheDocument()
+        expect(screen.getByText(/Share rationale with Bayes Lab/)).toBeInTheDocument()
     })
 
     it('renders the reject warning text', () => {

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-decision-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-decision-section.test.tsx
@@ -1,0 +1,58 @@
+import { renderWithProviders, screen, userEvent } from '@/tests/unit.helpers'
+import { useCodeReviewDecision } from '@/hooks/use-code-review-decision'
+import type { CodeDecision } from '@/lib/code-review'
+import { describe, expect, it } from 'vitest'
+import { CodeReviewDecisionSection } from './code-review-decision-section'
+
+function Harness({ labName, onChange }: { labName: string; onChange?: (value: CodeDecision | null) => void }) {
+    const decision = useCodeReviewDecision()
+    return (
+        <CodeReviewDecisionSection
+            decision={{
+                selected: decision.selected,
+                onSelect: (next) => {
+                    const value = typeof next === 'function' ? next(decision.selected) : next
+                    decision.onSelect(value)
+                    onChange?.(value)
+                },
+            }}
+            labName={labName}
+        />
+    )
+}
+
+describe('CodeReviewDecisionSection', () => {
+    it('renders the three decision radios with the spec-defined labels', () => {
+        renderWithProviders(<Harness labName="Bayes Lab" />)
+        expect(screen.getByRole('radio', { name: /Approve and run code/i })).toBeInTheDocument()
+        expect(screen.getByRole('radio', { name: /Request revision/i })).toBeInTheDocument()
+        expect(screen.getByRole('radio', { name: /Reject and end study/i })).toBeInTheDocument()
+    })
+
+    it('splices the lab name into each description', () => {
+        renderWithProviders(<Harness labName="Bayes Lab" />)
+        // Lab name appears in the section intro plus in the approve + request-revision + reject descriptions.
+        expect(screen.getAllByText('Bayes Lab').length).toBeGreaterThanOrEqual(3)
+    })
+
+    it('renders the reject warning text', () => {
+        renderWithProviders(<Harness labName="Bayes Lab" />)
+        expect(screen.getByText(/This terminates the study and cannot be undone/i)).toBeInTheDocument()
+    })
+
+    it('selects a single radio at a time and reports the value', async () => {
+        const user = userEvent.setup()
+        const selections: (CodeDecision | null)[] = []
+        renderWithProviders(<Harness labName="Bayes Lab" onChange={(v) => selections.push(v)} />)
+
+        await user.click(screen.getByRole('radio', { name: /Approve and run code/i }))
+        expect(screen.getByRole('radio', { name: /Approve and run code/i })).toBeChecked()
+        expect(screen.getByRole('radio', { name: /Request revision/i })).not.toBeChecked()
+
+        await user.click(screen.getByRole('radio', { name: /Reject and end study/i }))
+        expect(screen.getByRole('radio', { name: /Reject and end study/i })).toBeChecked()
+        expect(screen.getByRole('radio', { name: /Approve and run code/i })).not.toBeChecked()
+
+        expect(selections).toEqual(['approve', 'reject'])
+    })
+})

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-decision-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-decision-section.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import type { useCodeReviewDecision } from '@/hooks/use-code-review-decision'
+import type { CodeDecision } from '@/lib/code-review'
+import { Divider, Radio, Stack, Text } from '@mantine/core'
+import type { ReactNode } from 'react'
+import { CODE_DECISION_OPTIONS, type CodeDecisionOption } from './code-review-types'
+
+type CodeReviewDecisionSectionProps = {
+    decision: ReturnType<typeof useCodeReviewDecision>
+    labName: string
+}
+
+const RADIO_STYLES = {
+    label: { fontWeight: 600, fontSize: 16 },
+    description: { fontSize: 14 },
+}
+
+function spliceLabName(text: string, labName: string): string {
+    return text.replaceAll('{researchLab}', labName)
+}
+
+// Mantine's Radio.description renders inside a <p>, so children must be valid
+// phrasing content (no <div> or nested <p>). Use spans with display="block" to
+// stack the warning under the description without violating HTML nesting rules.
+function OptionDescription({ option, labName }: { option: CodeDecisionOption; labName: string }): ReactNode {
+    const description = spliceLabName(option.description, labName)
+    if (!option.warning) {
+        return (
+            <Text component="span" size="sm" c="grey.7">
+                {description}
+            </Text>
+        )
+    }
+    return (
+        <Text component="span" size="sm" c="grey.7">
+            {description}
+            <Text component="span" display="block" size="sm" c="charcoal.7" fw={600} mt={4}>
+                {option.warning}
+            </Text>
+        </Text>
+    )
+}
+
+export function CodeReviewDecisionSection({ decision, labName }: CodeReviewDecisionSectionProps) {
+    const handleChange = (value: string) => {
+        decision.onSelect(value as CodeDecision)
+    }
+
+    return (
+        <Stack gap="md" data-testid="code-review-decision-section">
+            <Divider />
+            <Text size="md">
+                Select a decision for this code submission. Your feedback and decision will be shared with the {labName}
+                .
+            </Text>
+            <Radio.Group value={decision.selected ?? ''} onChange={handleChange} name="code-review-decision">
+                <Stack gap="md" mt="xs">
+                    {CODE_DECISION_OPTIONS.map((option) => (
+                        <Radio
+                            key={option.value}
+                            value={option.value}
+                            label={option.label}
+                            description={<OptionDescription option={option} labName={labName} />}
+                            styles={RADIO_STYLES}
+                        />
+                    ))}
+                </Stack>
+            </Radio.Group>
+        </Stack>
+    )
+}

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-feedback-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-feedback-section.test.tsx
@@ -1,0 +1,60 @@
+import { renderWithProviders, screen, userEvent, waitFor } from '@/tests/unit.helpers'
+import { useCodeReviewFeedback } from '@/hooks/use-code-review-feedback'
+import { lexicalJson } from '@/lib/word-count'
+import { describe, expect, it, vi } from 'vitest'
+import { CodeReviewFeedbackSection } from './code-review-feedback-section'
+
+vi.mock('@/server/actions/editor.actions', () => ({
+    getYjsDocumentUpdatedAtAction: vi.fn(() => Promise.resolve(null)),
+}))
+
+function Harness({ labName, words }: { labName: string; words?: string }) {
+    const feedback = useCodeReviewFeedback()
+    return (
+        <>
+            <button
+                type="button"
+                data-testid="simulate-input"
+                onClick={() => feedback.onChange(lexicalJson(words ?? ''))}
+            >
+                simulate input
+            </button>
+            <CodeReviewFeedbackSection feedback={feedback} labName={labName} studyId="test-study-id" />
+        </>
+    )
+}
+
+describe('CodeReviewFeedbackSection', () => {
+    it('renders the "Code review" section title', () => {
+        renderWithProviders(<Harness labName="Bayes Lab" />)
+        expect(screen.getByText('Code review')).toBeInTheDocument()
+    })
+
+    it('renders the lab name inline in the description', () => {
+        renderWithProviders(<Harness labName="Bayes Lab" />)
+        expect(screen.getByText(/Share your feedback on this code submission with Bayes Lab/)).toBeInTheDocument()
+    })
+
+    it('starts with a 0/300 word counter', () => {
+        renderWithProviders(<Harness labName="Bayes Lab" />)
+        expect(screen.getByText('0/300')).toBeInTheDocument()
+    })
+
+    it('updates the word counter when feedback content changes', async () => {
+        const user = userEvent.setup()
+        renderWithProviders(<Harness labName="Bayes Lab" words="one two three four five" />)
+        await user.click(screen.getByTestId('simulate-input'))
+        await waitFor(() => {
+            expect(screen.getByText('5/300')).toBeInTheDocument()
+        })
+    })
+
+    it('flips the word counter into the over-limit state when content exceeds 300 words', async () => {
+        const user = userEvent.setup()
+        renderWithProviders(<Harness labName="Bayes Lab" words={'word '.repeat(301).trim()} />)
+        await user.click(screen.getByTestId('simulate-input'))
+        await waitFor(() => {
+            expect(screen.getByText('301/300')).toBeInTheDocument()
+        })
+    })
+})

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-feedback-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-feedback-section.test.tsx
@@ -35,26 +35,39 @@ describe('CodeReviewFeedbackSection', () => {
         expect(screen.getByText(/Share your feedback on this code submission with Bayes Lab/)).toBeInTheDocument()
     })
 
-    it('starts with a 0/300 word counter', () => {
+    it('starts with a 0/300 word counter', async () => {
         renderWithProviders(<Harness labName="Bayes Lab" />)
-        expect(screen.getByText('0/300')).toBeInTheDocument()
+        // The CollaborativeEditor is dynamically imported (ssr:false); wait for it to mount
+        // before asserting on its footer-rendered word counter.
+        await waitFor(
+            () => {
+                expect(screen.getByText('0/300')).toBeInTheDocument()
+            },
+            { timeout: 5000 },
+        )
     })
 
     it('updates the word counter when feedback content changes', async () => {
         const user = userEvent.setup()
         renderWithProviders(<Harness labName="Bayes Lab" words="one two three four five" />)
         await user.click(screen.getByTestId('simulate-input'))
-        await waitFor(() => {
-            expect(screen.getByText('5/300')).toBeInTheDocument()
-        })
+        await waitFor(
+            () => {
+                expect(screen.getByText('5/300')).toBeInTheDocument()
+            },
+            { timeout: 5000 },
+        )
     })
 
     it('flips the word counter into the over-limit state when content exceeds 300 words', async () => {
         const user = userEvent.setup()
         renderWithProviders(<Harness labName="Bayes Lab" words={'word '.repeat(301).trim()} />)
         await user.click(screen.getByTestId('simulate-input'))
-        await waitFor(() => {
-            expect(screen.getByText('301/300')).toBeInTheDocument()
-        })
+        await waitFor(
+            () => {
+                expect(screen.getByText('301/300')).toBeInTheDocument()
+            },
+            { timeout: 5000 },
+        )
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-feedback-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-feedback-section.test.tsx
@@ -1,6 +1,6 @@
 import { renderWithProviders, screen, userEvent, waitFor } from '@/tests/unit.helpers'
 import { useCodeReviewFeedback } from '@/hooks/use-code-review-feedback'
-import { lexicalJson } from '@/lib/word-count'
+import { lexicalJson } from '@/lib/lexical'
 import { describe, expect, it, vi } from 'vitest'
 import { CodeReviewFeedbackSection } from './code-review-feedback-section'
 

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-feedback-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-feedback-section.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { WordCounter } from '@/components/word-counter'
+import type { useCodeReviewFeedback } from '@/hooks/use-code-review-feedback'
+import { codeReviewFeedbackDocName } from '@/lib/collaboration-documents'
+import { useYjsWebsocket } from '@/lib/realtime/yjs-websocket-context'
+import { Divider, Skeleton, Stack, Text } from '@mantine/core'
+import dynamic from 'next/dynamic'
+
+const EDITOR_SKELETON = <Skeleton h={300} radius={4} />
+
+const CollaborativeEditor = dynamic(
+    () => import('@/components/editable-text/collaborative-editor').then((mod) => mod.CollaborativeEditor),
+    {
+        ssr: false,
+        loading: () => EDITOR_SKELETON,
+    },
+)
+
+const contentStyle = {
+    minHeight: 300,
+    padding: '8px 16px',
+    outline: 'none',
+    fontSize: '1rem',
+    lineHeight: 1.6,
+} as const
+
+type CodeReviewFeedbackSectionProps = {
+    feedback: ReturnType<typeof useCodeReviewFeedback>
+    labName: string
+    studyId: string
+}
+
+const PLACEHOLDER_TEXT =
+    'The code aligns with the approved proposal and accesses only the variables specified in the data use agreement. Outputs are aggregated at the group level, with no individual-level data exposed. Security scans passed with no issues. One question: the code filters by enrollment date, which appears to be a deviation from your initial proposal. Can you please share your rationale for using this variable?'
+
+function FeedbackEditor({
+    feedback,
+    studyId,
+}: {
+    feedback: CodeReviewFeedbackSectionProps['feedback']
+    studyId: string
+}) {
+    const websocketProvider = useYjsWebsocket()
+    if (!websocketProvider) return EDITOR_SKELETON
+    return (
+        <CollaborativeEditor
+            id={codeReviewFeedbackDocName(studyId)}
+            studyId={studyId}
+            websocketProvider={websocketProvider}
+            contentStyle={contentStyle}
+            placeholder={PLACEHOLDER_TEXT}
+            onChange={feedback.onChange}
+            footerRight={<WordCounter wordCount={feedback.wordCount} maxWords={feedback.maxWords} />}
+        />
+    )
+}
+
+export function CodeReviewFeedbackSection({ feedback, labName, studyId }: CodeReviewFeedbackSectionProps) {
+    return (
+        <Stack gap="md" data-testid="code-review-feedback-section">
+            <Text fz={20} fw={700} c="charcoal.9">
+                Code review{' '}
+                <Text component="span" c="red.9" aria-hidden="true">
+                    *
+                </Text>
+            </Text>
+            <Divider />
+            <Text size="md" c="charcoal.9">
+                Share your feedback on this code submission with {labName}. Your comments should address the code&apos;s
+                alignment with the approved study proposal/initial request and all the agreements, whether the security
+                log surfaced issues, and whether the analysis code risks exposing PII. You can also request
+                clarifications about the researchers&apos; approach and flag potential risks or misconceptions about
+                your dataset(s) before the code is approved to run.
+            </Text>
+            <FeedbackEditor feedback={feedback} studyId={studyId} />
+        </Stack>
+    )
+}

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-form.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-form.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { Link } from '@/components/links'
+import { useCodeReviewDecision } from '@/hooks/use-code-review-decision'
+import { useCodeReviewFeedback } from '@/hooks/use-code-review-feedback'
+import { Routes } from '@/lib/routes'
+import { Button, Group, Paper, Stack } from '@mantine/core'
+import { CaretLeftIcon } from '@phosphor-icons/react'
+import { CodeReviewDecisionSection } from './code-review-decision-section'
+import { CodeReviewFeedbackSection } from './code-review-feedback-section'
+
+type CodeReviewFormProps = {
+    labName: string
+    orgSlug: string
+    studyId: string
+}
+
+export function CodeReviewForm({ labName, orgSlug, studyId }: CodeReviewFormProps) {
+    const feedback = useCodeReviewFeedback()
+    const decision = useCodeReviewDecision()
+
+    const canSubmit = feedback.value.trim().length > 0 && !feedback.isOverLimit && decision.selected !== null
+
+    const handleSubmit = () => {
+        // TODO(future card): wire up server action to persist the decision + feedback
+        // and transition the job status. For now this is a UI-only stub.
+        // eslint-disable-next-line no-console
+        console.log('Submit code review:', { decision: decision.selected, feedback: feedback.value })
+    }
+
+    return (
+        <Stack gap="xl">
+            <Paper p="xl">
+                <Stack gap="md">
+                    <CodeReviewFeedbackSection feedback={feedback} labName={labName} studyId={studyId} />
+                    <CodeReviewDecisionSection decision={decision} labName={labName} />
+                </Stack>
+            </Paper>
+            <Group justify="space-between">
+                <Link
+                    href={Routes.orgDashboard({ orgSlug })}
+                    c="purple.5"
+                    td="none"
+                    style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
+                    data-testid="code-review-back-link"
+                >
+                    <CaretLeftIcon size={16} weight="bold" />
+                    Back
+                </Link>
+                <Button disabled={!canSubmit} onClick={handleSubmit} data-testid="code-review-submit-button">
+                    Submit review
+                </Button>
+            </Group>
+        </Stack>
+    )
+}

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.test.tsx
@@ -5,6 +5,7 @@ import {
     mockSessionWithTestData,
     renderWithProviders,
     screen,
+    userEvent,
     type Mock,
 } from '@/tests/unit.helpers'
 import dayjs from 'dayjs'
@@ -100,5 +101,23 @@ describe('CodeReviewRedesignView', () => {
         expect(criteria).toHaveTextContent('Have security and vulnerability checks been passed?')
         expect(criteria).toHaveTextContent('Privacy protection:')
         expect(criteria).toHaveTextContent('Is there any risk of PII exposure expected in the outputs?')
+    })
+
+    it('renders the feedback and decision sections', async () => {
+        renderWithProviders(await CodeReviewRedesignView({ orgSlug: ORG_SLUG, study }))
+        expect(screen.getByTestId('code-review-feedback-section')).toBeInTheDocument()
+        expect(screen.getByTestId('code-review-decision-section')).toBeInTheDocument()
+    })
+
+    it('disables the Submit review button on initial render', async () => {
+        renderWithProviders(await CodeReviewRedesignView({ orgSlug: ORG_SLUG, study }))
+        expect(screen.getByTestId('code-review-submit-button')).toBeDisabled()
+    })
+
+    it('keeps Submit disabled when only a decision is selected (no feedback yet)', async () => {
+        const user = userEvent.setup()
+        renderWithProviders(await CodeReviewRedesignView({ orgSlug: ORG_SLUG, study }))
+        await user.click(screen.getByRole('radio', { name: /Approve and run code/i }))
+        expect(screen.getByTestId('code-review-submit-button')).toBeDisabled()
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.tsx
@@ -4,6 +4,7 @@ import { latestJobForStudy } from '@/server/db/queries'
 import { Box, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
 import dayjs from 'dayjs'
 import type { SelectedStudy } from '@/server/actions/study.actions'
+import { CodeReviewForm } from './code-review-form'
 
 type CodeReviewRedesignViewProps = {
     orgSlug: string
@@ -104,6 +105,7 @@ function CodeReviewSection({ study, submittedAt }: CodeReviewSectionProps) {
 export async function CodeReviewRedesignView({ orgSlug, study }: CodeReviewRedesignViewProps) {
     const job = await latestJobForStudy(study.id)
     const proposalHref = `${Routes.studyReview({ orgSlug, studyId: study.id })}?from=code-review`
+    const labName = study.submittingLabName ?? study.submittedByOrgSlug
 
     return (
         <Box bg="grey.10">
@@ -119,6 +121,7 @@ export async function CodeReviewRedesignView({ orgSlug, study }: CodeReviewRedes
                     Study Proposal
                 </Title>
                 <CodeReviewSection study={study} submittedAt={job.createdAt} />
+                <CodeReviewForm labName={labName} orgSlug={orgSlug} studyId={study.id} />
             </Stack>
         </Box>
     )

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-types.ts
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-types.ts
@@ -1,0 +1,30 @@
+import type { CodeDecision } from '@/lib/code-review'
+
+export type CodeDecisionOption = {
+    value: CodeDecision
+    label: string
+    description: string
+    warning?: string
+}
+
+export const CODE_DECISION_OPTIONS: CodeDecisionOption[] = [
+    {
+        value: 'approve',
+        label: 'Approve and run code',
+        description:
+            'The code will proceed to run in your secure enclave. {researchLab} will be notified via email when the code is approved and is being run.',
+    },
+    {
+        value: 'request-revision',
+        label: 'Request revision',
+        description:
+            'Return this code submission to {researchLab} for necessary updates, additional information, or specific changes.',
+    },
+    {
+        value: 'reject',
+        label: 'Reject and end study',
+        description:
+            'Permanently end this study due to major, unresolvable issues. Share rationale with {researchLab}.',
+        warning: 'Warning: This terminates the study and cannot be undone.',
+    },
+]

--- a/src/hooks/use-code-review-decision.ts
+++ b/src/hooks/use-code-review-decision.ts
@@ -1,0 +1,11 @@
+import { useState } from 'react'
+import type { CodeDecision } from '@/lib/code-review'
+
+export function useCodeReviewDecision() {
+    const [selected, setSelected] = useState<CodeDecision | null>(null)
+
+    return {
+        selected,
+        onSelect: setSelected,
+    }
+}

--- a/src/hooks/use-code-review-feedback.test.ts
+++ b/src/hooks/use-code-review-feedback.test.ts
@@ -1,4 +1,4 @@
-import { lexicalJson } from '@/lib/word-count'
+import { lexicalJson } from '@/lib/lexical'
 import { act, renderHook } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import { useCodeReviewFeedback } from './use-code-review-feedback'

--- a/src/hooks/use-code-review-feedback.test.ts
+++ b/src/hooks/use-code-review-feedback.test.ts
@@ -1,0 +1,43 @@
+import { lexicalJson } from '@/lib/word-count'
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { useCodeReviewFeedback } from './use-code-review-feedback'
+
+describe('useCodeReviewFeedback', () => {
+    it('initializes with empty value and invalid state', () => {
+        const { result } = renderHook(() => useCodeReviewFeedback())
+        expect(result.current.value).toBe('')
+        expect(result.current.wordCount).toBe(0)
+        expect(result.current.isValid).toBe(false)
+        expect(result.current.isOverLimit).toBe(false)
+        expect(result.current.minWords).toBe(1)
+        expect(result.current.maxWords).toBe(300)
+    })
+
+    it('becomes valid once at least one word is entered', () => {
+        const { result } = renderHook(() => useCodeReviewFeedback())
+        act(() => result.current.onChange(lexicalJson('hello world')))
+        expect(result.current.wordCount).toBe(2)
+        expect(result.current.isValid).toBe(true)
+        expect(result.current.isOverLimit).toBe(false)
+    })
+
+    it('flips to invalid + over-limit when word count exceeds the max', () => {
+        const { result } = renderHook(() => useCodeReviewFeedback())
+        const longText = 'word '.repeat(301).trim()
+        act(() => result.current.onChange(lexicalJson(longText)))
+        expect(result.current.wordCount).toBe(301)
+        expect(result.current.isValid).toBe(false)
+        expect(result.current.isOverLimit).toBe(true)
+    })
+
+    it('returns to invalid state when cleared back to empty', () => {
+        const { result } = renderHook(() => useCodeReviewFeedback())
+        act(() => result.current.onChange(lexicalJson('something')))
+        expect(result.current.isValid).toBe(true)
+        act(() => result.current.onChange(lexicalJson('')))
+        expect(result.current.wordCount).toBe(0)
+        expect(result.current.isValid).toBe(false)
+        expect(result.current.isOverLimit).toBe(false)
+    })
+})

--- a/src/hooks/use-code-review-feedback.ts
+++ b/src/hooks/use-code-review-feedback.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react'
 import { CODE_REVIEW_MAX_WORDS, CODE_REVIEW_MIN_WORDS } from '@/lib/code-review'
-import { countWordsFromLexical } from '@/lib/word-count'
+import { countWordsFromLexical } from '@/lib/lexical'
 
 export function useCodeReviewFeedback() {
     const [value, setValue] = useState('')

--- a/src/hooks/use-code-review-feedback.ts
+++ b/src/hooks/use-code-review-feedback.ts
@@ -1,0 +1,29 @@
+import { useCallback, useState } from 'react'
+import { CODE_REVIEW_MAX_WORDS, CODE_REVIEW_MIN_WORDS } from '@/lib/code-review'
+import { countWordsFromLexical } from '@/lib/word-count'
+
+export function useCodeReviewFeedback() {
+    const [value, setValue] = useState('')
+    const [wordCount, setWordCount] = useState(0)
+
+    const isValid = wordCount >= CODE_REVIEW_MIN_WORDS && wordCount <= CODE_REVIEW_MAX_WORDS
+    const isOverLimit = wordCount > CODE_REVIEW_MAX_WORDS
+
+    // Value is the Lexical editor's serialized JSON state. The CollaborativeEditor
+    // pushes the JSON on every keystroke; we count words by extracting the plain
+    // text from the Lexical tree.
+    const onChange = useCallback((next: string) => {
+        setValue(next)
+        setWordCount(countWordsFromLexical(next))
+    }, [])
+
+    return {
+        value,
+        onChange,
+        wordCount,
+        minWords: CODE_REVIEW_MIN_WORDS,
+        maxWords: CODE_REVIEW_MAX_WORDS,
+        isValid,
+        isOverLimit,
+    }
+}

--- a/src/lib/code-review.ts
+++ b/src/lib/code-review.ts
@@ -1,0 +1,4 @@
+export type CodeDecision = 'approve' | 'request-revision' | 'reject'
+
+export const CODE_REVIEW_MIN_WORDS = 1
+export const CODE_REVIEW_MAX_WORDS = 300

--- a/src/lib/collaboration-documents.test.ts
+++ b/src/lib/collaboration-documents.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+    codeReviewFeedbackDocName,
     parseDocumentName,
     proposalFieldsDocName,
     proposalTextFieldDocName,
@@ -35,6 +36,12 @@ describe('collaboration document naming', () => {
         expect(parseDocumentName(name)).toEqual({ kind: 'review-feedback', studyId: STUDY_ID })
     })
 
+    it('round-trips code-review-feedback docs', () => {
+        const name = codeReviewFeedbackDocName(STUDY_ID)
+        expect(name).toBe(`code-review-feedback-${STUDY_ID}`)
+        expect(parseDocumentName(name)).toEqual({ kind: 'code-review-feedback', studyId: STUDY_ID })
+    })
+
     it('rejects malformed names', () => {
         expect(parseDocumentName('')).toBeNull()
         expect(parseDocumentName('proposal-not-a-uuid-fields')).toBeNull()
@@ -42,5 +49,6 @@ describe('collaboration document naming', () => {
         expect(parseDocumentName(`proposal-${STUDY_ID}-unknown-suffix`)).toBeNull()
         expect(parseDocumentName(`unknown-${STUDY_ID}`)).toBeNull()
         expect(parseDocumentName(`review-feedback-not-a-uuid`)).toBeNull()
+        expect(parseDocumentName(`code-review-feedback-not-a-uuid`)).toBeNull()
     })
 })

--- a/src/lib/collaboration-documents.ts
+++ b/src/lib/collaboration-documents.ts
@@ -8,6 +8,7 @@ const PROPOSAL_TEXT_FIELD_KEYS: ProposalTextFieldKey[] = [
 ]
 
 export const REVIEW_FEEDBACK_PREFIX = 'review-feedback-'
+export const CODE_REVIEW_FEEDBACK_PREFIX = 'code-review-feedback-'
 export const PROPOSAL_PREFIX = 'proposal-'
 export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -32,12 +33,23 @@ export const proposalTextFieldDocName = (studyId: string, fieldKey: ProposalText
 
 export const reviewFeedbackDocName = (studyId: string) => `${REVIEW_FEEDBACK_PREFIX}${studyId}`
 
+export const codeReviewFeedbackDocName = (studyId: string) => `${CODE_REVIEW_FEEDBACK_PREFIX}${studyId}`
+
 export type ParsedDocumentName =
     | { kind: 'proposal-fields'; studyId: string }
     | { kind: 'proposal-text'; studyId: string; fieldKey: ProposalTextFieldKey }
     | { kind: 'review-feedback'; studyId: string }
+    | { kind: 'code-review-feedback'; studyId: string }
 
 export const parseDocumentName = (name: string): ParsedDocumentName | null => {
+    // Order matters: check the longer prefix first since 'code-review-feedback-'
+    // does not start with 'review-feedback-' but a future rename could overlap.
+    if (name.startsWith(CODE_REVIEW_FEEDBACK_PREFIX)) {
+        const studyId = name.slice(CODE_REVIEW_FEEDBACK_PREFIX.length)
+        if (!UUID_RE.test(studyId)) return null
+        return { kind: 'code-review-feedback', studyId }
+    }
+
     if (name.startsWith(REVIEW_FEEDBACK_PREFIX)) {
         const studyId = name.slice(REVIEW_FEEDBACK_PREFIX.length)
         if (!UUID_RE.test(studyId)) return null


### PR DESCRIPTION
Issue: [OTTER-543](https://openstax.atlassian.net/browse/OTTER-543)

## Summary
- Adds the feedback + decision section to the DO code review page: mandatory feedback field, three radio decisions (Approve and run code / Request revision / Reject and end study), Submit button with disabled-state logic, and a "Back" link to the org dashboard.
- Auto-save: leveraged  existing auto-save functionality 
- All new UI lives inside `CodeReviewRedesignView`, which is already the `optInContent` of `CodeReviewFeatureFlag` — only OpenStax DOs with spy mode on see it; everyone else continues to see the legacy `CodeReviewView`.

## What's in scope
- New section UI: title "Code review" with required asterisk, divider, lab-name description, Lexical editor with live word count (1–300 words), radio decision group with code-specific labels and a stacked "terminates the study" warning on reject.
- New Yjs document kind `code-review-feedback-{studyId}` — added to `src/lib/collaboration-documents.ts` and the Hocuspocus server auth in `services/editor/auth.ts` (owned by the DO org; editable while study status is `APPROVED`).
- Back link → `Routes.orgDashboard({ orgSlug })` 
- Unit tests for the new constants, hooks, sections, doc-name parser, and server-side auth.

## Test plan
- [ ] As an OpenStax DO with spy mode on, navigate to `/openstax/study/{studyId}/review` for a study with `CODE-SUBMITTED` job + agreements acked. Verify:
   - "Code review *" section title with red asterisk
   - Lexical editor renders with "Last saved …" indicator after typing
   - Word counter goes 0/300 → counts up; turns red at 301
   - Three radio options with lab name spliced in; reject warning stacked below the description in `charcoal.7` semibold
   - Submit disabled until feedback is non-empty + ≤300 words + a decision is selected
   - Click "Back" → lands on `Routes.orgDashboard({ orgSlug })`
- [ ] Reload the page mid-edit — content reloads from `yjs_document`

[OTTER-543]: https://openstax.atlassian.net/browse/OTTER-543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ