### PR TITLE
add plaintext copies of scan and packaging error logs

### DIFF
--- a/src/app/api/services/containerizer/route.test.ts
+++ b/src/app/api/services/containerizer/route.test.ts
@@ -137,7 +137,7 @@ test('returns 404 job-not-found for unknown jobId', async () => {
     expect(body).toEqual({ error: 'job-not-found' })
 })
 
-test('containerizer encrypts and stores plaintextLog on JOB-ERRORED', async () => {
+test('containerizer stores encrypted and plaintext logs on JOB-ERRORED', async () => {
     const { org, user } = await mockSessionWithTestData({ orgType: 'enclave', useRealKeys: true })
     const { jobIds } = await insertTestStudyData({ org, researcherId: user.id })
     const jobId = jobIds[0]
@@ -153,6 +153,7 @@ test('containerizer encrypts and stores plaintextLog on JOB-ERRORED', async () =
 
     const files = await db.selectFrom('studyJobFile').select(['fileType']).where('studyJobId', '=', jobId).execute()
     expect(files.some((f) => f.fileType === 'ENCRYPTED-PACKAGING-ERROR-LOG')).toBe(true)
+    expect(files.some((f) => f.fileType === 'PACKAGING-ERROR-LOG')).toBe(true)
 })
 
 test('returns 401 when Authorization header is missing', async () => {

--- a/src/app/api/services/containerizer/route.ts
+++ b/src/app/api/services/containerizer/route.ts
@@ -1,5 +1,6 @@
 import { db } from '@/database'
 import { throwNotFound } from '@/lib/errors'
+import { storeStudyLogFile } from '@/server/storage'
 import { z } from 'zod'
 import { createWebhookHandler } from '../webhook-handler'
 import { encryptAndStoreLog } from '../encrypt-and-store-log'
@@ -36,6 +37,12 @@ export const POST = createWebhookHandler({
                 fileType: 'ENCRYPTED-PACKAGING-ERROR-LOG',
                 job,
             })
+            const file = new File([body.plaintextLog], 'packaging-error-log.txt', { type: 'text/plain' })
+            await storeStudyLogFile(
+                { orgSlug: job.orgSlug, studyId: job.studyId, studyJobId: job.jobId },
+                file,
+                'PACKAGING-ERROR-LOG',
+            )
         }
 
         const last = await db

--- a/src/app/api/services/job-scan-results/route.test.ts
+++ b/src/app/api/services/job-scan-results/route.test.ts
@@ -113,7 +113,7 @@ test('inserts JOB-ERRORED status', async () => {
     expect(rows.some((r) => r.status === 'JOB-ERRORED')).toBe(true)
 })
 
-test('encrypts and stores plaintextLog on JOB-ERRORED', async () => {
+test('stores encrypted and plaintext logs on JOB-ERRORED', async () => {
     const { org, user } = await mockSessionWithTestData({ orgType: 'enclave', useRealKeys: true })
     const { jobIds } = await insertTestStudyData({ org, researcherId: user.id })
     const jobId = jobIds[0]
@@ -125,9 +125,10 @@ test('encrypts and stores plaintextLog on JOB-ERRORED', async () => {
 
     const files = await db.selectFrom('studyJobFile').select(['fileType']).where('studyJobId', '=', jobId).execute()
     expect(files.some((f) => f.fileType === 'ENCRYPTED-PACKAGING-ERROR-LOG')).toBe(true)
+    expect(files.some((f) => f.fileType === 'PACKAGING-ERROR-LOG')).toBe(true)
 })
 
-test('encrypts and stores plaintextLog on CODE-SCANNED', async () => {
+test('stores encrypted and plaintext logs on CODE-SCANNED', async () => {
     const { org, user } = await mockSessionWithTestData({ orgType: 'enclave', useRealKeys: true })
     const { jobIds } = await insertTestStudyData({ org, researcherId: user.id })
     const jobId = jobIds[0]
@@ -139,6 +140,7 @@ test('encrypts and stores plaintextLog on CODE-SCANNED', async () => {
 
     const files = await db.selectFrom('studyJobFile').select(['fileType']).where('studyJobId', '=', jobId).execute()
     expect(files.some((f) => f.fileType === 'ENCRYPTED-SECURITY-SCAN-LOG')).toBe(true)
+    expect(files.some((f) => f.fileType === 'SECURITY-SCAN-LOG')).toBe(true)
 })
 
 test('idempotency: duplicate same-status calls do not create duplicate rows', async () => {

--- a/src/app/api/services/job-scan-results/route.ts
+++ b/src/app/api/services/job-scan-results/route.ts
@@ -1,6 +1,7 @@
 import { db } from '@/database'
 import type { FileType } from '@/database/types'
 import { throwNotFound } from '@/lib/errors'
+import { storeStudyLogFile } from '@/server/storage'
 import { z } from 'zod'
 import { createWebhookHandler } from '../webhook-handler'
 import { encryptAndStoreLog } from '../encrypt-and-store-log'
@@ -11,9 +12,9 @@ const schema = z.object({
     plaintextLog: z.string().optional(),
 })
 
-const LOG_FILE_TYPE: Partial<Record<string, FileType>> = {
-    'JOB-ERRORED': 'ENCRYPTED-PACKAGING-ERROR-LOG',
-    'CODE-SCANNED': 'ENCRYPTED-SECURITY-SCAN-LOG',
+const LOG_FILE_TYPES: Partial<Record<string, { encrypted: FileType; plaintext: FileType }>> = {
+    'JOB-ERRORED': { encrypted: 'ENCRYPTED-PACKAGING-ERROR-LOG', plaintext: 'PACKAGING-ERROR-LOG' },
+    'CODE-SCANNED': { encrypted: 'ENCRYPTED-SECURITY-SCAN-LOG', plaintext: 'SECURITY-SCAN-LOG' },
 }
 
 export const POST = createWebhookHandler({
@@ -35,14 +36,22 @@ export const POST = createWebhookHandler({
             ])
             .executeTakeFirstOrThrow(throwNotFound('job'))
 
-        const logFileType = LOG_FILE_TYPE[body.status]
-        if (logFileType && body.plaintextLog) {
+        const logFileTypes = LOG_FILE_TYPES[body.status]
+        if (logFileTypes && body.plaintextLog) {
             await encryptAndStoreLog({
                 route: '/api/services/job-scan-results',
                 plaintextLog: body.plaintextLog,
-                fileType: logFileType,
+                fileType: logFileTypes.encrypted,
                 job,
             })
+            const file = new File([body.plaintextLog], `${logFileTypes.plaintext.toLowerCase()}.txt`, {
+                type: 'text/plain',
+            })
+            await storeStudyLogFile(
+                { orgSlug: job.orgSlug, studyId: job.studyId, studyJobId: job.jobId },
+                file,
+                logFileTypes.plaintext,
+            )
         }
 
         const last = await db

--- a/src/database/migrations/1776600000000_add_plaintext_log_file_types.ts
+++ b/src/database/migrations/1776600000000_add_plaintext_log_file_types.ts
@@ -1,0 +1,9 @@
+import { type Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+    await sql`ALTER TYPE study_job_file_type ADD VALUE IF NOT EXISTS 'SECURITY-SCAN-LOG'`.execute(db)
+    await sql`ALTER TYPE study_job_file_type ADD VALUE IF NOT EXISTS 'PACKAGING-ERROR-LOG'`.execute(db)
+}
+
+// Postgres does not support removing enum values, so down is a no-op.
+export async function down(_db: Kysely<unknown>): Promise<void> {}

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -53,6 +53,8 @@ export type StudyJobFileType =
     | 'ENCRYPTED-RESULT'
     | 'ENCRYPTED-SECURITY-SCAN-LOG'
     | 'MAIN-CODE'
+    | 'PACKAGING-ERROR-LOG'
+    | 'SECURITY-SCAN-LOG'
     | 'SUPPLEMENTAL-CODE'
 
 export type StudyJobStatus =

--- a/src/lib/file-type-helpers.ts
+++ b/src/lib/file-type-helpers.ts
@@ -12,6 +12,8 @@ export const APPROVED_LOG_TYPES: FileType[] = [
     'APPROVED-PACKAGING-ERROR-LOG',
 ]
 
+export const PLAINTEXT_LOG_TYPES: FileType[] = ['SECURITY-SCAN-LOG', 'PACKAGING-ERROR-LOG']
+
 export const ENCRYPTED_TO_APPROVED: Record<string, FileType> = {
     'ENCRYPTED-RESULT': 'APPROVED-RESULT',
     'ENCRYPTED-CODE-RUN-LOG': 'APPROVED-CODE-RUN-LOG',
@@ -26,6 +28,8 @@ const LOG_LABELS: Partial<Record<FileType, string>> = {
     'ENCRYPTED-CODE-RUN-LOG': 'Code Run Log',
     'ENCRYPTED-SECURITY-SCAN-LOG': 'Security Scan Log',
     'ENCRYPTED-PACKAGING-ERROR-LOG': 'Packaging Error Log',
+    'SECURITY-SCAN-LOG': 'Security Scan Log',
+    'PACKAGING-ERROR-LOG': 'Packaging Error Log',
 }
 
 export function approvedTypeForFile(fileType: FileType): FileType {
@@ -42,12 +46,16 @@ export function isApprovedLogType(fileType: FileType): boolean {
     return APPROVED_LOG_TYPES.includes(fileType)
 }
 
+export function isPlaintextLogType(fileType: FileType): boolean {
+    return PLAINTEXT_LOG_TYPES.includes(fileType)
+}
+
 export function isResultFile(f: { fileType: FileType }): boolean {
     return ['ENCRYPTED-RESULT', 'APPROVED-RESULT'].includes(f.fileType)
 }
 
 export function isLogType(fileType: FileType): boolean {
-    return isEncryptedLogType(fileType) || isApprovedLogType(fileType)
+    return isEncryptedLogType(fileType) || isApprovedLogType(fileType) || isPlaintextLogType(fileType)
 }
 
 export function logLabel(fileType: FileType): string {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -195,6 +195,8 @@ const FILE_TYPES = [
     'ENCRYPTED-RESULT',
     'ENCRYPTED-SECURITY-SCAN-LOG',
     'MAIN-CODE',
+    'PACKAGING-ERROR-LOG',
+    'SECURITY-SCAN-LOG',
     'SUPPLEMENTAL-CODE',
 ] as const satisfies readonly FileType[]
 

--- a/src/server/storage.ts
+++ b/src/server/storage.ts
@@ -39,6 +39,11 @@ export async function storeStudyEncryptedLogFile(info: MinimalJobInfo, file: Fil
     return await storeJobFile(info, `${pathForStudyJob(info)}/results/${filename}.zip`, file, fileType)
 }
 
+export async function storeStudyLogFile(info: MinimalJobInfo, file: File, fileType: FileType) {
+    const filename = fileType.toLowerCase()
+    return await storeJobFile(info, `${pathForStudyJob(info)}/results/${filename}.txt`, file, fileType)
+}
+
 export async function storeStudyEncryptedResultsFile(info: MinimalJobInfo, file: File) {
     return await storeJobFile(info, `${pathForStudyJob(info)}/results/encrypted-results.zip`, file, 'ENCRYPTED-RESULT')
 }


### PR DESCRIPTION
## Summary
- Adds new `SECURITY-SCAN-LOG` and `PACKAGING-ERROR-LOG` file types (migration `1776600000000`).
- Job-scan-results and containerizer webhooks now write a plaintext `.txt` copy of `plaintextLog` in addition to the existing encrypted zip.
- Adds `storeStudyLogFile` storage helper and `isPlaintextLogType` / `PLAINTEXT_LOG_TYPES` to the file-type helpers; `isLogType` now also recognizes the new types.

Encryption flow is unchanged; this is additive groundwork so logs can later be surfaced without a reviewer key. No UI reads the new files yet.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:unit` — all 1142 tests pass
- [x] Route tests assert both `ENCRYPTED-*` and plaintext file types are written on `JOB-ERRORED` and `CODE-SCANNED`