### PR TITLE
OTTER-521: drop initialErrors seed on resubmission note form

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { renderWithProviders, screen, userEvent } from '@/tests/unit.helpers'
+import { EditResubmitProvider, type EditResubmitDraftData } from '@/contexts/edit-resubmit'
+import { lexicalJson } from '@/lib/lexical'
+import { EditResubmitFooter } from './footer'
+import { ResubmissionNoteSection } from './resubmission-note-section'
+import { RESUBMIT_NOTE_MIN_WORDS } from './schema'
+
+const STUDY_ID = '11111111-1111-4111-8111-111111111111'
+
+// Pre-fill the proposal-side of the form so `form.isValid()` is true. This
+// isolates the note gate: any disabled-state we observe is the note gate's
+// doing, not a side-effect of the proposal form being empty.
+const VALID_PROPOSAL_DRAFT: EditResubmitDraftData = {
+    title: 'A valid title',
+    datasets: ['some-dataset'],
+    researchQuestions: lexicalJson('Some research questions'),
+    projectSummary: lexicalJson('A project summary'),
+    impact: lexicalJson('Some impact'),
+    piName: 'PI Name',
+    piUserId: '22222222-2222-4222-8222-222222222222',
+}
+
+const renderFooter = (draft: EditResubmitDraftData = VALID_PROPOSAL_DRAFT) =>
+    renderWithProviders(
+        <EditResubmitProvider studyId={STUDY_ID} draftData={draft}>
+            <ResubmissionNoteSection orgName="Rice University" />
+            <EditResubmitFooter researcherName="Test Researcher" researcherId="" />
+        </EditResubmitProvider>,
+    )
+
+const wordsString = (count: number) => Array.from({ length: count }, (_, i) => `word${i}`).join(' ')
+
+describe('EditResubmitFooter — Resubmit gating', () => {
+    // OTTER-521 regression: the prior implementation relied on Mantine's
+    // `noteForm.isValid()` for the disabled check, but Mantine doesn't validate
+    // initial values. With a valid proposal form, `form.isValid()` returned true
+    // AND empty-note `noteForm.isValid()` falsely returned true — Resubmit was
+    // enabled on first paint. Footer now derives note validity from the schema
+    // against `noteForm.values` directly.
+    it('disables Resubmit on first paint when the resubmission note is empty, even if the proposal form is otherwise valid', () => {
+        renderFooter()
+        const resubmit = screen.getByRole('button', { name: /Resubmit initial request/i })
+        expect(resubmit).toBeDisabled()
+    })
+
+    it('keeps Resubmit disabled while the note is below the minimum word count', async () => {
+        const user = userEvent.setup()
+        renderFooter()
+        const textarea = screen.getByRole('textbox', { name: 'Resubmission Note' })
+        await user.type(textarea, 'too short')
+        const resubmit = screen.getByRole('button', { name: /Resubmit initial request/i })
+        expect(resubmit).toBeDisabled()
+    })
+
+    it('enables Resubmit once a valid-length note is pasted and the proposal form is valid', async () => {
+        const user = userEvent.setup()
+        renderFooter()
+        const textarea = screen.getByRole('textbox', { name: 'Resubmission Note' })
+        await user.click(textarea)
+        await user.paste(wordsString(RESUBMIT_NOTE_MIN_WORDS))
+        const resubmit = screen.getByRole('button', { name: /Resubmit initial request/i })
+        expect(resubmit).toBeEnabled()
+    })
+})

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/resubmission-note-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/resubmission-note-section.test.tsx
@@ -27,6 +27,15 @@ describe('ResubmissionNoteSection', () => {
         expect(screen.getByText('0/300')).toBeInTheDocument()
     })
 
+    // Mantine's default behavior is correct here: don't shout an error at the user
+    // before they've touched the field. The Resubmit button is gated separately
+    // (see footer.test.tsx) so it's safe to keep the inline error quiet on mount.
+    it('does not surface a validation error on first paint, before the user interacts', () => {
+        renderSection()
+        expect(screen.queryByText(/required/i)).not.toBeInTheDocument()
+        expect(screen.queryByText(/between 50 and 300 words/i)).not.toBeInTheDocument()
+    })
+
     it('updates the word counter live as the user types', async () => {
         const user = userEvent.setup()
         renderSection()

--- a/src/contexts/edit-resubmit/context.tsx
+++ b/src/contexts/edit-resubmit/context.tsx
@@ -52,18 +52,9 @@ export function EditResubmitProvider({ children, studyId, draftData }: EditResub
         validateInputOnChange: true,
     })
 
-    // Seed errors from the schema so the Resubmit button starts disabled
-    // (Mantine's useForm doesn't validate initial values otherwise — the
-    // note is empty by default, which violates the 50-word minimum).
-    const initialNoteValidation = resubmitNoteSchema.safeParse(initialResubmitNoteValue)
-    const initialNoteErrors = initialNoteValidation.success
-        ? undefined
-        : (initialNoteValidation.error.flatten().fieldErrors as Record<string, string>)
-
     const noteForm = useForm<ResubmitNoteValue>({
         validate: zodResolver(resubmitNoteSchema),
         initialValues: initialResubmitNoteValue,
-        initialErrors: initialNoteErrors,
         validateInputOnChange: true,
     })
 


### PR DESCRIPTION
## Stacked on #723

This is a small follow-up to #723 that removes the `initialErrors` seed on the resubmission note form. Posted as a stacked PR so the diff against #723 is the only thing under review here.

## What's wrong

`safeParse(initialResubmitNoteValue).error.flatten().fieldErrors` returns `Record<string, string[]>`, but the existing code casts it to `Record<string, string>` and hands it to Mantine's `useForm({ initialErrors })`. Mantine renders the array as-is in the input's error slot, and because an empty string trips **both** `.min(1)` and the word-count `.refine`, the user sees two messages glued together with no separator on first paint:

```
A resubmission note is required.Resubmission note must be between 50 and 300 words.
```

Verified by rendering `ResubmissionNoteSection` with no user interaction — see the new regression test, which fails against the current tip of #723 with that exact concatenated string.

## Why the seed isn't needed at all

The seed was added so the Resubmit button would start disabled. But Mantine's `noteForm.isValid()` (which the footer already uses) **runs the validation rules against the current values on demand** — it's not a stored-errors check. So the button has always been correctly disabled for an empty note, even before the seed was introduced. The seed only ever affected the inline-error UI on first paint, where it created the blob.

Removing the seed:
- Drops the dangerous cast and the redundant safeParse-on-every-render
- Lets Mantine's default no-error-until-blur behavior take over for the inline message
- Keeps the button correctly gated through `noteForm.isValid()`

Net diff: -9 / +1 lines in `context.tsx`. No `footer.tsx` change.

## Tests

| Test file | What it covers |
|---|---|
| `resubmission-note-section.test.tsx` (modified) | New test: no validation error rendered on first paint. Fails against #723's current code with the blob string visible in the assertion failure. |
| `footer.test.tsx` (new) | 3 tests covering Resubmit gating: disabled on empty note, disabled on too-short note, enabled once both forms are valid. Regression net for future changes to the gate. |

## Test plan

- [x] New regression test fails against the current tip of #723 with the literal blob string in the error output (confirmed locally)
- [x] All 14 tests in `edit-and-resubmit/` pass with the fix applied
- [x] `tsc --noEmit --skipLibCheck` clean
- [x] `eslint` clean on touched files

## Why stacked instead of comments on #723

Easier to look at the exact change than describe it in prose, and keeps #723 mergeable on its own if the team prefers to ship that and chase this separately.