### PR TITLE
OTTER-562: drop 50-word minimum on feedback and notes

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/resubmission-note-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/resubmission-note-section.test.tsx
@@ -35,13 +35,13 @@ describe('ResubmissionNoteSection', () => {
         expect(screen.getByText('3/300')).toBeInTheDocument()
     })
 
-    it('shows a validation error when the note is below the minimum word count and the field is blurred', async () => {
+    it('shows a validation error when the note is empty and the field is blurred', async () => {
         const user = userEvent.setup()
         renderSection()
         const textarea = screen.getByRole('textbox', { name: 'Resubmission Note' })
-        await user.type(textarea, 'too short')
+        await user.click(textarea)
         await user.tab()
-        expect(screen.getByText(/between 50 and 300 words/i)).toBeInTheDocument()
+        expect(screen.getByText(/resubmission note is required/i)).toBeInTheDocument()
     })
 
     it('accepts a note at the minimum word count without surfacing a range error', async () => {
@@ -49,8 +49,8 @@ describe('ResubmissionNoteSection', () => {
         renderSection()
         const textarea = screen.getByRole('textbox', { name: 'Resubmission Note' })
         await user.click(textarea)
-        // paste avoids per-keystroke validation thrash for a 50-word seed
         await user.paste(wordsString(RESUBMIT_NOTE_MIN_WORDS))
-        expect(screen.queryByText(/between 50 and 300 words/i)).not.toBeInTheDocument()
+        expect(screen.queryByText(/resubmission note is required/i)).not.toBeInTheDocument()
+        expect(screen.queryByText(/words or fewer/i)).not.toBeInTheDocument()
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/schema.test.ts
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/schema.test.ts
@@ -4,13 +4,12 @@ import { RESUBMIT_NOTE_MAX_WORDS, RESUBMIT_NOTE_MIN_WORDS, resubmitNoteSchema } 
 const buildNote = (wordCount: number) => Array.from({ length: wordCount }, (_, i) => `word${i}`).join(' ')
 
 describe('resubmitNoteSchema', () => {
+    // The MIN-1 boundary case (one word below the minimum) collapses to the
+    // empty-note case while RESUBMIT_NOTE_MIN_WORDS is 1; if MIN ever rises
+    // above 1, restore an explicit `buildNote(RESUBMIT_NOTE_MIN_WORDS - 1)`
+    // assertion here so the lower bound stays covered.
     it('rejects an empty note', () => {
         const result = resubmitNoteSchema.safeParse({ resubmissionNote: '' })
-        expect(result.success).toBe(false)
-    })
-
-    it('rejects a note below the minimum word count', () => {
-        const result = resubmitNoteSchema.safeParse({ resubmissionNote: buildNote(RESUBMIT_NOTE_MIN_WORDS - 1) })
         expect(result.success).toBe(false)
     })
 

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/schema.ts
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/schema.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod'
 import { countWords } from '@/lib/lexical'
 
-export const RESUBMIT_NOTE_MIN_WORDS = 50
+export const RESUBMIT_NOTE_MIN_WORDS = 1
 export const RESUBMIT_NOTE_MAX_WORDS = 300
 
 const REQUIRED_NOTE_ERROR = 'A resubmission note is required.'
-const NOTE_RANGE_ERROR = `Resubmission note must be between ${RESUBMIT_NOTE_MIN_WORDS} and ${RESUBMIT_NOTE_MAX_WORDS} words.`
+const NOTE_MAX_ERROR = `Resubmission note must be ${RESUBMIT_NOTE_MAX_WORDS} words or fewer.`
 
 export const resubmitNoteSchema = z.object({
     resubmissionNote: z
@@ -14,10 +14,11 @@ export const resubmitNoteSchema = z.object({
         .refine(
             (val) => {
                 const count = countWords(val)
-                return count >= RESUBMIT_NOTE_MIN_WORDS && count <= RESUBMIT_NOTE_MAX_WORDS
+                return count >= RESUBMIT_NOTE_MIN_WORDS
             },
-            { message: NOTE_RANGE_ERROR },
-        ),
+            { message: REQUIRED_NOTE_ERROR },
+        )
+        .refine((val) => countWords(val) <= RESUBMIT_NOTE_MAX_WORDS, { message: NOTE_MAX_ERROR }),
 })
 
 export type ResubmitNoteValue = z.infer<typeof resubmitNoteSchema>

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-feedback-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-feedback-section.tsx
@@ -69,9 +69,6 @@ export function CodeReviewFeedbackSection({ feedback, studyId, jobId }: CodeRevi
                 </Text>
                 <Divider />
                 <Stack gap="md">
-                    <Text fz={14} c="charcoal.7">
-                        Minimum {feedback.minWords} words required.
-                    </Text>
                     <FeedbackEditor feedback={feedback} studyId={studyId} jobId={jobId} />
                 </Stack>
             </Stack>

--- a/src/app/[orgSlug]/study/[studyId]/review/review-feedback-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/review-feedback-section.tsx
@@ -85,9 +85,6 @@ export function ReviewFeedbackSection({
                         the understanding of teaching and learning, and any questions or clarifications you need from
                         the research team.
                     </Text>
-                    <Text fz={14} c="charcoal.7">
-                        Minimum {feedback.minWords} words required.
-                    </Text>
                     <FeedbackEditor feedback={feedback} studyId={studyId} reviewVersion={reviewVersion} />
                 </Stack>
             </Stack>

--- a/src/hooks/use-review-feedback.test.ts
+++ b/src/hooks/use-review-feedback.test.ts
@@ -35,14 +35,14 @@ describe('useReviewFeedback', () => {
             const { result } = renderHook(() => useReviewFeedback())
 
             act(() => {
-                result.current.onChange(lexicalJson(repeatWords(FEEDBACK_MIN_WORDS - 1)))
+                result.current.onChange(lexicalJson(''))
             })
 
-            expect(result.current.wordCount).toBe(FEEDBACK_MIN_WORDS - 1)
+            expect(result.current.wordCount).toBe(0)
             expect(result.current.isValid).toBe(false)
         })
 
-        it('is true at exactly the minimum word count (50)', () => {
+        it('is true at exactly the minimum word count', () => {
             const { result } = renderHook(() => useReviewFeedback())
 
             act(() => {

--- a/src/lib/proposal-review.ts
+++ b/src/lib/proposal-review.ts
@@ -12,7 +12,7 @@ export function toReviewDecision(decision: Decision): ReviewDecision {
     return DECISION_TO_REVIEW[decision]
 }
 
-export const FEEDBACK_MIN_WORDS = 50
+export const FEEDBACK_MIN_WORDS = 1
 export const FEEDBACK_MAX_WORDS = 500
 
 export const SUBMITTED_PROPOSAL_REVIEW_STATUSES = [

--- a/src/server/actions/study-request.ts
+++ b/src/server/actions/study-request.ts
@@ -636,13 +636,14 @@ const proposalUpdatableFields = [
     'additionalNotes',
 ] as const
 
-const resubmissionNoteParam = z.string().refine(
-    (val) => {
-        const count = countWords(val)
-        return count >= RESUBMIT_NOTE_MIN_WORDS && count <= RESUBMIT_NOTE_MAX_WORDS
-    },
-    { message: `Resubmission note must be between ${RESUBMIT_NOTE_MIN_WORDS} and ${RESUBMIT_NOTE_MAX_WORDS} words.` },
-)
+const resubmissionNoteParam = z
+    .string()
+    .refine((val) => countWords(val) >= RESUBMIT_NOTE_MIN_WORDS, {
+        message: 'A resubmission note is required.',
+    })
+    .refine((val) => countWords(val) <= RESUBMIT_NOTE_MAX_WORDS, {
+        message: `Resubmission note must be ${RESUBMIT_NOTE_MAX_WORDS} words or fewer.`,
+    })
 
 // Persist proposal edits to a CHANGE-REQUESTED study (explicit "Save as draft"
 // click — auto-save is intentionally out of scope for OTTER-521). The

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -766,7 +766,7 @@ describe('submitProposalReviewAction', () => {
             studyId: study.id,
             orgSlug: org.slug,
             decision: 'approve',
-            feedback: buildFeedback(10),
+            feedback: buildFeedback(0),
             reviewVersion: 1,
         })
 
@@ -1277,7 +1277,7 @@ describe('submitCodeReviewDecisionAction', () => {
             studyId: study.id,
             orgSlug: org.slug,
             decision: 'needs-clarification',
-            feedback: buildFeedback(5),
+            feedback: buildFeedback(0),
             criteria: validCriteria,
         })
 
@@ -1292,7 +1292,7 @@ describe('submitCodeReviewDecisionAction', () => {
             studyId: study.id,
             orgSlug: org.slug,
             decision: 'approve',
-            feedback: buildFeedback(5),
+            feedback: buildFeedback(0),
             criteria: validCriteria,
         })
 

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -566,9 +566,12 @@ export const submitProposalReviewAction = new Action('submitProposalReviewAction
         const userId = session.user.id
         const { json, wordCount } = normalizeFeedbackToLexical(feedback)
 
-        if (wordCount < FEEDBACK_MIN_WORDS || wordCount > FEEDBACK_MAX_WORDS) {
+        if (wordCount < FEEDBACK_MIN_WORDS) {
+            throw new ActionFailure({ feedback: 'Feedback is required' })
+        }
+        if (wordCount > FEEDBACK_MAX_WORDS) {
             throw new ActionFailure({
-                feedback: `must be between ${FEEDBACK_MIN_WORDS} and ${FEEDBACK_MAX_WORDS} words (got ${wordCount})`,
+                feedback: `Feedback must be ${FEEDBACK_MAX_WORDS} words or fewer (got ${wordCount})`,
             })
         }
 
@@ -715,9 +718,12 @@ export const submitCodeReviewDecisionAction = new Action('submitCodeReviewDecisi
         const userId = session.user.id
 
         const { json, wordCount } = normalizeFeedbackToLexical(feedback)
-        if (wordCount < FEEDBACK_MIN_WORDS || wordCount > FEEDBACK_MAX_WORDS) {
+        if (wordCount < FEEDBACK_MIN_WORDS) {
+            throw new ActionFailure({ feedback: 'Feedback is required' })
+        }
+        if (wordCount > FEEDBACK_MAX_WORDS) {
             throw new ActionFailure({
-                feedback: `must be between ${FEEDBACK_MIN_WORDS} and ${FEEDBACK_MAX_WORDS} words (got ${wordCount})`,
+                feedback: `Feedback must be ${FEEDBACK_MAX_WORDS} words or fewer (got ${wordCount})`,
             })
         }
 

--- a/tests/code-review-collaboration.spec.ts
+++ b/tests/code-review-collaboration.spec.ts
@@ -30,7 +30,7 @@ test.beforeEach(async ({}, testInfo) => {
     testInfo.setTimeout(testInfo.timeout + 120_000)
 })
 
-// 60+ words to satisfy FEEDBACK_MIN_WORDS=50.
+// Realistic narrative feedback used to exercise the editor end-to-end.
 const FEEDBACK_TEXT =
     'After reviewing the submitted code I have concerns about how the proposal alignment is handled and whether the agreements are fully respected. The security checks pass but the privacy protections need more attention before this can move forward. I am sharing this feedback so the team can iterate before resubmission and make sure the analysis matches the approved research questions and dataset usage outlined in the proposal.'
 

--- a/tests/unit.helpers.tsx
+++ b/tests/unit.helpers.tsx
@@ -647,8 +647,9 @@ export const setTestStudyStatus = (studyId: string, status: StudyStatus) =>
     db.updateTable('study').set({ status }).where('id', '=', studyId).execute()
 
 // Generates a feedback string with `wordCount` whitespace-separated tokens. The
-// proposal-review action requires 50–500 words; default is 60 (a comfortable midpoint).
-// Pass smaller / larger counts to exercise the validation boundaries.
+// proposal-review action requires 1–500 words; default is 60, well above the
+// 1-word floor and far below the 500-word ceiling. Pass smaller / larger counts
+// to exercise the validation boundaries.
 export const buildFeedback = (wordCount = 60) => Array.from({ length: wordCount }, (_, i) => `word${i + 1}`).join(' ')
 
 export const createWorkspaceDir = async (prefix: string) => {


### PR DESCRIPTION
## Summary
- Implements [OTTER-562](https://openstax.atlassian.net/browse/OTTER-562): lower the minimum word count on every reviewer-feedback / resubmission-note field from 50 to 1.
- Bumped `FEEDBACK_MIN_WORDS` and `RESUBMIT_NOTE_MIN_WORDS` to `1`. Both client and server validators read these constants, so the bound flips in lockstep.
- Removed the "Minimum N words required." helper line from the feedback sections per the ticket. The numeric `WordCounter` stays.

## Test plan
- [ ] Submit a code-review with a one-word feedback body — passes validation.
- [ ] Submit a resubmission note with a single word — passes.
- [ ] Submit an empty feedback / empty note — still rejected with the server-side range error ("between 1 and 500 words").
- [ ] `npm run test:unit -- src/lib src/hooks src/server/actions src/app` clean for the touched paths.

[OTTER-562]: https://openstax.atlassian.net/browse/OTTER-562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ