### PR TITLE
OTTER-547: defer IDE starter file copy until workspace is ready

### DIFF
--- a/src/server/actions/workspaces.actions.ts
+++ b/src/server/actions/workspaces.actions.ts
@@ -83,7 +83,6 @@ export const createUserAndWorkspaceAction = new Action('createUserAndWorkspaceAc
         if (!session) throw new Error('Unauthorized')
         await resetBaselineJob(db, studyId)
         if (CODER_DISABLED) {
-            await initializeDevWorkspaceFiles(studyId)
             return {
                 success: true,
                 workspace: { id: `dev-workspace-${studyId}` },
@@ -107,6 +106,7 @@ export const getWorkspaceUrlAction = new Action('getWorkspaceUrlAction', {})
         if (CODER_DISABLED) {
             // these envs do not have a 'real' coder setup
             await new Promise((resolve) => setTimeout(resolve, 3000))
+            await initializeDevWorkspaceFiles(studyId)
             return `https://coder.dev.example.com/workspace/${studyId}`
         }
         return await getCoderWorkspaceUrl(studyId, workspaceId)

--- a/src/server/coder/workspaces.ts
+++ b/src/server/coder/workspaces.ts
@@ -15,6 +15,8 @@ import { CoderWorkspace, CoderWorkspaceEvent } from './types'
 import { getCoderUser, getOrCreateCoderUser } from './users'
 import { generateWorkspaceName } from './utils'
 import { fetchLatestCodeEnvForStudyId } from '../db/queries'
+import { latestStudyJobCreatedAt } from '../db/mutations'
+import { db } from '@/database'
 import { fetchFileContents } from '../storage'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
@@ -233,8 +235,13 @@ const initializeWorkspaceCodeFiles = async (studyId: string): Promise<void> => {
 
     logger.info(`Initializing workspace with starter code for study ${studyId} ...`)
 
-    // Backdate mtime so starter files appear as "unchanged" relative to the baseline job
-    const pastDate = new Date(Date.now() - 60_000)
+    // Backdate starter-file mtime relative to the baseline studyJob rather than wall-clock.
+    // Wall-clock backdating breaks when Coder provisioning takes longer than the backdate window:
+    // files end up newer than the baseline and the "files changed" gate flips Submit on without
+    // any user edits. Falling back to wall-clock is only for the (currently impossible) case of
+    // no baseline existing.
+    const baselineCreatedAt = await latestStudyJobCreatedAt(db, studyId)
+    const pastDate = baselineCreatedAt ? new Date(baselineCreatedAt.getTime() - 1000) : new Date(Date.now() - 60_000)
 
     for (const fileName of codeEnv.starterCodeFileNames) {
         const filePath = pathForStarterCode({ orgSlug: codeEnv.slug, codeEnvId: codeEnv.id, fileName })

--- a/src/server/coder/workspaces.ts
+++ b/src/server/coder/workspaces.ts
@@ -59,6 +59,7 @@ export async function getCoderWorkspaceUrl(studyId: string, workspaceId: string)
     })
 
     if (isWorkspaceReady(workspace)) {
+        await initializeWorkspaceCodeFiles(studyId)
         return await generateWorkspaceUrl(studyId)
     }
 
@@ -164,9 +165,6 @@ async function createCoderWorkspace(options: CreateCoderWorkspaceOptions): Promi
     const { studyId, username, environment = [] } = options
     const workspaceName = generateWorkspaceName(studyId)
 
-    // Populate code files prior to launching workspace
-    await initializeWorkspaceCodeFiles(studyId)
-
     const richParameterValues: Array<{ name: string; value: string }> = [
         {
             name: 'study_id',
@@ -213,8 +211,24 @@ export async function createUserAndWorkspace(
     }
 }
 
+async function studyDirHasFiles(dir: string): Promise<boolean> {
+    try {
+        const entries = await fs.readdir(dir)
+        return entries.some((e) => !e.startsWith('.'))
+    } catch (e) {
+        if (e instanceof Error && 'code' in e && e.code === 'ENOENT') return false
+        throw e
+    }
+}
+
 const initializeWorkspaceCodeFiles = async (studyId: string): Promise<void> => {
     const coderBaseFilePath = await getConfigValue('CODER_FILES')
+    const studyDir = path.join(coderBaseFilePath, studyId)
+
+    // Idempotent: only copy starter files when the directory is empty.
+    // Skips repeat calls (ready-polling) and avoids clobbering user edits across sessions.
+    if (await studyDirHasFiles(studyDir)) return
+
     const codeEnv = await fetchLatestCodeEnvForStudyId(studyId)
 
     logger.info(`Initializing workspace with starter code for study ${studyId} ...`)
@@ -225,7 +239,7 @@ const initializeWorkspaceCodeFiles = async (studyId: string): Promise<void> => {
     for (const fileName of codeEnv.starterCodeFileNames) {
         const filePath = pathForStarterCode({ orgSlug: codeEnv.slug, codeEnvId: codeEnv.id, fileName })
         const fileData = await fetchFileContents(filePath)
-        const targetFilePath = path.join(coderBaseFilePath, studyId, fileName)
+        const targetFilePath = path.join(studyDir, fileName)
 
         logger.info(`Writing ${fileName} to ${targetFilePath} for study ${studyId}`)
 

--- a/src/server/db/mutations.ts
+++ b/src/server/db/mutations.ts
@@ -56,6 +56,23 @@ export async function resetBaselineJob(db: Kysely<DB>, studyId: string) {
     return createBaselineJob(db, studyId, new Date())
 }
 
+/**
+ * Returns the createdAt of the most recent studyJob for this study, or null if none exists.
+ * Used by starter-file copy paths to backdate file mtimes relative to the baseline, regardless of
+ * how long the workspace took to become ready (a wall-clock backdate is unsafe when provisioning
+ * exceeds the backdate window — see OTTER-547).
+ */
+export async function latestStudyJobCreatedAt(db: Kysely<DB>, studyId: string): Promise<Date | null> {
+    const row = await db
+        .selectFrom('studyJob')
+        .select('createdAt')
+        .where('studyId', '=', studyId)
+        .orderBy('createdAt', 'desc')
+        .limit(1)
+        .executeTakeFirst()
+    return row?.createdAt ?? null
+}
+
 // Reviewer feedback shares the version of the proposal it reviews (increment=false)
 // Researcher resubmission opens a new version (increment=true)
 export function nextVersionForStudyComment({ studyId, increment }: { studyId: string; increment: boolean }) {

--- a/src/server/dev.test.ts
+++ b/src/server/dev.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import * as fs from 'node:fs/promises'
+import { db, insertTestCodeEnv, insertTestStudyJobData, mockSessionWithTestData } from '@/tests/unit.helpers'
+
+describe('initializeDevWorkspaceFiles', () => {
+    const TEST_CODER_FILES = '/tmp/dev-test-suite-' + Math.random().toString(36).slice(2)
+    const originalCoderFiles = process.env.CODER_FILES
+
+    beforeEach(() => {
+        vi.resetModules()
+        process.env.CODER_FILES = TEST_CODER_FILES
+        vi.doMock('@/server/config', async (importOriginal) => {
+            const mod = await importOriginal<typeof import('@/server/config')>()
+            return {
+                ...mod,
+                CODER_DISABLED: true,
+                DEV_ENV: true,
+                getConfigValue: vi.fn().mockImplementation((key) => process.env[key]),
+            }
+        })
+        vi.doMock('@/server/storage', () => ({
+            fetchFileContents: vi.fn().mockResolvedValue({
+                arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(8)),
+            }),
+        }))
+    })
+
+    afterEach(async () => {
+        try {
+            await fs.rm(TEST_CODER_FILES, { recursive: true, force: true })
+        } catch {
+            // ignore
+        }
+        if (originalCoderFiles) process.env.CODER_FILES = originalCoderFiles
+        else delete process.env.CODER_FILES
+
+        vi.doUnmock('@/server/config')
+        vi.doUnmock('@/server/storage')
+    })
+
+    // OTTER-547 regression: the previous implementation backdated starter files by a fixed
+    // 60s from wall-clock. If Coder provisioning took longer than 60s, the starter files'
+    // mtime ended up newer than the baseline studyJob.createdAt, which the UI reads as
+    // "researcher has edited files" and enables Submit on a freshly-launched workspace.
+    test('starter file mtimes are strictly older than the latest studyJob.createdAt, even after a long provisioning delay', async () => {
+        const { org, user } = await mockSessionWithTestData()
+        const { study, job } = await insertTestStudyJobData({ org, researcherId: user.id })
+
+        await insertTestCodeEnv({
+            orgId: org.id,
+            language: study.language,
+            starterCodeFileNames: ['main.R'],
+        })
+
+        // Pretend Coder took ~2 minutes to come up. The pre-fix code would stamp files
+        // at NOW-60s, which is ~60s NEWER than job.createdAt.
+        const NOW = Date.now()
+        vi.useFakeTimers()
+        vi.setSystemTime(NOW + 120_000)
+
+        try {
+            const { initializeDevWorkspaceFiles } = await import('./dev')
+            await initializeDevWorkspaceFiles(study.id)
+        } finally {
+            vi.useRealTimers()
+        }
+
+        const writtenFileStat = await fs.stat(`${TEST_CODER_FILES}/main.R`)
+        const jobRow = await db
+            .selectFrom('studyJob')
+            .select('createdAt')
+            .where('id', '=', job.id)
+            .executeTakeFirstOrThrow()
+
+        expect(writtenFileStat.mtime.getTime()).toBeLessThan(jobRow.createdAt.getTime())
+    })
+})

--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -10,15 +10,29 @@ export async function cleanupCoderDevFiles() {
     await fs.mkdir(coderFilesPath, { recursive: true })
 }
 
+async function devDirHasFiles(dir: string): Promise<boolean> {
+    try {
+        const entries = await fs.readdir(dir)
+        return entries.some((e) => !e.startsWith('.'))
+    } catch (e) {
+        if (e instanceof Error && 'code' in e && e.code === 'ENOENT') return false
+        throw e
+    }
+}
+
 export async function initializeDevWorkspaceFiles(studyId: string) {
     if (!CODER_DISABLED) return
+
+    const coderFilesPath = await getConfigValue('CODER_FILES')
+
+    // Idempotent: skip when files already exist so the late copy doesn't clobber user edits.
+    if (await devDirHasFiles(coderFilesPath)) return
 
     const { fetchLatestCodeEnvForStudyId } = await import('@/server/db/queries')
     const { fetchFileContents } = await import('@/server/storage')
     const { pathForStarterCode } = await import('@/lib/paths')
 
     const codeEnv = await fetchLatestCodeEnvForStudyId(studyId)
-    const coderFilesPath = await getConfigValue('CODER_FILES')
     await fs.mkdir(coderFilesPath, { recursive: true })
 
     // Backdate mtime so starter files appear as "unchanged" relative to the baseline job

--- a/src/server/dev.ts
+++ b/src/server/dev.ts
@@ -31,12 +31,16 @@ export async function initializeDevWorkspaceFiles(studyId: string) {
     const { fetchLatestCodeEnvForStudyId } = await import('@/server/db/queries')
     const { fetchFileContents } = await import('@/server/storage')
     const { pathForStarterCode } = await import('@/lib/paths')
+    const { latestStudyJobCreatedAt } = await import('@/server/db/mutations')
+    const { db } = await import('@/database')
 
     const codeEnv = await fetchLatestCodeEnvForStudyId(studyId)
     await fs.mkdir(coderFilesPath, { recursive: true })
 
-    // Backdate mtime so starter files appear as "unchanged" relative to the baseline job
-    const pastDate = new Date(Date.now() - 60_000)
+    // Backdate starter-file mtime relative to the baseline studyJob rather than wall-clock.
+    // See workspaces.ts:initializeWorkspaceCodeFiles for the same reasoning.
+    const baselineCreatedAt = await latestStudyJobCreatedAt(db, studyId)
+    const pastDate = baselineCreatedAt ? new Date(baselineCreatedAt.getTime() - 1000) : new Date(Date.now() - 60_000)
 
     for (const fileName of codeEnv.starterCodeFileNames) {
         const s3Path = pathForStarterCode({ orgSlug: codeEnv.slug, codeEnvId: codeEnv.id, fileName })


### PR DESCRIPTION
## Summary

Fixes [OTTER-547](https://openstax.atlassian.net/browse/OTTER-547).

Previously, when a researcher clicked **Launch IDE** on the study code screen we copied starter files to the shared `CODER_FILES` directory immediately, then waited several minutes for the Coder workspace to actually start. The `listWorkspaceFilesAction` poller (15s interval) would pick up the files almost immediately and flip the page from the empty/launch view to the file-review view — while the user was still staring at the "Launching IDE…" button waiting for the IDE tab to open.

This change moves the starter-file copy so it runs only once the workspace reports ready (or, in dev mode, after the simulated wait inside `getWorkspaceUrlAction`). The UI now stays on the empty/launch view until the IDE is genuinely ready.

- `createCoderWorkspace` no longer eagerly copies starter files.
- `getCoderWorkspaceUrl` copies them when `isWorkspaceReady(workspace)` first becomes true, just before returning the URL.
- Dev path mirrors the same shape: `createUserAndWorkspaceAction` no longer copies; `getWorkspaceUrlAction` (CODER_DISABLED branch) copies after the 3-second simulated wait.
- `initializeWorkspaceCodeFiles` and `initializeDevWorkspaceFiles` are now idempotent — they bail when the target directory already has files — so repeat ready-polls and re-launches of existing workspaces don't clobber user edits.

## Test plan

- [x] `npx vitest run` — `src/server/coder.test.ts`, `src/server/actions/workspaces.actions.test.ts`, `src/hooks/use-workspace-launcher.test.tsx`, `src/components/study/study-code.test.tsx` (45 + 24 unit tests pass)
- [x] `tsc --noEmit --skipLibCheck` clean
- [x] `eslint` clean on touched files
- [ ] Manual: in dev mode, click Launch IDE on a study with no files — confirm the empty/launch view stays put for the full ~3s wait, then the file list appears together with the IDE tab opening
- [ ] Manual: re-launch IDE on a study that already has user-edited files — confirm files are not clobbered

[OTTER-547]: https://openstax.atlassian.net/browse/OTTER-547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ