### PR TITLE
OTTER-519: Show decision date on proposal headers

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
@@ -52,28 +52,39 @@ describe('PostFeedbackView', () => {
 
     describe('decision header', () => {
         it('renders "Approved on {date}" timestamp for approve decision', () => {
+            const approvedStudy = {
+                ...study,
+                status: 'APPROVED' as const,
+                approvedAt: new Date('2026-04-20T10:00:00Z'),
+            }
             const entries = [buildEntry({ decision: 'APPROVE', createdAt: new Date('2026-04-16T10:00:00Z') })]
-            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={entries} />)
+            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={approvedStudy} entries={entries} />)
 
-            expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent('Approved on Apr 16, 2026')
+            expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent('Approved on Apr 20, 2026')
         })
 
         it('renders "Clarification requested on {date}" for needs-clarification', () => {
+            const changeRequestedStudy = { ...study, status: 'CHANGE-REQUESTED' as const }
             const entries = [
-                buildEntry({ decision: 'NEEDS-CLARIFICATION', createdAt: new Date('2026-04-16T10:00:00Z') }),
+                buildEntry({ decision: 'NEEDS-CLARIFICATION', createdAt: new Date('2026-04-18T10:00:00Z') }),
             ]
-            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={entries} />)
+            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={changeRequestedStudy} entries={entries} />)
 
             expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent(
-                'Clarification requested on Apr 16, 2026',
+                'Clarification requested on Apr 18, 2026',
             )
         })
 
         it('renders "Rejected on {date}" for reject decision', () => {
+            const rejectedStudy = {
+                ...study,
+                status: 'REJECTED' as const,
+                rejectedAt: new Date('2026-05-01T10:00:00Z'),
+            }
             const entries = [buildEntry({ decision: 'REJECT', createdAt: new Date('2026-04-16T10:00:00Z') })]
-            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={entries} />)
+            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={rejectedStudy} entries={entries} />)
 
-            expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent('Rejected on Apr 16, 2026')
+            expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent('Rejected on May 01, 2026')
         })
 
         it('renders the page title and study title', () => {

--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
@@ -140,7 +140,7 @@ export function PostFeedbackView({ orgSlug, study, entries, kind = 'PROPOSAL' }:
                     stepLabel={kindCopy.stepLabel}
                     heading={kindCopy.heading}
                     statusBadge={timestampLabel}
-                    timestampDate={latest.createdAt}
+                    entries={kind === 'PROPOSAL' ? (entries as ProposalFeedbackEntry[]) : []}
                     banner={<DecisionBanner decision={decision} kind={kind} />}
                     initialExpanded={false}
                 />

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-section.test.tsx
@@ -152,5 +152,4 @@ describe('ProposalSection', () => {
 
         expect(screen.getByText('Submitted on Mar 15, 2025')).toBeInTheDocument()
     })
-
 })

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-section.test.tsx
@@ -153,11 +153,4 @@ describe('ProposalSection', () => {
         expect(screen.getByText('Submitted on Mar 15, 2025')).toBeInTheDocument()
     })
 
-    it('does not render submitted date when study has no submission date', () => {
-        const unsubmittedStudy = { ...study, submittedAt: null }
-
-        renderWithProviders(<ProposalSection study={unsubmittedStudy} orgSlug="test-org" />)
-
-        expect(screen.queryByText(/Submitted on/)).not.toBeInTheDocument()
-    })
 })

--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.test.tsx
@@ -51,18 +51,20 @@ describe('ProposalSubmitted', () => {
                 ...study,
                 status: 'APPROVED' as const,
                 submittedAt: new Date('2025-04-16T10:00:00Z'),
+                approvedAt: new Date('2026-04-20T10:00:00Z'),
             }
+            const entries = [buildEntry({ decision: 'APPROVE', createdAt: new Date('2026-04-16T10:00:00Z') })]
             renderWithProviders(
                 <ProposalSubmitted
                     orgSlug={ORG_SLUG}
                     study={approvedStudy}
                     orgName={ORG_NAME}
-                    entries={[]}
+                    entries={entries}
                     studyVersion={1}
                 />,
             )
 
-            expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent('Approved on Apr 16, 2025')
+            expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent('Approved on Apr 20, 2026')
         })
 
         it('displays "Clarification requested on {date}" when status is CHANGE-REQUESTED', () => {
@@ -71,18 +73,21 @@ describe('ProposalSubmitted', () => {
                 status: 'CHANGE-REQUESTED' as const,
                 submittedAt: new Date('2025-04-16T10:00:00Z'),
             }
+            const entries = [
+                buildEntry({ decision: 'NEEDS-CLARIFICATION', createdAt: new Date('2026-04-18T10:00:00Z') }),
+            ]
             renderWithProviders(
                 <ProposalSubmitted
                     orgSlug={ORG_SLUG}
                     study={clarificationStudy}
                     orgName={ORG_NAME}
-                    entries={[]}
+                    entries={entries}
                     studyVersion={1}
                 />,
             )
 
             expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent(
-                'Clarification requested on Apr 16, 2025',
+                'Clarification requested on Apr 18, 2026',
             )
         })
 
@@ -91,18 +96,20 @@ describe('ProposalSubmitted', () => {
                 ...study,
                 status: 'REJECTED' as const,
                 submittedAt: new Date('2025-04-16T10:00:00Z'),
+                rejectedAt: new Date('2026-05-01T10:00:00Z'),
             }
+            const entries = [buildEntry({ decision: 'REJECT', createdAt: new Date('2026-04-16T10:00:00Z') })]
             renderWithProviders(
                 <ProposalSubmitted
                     orgSlug={ORG_SLUG}
                     study={rejectedStudy}
                     orgName={ORG_NAME}
-                    entries={[]}
+                    entries={entries}
                     studyVersion={1}
                 />,
             )
 
-            expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent('Rejected on Apr 16, 2025')
+            expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent('Rejected on May 01, 2026')
         })
 
         it('displays "Submitted on {date}" when status is PENDING-REVIEW', () => {
@@ -147,7 +154,8 @@ describe('ProposalSubmitted', () => {
             const approvedStudy = {
                 ...study,
                 status: 'APPROVED' as const,
-                submittedAt: new Date('2025-12-01T10:00:00Z'),
+                submittedAt: new Date('2025-04-16T10:00:00Z'),
+                approvedAt: new Date('2025-12-01T10:00:00Z'),
             }
             renderWithProviders(
                 <ProposalSubmitted
@@ -163,7 +171,12 @@ describe('ProposalSubmitted', () => {
         })
 
         it('renders the timestamp above the divider', () => {
-            const approvedStudy = { ...study, status: 'APPROVED' as const, submittedAt: new Date('2025-04-16') }
+            const approvedStudy = {
+                ...study,
+                status: 'APPROVED' as const,
+                submittedAt: new Date('2025-04-16'),
+                approvedAt: new Date('2026-04-20T10:00:00Z'),
+            }
             renderWithProviders(
                 <ProposalSubmitted
                     orgSlug={ORG_SLUG}

--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
@@ -167,6 +167,7 @@ export function ProposalSubmitted({
                     heading={proposalHeading(studyVersion)}
                     banner={<StatusBanner orgName={orgName} status={study.status} studyVersion={studyVersion} />}
                     statusBadge={statusBadge}
+                    entries={entries}
                     initialExpanded={false}
                 />
                 <FeedbackErrorAlert status={study.status} feedbackError={feedbackError} />

--- a/src/components/study/proposal-initial-request.tsx
+++ b/src/components/study/proposal-initial-request.tsx
@@ -5,7 +5,8 @@ import { Anchor, Collapse, Divider, Paper, Stack } from '@mantine/core'
 import { CaretRightIcon } from '@phosphor-icons/react/dist/ssr'
 import { stringifyJson } from '@/lib/string'
 import { usePopover } from '@/hooks/use-popover'
-import type { SelectedStudy } from '@/server/actions/study.actions'
+import type { ProposalFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
+import { decisionTimestampForProposalHeader } from '@/lib/studies'
 import { DatasetsField, LexicalProposalField, PIField, ResearcherField } from './proposal-fields'
 import { ProposalStepHeader } from './proposal-step-header'
 
@@ -17,8 +18,7 @@ type ProposalRequestProps = {
     banner: ReactNode
     initialExpanded?: boolean
     statusBadge?: string
-    /** Overrides study.submittedAt when rendering the timestamp (e.g. a decision date). */
-    timestampDate?: Date | string
+    entries?: ProposalFeedbackEntry[]
 }
 
 function useProposalRequest(initialExpanded: boolean) {
@@ -61,10 +61,10 @@ export function ProposalRequest({
     banner,
     initialExpanded = true,
     statusBadge = 'Submitted on',
-    timestampDate,
+    entries = [],
 }: ProposalRequestProps) {
     const { expanded, toggle, collapse, getPopoverProps } = useProposalRequest(initialExpanded)
-    const renderedTimestamp = timestampDate ?? study.submittedAt
+    const timestampDate = decisionTimestampForProposalHeader(study, entries)
 
     return (
         <Stack gap="md" data-testid="proposal-section">
@@ -72,7 +72,7 @@ export function ProposalRequest({
                 stepLabel={stepLabel}
                 heading={heading}
                 studyTitle={study.title}
-                timestampDate={renderedTimestamp}
+                timestampDate={timestampDate}
                 timestampLabel={statusBadge}
                 banner={banner}
             >

--- a/src/lib/studies.test.ts
+++ b/src/lib/studies.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import type { ProposalFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
+import { decisionTimestampForProposalHeader } from './studies'
+
+const submittedAt = new Date('2025-04-16T10:00:00Z')
+const approvedAt = new Date('2026-04-20T10:00:00Z')
+const rejectedAt = new Date('2026-05-01T10:00:00Z')
+const clarificationAt = new Date('2026-04-18T10:00:00Z')
+const olderClarificationAt = new Date('2026-04-10T10:00:00Z')
+
+const study = (
+    overrides: Partial<Pick<SelectedStudy, 'status' | 'approvedAt' | 'rejectedAt' | 'submittedAt'>>,
+): SelectedStudy =>
+    ({
+        status: 'PENDING-REVIEW',
+        approvedAt: null,
+        rejectedAt: null,
+        submittedAt,
+        ...overrides,
+    }) as SelectedStudy
+
+const entry = (overrides: Partial<Pick<ProposalFeedbackEntry, 'decision' | 'createdAt'>>): ProposalFeedbackEntry =>
+    ({
+        id: 'entry-1',
+        decision: 'APPROVE',
+        createdAt: new Date('2026-04-16T10:00:00Z'),
+        ...overrides,
+    }) as ProposalFeedbackEntry
+
+describe('decisionTimestampForProposalHeader', () => {
+    it.each([
+        {
+            name: 'APPROVED uses approvedAt',
+            study: study({ status: 'APPROVED', approvedAt }),
+            entries: [] as ProposalFeedbackEntry[],
+            expected: approvedAt,
+        },
+        {
+            name: 'REJECTED uses rejectedAt',
+            study: study({ status: 'REJECTED', rejectedAt }),
+            entries: [],
+            expected: rejectedAt,
+        },
+        {
+            name: 'APPROVED falls back to submittedAt when approvedAt is null',
+            study: study({ status: 'APPROVED', approvedAt: null }),
+            entries: [],
+            expected: submittedAt,
+        },
+        {
+            name: 'REJECTED falls back to submittedAt when rejectedAt is null',
+            study: study({ status: 'REJECTED', rejectedAt: null }),
+            entries: [],
+            expected: submittedAt,
+        },
+        {
+            name: 'PENDING-REVIEW uses submittedAt',
+            study: study({ status: 'PENDING-REVIEW' }),
+            entries: [],
+            expected: submittedAt,
+        },
+        {
+            name: 'CHANGE-REQUESTED with empty entries uses submittedAt',
+            study: study({ status: 'CHANGE-REQUESTED' }),
+            entries: [],
+            expected: submittedAt,
+        },
+        {
+            name: 'CHANGE-REQUESTED with no clarification entry uses submittedAt',
+            study: study({ status: 'CHANGE-REQUESTED' }),
+            entries: [entry({ decision: 'APPROVE', createdAt: new Date('2026-04-16T10:00:00Z') })],
+            expected: submittedAt,
+        },
+    ])('$name', ({ study: testStudy, entries, expected }) => {
+        expect(decisionTimestampForProposalHeader(testStudy, entries)).toEqual(expected)
+    })
+
+    it('CHANGE-REQUESTED uses the latest NEEDS-CLARIFICATION entry (desc-ordered)', () => {
+        const entries = [
+            entry({ decision: 'NEEDS-CLARIFICATION', createdAt: clarificationAt }),
+            entry({ decision: 'NEEDS-CLARIFICATION', createdAt: olderClarificationAt }),
+        ]
+
+        expect(decisionTimestampForProposalHeader(study({ status: 'CHANGE-REQUESTED' }), entries)).toEqual(
+            clarificationAt,
+        )
+    })
+
+    it('CHANGE-REQUESTED skips non-clarification entries before the latest clarification', () => {
+        const entries = [
+            entry({ decision: 'APPROVE', createdAt: new Date('2026-04-20T10:00:00Z') }),
+            entry({ decision: 'NEEDS-CLARIFICATION', createdAt: clarificationAt }),
+            entry({ decision: 'NEEDS-CLARIFICATION', createdAt: olderClarificationAt }),
+        ]
+
+        expect(decisionTimestampForProposalHeader(study({ status: 'CHANGE-REQUESTED' }), entries)).toEqual(
+            clarificationAt,
+        )
+    })
+})

--- a/src/lib/studies.test.ts
+++ b/src/lib/studies.test.ts
@@ -97,4 +97,12 @@ describe('decisionTimestampForProposalHeader', () => {
             clarificationAt,
         )
     })
+
+    // note: a draft study should never be passed to this function, but we should
+    // assert that it throws when submittedAt is null
+    it('throws when submittedAt is null on the fallback path', () => {
+        expect(() => decisionTimestampForProposalHeader(study({ status: 'DRAFT', submittedAt: null }), [])).toThrow(
+            'submittedAt is required for proposal header timestamp',
+        )
+    })
 })

--- a/src/lib/studies.ts
+++ b/src/lib/studies.ts
@@ -1,4 +1,5 @@
 import type { StudyJobStatus } from '@/database/types'
+import { ProposalFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
 
 type StudyWithJobStatuses = {
     jobStatusChanges: Array<{ status: StudyJobStatus }>
@@ -11,4 +12,20 @@ export function studyHasJobStatus(study: StudyWithJobStatuses, status: StudyJobS
 export function deriveStudyVersion(entries: { version: number }[]): number {
     if (entries.length === 0) return 1
     return Math.max(...entries.map((e) => e.version))
+}
+
+/** Returns the timestamp of the latest decision for the submitted proposal header. */
+export function decisionTimestampForProposalHeader(study: SelectedStudy, entries: ProposalFeedbackEntry[]): Date {
+    if (study.status === 'APPROVED' && study.approvedAt) {
+        return study.approvedAt
+    }
+    if (study.status === 'REJECTED' && study.rejectedAt) {
+        return study.rejectedAt
+    }
+    if (study.status === 'CHANGE-REQUESTED' && entries.length > 0) {
+        // entries are ordered by createdAt descending
+        const latestClarification = entries.find((e) => e.decision === 'NEEDS-CLARIFICATION')
+        if (latestClarification) return latestClarification.createdAt
+    }
+    return study.submittedAt!
 }

--- a/src/lib/studies.ts
+++ b/src/lib/studies.ts
@@ -1,5 +1,5 @@
 import type { StudyJobStatus } from '@/database/types'
-import { ProposalFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
+import type { ProposalFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
 
 type StudyWithJobStatuses = {
     jobStatusChanges: Array<{ status: StudyJobStatus }>
@@ -27,5 +27,9 @@ export function decisionTimestampForProposalHeader(study: SelectedStudy, entries
         const latestClarification = entries.find((e) => e.decision === 'NEEDS-CLARIFICATION')
         if (latestClarification) return latestClarification.createdAt
     }
-    return study.submittedAt!
+
+    if (!study.submittedAt) {
+        throw new Error('submittedAt is required for proposal header timestamp')
+    }
+    return study.submittedAt
 }

--- a/tests/unit.helpers.tsx
+++ b/tests/unit.helpers.tsx
@@ -286,6 +286,7 @@ export const insertTestStudyJobData = async ({
             researcherId: researcherId,
             piName: piName ?? 'test',
             status: studyStatus,
+            submittedAt: studyStatus === 'DRAFT' ? null : new Date(),
             dataSources: ['all'],
             outputMimeType: 'application/zip',
             language: language || 'R',


### PR DESCRIPTION
## Summary

Approved, rejected, and change-requested study views were showing the proposal **submission** date in the header timestamp instead of the date the decision was made. This PR centralizes timestamp resolution in a shared helper and wires it through ProposalRequest so post-decision views display the correct date.

## Changes

- Add decisionTimestampForProposalHeader in src/lib/studies.ts to pick the right date by study status: 
        APPROVED → study.approvedAt
        REJECTED → study.rejectedAt
        CHANGE-REQUESTED → latest NEEDS-CLARIFICATION entry createdAt
        Otherwise → study.submittedAt
- Refactor ProposalRequest to accept optional entries and call the helper internally, replacing the timestampDate prop.
- Pass entries from PostFeedbackView and ProposalSubmitted so reviewer and researcher post-decision views get the correct timestamp.
- Set submittedAt on non-draft studies in insertTestStudyJobData so test fixtures match production expectations.