### PR TITLE
OTTER-557: title-required validation on proposal Submit

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.test.tsx
@@ -1,0 +1,95 @@
+import { TextInput } from '@mantine/core'
+import { BLANK_UUID, describe, expect, it, renderWithProviders, screen, userEvent } from '@/tests/unit.helpers'
+import { EditResubmitProvider, useEditResubmit } from '@/contexts/edit-resubmit'
+import { DEFAULT_DRAFT_TITLE, type ProposalFormValues } from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
+import { EditResubmitFooter } from './footer'
+
+const STUDY_ID = '11111111-1111-4111-8111-111111111111'
+
+function lexicalText(text: string): string {
+    return JSON.stringify({
+        root: {
+            type: 'root',
+            children: [{ type: 'paragraph', children: [{ type: 'text', text }] }],
+        },
+    })
+}
+
+// Every required proposal field populated EXCEPT the title (which holds the
+// server-assigned DEFAULT_DRAFT_TITLE placeholder, reproducing OTTER-557).
+const fullyValidExceptTitle: ProposalFormValues = {
+    title: DEFAULT_DRAFT_TITLE,
+    datasets: ['dataset-1'],
+    researchQuestions: lexicalText('What is the primary research question?'),
+    projectSummary: lexicalText('This study examines outcomes.'),
+    impact: lexicalText('Findings will inform practice.'),
+    additionalNotes: '',
+    piName: 'Jane Smith',
+    piUserId: BLANK_UUID,
+}
+
+// A 60-word note (above the 50-word minimum) so the note form's validity
+// doesn't get in the way of the title-gate assertions.
+const VALID_NOTE = Array.from({ length: 60 }, (_, i) => `word${i + 1}`).join(' ')
+
+// Test-only probe that primes the note form with a valid value so we can
+// isolate the title-gate behavior under test.
+const FormProbes = ({ titleOverride }: { titleOverride?: string }) => {
+    const { form, noteForm } = useEditResubmit()
+    if (noteForm.values.resubmissionNote !== VALID_NOTE) {
+        noteForm.setFieldValue('resubmissionNote', VALID_NOTE)
+    }
+    if (titleOverride !== undefined && form.values.title !== titleOverride) {
+        form.setFieldValue('title', titleOverride)
+    }
+    return null
+}
+
+const TitleInputProbe = () => {
+    const { form } = useEditResubmit()
+    return <TextInput aria-label="Study Title Probe" {...form.getInputProps('title')} />
+}
+
+const renderFooter = (draftData: ProposalFormValues = fullyValidExceptTitle, titleOverride?: string) =>
+    renderWithProviders(
+        <EditResubmitProvider studyId={STUDY_ID} draftData={draftData}>
+            <FormProbes titleOverride={titleOverride} />
+            <EditResubmitFooter researcherName="Researcher" researcherId="researcher-1" />
+        </EditResubmitProvider>,
+    )
+
+describe('EditResubmitFooter submit gating (OTTER-557)', () => {
+    it('keeps Resubmit disabled when only the default draft title is present', () => {
+        renderFooter()
+        expect(screen.getByRole('button', { name: 'Resubmit initial request' })).toBeDisabled()
+    })
+
+    it('keeps Resubmit disabled when the title is whitespace only', () => {
+        renderFooter(fullyValidExceptTitle, '   ')
+        expect(screen.getByRole('button', { name: 'Resubmit initial request' })).toBeDisabled()
+    })
+
+    it('enables Resubmit when the researcher provides a real title', () => {
+        renderFooter(fullyValidExceptTitle, 'My Real Study Title')
+        expect(screen.getByRole('button', { name: 'Resubmit initial request' })).toBeEnabled()
+    })
+
+    it('enables Resubmit after the researcher types a real title in the form input', async () => {
+        const user = userEvent.setup()
+        renderWithProviders(
+            <EditResubmitProvider studyId={STUDY_ID} draftData={fullyValidExceptTitle}>
+                <FormProbes />
+                <TitleInputProbe />
+                <EditResubmitFooter researcherName="Researcher" researcherId="researcher-1" />
+            </EditResubmitProvider>,
+        )
+
+        const submit = screen.getByRole('button', { name: 'Resubmit initial request' })
+        expect(submit).toBeDisabled()
+
+        await user.clear(screen.getByLabelText('Study Title Probe'))
+        await user.type(screen.getByLabelText('Study Title Probe'), 'My Real Study Title')
+
+        expect(submit).toBeEnabled()
+    })
+})

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.tsx
@@ -9,6 +9,7 @@ import { Routes } from '@/lib/routes'
 import { hasLexicalContent } from '@/lib/lexical'
 import { useEditResubmit } from '@/contexts/edit-resubmit'
 import { ReviewerPreview } from '@/app/[orgSlug]/study/[studyId]/proposal/reviewer-preview'
+import { hasUserProvidedTitle } from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
 
 interface EditResubmitFooterProps {
     researcherName: string
@@ -26,11 +27,11 @@ export const EditResubmitFooter: FC<EditResubmitFooterProps> = ({ researcherName
 
     const isBusy = isSaving || isSubmitting
 
-    const { researchQuestions, projectSummary, impact, additionalNotes, datasets, piName } = form.values
+    const { title, researchQuestions, projectSummary, impact, additionalNotes, datasets, piName } = form.values
     const hasContent =
         hasLexicalContent(researchQuestions, projectSummary, impact, additionalNotes) || datasets.length > 0 || !!piName
 
-    const isFormValid = form.isValid() && noteForm.isValid()
+    const isFormValid = form.isValid() && noteForm.isValid() && hasUserProvidedTitle(title)
 
     const handleBack = async () => {
         if (form.isDirty()) {

--- a/src/app/[orgSlug]/study/[studyId]/proposal/footer.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/footer.test.tsx
@@ -1,0 +1,78 @@
+import { TextInput } from '@mantine/core'
+import { BLANK_UUID, describe, expect, it, renderWithProviders, screen, userEvent } from '@/tests/unit.helpers'
+import { ProposalProvider, useProposal, type ProposalDraftData } from '@/contexts/proposal'
+import { ProposalFooter } from './footer'
+import { DEFAULT_DRAFT_TITLE, type ProposalFormValues } from './schema'
+
+const STUDY_ID = '11111111-1111-4111-8111-111111111111'
+
+function lexicalText(text: string): string {
+    return JSON.stringify({
+        root: {
+            type: 'root',
+            children: [{ type: 'paragraph', children: [{ type: 'text', text }] }],
+        },
+    })
+}
+
+// Every required field populated EXCEPT the title (which holds the
+// server-assigned DEFAULT_DRAFT_TITLE placeholder, reproducing OTTER-557).
+const fullyValidExceptTitle: ProposalFormValues = {
+    title: DEFAULT_DRAFT_TITLE,
+    datasets: ['dataset-1'],
+    researchQuestions: lexicalText('What is the primary research question?'),
+    projectSummary: lexicalText('This study examines outcomes.'),
+    impact: lexicalText('Findings will inform practice.'),
+    additionalNotes: '',
+    piName: 'Jane Smith',
+    piUserId: BLANK_UUID,
+}
+
+// Test-only title input wired through useProposal so changes flow through the
+// real Mantine form the footer reads.
+const TitleInputProbe = () => {
+    const { form } = useProposal()
+    return <TextInput aria-label="Study Title Probe" {...form.getInputProps('title')} />
+}
+
+const renderFooter = (draftData: ProposalDraftData = fullyValidExceptTitle) =>
+    renderWithProviders(
+        <ProposalProvider studyId={STUDY_ID} draftData={draftData}>
+            <ProposalFooter researcherName="Researcher" researcherId="researcher-1" />
+        </ProposalProvider>,
+    )
+
+describe('ProposalFooter submit gating (OTTER-557)', () => {
+    it('keeps Submit disabled when only the default draft title is present', () => {
+        renderFooter()
+        expect(screen.getByRole('button', { name: 'Submit study proposal' })).toBeDisabled()
+    })
+
+    it('keeps Submit disabled when the title is whitespace only', () => {
+        renderFooter({ ...fullyValidExceptTitle, title: '   ' })
+        expect(screen.getByRole('button', { name: 'Submit study proposal' })).toBeDisabled()
+    })
+
+    it('enables Submit when the researcher provides a real title', () => {
+        renderFooter({ ...fullyValidExceptTitle, title: 'My Real Study Title' })
+        expect(screen.getByRole('button', { name: 'Submit study proposal' })).toBeEnabled()
+    })
+
+    it('enables Submit after the researcher types a real title in the form input', async () => {
+        const user = userEvent.setup()
+        renderWithProviders(
+            <ProposalProvider studyId={STUDY_ID} draftData={fullyValidExceptTitle}>
+                <TitleInputProbe />
+                <ProposalFooter researcherName="Researcher" researcherId="researcher-1" />
+            </ProposalProvider>,
+        )
+
+        const submit = screen.getByRole('button', { name: 'Submit study proposal' })
+        expect(submit).toBeDisabled()
+
+        await user.clear(screen.getByLabelText('Study Title Probe'))
+        await user.type(screen.getByLabelText('Study Title Probe'), 'My Real Study Title')
+
+        expect(submit).toBeEnabled()
+    })
+})

--- a/src/app/[orgSlug]/study/[studyId]/proposal/footer.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/footer.tsx
@@ -8,6 +8,7 @@ import { CaretLeftIcon } from '@phosphor-icons/react'
 import { useProposal } from '@/contexts/proposal'
 import { Routes } from '@/lib/routes'
 import { hasLexicalContent } from '@/lib/lexical'
+import { hasUserProvidedTitle } from './schema'
 import { ReviewerPreview } from './reviewer-preview'
 
 interface ProposalFooterProps {
@@ -26,9 +27,10 @@ export const ProposalFooter: FC<ProposalFooterProps> = ({ researcherName, resear
     // lexical fields store JSON even when empty, so we extract the
     // text to determine if there's real content. title is excluded
     // because it's always pre-populated as "Untitled draft".
-    const { researchQuestions, projectSummary, impact, additionalNotes, datasets, piName } = form.values
+    const { title, researchQuestions, projectSummary, impact, additionalNotes, datasets, piName } = form.values
     const hasContent =
         hasLexicalContent(researchQuestions, projectSummary, impact, additionalNotes) || datasets.length > 0 || !!piName
+    const canSubmit = form.isValid() && hasUserProvidedTitle(title)
 
     const handlePrevious = async () => {
         const saved = await saveDraft()
@@ -70,7 +72,7 @@ export const ProposalFooter: FC<ProposalFooterProps> = ({ researcherName, resear
                     <Button
                         size="md"
                         variant="primary"
-                        disabled={!form.isValid() || isBusy}
+                        disabled={!canSubmit || isBusy}
                         loading={isSubmitting}
                         onClick={submitProposal}
                     >

--- a/src/app/[orgSlug]/study/[studyId]/proposal/schema.ts
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/schema.ts
@@ -6,6 +6,17 @@ const REQUIRED_FIELD_ERROR = 'This field is required.'
 
 export const DEFAULT_DRAFT_TITLE = 'Untitled Draft'
 
+// Drafts are persisted with `DEFAULT_DRAFT_TITLE` so they have *something* in the DB
+// title column, but the user-visible input is blanked out (see form.tsx ternary).
+// `form.isValid()` would otherwise pass for a never-entered title because the
+// persisted value satisfies `.min(1)`, so callers must use this helper to gate
+// submit buttons.
+export function hasUserProvidedTitle(title: string | undefined | null): boolean {
+    if (!title) return false
+    const trimmed = title.trim()
+    return trimmed.length > 0 && trimmed !== DEFAULT_DRAFT_TITLE
+}
+
 export const WORD_LIMITS = {
     title: 20,
     researchQuestions: 500,


### PR DESCRIPTION
## Summary
- Fixes [OTTER-557](https://openstax.atlassian.net/browse/OTTER-557) (Highest priority): the proposal form's Submit button stayed enabled even when the Study Title was blank.
- Root cause was subtler than the bug ticket suggested. Drafts are persisted with `title = 'Untitled Draft'` (the `DEFAULT_DRAFT_TITLE` placeholder), and the form input renders that placeholder as blank via a ternary. The Zod `.min(1)` was passing on the placeholder, so `form.isValid()` returned `true` on a value the user couldn't see.
- Extracted a `hasUserProvidedTitle()` helper in `proposal/schema.ts` that rejects blank/whitespace AND the `DEFAULT_DRAFT_TITLE` placeholder. Wired into both the proposal footer and the edit-and-resubmit footer.

## Test plan
- [ ] Open a brand-new RL proposal, fill every mandatory field except title — Submit stays disabled.
- [ ] Type a title, Submit enables. Clear the title, Submit disables again.
- [ ] Open the edit-and-resubmit flow on an existing study with `CHANGE-REQUESTED` and confirm the same gate fires.
- [ ] `npm run test:unit -- src/app/[orgSlug]/study/[studyId]/proposal src/app/[orgSlug]/study/[studyId]/edit-and-resubmit` (39 tests).

[OTTER-557]: https://openstax.atlassian.net/browse/OTTER-557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ