### PR TITLE
OTTER-471: true-parallel test

### DIFF
--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -951,11 +951,8 @@ describe('submitProposalReviewAction', () => {
         expect(unchanged.status).toBe('CHANGE-REQUESTED')
     })
 
-    // OTTER-471: true-parallel belt-and-suspenders for submitProposalReviewAction.
-    // Earlier tests exercise the sequential A-then-B path; this one fires approve
-    // and reject through Promise.all so the claim CAS + per-round comment insert
-    // actually have to serialize concurrent writers. Exactly one must win, and the
-    // study must land in exactly one terminal state with exactly one feedback row.
+    // OTTER-471: exercises the claim CAS under true concurrency (Promise.all),
+    // not just the sequential A-then-B path covered above.
     it('OTTER-471: parallel approve + reject through submit action, exactly one wins', async () => {
         const { user, org } = await mockSessionWithTestData({ orgType: 'enclave' })
         const { study } = await insertTestStudyJobData({ org, researcherId: user.id, studyStatus: 'PENDING-REVIEW' })
@@ -1563,11 +1560,8 @@ describe('submitCodeReviewDecisionAction', () => {
         expect(await loadCodeReviewRows(study.id)).toHaveLength(1)
     })
 
-    // OTTER-471: true-parallel belt-and-suspenders for submitCodeReviewDecisionAction.
-    // The sequential approve-then-reject case is already covered; this one fires
-    // both through Promise.all so the studyJob row lock + composite unique
-    // constraint actually have to arbitrate concurrent writers. Exactly one must
-    // win: one CODE-* terminal status row, one studyReviewComment row.
+    // OTTER-471: exercises the studyJob row lock + composite unique constraint
+    // under true concurrency (Promise.all), not just the sequential case above.
     it('OTTER-471: parallel approve + reject through submit action, exactly one CODE-* terminal row', async () => {
         const { org, study, job } = await setApprovedStudyAndCodeSubmitted()
 

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -951,6 +951,52 @@ describe('submitProposalReviewAction', () => {
         expect(unchanged.status).toBe('CHANGE-REQUESTED')
     })
 
+    // OTTER-471: true-parallel belt-and-suspenders for submitProposalReviewAction.
+    // Earlier tests exercise the sequential A-then-B path; this one fires approve
+    // and reject through Promise.all so the claim CAS + per-round comment insert
+    // actually have to serialize concurrent writers. Exactly one must win, and the
+    // study must land in exactly one terminal state with exactly one feedback row.
+    it('OTTER-471: parallel approve + reject through submit action, exactly one wins', async () => {
+        const { user, org } = await mockSessionWithTestData({ orgType: 'enclave' })
+        const { study } = await insertTestStudyJobData({ org, researcherId: user.id, studyStatus: 'PENDING-REVIEW' })
+
+        const results = await Promise.all([
+            submitProposalReviewAction({
+                studyId: study.id,
+                orgSlug: org.slug,
+                decision: 'approve',
+                feedback: validFeedback,
+                reviewVersion: 1,
+            }),
+            submitProposalReviewAction({
+                studyId: study.id,
+                orgSlug: org.slug,
+                decision: 'reject',
+                feedback: validFeedback,
+                reviewVersion: 1,
+            }),
+        ])
+
+        const errors = results.filter((r) => r != null && typeof r === 'object' && 'error' in r)
+        expect(errors).toHaveLength(1)
+
+        const updatedStudy = await db
+            .selectFrom('study')
+            .select(['status', 'approvedAt', 'rejectedAt'])
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+
+        const isApproved = updatedStudy.status === 'APPROVED' && !!updatedStudy.approvedAt && !updatedStudy.rejectedAt
+        const isRejected = updatedStudy.status === 'REJECTED' && !!updatedStudy.rejectedAt && !updatedStudy.approvedAt
+        expect(isApproved || isRejected).toBe(true)
+        expect(isApproved && isRejected).toBe(false)
+
+        const rows = await loadCommentRows(study.id)
+        expect(rows).toHaveLength(1)
+        expect(rows[0].entryType).toBe('REVIEWER-FEEDBACK')
+        expect(rows[0].decision === 'APPROVE' || rows[0].decision === 'REJECT').toBe(true)
+    })
+
     it('rejects review submission for code-review studies without writing a review row', async () => {
         const { user, org } = await mockSessionWithTestData({ orgType: 'enclave' })
         const { study } = await insertTestStudyJobData({
@@ -1515,6 +1561,51 @@ describe('submitCodeReviewDecisionAction', () => {
         })
         // The pre-seeded row is the only CODE row; the action did not create a second.
         expect(await loadCodeReviewRows(study.id)).toHaveLength(1)
+    })
+
+    // OTTER-471: true-parallel belt-and-suspenders for submitCodeReviewDecisionAction.
+    // The sequential approve-then-reject case is already covered; this one fires
+    // both through Promise.all so the studyJob row lock + composite unique
+    // constraint actually have to arbitrate concurrent writers. Exactly one must
+    // win: one CODE-* terminal status row, one studyReviewComment row.
+    it('OTTER-471: parallel approve + reject through submit action, exactly one CODE-* terminal row', async () => {
+        const { org, study, job } = await setApprovedStudyAndCodeSubmitted()
+
+        const results = await Promise.all([
+            submitCodeReviewDecisionAction({
+                studyId: study.id,
+                orgSlug: org.slug,
+                decision: 'approve',
+                feedback: validFeedback,
+                criteria: validCriteria,
+            }),
+            submitCodeReviewDecisionAction({
+                studyId: study.id,
+                orgSlug: org.slug,
+                decision: 'reject',
+                feedback: validFeedback,
+                criteria: validCriteria,
+            }),
+        ])
+
+        const errors = results.filter((r) => r != null && typeof r === 'object' && 'error' in r)
+        expect(errors).toHaveLength(1)
+
+        expect(await loadCodeReviewRows(study.id)).toHaveLength(1)
+
+        const codeApproved = await db
+            .selectFrom('jobStatusChange')
+            .select('id')
+            .where('studyJobId', '=', job.id)
+            .where('status', '=', 'CODE-APPROVED')
+            .execute()
+        const codeRejected = await db
+            .selectFrom('jobStatusChange')
+            .select('id')
+            .where('studyJobId', '=', job.id)
+            .where('status', '=', 'CODE-REJECTED')
+            .execute()
+        expect(codeApproved.length + codeRejected.length).toBe(1)
     })
 
     it('composite unique constraint blocks two CODE review rows for the same job', async () => {


### PR DESCRIPTION
Main fix for feature flag behaviour is merged through https://github.com/safeinsights/management-app/pull/710

Legacy paths are not fixed because soon gone (will also mention that in OTTER-471 card).

This branch only adds minor additions in test coverage:

- Adds a true-parallel race test for the proposal review submit action, verifying that simultaneous approve and reject calls produce exactly one winner and one terminal state.
- Adds a matching parallel race test for the code review decision submit action, verifying that concurrent approve and reject calls leave exactly one terminal status row and one review comment.