### PR TITLE
OTTER-546: scope agreements ack to the role the page was rendered for

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/agreements/agreements-page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/agreements-page.tsx
@@ -105,7 +105,7 @@ export function AgreementsPage({
     const resolvedProceedLabel = proceedLabel ?? (isReviewer ? 'Proceed to Step 3' : 'Proceed to Step 4')
 
     const handleProceed = async () => {
-        await ackAgreementsAction({ studyId })
+        await ackAgreementsAction({ studyId, role: isReviewer ? 'reviewer' : 'researcher' })
         router.push(proceedHref as Route)
     }
     const handlePrevious = () => router.push(previousHref as Route)

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -516,14 +516,14 @@ describe('Study Actions', () => {
 })
 
 describe('ackAgreementsAction', () => {
-    it('sets researcherAgreementsAckedAt when called by lab member', async () => {
+    it('sets researcherAgreementsAckedAt when called with role=researcher by lab member', async () => {
         const { org: labOrg, user } = await mockSessionWithTestData({ orgType: 'lab' })
         const enclaveOrg = await insertTestOrg({ slug: 'test-enclave', type: 'enclave' })
         const { study } = await insertTestStudyJobData({ org: enclaveOrg, researcherId: user.id })
         // Set submittedByOrgId to the lab org (realistic: enclave owns, lab submits)
         await db.updateTable('study').set({ submittedByOrgId: labOrg.id }).where('id', '=', study.id).execute()
 
-        await ackAgreementsAction({ studyId: study.id })
+        await ackAgreementsAction({ studyId: study.id, role: 'researcher' })
 
         const updated = await db
             .selectFrom('study')
@@ -535,13 +535,13 @@ describe('ackAgreementsAction', () => {
         expect(updated.reviewerAgreementsAckedAt).toBeNull()
     })
 
-    it('sets reviewerAgreementsAckedAt when called by enclave member', async () => {
+    it('sets reviewerAgreementsAckedAt when called with role=reviewer by enclave member', async () => {
         const { org: enclaveOrg, user } = await mockSessionWithTestData({ orgType: 'enclave' })
         const labOrg = await insertTestOrg({ slug: 'test-lab', type: 'lab' })
         const { study } = await insertTestStudyJobData({ org: enclaveOrg, researcherId: user.id })
         await db.updateTable('study').set({ submittedByOrgId: labOrg.id }).where('id', '=', study.id).execute()
 
-        await ackAgreementsAction({ studyId: study.id })
+        await ackAgreementsAction({ studyId: study.id, role: 'reviewer' })
 
         const updated = await db
             .selectFrom('study')
@@ -553,11 +553,35 @@ describe('ackAgreementsAction', () => {
         expect(updated.researcherAgreementsAckedAt).toBeNull()
     })
 
+    // OTTER-546: a user who is a member of BOTH orgs (e.g. multi-org QA accounts, or
+    // a test fixture where orgId === submittedByOrgId) used to silently ack both
+    // columns when proceeding from the researcher view, which skipped the reviewer's
+    // Agreements page on their next visit. With the explicit `role` param, acking on
+    // the researcher side never touches the reviewer column even when the caller
+    // would otherwise pass both org checks.
+    it('does NOT set reviewerAgreementsAckedAt when role=researcher and caller would pass both org checks', async () => {
+        // insertTestStudyJobData defaults orgId === submittedByOrgId, which is the
+        // same condition as a multi-org QA user against a real study.
+        const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+        const { study } = await insertTestStudyJobData({ org, researcherId: user.id })
+
+        await ackAgreementsAction({ studyId: study.id, role: 'researcher' })
+
+        const updated = await db
+            .selectFrom('study')
+            .select(['researcherAgreementsAckedAt', 'reviewerAgreementsAckedAt'])
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+
+        expect(updated.researcherAgreementsAckedAt).not.toBeNull()
+        expect(updated.reviewerAgreementsAckedAt).toBeNull()
+    })
+
     it('does not overwrite an existing ack timestamp', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
         const { study } = await insertTestStudyJobData({ org, researcherId: user.id })
 
-        await ackAgreementsAction({ studyId: study.id })
+        await ackAgreementsAction({ studyId: study.id, role: 'researcher' })
 
         const first = await db
             .selectFrom('study')
@@ -566,7 +590,7 @@ describe('ackAgreementsAction', () => {
             .executeTakeFirstOrThrow()
 
         // Call again — should not change the timestamp
-        await ackAgreementsAction({ studyId: study.id })
+        await ackAgreementsAction({ studyId: study.id, role: 'researcher' })
 
         const second = await db
             .selectFrom('study')
@@ -577,16 +601,38 @@ describe('ackAgreementsAction', () => {
         expect(second.researcherAgreementsAckedAt).toEqual(first.researcherAgreementsAckedAt)
     })
 
-    it('fails when user is neither reviewer nor researcher org member', async () => {
+    it('fails when role=reviewer but user is not a member of the reviewer org', async () => {
+        // Caller belongs to the lab that submitted the study (so the `view Study`
+        // ability check passes), but does NOT belong to the reviewer enclave — they
+        // must not be able to ack as a reviewer.
         const enclaveOrg = await insertTestOrg({ slug: 'acker-enclave', type: 'enclave' })
-        const labOrg = await insertTestOrg({ slug: 'acker-lab', type: 'lab' })
+        const { org: labOrg, user } = await mockSessionWithTestData({ orgType: 'lab' })
+        const { study } = await insertTestStudyJobData({ org: enclaveOrg, researcherId: user.id })
+        await db.updateTable('study').set({ submittedByOrgId: labOrg.id }).where('id', '=', study.id).execute()
+
+        await expect(ackAgreementsAction({ studyId: study.id, role: 'reviewer' })).resolves.toMatchObject({
+            error: expect.objectContaining({ user: expect.any(String) }),
+        })
+
+        const after = await db
+            .selectFrom('study')
+            .select(['researcherAgreementsAckedAt', 'reviewerAgreementsAckedAt'])
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+        expect(after.researcherAgreementsAckedAt).toBeNull()
+        expect(after.reviewerAgreementsAckedAt).toBeNull()
+    })
+
+    it('fails when user is neither reviewer nor researcher org member', async () => {
+        const enclaveOrg = await insertTestOrg({ slug: 'acker-enclave-2', type: 'enclave' })
+        const labOrg = await insertTestOrg({ slug: 'acker-lab-2', type: 'lab' })
         const { study } = await insertTestStudyJobData({ org: enclaveOrg })
         await db.updateTable('study').set({ submittedByOrgId: labOrg.id }).where('id', '=', study.id).execute()
 
         // SI admin can `view` any Study but belongs to neither org — handler should refuse the ack
         await mockSessionWithTestData({ isSiAdmin: true })
 
-        await expect(ackAgreementsAction({ studyId: study.id })).resolves.toMatchObject({
+        await expect(ackAgreementsAction({ studyId: study.id, role: 'researcher' })).resolves.toMatchObject({
             error: expect.objectContaining({ user: expect.any(String) }),
         })
 

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -191,7 +191,7 @@ export const getStudyAction = new Action('getStudyAction')
 export type SelectedStudy = ActionSuccessType<typeof getStudyAction>
 
 export const ackAgreementsAction = new Action('ackAgreementsAction', { performsMutations: true })
-    .params(z.object({ studyId: z.string() }))
+    .params(z.object({ studyId: z.string(), role: z.enum(['researcher', 'reviewer']) }))
     .middleware(async ({ params: { studyId }, db }) => {
         const study = await db
             .selectFrom('study')
@@ -201,32 +201,26 @@ export const ackAgreementsAction = new Action('ackAgreementsAction', { performsM
         return { study, orgId: study.orgId, submittedByOrgId: study.submittedByOrgId }
     })
     .requireAbilityTo('view', 'Study')
-    .handler(async ({ study, params: { studyId }, db, session }) => {
+    .handler(async ({ study, params: { studyId, role }, db, session }) => {
         const userOrgIds = new Set(Object.values(session?.orgs ?? {}).map((org) => org.id))
 
-        const isReviewer = userOrgIds.has(study.orgId)
-        const isResearcher = userOrgIds.has(study.submittedByOrgId)
-
-        if (!isReviewer && !isResearcher) {
-            throw new ActionFailure({ user: 'not a member of the study reviewer or submitter org' })
+        // OTTER-546: scope the ack strictly to the role the agreements page was rendered for.
+        // A user who happens to belong to BOTH the reviewer enclave and the submitting lab
+        // (common in test accounts) would otherwise ack both columns when proceeding from
+        // the researcher view, silently consuming the reviewer's gate and skipping the
+        // Agreements page on their next visit.
+        const requiredOrgId = role === 'reviewer' ? study.orgId : study.submittedByOrgId
+        if (!userOrgIds.has(requiredOrgId)) {
+            throw new ActionFailure({ user: `not a member of the study ${role} org` })
         }
 
-        if (isReviewer) {
-            await db
-                .updateTable('study')
-                .set({ reviewerAgreementsAckedAt: new Date() })
-                .where('id', '=', studyId)
-                .where('reviewerAgreementsAckedAt', 'is', null)
-                .execute()
-        }
-        if (isResearcher) {
-            await db
-                .updateTable('study')
-                .set({ researcherAgreementsAckedAt: new Date() })
-                .where('id', '=', studyId)
-                .where('researcherAgreementsAckedAt', 'is', null)
-                .execute()
-        }
+        const column = role === 'reviewer' ? 'reviewerAgreementsAckedAt' : 'researcherAgreementsAckedAt'
+        await db
+            .updateTable('study')
+            .set({ [column]: new Date() })
+            .where('id', '=', studyId)
+            .where(column, 'is', null)
+            .execute()
     })
 
 async function approveJobCode({


### PR DESCRIPTION
## Summary

Fixes [OTTER-546](https://openstax.atlassian.net/browse/OTTER-546).

QA was still reporting the Agreements page never appearing for DOs on studies in *Code needs review*, even after PR #636 wired up the gate. Investigation found that `ackAgreementsAction` was updating the ack column based on **session org membership only**, not on which Agreements page the user was actually on. When a user belonged to both the reviewer enclave and the submitting lab — common with multi-org QA accounts, and the default shape of test fixtures where `orgId === submittedByOrgId` — proceeding past the **researcher** Agreements page silently set BOTH `researcherAgreementsAckedAt` and `reviewerAgreementsAckedAt`. The reviewer gate in `review/page.tsx` then saw a non-null `reviewerAgreementsAckedAt` and skipped the Agreements page, dropping the DO directly onto the code-review view.

### Fix

- Add a required `role: 'researcher' | 'reviewer'` param to `ackAgreementsAction`.
- The action only updates the column that matches that role, and verifies the caller actually belongs to the corresponding org.
- `AgreementsPage` already knows whether it is the reviewer variant via its `isReviewer` prop, so it passes that through.

### Caveat

This fixes the behavior going forward. Studies already in the wild that had `reviewerAgreementsAckedAt` populated incorrectly by the prior behavior will still skip the gate — no migration is included because there is no reliable way to distinguish bug-set acks from legitimate ones. If QA wants those historical studies re-gated, a DBA can `UPDATE study SET reviewer_agreements_acked_at = NULL WHERE …` against the affected rows. Please flag any staging/prod studies that QA wants reset.

## Test plan

- [x] `npx vitest run src/server/actions/study.actions.test.ts src/app/[orgSlug]/study/[studyId]/agreements/page.test.tsx src/app/[orgSlug]/study/[studyId]/review/page.test.tsx` — 88 tests pass
- [x] New unit test: `does NOT set reviewerAgreementsAckedAt when role=researcher and caller would pass both org checks` — directly exercises the bug
- [x] New unit test: `fails when role=reviewer but user is not a member of the reviewer org` — ensures the role param can't be abused to ack a column the caller has no business touching
- [x] `tsc --noEmit --skipLibCheck` clean
- [x] `eslint` clean on touched files
- [ ] Manual on staging with QA's reproducible test account: researcher submits code → reviewer opens dashboard → clicks View → Agreements page is shown (not skipped). Click Proceed → land on code-review view. Re-open from dashboard → land directly on code-review view (Rule 3 still works).

[OTTER-546]: https://openstax.atlassian.net/browse/OTTER-546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ