### PR TITLE
OTTER-559 + OTTER-554: review header copy and proposal modal text

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.test.tsx
@@ -76,7 +76,7 @@ describe('CodeReviewRedesignView', () => {
         expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent(`Submitted on ${formatted}`)
     })
 
-    it('renders the status banner with the submitting lab name in bold', async () => {
+    it('renders the status banner with the new intro copy and the lab name not bold', async () => {
         renderWithProviders(await CodeReviewRedesignView({ orgSlug: ORG_SLUG, study }))
 
         const banner = screen.getByTestId('code-review-status-banner')
@@ -84,8 +84,14 @@ describe('CodeReviewRedesignView', () => {
         const labName = study.submittingLabName ?? study.submittedByOrgSlug
         expect(banner).toHaveTextContent(labName)
         expect(banner).toHaveTextContent(
-            'has submitted their study code for review. Below, you will review their code and an AI-generated summary of its behavior, then share your feedback and decision.',
+            'has submitted their study code for review. Below, you will review their code and an AI-generated summary of its behavior, then share your feedback and decision. Consider evaluating the code based on these criteria:',
         )
+
+        // The lab name should not be wrapped in <strong> / fw=700
+        const strongs = banner.querySelectorAll('strong')
+        for (const strong of strongs) {
+            expect(strong.textContent ?? '').not.toContain(labName)
+        }
     })
 
     it('renders all four review criteria', async () => {

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.tsx
@@ -22,8 +22,9 @@ function CodeReviewStatusBanner({ labName }: { labName: string }) {
             criteriaTestId="code-review-criteria"
             intro={
                 <>
-                    <strong>{labName}</strong> has submitted their study code for review. Below, you will review their
-                    code and an AI-generated summary of its behavior, then share your feedback and decision.
+                    {labName} has submitted their study code for review. Below, you will review their code and an
+                    AI-generated summary of its behavior, then share your feedback and decision. Consider evaluating the
+                    code based on these criteria:
                 </>
             }
             criteria={CODE_REVIEW_CRITERIA}

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-review-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-review-view.test.tsx
@@ -12,7 +12,7 @@ import { lexicalJson } from '@/lib/lexical'
 import { memoryRouter } from 'next-router-mock'
 import { useParams } from 'next/navigation'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { ProposalReviewView } from './proposal-review-view'
+import { ProposalReviewView, REJECTION_WARNING, ReviewConfirmationModal } from './proposal-review-view'
 
 describe('ProposalReviewView', () => {
     let study: SelectedStudy
@@ -134,6 +134,54 @@ describe('ProposalReviewView', () => {
             expect(screen.getByTestId('feedback-and-notes-section')).toBeInTheDocument()
             // Round-aware heading on the editable section
             expect(screen.getByText('Round 2 review')).toBeInTheDocument()
+        })
+    })
+
+    describe('ReviewConfirmationModal copy', () => {
+        it('renders the reject modal with the new title and both paragraphs', () => {
+            renderWithProviders(
+                <ReviewConfirmationModal
+                    isOpen
+                    onClose={() => {}}
+                    onConfirm={() => {}}
+                    isPending={false}
+                    title="Reject initial request"
+                    confirmLabel="Reject initial request"
+                    variant="destructive"
+                    warning={REJECTION_WARNING}
+                />,
+            )
+
+            const dialog = screen.getByRole('dialog')
+            expect(dialog).toHaveTextContent('Reject initial request')
+            expect(dialog).toHaveTextContent(
+                'Please confirm you are ready to submit your review. Further edits are not permitted once submitted.',
+            )
+            expect(dialog).toHaveTextContent(
+                'Rejection: This is intended as a last resort due to major, unresolvable issues and will end this study. This action cannot be undone.',
+            )
+            expect(dialog.textContent ?? '').not.toContain('Other teammates')
+        })
+
+        it('renders the approve/needs-clarification modal with the shared body and no rejection warning', () => {
+            renderWithProviders(
+                <ReviewConfirmationModal
+                    isOpen
+                    onClose={() => {}}
+                    onConfirm={() => {}}
+                    isPending={false}
+                    title="Confirm review submission?"
+                    confirmLabel="Yes, submit review"
+                />,
+            )
+
+            const dialog = screen.getByRole('dialog')
+            expect(dialog).toHaveTextContent('Confirm review submission?')
+            expect(dialog).toHaveTextContent(
+                'Please confirm you are ready to submit your review. Further edits are not permitted once submitted.',
+            )
+            expect(dialog.textContent ?? '').not.toContain('Rejection:')
+            expect(dialog.textContent ?? '').not.toContain('Other teammates')
         })
     })
 

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-review-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-review-view.tsx
@@ -127,14 +127,14 @@ type ReviewConfirmationModalProps = {
     warning?: ReactNode
 }
 
-const REJECTION_WARNING = (
+export const REJECTION_WARNING = (
     <Text size="md" fw={600} c="red.9">
         Rejection: This is intended as a last resort due to major, unresolvable issues and will end this study. This
         action cannot be undone.
     </Text>
 )
 
-const ReviewConfirmationModal: FC<ReviewConfirmationModalProps> = ({
+export const ReviewConfirmationModal: FC<ReviewConfirmationModalProps> = ({
     isOpen,
     onClose,
     onConfirm,
@@ -157,8 +157,7 @@ const ReviewConfirmationModal: FC<ReviewConfirmationModalProps> = ({
         >
             <Stack>
                 <Text size="md">
-                    Please confirm you are ready to submit your review. Other teammates may still be working on it and
-                    further edits are not permitted once submitted.
+                    Please confirm you are ready to submit your review. Further edits are not permitted once submitted.
                 </Text>
                 {warning}
                 <Group justify="flex-end">
@@ -256,7 +255,7 @@ function ProposalReviewViewContent({ orgSlug, study, priorEntries, reviewVersion
                 onClose={closeReject}
                 onConfirm={handleConfirmSubmit}
                 isPending={isPending}
-                title="Reject initial request?"
+                title="Reject initial request"
                 confirmLabel="Reject initial request"
                 variant="destructive"
                 warning={REJECTION_WARNING}

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-section.test.tsx
@@ -82,11 +82,16 @@ describe('ProposalSection', () => {
         expect(screen.getByText(/Does the researcher have relevant expertise/)).toBeInTheDocument()
     })
 
-    it('shows the submitting lab name in the status banner', () => {
+    it('shows the submitting lab name in the status banner, not bold', () => {
         renderWithProviders(<ProposalSection study={study} orgSlug="test-org" />)
 
         const labName = study.submittingLabName ?? study.submittedByOrgSlug
-        expect(screen.getByTestId('status-banner')).toHaveTextContent(labName)
+        const banner = screen.getByTestId('status-banner')
+        expect(banner).toHaveTextContent(labName)
+
+        for (const strong of banner.querySelectorAll('strong')) {
+            expect(strong.textContent ?? '').not.toContain(labName)
+        }
     })
 
     it('is expanded by default showing the proposal body', () => {

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-section.tsx
@@ -34,9 +34,8 @@ function StatusBanner({ labName }: { labName: string }) {
             criteriaTestId="evaluation-criteria"
             intro={
                 <>
-                    <strong>{labName}</strong> has submitted an initial request requesting permission to use your data.
-                    Please review it and share your feedback and decision. Consider evaluating the initial request on
-                    these criteria:
+                    {labName} has submitted an initial request requesting permission to use your data. Please review it
+                    and share your feedback and decision. Consider evaluating the initial request on these criteria:
                 </>
             }
             criteria={EVALUATION_CRITERIA}

--- a/src/components/study/review-criteria-banner.tsx
+++ b/src/components/study/review-criteria-banner.tsx
@@ -26,7 +26,7 @@ export function ReviewCriteriaBanner({
         <Box bg="purple.0" p="md" mb={mb} style={{ borderRadius: 'var(--mantine-radius-sm)' }} data-testid={testId}>
             <Stack gap="xs">
                 <Text size="sm">{intro}</Text>
-                <Stack gap={4} data-testid={criteriaTestId}>
+                <Stack gap={4} mt="md" data-testid={criteriaTestId}>
                     {criteria.map(({ label, description }) => (
                         <Text size="sm" key={label}>
                             <strong>{label}:</strong> {description}


### PR DESCRIPTION
## Summary
Bundled copy/styling fixes for the DO review pages.

[OTTER-559](https://openstax.atlassian.net/browse/OTTER-559) — DO Code Review page header:
- Added the missing intro sentence ("Consider evaluating the code based on these criteria:") so the header reads as designed.
- Removed the \`<strong>\` wrapper around the research-lab interpolation so the lab name is rendered in normal weight.
- Added vertical spacing between the intro paragraph and the criteria bullets via the shared \`review-criteria-banner\` component.

[OTTER-554](https://openstax.atlassian.net/browse/OTTER-554) — DO Proposal Review modal copy:
- Dropped the "Other teammates may still be working on it and" phrasing from the modal body.
- Updated the reject modal title from "Reject initial request?" to "Reject initial request" (no question mark per spec).

## Test plan
- [ ] DO code-review page header shows the new intro sentence with a visible gap before the bullets; lab name is normal weight.
- [ ] DO proposal review approve/needs-clarification modal body uses the new copy.
- [ ] DO proposal review reject modal title reads "Reject initial request" and still shows the red rejection warning paragraph.
- [ ] \`npm run test:unit -- src/app/[orgSlug]/study/[studyId]/review/proposal-review-view.test.tsx src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.test.tsx\` (21 tests).

[OTTER-559]: https://openstax.atlassian.net/browse/OTTER-559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OTTER-554]: https://openstax.atlassian.net/browse/OTTER-554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ