### PR TITLE
study: allow null title on DRAFT, enforce non-null otherwise

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/code/code-upload.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/code/code-upload.tsx
@@ -10,7 +10,7 @@ import { Routes } from '@/lib/routes'
 interface CodeUploadPageProps {
     orgSlug: string
     studyId: string
-    studyTitle: string
+    studyTitle: string | null
     previousHref: Route
 }
 

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/edit-initial-request-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/edit-initial-request-section.tsx
@@ -10,11 +10,7 @@ import { EditableText } from '@/components/editable-text'
 import { DatasetMultiSelect } from '@/components/dataset-multi-select'
 import { countWords, countWordsFromLexical } from '@/lib/lexical'
 import { Routes, ExternalLinks } from '@/lib/routes'
-import {
-    DEFAULT_DRAFT_TITLE,
-    WORD_LIMITS,
-    type ProposalFormValues,
-} from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
+import { WORD_LIMITS, type ProposalFormValues } from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
 import { useEditResubmit } from '@/contexts/edit-resubmit'
 import { editableTextFields, type EditableTextField } from '@/app/[orgSlug]/study/[studyId]/proposal/field-config'
 
@@ -98,7 +94,7 @@ export const EditInitialRequestSection: FC<EditInitialRequestSectionProps> = ({
                         aria-label="Study Title"
                         placeholder="Ex. Impact of highlighting on student learning outcomes."
                         {...form.getInputProps('title')}
-                        value={form.values.title === DEFAULT_DRAFT_TITLE ? '' : form.values.title}
+                        value={form.values.title ?? ''}
                         error={!!form.errors.title}
                     />
                     <Group justify={form.errors.title ? 'space-between' : 'flex-end'} mt={4}>

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.test.tsx
@@ -1,7 +1,7 @@
 import { TextInput } from '@mantine/core'
 import { BLANK_UUID, describe, expect, it, renderWithProviders, screen, userEvent } from '@/tests/unit.helpers'
 import { EditResubmitProvider, useEditResubmit } from '@/contexts/edit-resubmit'
-import { DEFAULT_DRAFT_TITLE, type ProposalFormValues } from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
+import { type ProposalFormValues } from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
 import { EditResubmitFooter } from './footer'
 
 const STUDY_ID = '11111111-1111-4111-8111-111111111111'
@@ -15,10 +15,10 @@ function lexicalText(text: string): string {
     })
 }
 
-// Every required proposal field populated EXCEPT the title (which holds the
-// server-assigned DEFAULT_DRAFT_TITLE placeholder, reproducing OTTER-557).
+// Every required proposal field populated EXCEPT the title (left blank, as drafts now
+// persist a NULL title instead of a placeholder; reproduces OTTER-557).
 const fullyValidExceptTitle: ProposalFormValues = {
-    title: DEFAULT_DRAFT_TITLE,
+    title: '',
     datasets: ['dataset-1'],
     researchQuestions: lexicalText('What is the primary research question?'),
     projectSummary: lexicalText('This study examines outcomes.'),
@@ -59,7 +59,7 @@ const renderFooter = (draftData: ProposalFormValues = fullyValidExceptTitle, tit
     )
 
 describe('EditResubmitFooter submit gating (OTTER-557)', () => {
-    it('keeps Resubmit disabled when only the default draft title is present', () => {
+    it('keeps Resubmit disabled when the title is empty', () => {
         renderFooter()
         expect(screen.getByRole('button', { name: 'Resubmit initial request' })).toBeDisabled()
     })

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/page.tsx
@@ -40,7 +40,7 @@ export default async function StudyEditAndResubmitRoute(props: {
                 <EditResubmitProvider
                     studyId={studyId}
                     draftData={{
-                        title: study.title,
+                        title: study.title ?? '',
                         piName: study.piName,
                         piUserId: study.piUserId ?? undefined,
                         datasets: study.datasets ?? undefined,

--- a/src/app/[orgSlug]/study/[studyId]/edit/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit/page.tsx
@@ -38,7 +38,7 @@ export default async function StudyEditPage(props: { params: Promise<{ studyId: 
             studyId={studyId}
             draftData={{
                 id: studyId,
-                title: study.title,
+                title: study.title ?? '',
                 piName: study.piName,
                 language: study.language,
                 orgSlug: study.orgSlug,

--- a/src/app/[orgSlug]/study/[studyId]/proposal/footer.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/footer.test.tsx
@@ -2,7 +2,7 @@ import { TextInput } from '@mantine/core'
 import { BLANK_UUID, describe, expect, it, renderWithProviders, screen, userEvent } from '@/tests/unit.helpers'
 import { ProposalProvider, useProposal, type ProposalDraftData } from '@/contexts/proposal'
 import { ProposalFooter } from './footer'
-import { DEFAULT_DRAFT_TITLE, type ProposalFormValues } from './schema'
+import { type ProposalFormValues } from './schema'
 
 const STUDY_ID = '11111111-1111-4111-8111-111111111111'
 
@@ -15,10 +15,10 @@ function lexicalText(text: string): string {
     })
 }
 
-// Every required field populated EXCEPT the title (which holds the
-// server-assigned DEFAULT_DRAFT_TITLE placeholder, reproducing OTTER-557).
+// Every required field populated EXCEPT the title (left blank, as drafts now
+// persist a NULL title instead of a placeholder; reproduces OTTER-557).
 const fullyValidExceptTitle: ProposalFormValues = {
-    title: DEFAULT_DRAFT_TITLE,
+    title: '',
     datasets: ['dataset-1'],
     researchQuestions: lexicalText('What is the primary research question?'),
     projectSummary: lexicalText('This study examines outcomes.'),
@@ -43,7 +43,7 @@ const renderFooter = (draftData: ProposalDraftData = fullyValidExceptTitle) =>
     )
 
 describe('ProposalFooter submit gating (OTTER-557)', () => {
-    it('keeps Submit disabled when only the default draft title is present', () => {
+    it('keeps Submit disabled when the title is empty', () => {
         renderFooter()
         expect(screen.getByRole('button', { name: 'Submit study proposal' })).toBeDisabled()
     })

--- a/src/app/[orgSlug]/study/[studyId]/proposal/form.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/form.tsx
@@ -14,7 +14,7 @@ import ProxyProvider from '@/components/proxy-provider'
 import { DatasetMultiSelect } from '@/components/dataset-multi-select'
 import { countWords } from '@/lib/lexical'
 import { Routes, ExternalLinks } from '@/lib/routes'
-import { DEFAULT_DRAFT_TITLE, WORD_LIMITS, type ProposalFormValues } from './schema'
+import { WORD_LIMITS, type ProposalFormValues } from './schema'
 import { useProposal } from '@/contexts/proposal'
 import { ProposalFooter } from './footer'
 import { editableTextFields, type EditableTextField } from './field-config'
@@ -172,7 +172,7 @@ export const ProposalForm: FC<ProposalFormProps> = ({
                                         titleInputProps.onChange?.(event)
                                         yjsForm.pushField('title', event.currentTarget.value)
                                     }}
-                                    value={form.values.title === DEFAULT_DRAFT_TITLE ? '' : form.values.title}
+                                    value={form.values.title ?? ''}
                                     error={!!form.errors.title}
                                 />
                                 <Group justify={form.errors.title ? 'space-between' : 'flex-end'} mt={4}>

--- a/src/app/[orgSlug]/study/[studyId]/proposal/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/page.tsx
@@ -30,7 +30,7 @@ export default async function StudyProposalRoute(props: { params: Promise<{ stud
             <ProposalProvider
                 studyId={studyId}
                 draftData={{
-                    title: result.title,
+                    title: result.title ?? '',
                     piName: result.piName,
                     piUserId: result.piUserId ?? undefined,
                     datasets: result.datasets ?? undefined,

--- a/src/app/[orgSlug]/study/[studyId]/proposal/reviewer-preview.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/reviewer-preview.tsx
@@ -8,7 +8,7 @@ import { ResearcherProfilePopover } from '@/components/researcher-profile-popove
 import { extractTextFromLexical } from '@/lib/lexical'
 import { useOrgDataSources } from '@/hooks/use-org-data-sources'
 import { usePopover } from '@/hooks/use-popover'
-import { DEFAULT_DRAFT_TITLE, type ProposalFormValues } from './schema'
+import { type ProposalFormValues } from './schema'
 import { editableTextFields } from './field-config'
 
 interface ReviewerPreviewProps {
@@ -39,7 +39,7 @@ export const ReviewerPreview: FC<ReviewerPreviewProps> = ({
                     Study title
                 </Text>
                 <Text size="md" fw={400}>
-                    {values.title || DEFAULT_DRAFT_TITLE}
+                    {values.title?.trim() || 'Not provided'}
                 </Text>
             </Box>
 

--- a/src/app/[orgSlug]/study/[studyId]/proposal/schema.ts
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/schema.ts
@@ -4,17 +4,8 @@ import { extractTextFromLexical, countWordsFromLexical } from '@/lib/lexical'
 const WORD_LIMIT_ERROR = 'Word limit exceeded. Please shorten your text.'
 const REQUIRED_FIELD_ERROR = 'This field is required.'
 
-export const DEFAULT_DRAFT_TITLE = 'Untitled Draft'
-
-// Drafts are persisted with `DEFAULT_DRAFT_TITLE` so they have *something* in the DB
-// title column, but the user-visible input is blanked out (see form.tsx ternary).
-// `form.isValid()` would otherwise pass for a never-entered title because the
-// persisted value satisfies `.min(1)`, so callers must use this helper to gate
-// submit buttons.
 export function hasUserProvidedTitle(title: string | undefined | null): boolean {
-    if (!title) return false
-    const trimmed = title.trim()
-    return trimmed.length > 0 && trimmed !== DEFAULT_DRAFT_TITLE
+    return !!title?.trim()
 }
 
 export const WORD_LIMITS = {

--- a/src/app/[orgSlug]/study/[studyId]/resubmit/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/resubmit/page.tsx
@@ -9,12 +9,12 @@ export default async function ResubmitStudyCodePage(props: { params: Promise<{ s
     const { studyId, orgSlug } = await props.params
     const study = await getStudyAction({ studyId })
 
-    if ('error' in study || !study.submittedByOrgSlug) {
+    if ('error' in study || !study.submittedByOrgSlug || study.title === null) {
         return notFound()
     }
 
     return (
-        <ResubmitCodeProvider study={{ ...study, submittedByOrgSlug: study.submittedByOrgSlug }}>
+        <ResubmitCodeProvider study={{ ...study, title: study.title, submittedByOrgSlug: study.submittedByOrgSlug }}>
             <Stack p="xl" gap="xl">
                 <ResearcherBreadcrumbs
                     crumbs={{

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.test.tsx
@@ -1,4 +1,5 @@
 import { getStudyAction, type SelectedStudy } from '@/server/actions/study.actions'
+import { isSubmittedStudy, type Submitted } from '@/schema/study'
 import {
     actionResult,
     insertTestStudyJobData,
@@ -19,7 +20,7 @@ vi.unmock('@/components/page-breadcrumbs')
 const ORG_SLUG = 'test-org'
 
 describe('CodeReviewRedesignView', () => {
-    let study: SelectedStudy
+    let study: Submitted<SelectedStudy>
     let jobCreatedAt: Date
 
     beforeEach(async () => {
@@ -31,7 +32,9 @@ describe('CodeReviewRedesignView', () => {
             jobStatus: 'CODE-SUBMITTED',
             title: 'Effect of Reading Comprehension Tools',
         })
-        study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+        const loaded = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+        if (!isSubmittedStudy(loaded)) throw new Error('test fixture must be a submitted study')
+        study = loaded
         jobCreatedAt = latestJobWithStatus.createdAt
         ;(useParams as Mock).mockReturnValue({ orgSlug: ORG_SLUG, studyId: study.id })
     })

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.tsx
@@ -3,6 +3,7 @@ import { PageBreadcrumbs } from '@/components/page-breadcrumbs'
 import { ProposalStepHeader } from '@/components/study/proposal-step-header'
 import { ReviewCriteriaBanner } from '@/components/study/review-criteria-banner'
 import { Routes } from '@/lib/routes'
+import { requireTitle } from '@/schema/study'
 import { getStudyReviewForJob, jobScanResultForJob, latestJobForStudyOrNull } from '@/server/db/queries'
 import { Box, Stack, Title } from '@mantine/core'
 import type { SelectedStudy } from '@/server/actions/study.actions'
@@ -44,7 +45,7 @@ function CodeReviewSection({ study, submittedAt }: CodeReviewSectionProps) {
         <ProposalStepHeader
             stepLabel="STEP 3"
             heading="Review study code"
-            studyTitle={study.title}
+            studyTitle={requireTitle(study)}
             timestampDate={submittedAt}
             banner={<CodeReviewStatusBanner labName={labName} />}
         />

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.tsx
@@ -3,7 +3,7 @@ import { PageBreadcrumbs } from '@/components/page-breadcrumbs'
 import { ProposalStepHeader } from '@/components/study/proposal-step-header'
 import { ReviewCriteriaBanner } from '@/components/study/review-criteria-banner'
 import { Routes } from '@/lib/routes'
-import { requireTitle } from '@/schema/study'
+import { type Submitted } from '@/schema/study'
 import { getStudyReviewForJob, jobScanResultForJob, latestJobForStudyOrNull } from '@/server/db/queries'
 import { Box, Stack, Title } from '@mantine/core'
 import type { SelectedStudy } from '@/server/actions/study.actions'
@@ -13,7 +13,7 @@ import { SubmittedCodeSection } from './submitted-code-section'
 
 type CodeReviewRedesignViewProps = {
     orgSlug: string
-    study: SelectedStudy
+    study: Submitted<SelectedStudy>
 }
 
 function CodeReviewStatusBanner({ labName }: { labName: string }) {
@@ -34,7 +34,7 @@ function CodeReviewStatusBanner({ labName }: { labName: string }) {
 }
 
 type CodeReviewSectionProps = {
-    study: SelectedStudy
+    study: Submitted<SelectedStudy>
     submittedAt: Date | string
 }
 
@@ -45,7 +45,7 @@ function CodeReviewSection({ study, submittedAt }: CodeReviewSectionProps) {
         <ProposalStepHeader
             stepLabel="STEP 3"
             heading="Review study code"
-            studyTitle={requireTitle(study)}
+            studyTitle={study.title}
             timestampDate={submittedAt}
             banner={<CodeReviewStatusBanner labName={labName} />}
         />

--- a/src/app/[orgSlug]/study/[studyId]/review/legacy-proposal-review-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/legacy-proposal-review-view.test.tsx
@@ -1,5 +1,6 @@
 import { lexicalJson } from '@/lib/lexical'
 import { getStudyAction, type SelectedStudy } from '@/server/actions/study.actions'
+import { isSubmittedStudy, type Submitted } from '@/schema/study'
 import {
     actionResult,
     insertTestStudyJobData,
@@ -31,7 +32,7 @@ vi.mock('@/components/openstax-feature-flag', async (importOriginal) => {
 })
 
 describe('LegacyProposalReviewView', () => {
-    let study: SelectedStudy
+    let study: Submitted<SelectedStudy>
 
     beforeEach(async () => {
         featureFlagState.enabled = false
@@ -48,7 +49,9 @@ describe('LegacyProposalReviewView', () => {
             impact: lexicalJson('This could improve treatment outcomes.'),
             additionalNotes: lexicalJson('Funding secured from NIH.'),
         })
-        study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+        const loaded = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+        if (!isSubmittedStudy(loaded)) throw new Error('test fixture must be a submitted study')
+        study = loaded
         ;(useParams as Mock).mockReturnValue({ orgSlug: 'test-org', studyId: study.id })
     })
 
@@ -86,6 +89,7 @@ describe('LegacyProposalReviewView', () => {
             piName: '',
         })
         const nullStudy = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+        if (!isSubmittedStudy(nullStudy)) throw new Error('test fixture must be a submitted study')
         ;(useParams as Mock).mockReturnValue({ orgSlug: 'test-org', studyId: nullStudy.id })
 
         renderWithProviders(<LegacyProposalReviewView orgSlug="test-org" study={nullStudy} />)
@@ -108,6 +112,7 @@ describe('LegacyProposalReviewView', () => {
             piName: 'Dr. Jones',
         })
         const lexicalStudy = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+        if (!isSubmittedStudy(lexicalStudy)) throw new Error('test fixture must be a submitted study')
         ;(useParams as Mock).mockReturnValue({ orgSlug: 'test-org', studyId: lexicalStudy.id })
 
         renderWithProviders(<LegacyProposalReviewView orgSlug="test-org" study={lexicalStudy} />)

--- a/src/app/[orgSlug]/study/[studyId]/review/legacy-proposal-review-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/legacy-proposal-review-view.tsx
@@ -8,13 +8,14 @@ import { stringifyJson } from '@/lib/string'
 import { Routes } from '@/lib/routes'
 import { Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
 import type { SelectedStudy } from '@/server/actions/study.actions'
+import type { Submitted } from '@/schema/study'
 import { usePopover } from '@/hooks/use-popover'
 import { ProposalReviewView } from './proposal-review-view'
 import { ProposalReviewButtons } from './proposal-review-buttons'
 
 type LegacyProposalReviewViewProps = {
     orgSlug: string
-    study: SelectedStudy
+    study: Submitted<SelectedStudy>
     agreementsHref?: string
 }
 

--- a/src/app/[orgSlug]/study/[studyId]/review/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.tsx
@@ -12,6 +12,7 @@ import { isSubmittedProposalReviewStatus } from '@/lib/proposal-review'
 import { Routes } from '@/lib/routes'
 import { studyHasJobStatus } from '@/lib/studies'
 import { isStudyResultsStatus } from '@/lib/study-job-status'
+import { isSubmittedStudy } from '@/schema/study'
 import {
     getCodeReviewFeedbackAction,
     getProposalFeedbackForStudyAction,
@@ -51,6 +52,12 @@ export default async function StudyReviewPage(props: {
 
     if (currentOrg.type === 'lab') {
         redirect(Routes.studyView({ orgSlug: study.submittedByOrgSlug, studyId }))
+    }
+
+    // Reviewer dashboards filter out DRAFT studies, but a direct URL could still
+    // hit this route. Narrow here so downstream views see a guaranteed non-null title.
+    if (!isSubmittedStudy(study)) {
+        return <AlertNotFound title="Study was not found" message="no such study exists" />
     }
 
     if (currentOrg.type === 'enclave') {

--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
@@ -7,6 +7,7 @@ import {
     type SelectedStudy,
 } from '@/server/actions/study.actions'
 import { latestJobForStudy, type LatestJobForStudy } from '@/server/db/queries'
+import { isSubmittedStudy, type Submitted } from '@/schema/study'
 import {
     actionResult,
     db,
@@ -60,7 +61,7 @@ const buildEntry = (overrides: Partial<ProposalFeedbackEntry> = {}): ProposalFee
     }) as ProposalFeedbackEntry
 
 describe('PostFeedbackView', () => {
-    let study: SelectedStudy
+    let study: Submitted<SelectedStudy>
 
     beforeEach(async () => {
         const { org, user } = await mockSessionWithTestData({ orgSlug: ORG_SLUG, orgType: 'enclave' })
@@ -70,7 +71,9 @@ describe('PostFeedbackView', () => {
             studyStatus: 'PENDING-REVIEW',
             title: 'Effect of Reading Comprehension Tools',
         })
-        study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+        const loaded = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+        if (!isSubmittedStudy(loaded)) throw new Error('test fixture must be a submitted study')
+        study = loaded
         ;(useParams as Mock).mockReturnValue({ orgSlug: ORG_SLUG, studyId: study.id })
         memoryRouter.setCurrentUrl('/')
     })
@@ -410,6 +413,7 @@ describe('PostFeedbackView', () => {
                 })
                 .execute()
             const codeStudy = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+            if (!isSubmittedStudy(codeStudy)) throw new Error('test fixture must be a submitted study')
             const latestJob: LatestJobForStudy = await latestJobForStudy(codeStudy.id)
             ;(useParams as Mock).mockReturnValue({ orgSlug: ORG_SLUG, studyId: codeStudy.id })
 

--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
@@ -6,6 +6,7 @@ import { FeedbackAndNotesSection } from '@/components/study/feedback-and-notes'
 import { ProposalRequest } from '@/components/study/proposal-initial-request'
 import { ProposalStepHeader } from '@/components/study/proposal-step-header'
 import { Routes } from '@/lib/routes'
+import { requireTitle } from '@/schema/study'
 import { Box, Button, Group, Stack, Text, Title } from '@mantine/core'
 import { useRouter } from 'next/navigation'
 import type { ReactNode } from 'react'
@@ -145,7 +146,7 @@ function CodeSection({ isVisible, study, job, kindCopy, timestampLabel, timestam
         <ProposalStepHeader
             stepLabel={kindCopy.stepLabel}
             heading={kindCopy.heading}
-            studyTitle={study.title}
+            studyTitle={requireTitle(study)}
             timestampDate={timestampDate}
             timestampLabel={timestampLabel}
             banner={banner}

--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
@@ -6,7 +6,7 @@ import { FeedbackAndNotesSection } from '@/components/study/feedback-and-notes'
 import { ProposalRequest } from '@/components/study/proposal-initial-request'
 import { ProposalStepHeader } from '@/components/study/proposal-step-header'
 import { Routes } from '@/lib/routes'
-import { requireTitle } from '@/schema/study'
+import { type Submitted } from '@/schema/study'
 import { Box, Button, Group, Stack, Text, Title } from '@mantine/core'
 import { useRouter } from 'next/navigation'
 import type { ReactNode } from 'react'
@@ -19,7 +19,7 @@ export type PostFeedbackKind = 'PROPOSAL' | 'CODE'
 
 type PostFeedbackViewProps = {
     orgSlug: string
-    study: SelectedStudy
+    study: Submitted<SelectedStudy>
     entries: ProposalFeedbackEntry[] | CodeReviewFeedbackEntry[]
     kind?: PostFeedbackKind
     job?: LatestJobForStudy | null
@@ -131,7 +131,7 @@ function GoToDashboardButton() {
 
 type CodeSectionProps = {
     isVisible: boolean
-    study: SelectedStudy
+    study: Submitted<SelectedStudy>
     job: LatestJobForStudy | null
     kindCopy: KindCopy
     timestampLabel: string
@@ -146,7 +146,7 @@ function CodeSection({ isVisible, study, job, kindCopy, timestampLabel, timestam
         <ProposalStepHeader
             stepLabel={kindCopy.stepLabel}
             heading={kindCopy.heading}
-            studyTitle={requireTitle(study)}
+            studyTitle={study.title}
             timestampDate={timestampDate}
             timestampLabel={timestampLabel}
             banner={banner}
@@ -158,7 +158,7 @@ function CodeSection({ isVisible, study, job, kindCopy, timestampLabel, timestam
 
 type ProposalSectionProps = {
     isVisible: boolean
-    study: SelectedStudy
+    study: Submitted<SelectedStudy>
     orgSlug: string
     kindCopy: KindCopy
     entries: ProposalFeedbackEntry[]

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-review-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-review-view.test.tsx
@@ -1,4 +1,5 @@
 import { getStudyAction, type SelectedStudy } from '@/server/actions/study.actions'
+import { isSubmittedStudy, type Submitted } from '@/schema/study'
 import {
     actionResult,
     insertTestStudyJobData,
@@ -15,7 +16,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { ProposalReviewView, REJECTION_WARNING, ReviewConfirmationModal } from './proposal-review-view'
 
 describe('ProposalReviewView', () => {
-    let study: SelectedStudy
+    let study: Submitted<SelectedStudy>
 
     beforeEach(async () => {
         memoryRouter.setCurrentUrl('/')
@@ -26,7 +27,9 @@ describe('ProposalReviewView', () => {
             studyStatus: 'PENDING-REVIEW',
             title: 'Test Study Title',
         })
-        study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+        const loaded = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+        if (!isSubmittedStudy(loaded)) throw new Error('test fixture must be a submitted study')
+        study = loaded
         ;(useParams as Mock).mockReturnValue({ orgSlug: 'test-org', studyId: study.id })
     })
 

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-section.test.tsx
@@ -1,5 +1,6 @@
 import { lexicalJson } from '@/lib/lexical'
 import { getStudyAction, type SelectedStudy } from '@/server/actions/study.actions'
+import { isSubmittedStudy, type Submitted } from '@/schema/study'
 import {
     actionResult,
     fireEvent,
@@ -16,7 +17,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { ProposalSection } from './proposal-section'
 
 describe('ProposalSection', () => {
-    let study: SelectedStudy
+    let study: Submitted<SelectedStudy>
 
     beforeEach(async () => {
         const { org, user } = await mockSessionWithTestData({ orgSlug: 'test-org', orgType: 'enclave' })
@@ -32,7 +33,9 @@ describe('ProposalSection', () => {
             impact: lexicalJson('This could improve outcomes.'),
             additionalNotes: lexicalJson('Funded by NIH.'),
         })
-        study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+        const loaded = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+        if (!isSubmittedStudy(loaded)) throw new Error('test fixture must be a submitted study')
+        study = loaded
         ;(useParams as Mock).mockReturnValue({ orgSlug: 'test-org', studyId: study.id })
     })
 

--- a/src/app/[orgSlug]/study/[studyId]/review/review-decision-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/review-decision-section.test.tsx
@@ -1,5 +1,6 @@
 import { useReviewDecision } from '@/hooks/use-review-decision'
 import { getStudyAction, type SelectedStudy } from '@/server/actions/study.actions'
+import { isSubmittedStudy, type Submitted } from '@/schema/study'
 import {
     actionResult,
     insertTestStudyJobData,
@@ -11,13 +12,13 @@ import {
 import { beforeEach, describe, expect, it } from 'vitest'
 import { ReviewDecisionSection } from './review-decision-section'
 
-function Wrapper({ study, labName = 'Rice University' }: { study: SelectedStudy; labName?: string }) {
+function Wrapper({ study, labName = 'Rice University' }: { study: Submitted<SelectedStudy>; labName?: string }) {
     const decision = useReviewDecision()
     return <ReviewDecisionSection decision={decision} study={study} labName={labName} />
 }
 
 describe('ReviewDecisionSection', () => {
-    let study: SelectedStudy
+    let study: Submitted<SelectedStudy>
 
     beforeEach(async () => {
         const { org, user } = await mockSessionWithTestData({ orgSlug: 'test-org', orgType: 'enclave' })
@@ -27,7 +28,9 @@ describe('ReviewDecisionSection', () => {
             studyStatus: 'PENDING-REVIEW',
             title: 'Test Study Title',
         })
-        study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+        const loaded = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+        if (!isSubmittedStudy(loaded)) throw new Error('test fixture must be a submitted study')
+        study = loaded
     })
 
     it('renders all three decision options with correct labels', () => {

--- a/src/app/[orgSlug]/study/[studyId]/review/review-types.ts
+++ b/src/app/[orgSlug]/study/[studyId]/review/review-types.ts
@@ -1,7 +1,11 @@
 import type { SelectedStudy } from '@/server/actions/study.actions'
 import type { Decision } from '@/lib/review-decision'
+import type { Submitted } from '@/schema/study'
 
-export type StudyForReview = SelectedStudy
+// Review flows always operate on a submitted study (status != DRAFT), so the
+// title is guaranteed non-null by the DB CHECK constraint. Route entry points
+// must narrow with isSubmittedStudy() before rendering review components.
+export type StudyForReview = Submitted<SelectedStudy>
 
 export type DecisionOption = {
     value: Decision

--- a/src/app/[orgSlug]/study/[studyId]/submitted/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/page.tsx
@@ -4,6 +4,7 @@ import { getOrgNameFromId } from '@/server/db/queries'
 import { deriveStudyVersion } from '@/lib/studies'
 import { isActionError } from '@/lib/errors'
 import { AlertNotFound } from '@/components/errors'
+import { isSubmittedStudy } from '@/schema/study'
 import { SubmittedView } from './submitted-view'
 
 export default async function StudySubmittedRoute(props: { params: Promise<{ studyId: string; orgSlug: string }> }) {
@@ -13,6 +14,10 @@ export default async function StudySubmittedRoute(props: { params: Promise<{ stu
 
     if (isActionError(result) || !result) {
         return <AlertNotFound title="Study was not found" message="no such study exists" />
+    }
+
+    if (!isSubmittedStudy(result)) {
+        return <AlertNotFound title="Study was not found" message="this study has not been submitted yet" />
     }
 
     const [orgName, feedbackResult] = await Promise.all([

--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.test.tsx
@@ -1,6 +1,7 @@
 import { lexicalJson } from '@/lib/lexical'
 import { Routes } from '@/lib/routes'
 import { getStudyAction, type ProposalFeedbackEntry, type SelectedStudy } from '@/server/actions/study.actions'
+import { isSubmittedStudy, type Submitted } from '@/schema/study'
 import {
     actionResult,
     insertTestStudyJobData,
@@ -31,7 +32,7 @@ const buildEntry = (overrides: Partial<ProposalFeedbackEntry> = {}): ProposalFee
     }) as ProposalFeedbackEntry
 
 describe('ProposalSubmitted', () => {
-    let study: SelectedStudy
+    let study: Submitted<SelectedStudy>
 
     beforeEach(async () => {
         const { org, user } = await mockSessionWithTestData({ orgSlug: ORG_SLUG, orgType: 'enclave' })
@@ -41,7 +42,9 @@ describe('ProposalSubmitted', () => {
             studyStatus: 'APPROVED',
             title: 'Effect of Reading Comprehension Tools',
         })
-        study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+        const loaded = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+        if (!isSubmittedStudy(loaded)) throw new Error('test fixture must be a submitted study')
+        study = loaded
         ;(useParams as Mock).mockReturnValue({ orgSlug: ORG_SLUG, studyId: study.id })
     })
 

--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
@@ -9,13 +9,14 @@ import { ProposalRequest } from '@/components/study/proposal-initial-request'
 import { FeedbackAndNotesSection } from '@/components/study/feedback-and-notes'
 import type { ProposalFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
 import type { StudyStatus } from '@/database/types'
+import type { Submitted } from '@/schema/study'
 import { ProposalHeader } from '../../request/page-header'
 import { Routes } from '@/lib/routes'
 import { Link } from '@/components/links'
 
 interface ProposalSubmittedProps {
     orgSlug: string
-    study: SelectedStudy
+    study: Submitted<SelectedStudy>
     orgName: string
     entries: ProposalFeedbackEntry[]
     studyVersion: number

--- a/src/app/[orgSlug]/study/[studyId]/submitted/submitted-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/submitted-view.tsx
@@ -5,13 +5,14 @@ import { Routes } from '@/lib/routes'
 import { displayOrgName } from '@/lib/string'
 import { PostSubmissionFeatureFlag } from '@/components/openstax-feature-flag'
 import type { ProposalFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
+import type { Submitted } from '@/schema/study'
 import { StudyRequestPageHeader } from '../../request/page-header'
 import { SubmittedProposalPreview } from './submitted-proposal-preview'
 import { ProposalSubmitted } from './proposal-submitted'
 
 interface SubmittedViewProps {
     orgSlug: string
-    study: SelectedStudy
+    study: Submitted<SelectedStudy>
     orgName: string
     entries: ProposalFeedbackEntry[]
     studyVersion: number

--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.test.tsx
@@ -16,6 +16,7 @@ import {
 import { lexicalJson } from '@/lib/lexical'
 import { Routes } from '@/lib/routes'
 import { getStudyAction, type CodeReviewFeedbackEntry, type SelectedStudy } from '@/server/actions/study.actions'
+import { isSubmittedStudy, type Submitted } from '@/schema/study'
 import { latestJobForStudy, type LatestJobForStudy } from '@/server/db/queries'
 import { CodePostDecisionView } from './code-post-decision-view'
 
@@ -83,6 +84,7 @@ async function setupDecidedStudy(decisionStatus: DecisionStatus, title = 'Effect
         .execute()
 
     const study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+    if (!isSubmittedStudy(study)) throw new Error('test fixture must be a submitted study')
     const latestJob = (await latestJobForStudy(dbStudy.id)) as LatestJobForStudy
     ;(useParams as Mock).mockReturnValue({ orgSlug: ORG_SLUG, studyId: study.id })
     memoryRouter.setCurrentUrl('/')
@@ -92,7 +94,7 @@ async function setupDecidedStudy(decisionStatus: DecisionStatus, title = 'Effect
 const DEFAULT_DASHBOARD_HREF = Routes.orgDashboard({ orgSlug: ORG_SLUG })
 
 function renderView(
-    study: SelectedStudy,
+    study: Submitted<SelectedStudy>,
     job: LatestJobForStudy,
     entries: CodeReviewFeedbackEntry[],
     latestJobStatus: DecisionStatus,

--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.tsx
@@ -15,6 +15,7 @@ import {
 import { filterAndOrderCodeFiles, type CodeFile } from '@/app/[orgSlug]/study/[studyId]/review/study-code-files'
 import { displayOrgName } from '@/lib/string'
 import { Routes } from '@/lib/routes'
+import { requireTitle } from '@/schema/study'
 import type { CodeReviewFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
 import type { LatestJobForStudy } from '@/server/db/queries'
 import { type CodeDecisionStatus } from './code-decision-status'
@@ -148,7 +149,7 @@ function StepCard({ study, job, copy, timestampDate, codeFiles, banner }: StepCa
         <ProposalStepHeader
             stepLabel="STEP 4"
             heading="Study code"
-            studyTitle={study.title}
+            studyTitle={requireTitle(study)}
             timestampLabel={copy.timestampLabel}
             timestampDate={timestampDate}
             banner={banner}

--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.tsx
@@ -15,14 +15,14 @@ import {
 import { filterAndOrderCodeFiles, type CodeFile } from '@/app/[orgSlug]/study/[studyId]/review/study-code-files'
 import { displayOrgName } from '@/lib/string'
 import { Routes } from '@/lib/routes'
-import { requireTitle } from '@/schema/study'
+import { type Submitted } from '@/schema/study'
 import type { CodeReviewFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
 import type { LatestJobForStudy } from '@/server/db/queries'
 import { type CodeDecisionStatus } from './code-decision-status'
 
 interface CodePostDecisionViewProps {
     orgSlug: string
-    study: SelectedStudy
+    study: Submitted<SelectedStudy>
     job: LatestJobForStudy
     entries: CodeReviewFeedbackEntry[]
     reviewingOrgName: string
@@ -136,7 +136,7 @@ function DecisionActions({ decision, previousHref, dashboardHref, resubmitHref }
 }
 
 type StepCardProps = {
-    study: SelectedStudy
+    study: Submitted<SelectedStudy>
     job: LatestJobForStudy
     copy: DecisionCopy
     timestampDate: Date | string
@@ -149,7 +149,7 @@ function StepCard({ study, job, copy, timestampDate, codeFiles, banner }: StepCa
         <ProposalStepHeader
             stepLabel="STEP 4"
             heading="Study code"
-            studyTitle={requireTitle(study)}
+            studyTitle={study.title}
             timestampLabel={copy.timestampLabel}
             timestampDate={timestampDate}
             banner={banner}

--- a/src/app/[orgSlug]/study/[studyId]/view/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/page.tsx
@@ -8,6 +8,8 @@ import { Routes } from '@/lib/routes'
 import { isActionError } from '@/lib/errors'
 import { actionResult } from '@/lib/utils'
 import { isStudyResultsStatus } from '@/lib/study-job-status'
+import { isSubmittedStudy } from '@/schema/study'
+import { notFound } from 'next/navigation'
 import type { StudyJobStatus } from '@/database/types'
 import { PostCodeSubmissionFeatureFlag, StudyDetailsRedesignFeatureFlag } from '@/components/openstax-feature-flag'
 import { CodeOnlyView } from './code-only-view'
@@ -52,6 +54,12 @@ export default async function StudyReviewPage(props: {
             const entries = await getCodeReviewFeedbackAction({ studyId })
             if (isActionError(entries) || entries.length === 0) {
                 return codeOnlyFallback
+            }
+            // A code decision implies the study was submitted long ago — this branch
+            // should be unreachable for DRAFTs. Guard explicitly so the narrowed view
+            // type holds and a corrupt row can't surface a runtime error in render.
+            if (!isSubmittedStudy(study)) {
+                notFound()
             }
             const reviewingOrgName = await getOrgNameFromId(study.orgId)
             return (

--- a/src/app/[orgSlug]/study/request/form-schemas.ts
+++ b/src/app/[orgSlug]/study/request/form-schemas.ts
@@ -147,7 +147,12 @@ export const step2ProposalApiSchema = z.object({
     additionalNotes: z.string(),
 })
 
-export const draftStudyApiSchema = studyProposalApiSchema.extend(step2ProposalApiSchema.shape).partial()
+// Drafts allow `title: null` so a researcher can save without filling it in;
+// the DB enforces non-null only when status leaves DRAFT.
+export const draftStudyApiSchema = studyProposalApiSchema
+    .extend(step2ProposalApiSchema.shape)
+    .partial()
+    .extend({ title: z.string().nullable().optional() })
 
 export const step1ReadinessSchema = z.object({
     orgSlug: z.string().min(1),

--- a/src/app/[orgSlug]/study/request/page-header.tsx
+++ b/src/app/[orgSlug]/study/request/page-header.tsx
@@ -8,7 +8,7 @@ interface ProposalHeaderProps {
     orgSlug: string
     title: string
     studyId?: string
-    studyTitle?: string
+    studyTitle?: string | null
 }
 
 export const ProposalHeader: FC<ProposalHeaderProps> = ({ orgSlug, title, studyId, studyTitle }) => {
@@ -23,7 +23,7 @@ export const ProposalHeader: FC<ProposalHeaderProps> = ({ orgSlug, title, studyI
 interface StudyRequestPageHeaderProps {
     orgSlug: string
     studyId?: string
-    studyTitle?: string
+    studyTitle?: string | null
 }
 
 export const StudyRequestPageHeader: FC<StudyRequestPageHeaderProps> = ({ orgSlug, studyId, studyTitle }) => {

--- a/src/components/page-breadcrumbs.tsx
+++ b/src/components/page-breadcrumbs.tsx
@@ -30,7 +30,7 @@ export const PageBreadcrumbs: FC<{
 export const OrgBreadcrumbs: FC<{
     crumbs: {
         orgSlug: string
-        studyTitle?: string
+        studyTitle?: string | null
         studyId?: string
         current?: string
     }
@@ -48,7 +48,7 @@ export const OrgBreadcrumbs: FC<{
 export const ResearcherBreadcrumbs: FC<{
     crumbs: {
         orgSlug: string
-        studyTitle?: string
+        studyTitle?: string | null
         studyId?: string
         current?: string
         dashboardHref?: string

--- a/src/components/study/proposal-initial-request.tsx
+++ b/src/components/study/proposal-initial-request.tsx
@@ -7,12 +7,12 @@ import { stringifyJson } from '@/lib/string'
 import { usePopover } from '@/hooks/use-popover'
 import type { ProposalFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
 import { decisionTimestampForProposalHeader } from '@/lib/studies'
-import { requireTitle } from '@/schema/study'
+import { type Submitted } from '@/schema/study'
 import { DatasetsField, LexicalProposalField, PIField, ResearcherField } from './proposal-fields'
 import { ProposalStepHeader } from './proposal-step-header'
 
 type ProposalRequestProps = {
-    study: SelectedStudy
+    study: Submitted<SelectedStudy>
     orgSlug: string
     stepLabel: string
     heading: string
@@ -72,7 +72,7 @@ export function ProposalRequest({
             <ProposalStepHeader
                 stepLabel={stepLabel}
                 heading={heading}
-                studyTitle={requireTitle(study)}
+                studyTitle={study.title}
                 timestampDate={timestampDate}
                 timestampLabel={statusBadge}
                 banner={banner}

--- a/src/components/study/proposal-initial-request.tsx
+++ b/src/components/study/proposal-initial-request.tsx
@@ -7,6 +7,7 @@ import { stringifyJson } from '@/lib/string'
 import { usePopover } from '@/hooks/use-popover'
 import type { ProposalFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
 import { decisionTimestampForProposalHeader } from '@/lib/studies'
+import { requireTitle } from '@/schema/study'
 import { DatasetsField, LexicalProposalField, PIField, ResearcherField } from './proposal-fields'
 import { ProposalStepHeader } from './proposal-step-header'
 
@@ -71,7 +72,7 @@ export function ProposalRequest({
             <ProposalStepHeader
                 stepLabel={stepLabel}
                 heading={heading}
-                studyTitle={study.title}
+                studyTitle={requireTitle(study)}
                 timestampDate={timestampDate}
                 timestampLabel={statusBadge}
                 banner={banner}

--- a/src/components/study/study-code-panel.tsx
+++ b/src/components/study/study-code-panel.tsx
@@ -10,7 +10,7 @@ export type StudyCodeIDE = ReturnType<typeof useIDEFiles>
 interface StudyCodePanelProps {
     ide: StudyCodeIDE
     stepLabel?: string
-    studyTitle: string
+    studyTitle: string | null
     footer: ReactNode
 }
 
@@ -58,7 +58,7 @@ export const StudyCodePanel = ({ ide, stepLabel, studyTitle, footer }: StudyCode
                     )}
                     <Title order={4}>Study code</Title>
                     <Text size="sm" c="dimmed">
-                        Title: {studyTitle}
+                        Title: {studyTitle ?? 'Untitled draft'}
                     </Text>
                 </Stack>
                 {body}

--- a/src/components/study/study-code.tsx
+++ b/src/components/study/study-code.tsx
@@ -9,7 +9,7 @@ import { StudyCodePanel } from './study-code-panel'
 
 interface StudyCodeProps {
     studyId: string
-    studyTitle: string
+    studyTitle: string | null
     previousHref: Route
     onSubmitSuccess?: () => void
 }

--- a/src/contexts/proposal/hooks/use-save-draft.test.ts
+++ b/src/contexts/proposal/hooks/use-save-draft.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { buildStudyInfo } from './use-save-draft'
-import { DEFAULT_DRAFT_TITLE, type ProposalFormValues } from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
+import { type ProposalFormValues } from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
 import { BLANK_UUID } from '@/tests/unit.helpers'
 
 describe('buildStudyInfo', () => {
@@ -30,7 +30,7 @@ describe('buildStudyInfo', () => {
         })
     })
 
-    it('converts empty strings to undefined (except title which defaults to Untitled Draft)', () => {
+    it('converts empty strings to undefined and a blank title to null', () => {
         const formValues: ProposalFormValues = {
             title: '',
             datasets: [],
@@ -44,7 +44,7 @@ describe('buildStudyInfo', () => {
 
         const result = buildStudyInfo(formValues)
 
-        expect(result.title).toBe(DEFAULT_DRAFT_TITLE)
+        expect(result.title).toBeNull()
         expect(result.piName).toBeUndefined()
         expect(result.piUserId).toBeUndefined()
         expect(result.researchQuestions).toBeUndefined()

--- a/src/contexts/proposal/hooks/use-save-draft.ts
+++ b/src/contexts/proposal/hooks/use-save-draft.ts
@@ -3,11 +3,11 @@ import { notifications } from '@mantine/notifications'
 import { type UseFormReturnType } from '@mantine/form'
 import { useMutation } from '@/common'
 import { onUpdateDraftStudyAction } from '@/server/actions/study-request'
-import { DEFAULT_DRAFT_TITLE, type ProposalFormValues } from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
+import { type ProposalFormValues } from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
 
 export function buildStudyInfo(values: ProposalFormValues) {
     return {
-        title: values.title || DEFAULT_DRAFT_TITLE,
+        title: values.title?.trim() || null,
         piName: values.piName || undefined,
         piUserId: values.piUserId || undefined,
         datasets: values.datasets,

--- a/src/database/migrations/1779000000000_allow_null_title_on_draft_study.ts
+++ b/src/database/migrations/1779000000000_allow_null_title_on_draft_study.ts
@@ -1,0 +1,19 @@
+import { type Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+    await sql`ALTER TABLE study ALTER COLUMN title DROP NOT NULL`.execute(db)
+
+    await sql`UPDATE study SET title = NULL WHERE status = 'DRAFT' AND title = 'Untitled Draft'`.execute(db)
+
+    await sql`
+        ALTER TABLE study
+        ADD CONSTRAINT study_title_required_when_not_draft
+        CHECK (status = 'DRAFT' OR (title IS NOT NULL AND length(btrim(title)) > 0))
+    `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+    await sql`ALTER TABLE study DROP CONSTRAINT IF EXISTS study_title_required_when_not_draft`.execute(db)
+    await sql`UPDATE study SET title = 'Untitled Draft' WHERE title IS NULL`.execute(db)
+    await sql`ALTER TABLE study ALTER COLUMN title SET NOT NULL`.execute(db)
+}

--- a/src/database/study_title_constraint.test.ts
+++ b/src/database/study_title_constraint.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { db, insertTestOrg, insertTestUser } from '@/tests/unit.helpers'
+
+// Verifies the CHECK constraint added in 1779000000000_allow_null_title_on_draft_study.ts.
+// The constraint shape is:
+//   status = 'DRAFT' OR (title IS NOT NULL AND length(btrim(title)) > 0)
+describe('study_title_required_when_not_draft constraint', () => {
+    async function setupOrgAndResearcher() {
+        const org = await insertTestOrg()
+        const { user } = await insertTestUser({ org })
+        return { org, researcherId: user.id }
+    }
+
+    function studyValues({
+        orgId,
+        researcherId,
+        title,
+        status,
+    }: {
+        orgId: string
+        researcherId: string
+        title: string | null
+        status: 'DRAFT' | 'PENDING-REVIEW' | 'APPROVED'
+    }) {
+        return {
+            orgId,
+            submittedByOrgId: orgId,
+            containerLocation: 'test-container',
+            title,
+            researcherId,
+            piName: 'test',
+            status,
+            dataSources: ['all'],
+            outputMimeType: 'text/csv',
+            language: 'R' as const,
+        }
+    }
+
+    it('allows DRAFT with NULL title', async () => {
+        const { org, researcherId } = await setupOrgAndResearcher()
+        const inserted = await db
+            .insertInto('study')
+            .values(studyValues({ orgId: org.id, researcherId, title: null, status: 'DRAFT' }))
+            .returning(['id', 'title', 'status'])
+            .executeTakeFirstOrThrow()
+        expect(inserted.title).toBeNull()
+        expect(inserted.status).toBe('DRAFT')
+    })
+
+    it('rejects non-DRAFT insert with NULL title', async () => {
+        const { org, researcherId } = await setupOrgAndResearcher()
+        await expect(
+            db
+                .insertInto('study')
+                .values(studyValues({ orgId: org.id, researcherId, title: null, status: 'PENDING-REVIEW' }))
+                .execute(),
+        ).rejects.toThrow(/study_title_required_when_not_draft/)
+    })
+
+    it('rejects non-DRAFT insert with whitespace-only title', async () => {
+        const { org, researcherId } = await setupOrgAndResearcher()
+        await expect(
+            db
+                .insertInto('study')
+                .values(studyValues({ orgId: org.id, researcherId, title: '   ', status: 'APPROVED' }))
+                .execute(),
+        ).rejects.toThrow(/study_title_required_when_not_draft/)
+    })
+
+    it('rejects transitioning a NULL-title DRAFT out of DRAFT', async () => {
+        const { org, researcherId } = await setupOrgAndResearcher()
+        const draft = await db
+            .insertInto('study')
+            .values(studyValues({ orgId: org.id, researcherId, title: null, status: 'DRAFT' }))
+            .returning('id')
+            .executeTakeFirstOrThrow()
+
+        await expect(
+            db.updateTable('study').set({ status: 'PENDING-REVIEW' }).where('id', '=', draft.id).execute(),
+        ).rejects.toThrow(/study_title_required_when_not_draft/)
+    })
+})

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -231,7 +231,7 @@ export interface Study {
     status: Generated<StudyStatus>
     submittedAt: Timestamp | null
     submittedByOrgId: string
-    title: string
+    title: string | null
 }
 
 export interface StudyJob {

--- a/src/schema/study.ts
+++ b/src/schema/study.ts
@@ -5,17 +5,12 @@ export type Study = Selectable<DefinedStudy>
 
 export type StudyJob = Selectable<DefinedStudyJob>
 
-export type SubmittedStudy = Study & { title: string; status: Exclude<StudyStatus, 'DRAFT'> }
+type StudyShape = { status: StudyStatus; title: string | null }
 
-export function isSubmittedStudy(study: Study): study is SubmittedStudy {
+export type Submitted<T extends StudyShape> = T & { title: string; status: Exclude<StudyStatus, 'DRAFT'> }
+
+export type SubmittedStudy = Submitted<Study>
+
+export function isSubmittedStudy<T extends StudyShape>(study: T): study is Submitted<T> {
     return study.status !== 'DRAFT' && study.title !== null
-}
-
-// Use when calling code knows the row must be non-DRAFT (DB CHECK constraint
-// guarantees title is non-null there) but only has a `Study` in hand.
-export function requireTitle(study: Pick<Study, 'id' | 'status' | 'title'>): string {
-    if (study.title === null) {
-        throw new Error(`Study ${study.id} has null title in status ${study.status}`)
-    }
-    return study.title
 }

--- a/src/schema/study.ts
+++ b/src/schema/study.ts
@@ -1,6 +1,21 @@
 import { Selectable } from 'kysely'
-import { Study as DefinedStudy, StudyJob as DefinedStudyJob } from '@/database/types'
+import { Study as DefinedStudy, StudyJob as DefinedStudyJob, StudyStatus } from '@/database/types'
 
 export type Study = Selectable<DefinedStudy>
 
 export type StudyJob = Selectable<DefinedStudyJob>
+
+export type SubmittedStudy = Study & { title: string; status: Exclude<StudyStatus, 'DRAFT'> }
+
+export function isSubmittedStudy(study: Study): study is SubmittedStudy {
+    return study.status !== 'DRAFT' && study.title !== null
+}
+
+// Use when calling code knows the row must be non-DRAFT (DB CHECK constraint
+// guarantees title is non-null there) but only has a `Study` in hand.
+export function requireTitle(study: Pick<Study, 'id' | 'status' | 'title'>): string {
+    if (study.title === null) {
+        throw new Error(`Study ${study.id} has null title in status ${study.status}`)
+    }
+    return study.title
+}

--- a/src/server/actions/study-request.test.ts
+++ b/src/server/actions/study-request.test.ts
@@ -28,7 +28,6 @@ import {
 } from '@/server/actions/study-request'
 import { purgeProposalYjsDocsBeforeAt } from '@/server/db/yjs-cleanup'
 import { lexicalJson } from '@/lib/lexical'
-import { DEFAULT_DRAFT_TITLE } from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
 
 vi.mock('@/server/aws', async () => {
     const actual = await vi.importActual('@/server/aws')
@@ -307,7 +306,7 @@ describe('Request Study Actions', () => {
 
             expect(draftResult.studyId).toBeDefined()
 
-            // Verify draft created with default title
+            // Drafts persist a NULL title until the researcher fills one in.
             let study = await db
                 .selectFrom('study')
                 .selectAll('study')
@@ -315,7 +314,7 @@ describe('Request Study Actions', () => {
                 .executeTakeFirst()
             expect(study?.status).toEqual('DRAFT')
             expect(study?.language).toEqual('PYTHON')
-            expect(study?.title).toEqual(DEFAULT_DRAFT_TITLE)
+            expect(study?.title).toBeNull()
 
             // Step 2: Update with proposal fields
             const proposalFields = {

--- a/src/server/actions/study-request.ts
+++ b/src/server/actions/study-request.ts
@@ -26,7 +26,6 @@ import { Kysely } from 'kysely'
 import { revalidatePath } from 'next/cache'
 import { v7 as uuidv7 } from 'uuid'
 import { draftStudyApiSchema } from '@/app/[orgSlug]/study/request/form-schemas'
-import { DEFAULT_DRAFT_TITLE } from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
 import {
     RESUBMIT_NOTE_MAX_WORDS,
     RESUBMIT_NOTE_MIN_WORDS,
@@ -142,7 +141,7 @@ export const onSaveDraftStudyAction = new Action('onSaveDraftStudyAction', { per
             .insertInto('study')
             .values({
                 id: studyId,
-                title: studyInfo.title || DEFAULT_DRAFT_TITLE,
+                title: studyInfo.title?.trim() || null,
                 piName: studyInfo.piName || '',
                 piUserId: studyInfo.piUserId || null,
                 language: studyInfo.language,
@@ -301,7 +300,7 @@ export const onSubmitDraftStudyAction = new Action('onSubmitDraftStudyAction', {
 // loser's stale snapshot.
 const finalizeStudySubmissionInfoSchema = z
     .object({
-        title: z.string().optional(),
+        title: z.string().nullable().optional(),
         piName: z.string().optional(),
         piUserId: z.string().nullable().optional(),
         datasets: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary

- Drafts can now persist `study.title = NULL` instead of an `'Untitled Draft'` placeholder; a DB `CHECK` constraint guarantees any non-DRAFT row has a non-empty title.
- `DEFAULT_DRAFT_TITLE` is removed everywhere; `hasUserProvidedTitle` simplifies to a trimmed truthy check.
- New `src/schema/study.ts` helpers (`SubmittedStudy`, `isSubmittedStudy`, `requireTitle`) let submitted-context views narrow `Study` to a non-null title; draft-context views fall back to a UI literal.

Implements https://openstax.atlassian.net/browse/OTTER-557

## Migration

`1779000000000_allow_null_title_on_draft_study.ts`:
1. `ALTER COLUMN title DROP NOT NULL`
2. Backfill: `UPDATE study SET title = NULL WHERE status = 'DRAFT' AND title = 'Untitled Draft'`
3. Add `CHECK (status = 'DRAFT' OR (title IS NOT NULL AND length(btrim(title)) > 0))`

Down migration reverses each step.

## Test plan

- [x] `npm run checks` (typecheck + lint + validate-actions) passes
- [x] `npm run test:unit` — 1314/1314 pass
- [ ] Manual: create a new draft without filling title, save, reload — UI shows blank input; DB row has `title IS NULL`
- [ ] Manual: try to submit without a title — client validation blocks; even if bypassed, DB CHECK rejects the status flip
- [ ] Manual: existing drafts that previously stored `'Untitled Draft'` are visible with an empty title field after migration