### PR TITLE
OTTER-555: Update DO view for resubmitted proposals in review

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-review-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-review-view.tsx
@@ -223,7 +223,7 @@ function ProposalReviewViewContent({ orgSlug, study, priorEntries, reviewVersion
                     Review initial request
                 </Title>
 
-                <ProposalSection study={study} orgSlug={orgSlug} />
+                <ProposalSection study={study} orgSlug={orgSlug} priorEntries={priorEntries} />
                 <FeedbackAndNotesSection entries={priorEntries} />
                 <ReviewFeedbackSection
                     feedback={feedback}

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-section.test.tsx
@@ -1,5 +1,5 @@
 import { lexicalJson } from '@/lib/lexical'
-import { getStudyAction, type SelectedStudy } from '@/server/actions/study.actions'
+import { getStudyAction, type ProposalFeedbackEntry, type SelectedStudy } from '@/server/actions/study.actions'
 import {
     actionResult,
     fireEvent,
@@ -69,6 +69,17 @@ describe('ProposalSection', () => {
         expect(screen.getByText('Researcher')).toBeInTheDocument()
     })
 
+    it('shows resubmission copy and versioned heading when prior entries indicate a resubmission', () => {
+        const priorEntries = [{ version: 2 }] as ProposalFeedbackEntry[]
+
+        renderWithProviders(<ProposalSection study={study} orgSlug="test-org" priorEntries={priorEntries} />)
+
+        expect(screen.getByRole('heading', { name: 'Review initial request v2.0' })).toBeInTheDocument()
+        expect(screen.getByTestId('status-banner')).toHaveTextContent(
+            'has resubmitted a revised initial request requesting permission to use your data',
+        )
+    })
+
     it('renders the status banner with evaluation criteria', () => {
         renderWithProviders(<ProposalSection study={study} orgSlug="test-org" />)
 
@@ -94,12 +105,21 @@ describe('ProposalSection', () => {
         }
     })
 
-    it('is expanded by default showing the proposal body', () => {
+    it('is expanded by default on first submission', () => {
         renderWithProviders(<ProposalSection study={study} orgSlug="test-org" />)
 
         expect(screen.getByTestId('proposal-body')).toBeInTheDocument()
         expect(screen.getByTestId('proposal-toggle-header')).toHaveTextContent('Hide full initial request')
         expect(screen.getByTestId('proposal-toggle-body')).toHaveTextContent('Hide full initial request')
+    })
+
+    it('is collapsed by default on resubmission', () => {
+        const priorEntries = [{ version: 2 }] as ProposalFeedbackEntry[]
+
+        renderWithProviders(<ProposalSection study={study} orgSlug="test-org" priorEntries={priorEntries} />)
+
+        expect(screen.getByTestId('proposal-toggle-header')).toHaveTextContent('View full initial request')
+        expect(screen.getByTestId('proposal-body')).not.toBeVisible()
     })
 
     it('collapses the proposal body when the header toggle is clicked', () => {

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-section.test.tsx
@@ -177,4 +177,17 @@ describe('ProposalSection', () => {
 
         expect(screen.getByText('Submitted on Mar 15, 2025')).toBeInTheDocument()
     })
+
+    it('renders the resubmission date (not the original submittedAt) on resubmission', () => {
+        const submittedStudy = { ...study, submittedAt: new Date('2025-03-15T12:00:00Z') }
+        const priorEntries = [
+            { version: 2, entryType: 'RESUBMISSION-NOTE', createdAt: new Date('2026-05-10T12:00:00Z') },
+            { version: 1, entryType: 'REVIEWER-FEEDBACK', createdAt: new Date('2026-04-01T12:00:00Z') },
+        ] as ProposalFeedbackEntry[]
+
+        renderWithProviders(<ProposalSection study={submittedStudy} orgSlug="test-org" priorEntries={priorEntries} />)
+
+        expect(screen.getByText('Resubmitted on May 10, 2026')).toBeInTheDocument()
+        expect(screen.queryByText(/Mar 15, 2025/)).not.toBeInTheDocument()
+    })
 })

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-section.tsx
@@ -28,27 +28,27 @@ const EVALUATION_CRITERIA = [
     },
 ]
 
+function bannerIntro(labName: string, isResubmission: boolean) {
+    const action = isResubmission ? 'has resubmitted a revised initial request' : 'has submitted an initial request'
+    const review = isResubmission
+        ? 'Please review the changes and share your updated feedback and decision.'
+        : 'Please review it and share your feedback and decision.'
+
+    return (
+        <>
+            {labName} {action} requesting permission to use your data. {review} Consider evaluating based on these
+            criteria:
+        </>
+    )
+}
+
 function StatusBanner({ labName, isResubmission }: { labName: string; isResubmission: boolean }) {
     return (
         <ReviewCriteriaBanner
             mb="md"
             testId="status-banner"
             criteriaTestId="evaluation-criteria"
-            intro={
-                isResubmission ? (
-                    <>
-                        {labName} has resubmitted a revised initial request requesting permission to use your data.
-                        Please review the changes and share your updated feedback and decision. Consider evaluating
-                        based on these criteria:
-                    </>
-                ) : (
-                    <>
-                        {labName} has submitted an initial request requesting permission to use your data. Please review
-                        it and share your feedback and decision. Consider evaluating the initial request on these
-                        criteria:
-                    </>
-                )
-            }
+            intro={bannerIntro(labName, isResubmission)}
             criteria={EVALUATION_CRITERIA}
         />
     )

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-section.tsx
@@ -68,6 +68,7 @@ export function ProposalSection({ study, orgSlug, priorEntries = [] }: ProposalS
             banner={<StatusBanner labName={labName} isResubmission={isResubmission} />}
             initialExpanded={!isResubmission}
             statusBadge={isResubmission ? 'Resubmitted on' : undefined}
+            entries={priorEntries}
         />
     )
 }

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal-section.tsx
@@ -2,12 +2,14 @@
 
 import { ProposalRequest } from '@/components/study/proposal-initial-request'
 import { ReviewCriteriaBanner } from '@/components/study/review-criteria-banner'
+import { deriveStudyVersion } from '@/lib/studies'
+import type { ProposalFeedbackEntry } from '@/server/actions/study.actions'
 import type { StudyForReview } from './review-types'
 
 type ProposalSectionProps = {
     study: StudyForReview
     orgSlug: string
-    initialExpanded?: boolean
+    priorEntries?: ProposalFeedbackEntry[]
 }
 
 const EVALUATION_CRITERIA = [
@@ -26,34 +28,46 @@ const EVALUATION_CRITERIA = [
     },
 ]
 
-function StatusBanner({ labName }: { labName: string }) {
+function StatusBanner({ labName, isResubmission }: { labName: string; isResubmission: boolean }) {
     return (
         <ReviewCriteriaBanner
             mb="md"
             testId="status-banner"
             criteriaTestId="evaluation-criteria"
             intro={
-                <>
-                    {labName} has submitted an initial request requesting permission to use your data. Please review it
-                    and share your feedback and decision. Consider evaluating the initial request on these criteria:
-                </>
+                isResubmission ? (
+                    <>
+                        {labName} has resubmitted a revised initial request requesting permission to use your data.
+                        Please review the changes and share your updated feedback and decision. Consider evaluating
+                        based on these criteria:
+                    </>
+                ) : (
+                    <>
+                        {labName} has submitted an initial request requesting permission to use your data. Please review
+                        it and share your feedback and decision. Consider evaluating the initial request on these
+                        criteria:
+                    </>
+                )
             }
             criteria={EVALUATION_CRITERIA}
         />
     )
 }
 
-export function ProposalSection({ study, orgSlug, initialExpanded = true }: ProposalSectionProps) {
+export function ProposalSection({ study, orgSlug, priorEntries = [] }: ProposalSectionProps) {
     const labName = study.submittingLabName ?? study.submittedByOrgSlug
+    const studyVersion = deriveStudyVersion(priorEntries)
+    const isResubmission = studyVersion > 1
 
     return (
         <ProposalRequest
             study={study}
             orgSlug={orgSlug}
             stepLabel="STEP 1"
-            heading="Review initial request"
-            banner={<StatusBanner labName={labName} />}
-            initialExpanded={initialExpanded}
+            heading={`Review initial request ${isResubmission ? `v${studyVersion}.0` : ''}`}
+            banner={<StatusBanner labName={labName} isResubmission={isResubmission} />}
+            initialExpanded={!isResubmission}
+            statusBadge={isResubmission ? 'Resubmitted on' : undefined}
         />
     )
 }

--- a/src/lib/studies.test.ts
+++ b/src/lib/studies.test.ts
@@ -19,7 +19,9 @@ const study = (
         ...overrides,
     }) as SelectedStudy
 
-const entry = (overrides: Partial<Pick<ProposalFeedbackEntry, 'decision' | 'createdAt'>>): ProposalFeedbackEntry =>
+const entry = (
+    overrides: Partial<Pick<ProposalFeedbackEntry, 'decision' | 'createdAt' | 'entryType'>>,
+): ProposalFeedbackEntry =>
     ({
         id: 'entry-1',
         decision: 'APPROVE',
@@ -54,7 +56,7 @@ describe('decisionTimestampForProposalHeader', () => {
             expected: submittedAt,
         },
         {
-            name: 'PENDING-REVIEW uses submittedAt',
+            name: 'PENDING-REVIEW uses submittedAt, when no RESUBMISSION-NOTE entry is present',
             study: study({ status: 'PENDING-REVIEW' }),
             entries: [],
             expected: submittedAt,
@@ -83,6 +85,19 @@ describe('decisionTimestampForProposalHeader', () => {
 
         expect(decisionTimestampForProposalHeader(study({ status: 'CHANGE-REQUESTED' }), entries)).toEqual(
             clarificationAt,
+        )
+    })
+
+    it('PENDING-REVIEW uses the latest RESUBMISSION-NOTE entry when present', () => {
+        const olderResubmission = new Date('2026-04-25T10:00:00Z')
+        const latestResubmission = new Date('2026-05-10T10:00:00Z')
+        const entries = [
+            entry({ createdAt: latestResubmission, entryType: 'RESUBMISSION-NOTE' }),
+            entry({ createdAt: olderResubmission, entryType: 'RESUBMISSION-NOTE' }),
+        ] as ProposalFeedbackEntry[]
+
+        expect(decisionTimestampForProposalHeader(study({ status: 'PENDING-REVIEW' }), entries)).toEqual(
+            latestResubmission,
         )
     })
 

--- a/src/lib/studies.ts
+++ b/src/lib/studies.ts
@@ -27,6 +27,11 @@ export function decisionTimestampForProposalHeader(study: SelectedStudy, entries
         const latestClarification = entries.find((e) => e.decision === 'NEEDS-CLARIFICATION')
         if (latestClarification) return latestClarification.createdAt
     }
+    if (study.status === 'PENDING-REVIEW' && entries.length > 0) {
+        // source the resubmission date from the latest RESUBMISSION-NOTE entry.
+        const latestResubmission = entries.find((e) => e.entryType === 'RESUBMISSION-NOTE')
+        if (latestResubmission) return latestResubmission.createdAt
+    }
 
     if (!study.submittedAt) {
         throw new Error('submittedAt is required for proposal header timestamp')


### PR DESCRIPTION
This pull request enhances the handling and display of study proposal resubmissions in the review workflow. It updates both the UI and supporting logic to clearly indicate when a proposal is a resubmission, ensures the correct version and resubmission date are shown, and adds comprehensive test coverage for these behaviors.

Key changes include:

### UI/Component updates

* Updated `ProposalSection` to accept `priorEntries` and determine if the proposal is a resubmission, displaying the correct version number, resubmission status, and date. The section is now collapsed by default on resubmissions, and the status banner and headings reflect the resubmission state.

### Logic improvements

* Enhanced `decisionTimestampForProposalHeader` to use the latest `RESUBMISSION-NOTE` entry as the submission date for resubmitted proposals, ensuring accurate date display in the UI.

### Test coverage

* Added and updated tests to verify resubmission-specific UI behavior, including versioned headings, banner content, collapsed/expanded state, and correct date handling for resubmissions. 