### PR TITLE
Extend inactivity timeout to 8 hours

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "build:editor": "./services/editor/build",
         "ci:server": "./bin/ci-server",
         "dev": "next dev -p 4000",
-        "dev:local": "concurrently --kill-others-on-fail npm:dev npm:s3:local npm:editor:local",
+        "dev:local": "concurrently --kill-others-on-fail --kill-signal SIGKILL npm:dev npm:s3:local npm:editor:local",
         "editor:local": "node --env-file=.env services/editor/server.ts",
         "hocuspocus": "node services/editor/server.ts",
         "s3:local": "./bin/local-seaweedfs",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -168,8 +168,8 @@ export const JOB_FINAL_STATUSES: StudyJobStatus[] = ['CODE-REJECTED', 'JOB-ERROR
 export const CLERK_ADMIN_ORG_SLUG = 'safe-insights' as const
 
 // inactivity timeout and warning threshold for user sessions
-export const INACTIVITY_TIMEOUT_MS = 20 * 60 * 1000 // 20 minutes
-export const WARNING_THRESHOLD_MS = 2 * 60 * 1000 // 2 minutes
+export const INACTIVITY_TIMEOUT_MS = 8 * 60 * 60 * 1000 // 8 hours
+export const WARNING_THRESHOLD_MS = 10 * 60 * 1000 // 10 minutes
 
 export enum AuthRole {
     Admin = 'admin',


### PR DESCRIPTION
## Summary
Bumps the auto-logout idle window from 20 minutes to **8 hours** and extends the "Stay Signed In" warning lead time from 2 minutes to **10 minutes**. Both knobs are constants in \`src/lib/types.ts\` consumed by \`activity-context.tsx\`; no env vars or DB rows involved.

https://openstax.atlassian.net/browse/OTTER-564

- \`INACTIVITY_TIMEOUT_MS\`: \`20 * 60 * 1000\` → \`8 * 60 * 60 * 1000\`
- \`WARNING_THRESHOLD_MS\`: \`2 * 60 * 1000\` → \`10 * 60 * 1000\`

The warning toast copy is derived from \`WARNING_THRESHOLD_MS\` (rendered via \`Math.ceil((INACTIVITY_TIMEOUT_MS - inactivityDuration) / 60000)\` minutes), so it now reads "logged out in 10 minutes due to inactivity" without a string edit.

## Test plan
- [ ] Sign in, leave the tab idle for ~7h 50m, confirm the "Stay Signed In" toast appears with "10 minutes" wording.
- [ ] Click "Stay Signed In", confirm the session continues (timer resets).
- [ ] Leave idle past the full 8h, confirm auto-signout fires and redirects to sign-in with the existing toast.