### PR TITLE
editor: surface real auth failure code instead of generic permission-denied

### DIFF
--- a/services/editor/auth.test.ts
+++ b/services/editor/auth.test.ts
@@ -517,12 +517,16 @@ describe('authenticate', () => {
         })
     })
 
-    it('AuthFailureError instances carry name and code', () => {
+    it('AuthFailureError instances carry name, code, and reason', () => {
         const err = new AuthFailureError('NO_MEMBERSHIP', 'no membership in study orgs')
         expect(err).toBeInstanceOf(Error)
         expect(err.name).toBe('AuthFailureError')
         expect(err.code).toBe('NO_MEMBERSHIP')
         expect(err.message).toBe('NO_MEMBERSHIP: no membership in study orgs')
+        // Hocuspocus forwards `err.reason` to the client; without this Hocuspocus
+        // falls back to the literal string "permission-denied" and the client
+        // loses the specific code.
+        expect(err.reason).toBe('NO_MEMBERSHIP: no membership in study orgs')
     })
 })
 

--- a/services/editor/auth.ts
+++ b/services/editor/auth.ts
@@ -279,12 +279,17 @@ export type AuthFailureCode =
 
 export class AuthFailureError extends Error {
     readonly code: AuthFailureCode
+    readonly reason: string
     constructor(code: AuthFailureCode, message: string) {
-        // The wire format `CODE: message` must be the Error.message because
-        // Hocuspocus only forwards `err.message` to the client.
-        super(`${code}: ${message}`)
+        // Hocuspocus forwards `err.reason` to the client (falling back to the
+        // literal string "permission-denied" if absent); set both so the
+        // `CODE: message` wire format survives. The client splits on the first
+        // colon to recover `code`.
+        const wire = `${code}: ${message}`
+        super(wire)
         this.name = 'AuthFailureError'
         this.code = code
+        this.reason = wire
     }
 }
 

--- a/services/editor/server.ts
+++ b/services/editor/server.ts
@@ -8,6 +8,7 @@ import { TYPING_DEBOUNCE_MS, MAX_SAVE_INTERVAL_MS } from './constants.ts'
 import {
     type AuthenticatedContext,
     type StudyStatus,
+    AuthFailureError,
     assertStatelessEventConsistent,
     authenticate,
     parseDocumentName,
@@ -16,6 +17,20 @@ import {
     studyIdForDocument,
 } from './auth.ts'
 import { SLUG_TO_STUDY_COLUMN, seedYDocFromLexical } from './lexical-seed.ts'
+
+// Decode (without verifying) the JWT's `sub` claim, purely for diagnostic
+// logging when authentication has already failed. Returns null on any error.
+function unsafeJwtSubject(token: string | null | undefined): string | null {
+    if (!token) return null
+    const parts = token.split('.')
+    if (parts.length < 2) return null
+    try {
+        const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'))
+        return typeof payload?.sub === 'string' ? payload.sub : null
+    } catch {
+        return null
+    }
+}
 
 function log(event: string, fields: Record<string, unknown> = {}): void {
     process.stdout.write(JSON.stringify({ ts: new Date().toISOString(), event, ...fields }) + '\n')
@@ -144,7 +159,9 @@ const server = new Server({
         } catch (err) {
             log('auth.fail', {
                 documentName,
+                code: err instanceof AuthFailureError ? err.code : null,
                 message: err instanceof Error ? err.message : String(err),
+                clerkUserId: unsafeJwtSubject(token),
             })
             throw err
         }

--- a/src/components/editable-text/collaborative-editor.tsx
+++ b/src/components/editable-text/collaborative-editor.tsx
@@ -384,14 +384,15 @@ export function CollaborativeEditor({
     const fetchToken = useCallback(async () => getToken(), [getToken])
     const onAuthError = useCallback(
         (reason: string) => {
-            const { code } = parseAuthFailureReason(reason)
+            const { code, message } = parseAuthFailureReason(reason)
+            console.error('[collaborative-editor] auth failed', { documentName: id, code, message, reason })
             setAuthFailureCode(code)
             // Belt-and-braces: a per-document auth failure can fire without the shared
             // websocket dropping (server forcibly closes one handshake), so the page-level
             // reconnect listener wouldn't run. Drive the kick-out check from here too.
             if (code === 'STUDY_NOT_EDITABLE') triggerKickOut()
         },
-        [triggerKickOut],
+        [id, triggerKickOut],
     )
     const providerFactory = useCollaborationProvider(
         websocketProvider,


### PR DESCRIPTION
## Summary
- Hocuspocus forwards `err.reason` (not `err.message`) to the client. `AuthFailureError` set only `message`, so every editor auth failure reached the client as the literal string `"permission-denied"` and the client lost the specific code (`NO_MEMBERSHIP`, `USER_NOT_PROVISIONED`, `STUDY_NOT_EDITABLE`, etc.). Setting `.reason` on the error preserves the `CODE: message` wire format the client parser already expects.
- Enriched the server-side `auth.fail` log with the parsed `code` and the JWT subject (decoded without verification, only for diagnostics) so failures can be triaged by Clerk user id without re-walking the failing branch.
- Added a `console.error` in the editor's `onAuthError` so the resolved `code` / `message` / raw `reason` appear in the browser console when the "Editor unavailable" banner shows — previously the client only knew the failure happened, not why.

## Test plan
- [x] `services/editor/auth.test.ts` — added an assertion that `AuthFailureError.reason` carries the wire format; all 86 tests pass.
- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] Manual: trigger an auth failure in dev (e.g. open a doc for a study you don't belong to), verify the browser console shows `[collaborative-editor] auth failed { code: "NO_MEMBERSHIP", … }` and the editor-service CloudWatch log line carries `"code":"NO_MEMBERSHIP"` and the `clerkUserId`.