### PR TITLE
add delete button to proposal draft studies

### DIFF
--- a/src/components/dashboard/studies-table/delete-draft-button.test.tsx
+++ b/src/components/dashboard/studies-table/delete-draft-button.test.tsx
@@ -135,6 +135,37 @@ describe('DeleteDraftButton', () => {
         expect(row.deletedAt).not.toBeNull()
     })
 
+    it('uses the same "Untitled Draft" fallback in both the aria-label and the success toast when title is null', async () => {
+        const { studyId, user } = await createTestProposalDraft({
+            enclaveSlug: 'delete-draft-untitled-enclave',
+            studyInfo: { title: 'Has a title' }, // createTestProposalDraft requires a title; we null it below
+        })
+        await db.updateTable('study').set({ title: null }).where('id', '=', studyId).execute()
+
+        const user1 = userEvent.setup()
+        renderWithProviders(
+            <DeleteDraftButton
+                study={makeStudyRow({ id: studyId, researcherId: user.id, title: null as unknown as string })}
+            />,
+        )
+
+        // aria-label uses the fallback
+        expect(screen.getByLabelText('Delete draft study Untitled Draft')).toBeInTheDocument()
+
+        await user1.click(screen.getByLabelText('Delete draft study Untitled Draft'))
+        await user1.click(await screen.findByRole('button', { name: /yes, delete proposal draft/i }))
+
+        // success toast uses the same fallback
+        await waitFor(() => {
+            expect(notifications.show).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    color: 'green',
+                    message: 'Proposal draft Untitled Draft was successfully deleted',
+                }),
+            )
+        })
+    })
+
     it('shows an error toast when the action fails', async () => {
         const { studyId, user } = await createTestProposalDraft({
             enclaveSlug: 'delete-draft-error-enclave',

--- a/src/components/dashboard/studies-table/delete-draft-button.test.tsx
+++ b/src/components/dashboard/studies-table/delete-draft-button.test.tsx
@@ -18,7 +18,7 @@ function makeStudyRow(overrides: Partial<StudyRow> & { id: string; researcherId:
 }
 
 describe('DeleteDraftButton', () => {
-    it('opens the confirmation modal when the trash icon is clicked', async () => {
+    it('opens the confirmation modal with the spec title, body, and buttons when the trash icon is clicked', async () => {
         const { studyId, user } = await createTestProposalDraft({
             enclaveSlug: 'delete-draft-modal-enclave',
             studyInfo: { title: 'Modal Draft' },
@@ -32,9 +32,58 @@ describe('DeleteDraftButton', () => {
         await user1.click(screen.getByLabelText(/delete draft study/i))
 
         expect(await screen.findByText('Confirm proposal draft deletion?')).toBeInTheDocument()
-        expect(screen.getByText(/cannot be undone/i)).toBeInTheDocument()
+        expect(
+            screen.getByText(
+                'Please confirm that you are wanting to delete this proposal draft. Once this draft is deleted you will not be able to recover it. This action cannot be undone.',
+            ),
+        ).toBeInTheDocument()
         expect(screen.getByRole('button', { name: /yes, delete proposal draft/i })).toBeInTheDocument()
         expect(screen.getByRole('button', { name: /^cancel$/i })).toBeInTheDocument()
+    })
+
+    it('renders the delete confirm button with a red.9 background', async () => {
+        const { studyId, user } = await createTestProposalDraft({
+            enclaveSlug: 'delete-draft-red-color-enclave',
+            studyInfo: { title: 'Red Draft' },
+        })
+        const user1 = userEvent.setup()
+
+        renderWithProviders(
+            <DeleteDraftButton study={makeStudyRow({ id: studyId, researcherId: user.id, title: 'Red Draft' })} />,
+        )
+
+        await user1.click(screen.getByLabelText(/delete draft study/i))
+        const confirm = await screen.findByRole('button', { name: /yes, delete proposal draft/i })
+
+        // Mantine v7 maps `color="red.9"` to an inline CSS variable on the button.
+        // Asserting on the variable rather than the resolved color keeps the test
+        // resilient to theme changes while pinning the red.9 contract from the spec.
+        expect(confirm.getAttribute('style') || '').toContain('--button-bg: var(--mantine-color-red-9)')
+    })
+
+    it('closes the modal when the header X close button is clicked', async () => {
+        const { studyId, user } = await createTestProposalDraft({
+            enclaveSlug: 'delete-draft-xclose-enclave',
+            studyInfo: { title: 'X Draft' },
+        })
+        const user1 = userEvent.setup()
+
+        renderWithProviders(
+            <DeleteDraftButton study={makeStudyRow({ id: studyId, researcherId: user.id, title: 'X Draft' })} />,
+        )
+
+        await user1.click(screen.getByLabelText(/delete draft study/i))
+        await screen.findByText('Confirm proposal draft deletion?')
+
+        // Mantine's Modal close button uses aria-label="Close" by default
+        await user1.click(screen.getByRole('button', { name: /^close$/i }))
+
+        await waitFor(() => {
+            expect(screen.queryByText('Confirm proposal draft deletion?')).not.toBeInTheDocument()
+        })
+
+        const row = await db.selectFrom('study').select('deletedAt').where('id', '=', studyId).executeTakeFirstOrThrow()
+        expect(row.deletedAt).toBeNull()
     })
 
     it('closes the modal without deleting when Cancel is clicked', async () => {

--- a/src/components/dashboard/studies-table/delete-draft-button.test.tsx
+++ b/src/components/dashboard/studies-table/delete-draft-button.test.tsx
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest'
+import { notifications } from '@mantine/notifications'
+import { db, createTestProposalDraft, renderWithProviders, screen, userEvent, waitFor } from '@/tests/unit.helpers'
+import { DeleteDraftButton } from './delete-draft-button'
+import { StudyRow } from './types'
+
+function makeStudyRow(overrides: Partial<StudyRow> & { id: string; researcherId: string }): StudyRow {
+    return {
+        title: 'My Draft',
+        status: 'DRAFT',
+        createdAt: new Date(),
+        submittedAt: null,
+        reviewerId: null,
+        createdBy: null,
+        jobStatusChanges: [],
+        ...overrides,
+    } as StudyRow
+}
+
+describe('DeleteDraftButton', () => {
+    it('opens the confirmation modal when the trash icon is clicked', async () => {
+        const { studyId, user } = await createTestProposalDraft({
+            enclaveSlug: 'delete-draft-modal-enclave',
+            studyInfo: { title: 'Modal Draft' },
+        })
+        const user1 = userEvent.setup()
+
+        renderWithProviders(
+            <DeleteDraftButton study={makeStudyRow({ id: studyId, researcherId: user.id, title: 'Modal Draft' })} />,
+        )
+
+        await user1.click(screen.getByLabelText(/delete draft study/i))
+
+        expect(await screen.findByText('Confirm proposal draft deletion?')).toBeInTheDocument()
+        expect(screen.getByText(/cannot be undone/i)).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /yes, delete proposal draft/i })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /^cancel$/i })).toBeInTheDocument()
+    })
+
+    it('closes the modal without deleting when Cancel is clicked', async () => {
+        const { studyId, user } = await createTestProposalDraft({
+            enclaveSlug: 'delete-draft-cancel-enclave',
+            studyInfo: { title: 'Cancel Draft' },
+        })
+        const user1 = userEvent.setup()
+
+        renderWithProviders(
+            <DeleteDraftButton study={makeStudyRow({ id: studyId, researcherId: user.id, title: 'Cancel Draft' })} />,
+        )
+
+        await user1.click(screen.getByLabelText(/delete draft study/i))
+        await user1.click(await screen.findByRole('button', { name: /^cancel$/i }))
+
+        await waitFor(() => {
+            expect(screen.queryByText('Confirm proposal draft deletion?')).not.toBeInTheDocument()
+        })
+
+        const row = await db.selectFrom('study').select('deletedAt').where('id', '=', studyId).executeTakeFirstOrThrow()
+        expect(row.deletedAt).toBeNull()
+    })
+
+    it('soft-deletes the study and shows a success toast on confirm', async () => {
+        const { studyId, user } = await createTestProposalDraft({
+            enclaveSlug: 'delete-draft-confirm-enclave',
+            studyInfo: { title: 'Doomed' },
+        })
+        const user1 = userEvent.setup()
+
+        renderWithProviders(
+            <DeleteDraftButton study={makeStudyRow({ id: studyId, researcherId: user.id, title: 'Doomed' })} />,
+        )
+
+        await user1.click(screen.getByLabelText(/delete draft study/i))
+        await user1.click(await screen.findByRole('button', { name: /yes, delete proposal draft/i }))
+
+        await waitFor(() => {
+            expect(notifications.show).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    color: 'green',
+                    message: 'Proposal draft Doomed was successfully deleted',
+                }),
+            )
+        })
+
+        const row = await db.selectFrom('study').select('deletedAt').where('id', '=', studyId).executeTakeFirstOrThrow()
+        expect(row.deletedAt).not.toBeNull()
+    })
+
+    it('shows an error toast when the action fails', async () => {
+        const { studyId, user } = await createTestProposalDraft({
+            enclaveSlug: 'delete-draft-error-enclave',
+            studyInfo: { title: 'Already Submitted' },
+        })
+        // Flip status to a non-draft state so the server action rejects with ActionFailure
+        await db.updateTable('study').set({ status: 'PENDING-REVIEW' }).where('id', '=', studyId).execute()
+
+        const user1 = userEvent.setup()
+        renderWithProviders(
+            <DeleteDraftButton
+                study={makeStudyRow({ id: studyId, researcherId: user.id, title: 'Already Submitted' })}
+            />,
+        )
+
+        await user1.click(screen.getByLabelText(/delete draft study/i))
+        await user1.click(await screen.findByRole('button', { name: /yes, delete proposal draft/i }))
+
+        await waitFor(() => {
+            expect(notifications.show).toHaveBeenCalledWith(
+                expect.objectContaining({ color: 'red', title: 'Failed to delete proposal draft' }),
+            )
+        })
+
+        // ensure success toast was not also fired
+        const calls = (notifications.show as unknown as ReturnType<typeof vi.fn>).mock.calls
+        expect(calls.some(([arg]) => arg?.color === 'green')).toBe(false)
+    })
+})

--- a/src/components/dashboard/studies-table/delete-draft-button.tsx
+++ b/src/components/dashboard/studies-table/delete-draft-button.tsx
@@ -60,7 +60,12 @@ export function DeleteDraftButton({ study }: { study: StudyRow }) {
             >
                 <TrashIcon />
             </ActionIcon>
-            <AppModal isOpen={isOpen} onClose={close} title="Confirm proposal draft deletion?">
+            <AppModal
+                isOpen={isOpen}
+                onClose={close}
+                title="Confirm proposal draft deletion?"
+                closeButtonProps={{ 'aria-label': 'Close' }}
+            >
                 <Stack>
                     <Text size="md">
                         Please confirm that you are wanting to delete this proposal draft. Once this draft is deleted

--- a/src/components/dashboard/studies-table/delete-draft-button.tsx
+++ b/src/components/dashboard/studies-table/delete-draft-button.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { ActionIcon, Button, Group, Stack, Text } from '@mantine/core'
+import { notifications } from '@mantine/notifications'
+import { TrashIcon } from '@phosphor-icons/react/dist/ssr'
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@/common'
+import { AppModal } from '@/components/modal'
+import { softDeleteStudyAction } from '@/server/actions/study.actions'
+import { StudyRow } from './types'
+
+function useDeleteDraft(study: StudyRow) {
+    const queryClient = useQueryClient()
+    const [isOpen, setIsOpen] = useState(false)
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: softDeleteStudyAction,
+        onSuccess: async () => {
+            setIsOpen(false)
+            await Promise.all([
+                queryClient.invalidateQueries({ queryKey: ['user-researcher-studies'] }),
+                queryClient.invalidateQueries({ queryKey: ['researcher-studies'] }),
+            ])
+            notifications.show({
+                title: 'Proposal draft deleted',
+                message: `Proposal draft ${study.title ?? 'Untitled Draft'} was successfully deleted`,
+                color: 'green',
+            })
+        },
+        onError: (error) => {
+            notifications.show({
+                title: 'Failed to delete proposal draft',
+                message: error instanceof Error ? error.message : 'An unexpected error occurred. Please try again.',
+                color: 'red',
+            })
+        },
+    })
+
+    return {
+        isOpen,
+        open: () => setIsOpen(true),
+        close: () => setIsOpen(false),
+        confirm: () => mutate({ studyId: study.id }),
+        isPending,
+    }
+}
+
+export function DeleteDraftButton({ study }: { study: StudyRow }) {
+    const { isOpen, open, close, confirm, isPending } = useDeleteDraft(study)
+    const draftLabel = study.title ?? 'draft proposal'
+
+    return (
+        <>
+            <ActionIcon
+                variant="subtle"
+                color="red.9"
+                onClick={open}
+                aria-label={`Delete draft study ${draftLabel}`}
+                data-testid="delete-draft-button"
+            >
+                <TrashIcon />
+            </ActionIcon>
+            <AppModal isOpen={isOpen} onClose={close} title="Confirm proposal draft deletion?">
+                <Stack>
+                    <Text size="md">
+                        Please confirm that you are wanting to delete this proposal draft. Once this draft is deleted
+                        you will not be able to recover it. This action cannot be undone.
+                    </Text>
+                    <Group justify="flex-end">
+                        <Button variant="outline" onClick={close} disabled={isPending}>
+                            Cancel
+                        </Button>
+                        <Button variant="filled" color="red.9" onClick={confirm} loading={isPending}>
+                            Yes, delete proposal draft
+                        </Button>
+                    </Group>
+                </Stack>
+            </AppModal>
+        </>
+    )
+}

--- a/src/components/dashboard/studies-table/delete-draft-button.tsx
+++ b/src/components/dashboard/studies-table/delete-draft-button.tsx
@@ -9,9 +9,12 @@ import { AppModal } from '@/components/modal'
 import { softDeleteStudyAction } from '@/server/actions/study.actions'
 import { StudyRow } from './types'
 
+const UNTITLED_DRAFT_FALLBACK = 'Untitled Draft'
+
 function useDeleteDraft(study: StudyRow) {
     const queryClient = useQueryClient()
     const [isOpen, setIsOpen] = useState(false)
+    const draftLabel = study.title ?? UNTITLED_DRAFT_FALLBACK
 
     const { mutate, isPending } = useMutation({
         mutationFn: softDeleteStudyAction,
@@ -23,7 +26,7 @@ function useDeleteDraft(study: StudyRow) {
             ])
             notifications.show({
                 title: 'Proposal draft deleted',
-                message: `Proposal draft ${study.title ?? 'Untitled Draft'} was successfully deleted`,
+                message: `Proposal draft ${draftLabel} was successfully deleted`,
                 color: 'green',
             })
         },
@@ -42,12 +45,12 @@ function useDeleteDraft(study: StudyRow) {
         close: () => setIsOpen(false),
         confirm: () => mutate({ studyId: study.id }),
         isPending,
+        draftLabel,
     }
 }
 
 export function DeleteDraftButton({ study }: { study: StudyRow }) {
-    const { isOpen, open, close, confirm, isPending } = useDeleteDraft(study)
-    const draftLabel = study.title ?? 'draft proposal'
+    const { isOpen, open, close, confirm, isPending, draftLabel } = useDeleteDraft(study)
 
     return (
         <>

--- a/src/components/dashboard/studies-table/study-action-link.test.tsx
+++ b/src/components/dashboard/studies-table/study-action-link.test.tsx
@@ -1,13 +1,39 @@
+import { useUser } from '@clerk/nextjs'
 import { StudyJobStatus, StudyStatus } from '@/database/types'
 import { mockStudyRow, renderWithProviders } from '@/tests/unit.helpers'
 import { screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { StudyActionLink } from './study-action-link'
 
 const ORG_SLUG = 'test-org'
 const STUDY_ID = '11111111-1111-4111-8111-111111111111'
+const RESEARCHER_ID = 'researcher-1' // matches mockStudyRow default
+
+function mockSignedInAs(userId: string) {
+    vi.mocked(useUser).mockReturnValue({
+        isLoaded: true,
+        isSignedIn: true,
+        user: {
+            id: 'clerk-id',
+            publicMetadata: {
+                format: 'v3',
+                user: { id: userId },
+                teams: null,
+                orgs: {
+                    [ORG_SLUG]: { id: 'org-id', slug: ORG_SLUG, type: 'lab', isAdmin: false },
+                },
+            },
+            unsafeMetadata: { currentOrgSlug: ORG_SLUG },
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+}
 
 describe('StudyActionLink', () => {
+    afterEach(() => {
+        vi.mocked(useUser).mockReset()
+    })
+
     describe('researcher audience', () => {
         it('links to edit page for DRAFT studies', () => {
             const study = mockStudyRow({ status: 'DRAFT' as StudyStatus })
@@ -151,6 +177,69 @@ describe('StudyActionLink', () => {
 
             const link = screen.getByRole('link', { name: /view details/i })
             expect(link.getAttribute('href')).toBe(`/lab-org/study/${STUDY_ID}/submitted`)
+        })
+
+        describe('delete bin icon visibility', () => {
+            beforeEach(() => {
+                mockSignedInAs(RESEARCHER_ID)
+            })
+
+            it('renders the bin icon to the right of Edit for DRAFT studies authored by the current user', async () => {
+                const study = mockStudyRow({ status: 'DRAFT' as StudyStatus, researcherId: RESEARCHER_ID })
+                renderWithProviders(
+                    <StudyActionLink
+                        study={study}
+                        audience="researcher"
+                        scope="user"
+                        orgSlug={ORG_SLUG}
+                        isHighlighted={false}
+                    />,
+                )
+
+                const editLink = await screen.findByRole('link', { name: /edit draft study/i })
+                const binButton = await screen.findByLabelText(/delete draft study/i)
+
+                expect(editLink).toBeInTheDocument()
+                expect(binButton).toBeInTheDocument()
+
+                // Bin must come AFTER the edit link in document order (i.e. to the right)
+                expect(editLink.compareDocumentPosition(binButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+            })
+
+            it('does NOT render the bin icon for DRAFT studies authored by a different user', async () => {
+                const study = mockStudyRow({ status: 'DRAFT' as StudyStatus, researcherId: 'someone-else' })
+                renderWithProviders(
+                    <StudyActionLink
+                        study={study}
+                        audience="researcher"
+                        scope="user"
+                        orgSlug={ORG_SLUG}
+                        isHighlighted={false}
+                    />,
+                )
+
+                await screen.findByRole('link', { name: /edit draft study/i })
+                expect(screen.queryByLabelText(/delete draft study/i)).not.toBeInTheDocument()
+            })
+
+            it.each<StudyStatus>(['PENDING-REVIEW', 'CHANGE-REQUESTED', 'APPROVED', 'REJECTED', 'ARCHIVED'])(
+                'does NOT render the bin icon when status is %s (even when current user is the researcher)',
+                async (status) => {
+                    const study = mockStudyRow({ status, researcherId: RESEARCHER_ID, jobStatusChanges: [] })
+                    renderWithProviders(
+                        <StudyActionLink
+                            study={study}
+                            audience="researcher"
+                            scope="user"
+                            orgSlug={ORG_SLUG}
+                            isHighlighted={false}
+                        />,
+                    )
+
+                    await screen.findByRole('link', { name: /view details/i })
+                    expect(screen.queryByLabelText(/delete draft study/i)).not.toBeInTheDocument()
+                },
+            )
         })
     })
 

--- a/src/components/dashboard/studies-table/study-action-link.tsx
+++ b/src/components/dashboard/studies-table/study-action-link.tsx
@@ -1,8 +1,11 @@
+import { Group } from '@mantine/core'
 import { Link } from '@/components/links'
 import { Routes } from '@/lib/routes'
 import { usePostSubmissionFeatureFlag } from '@/components/openstax-feature-flag'
+import { useSession } from '@/hooks/session'
 import { Audience, Scope, StudyRow } from './types'
 import { useStudyHref } from '@/hooks/use-study-href'
+import { DeleteDraftButton } from './delete-draft-button'
 
 type StudyActionLinkProps = {
     study: StudyRow
@@ -23,6 +26,7 @@ function ResearcherLink({
     scope: Scope
     isHighlighted: boolean
 }) {
+    const { session } = useSession()
     const isPostSubmissionFlow = usePostSubmissionFeatureFlag()
     const labSlug = study.submittedByOrgSlug || orgSlug
     const hasJobActivity = study.jobStatusChanges.length > 0
@@ -32,13 +36,17 @@ function ResearcherLink({
     const href = scope === 'org' ? (`${baseHref}?returnTo=org` as typeof baseHref) : baseHref
 
     if (study.status === 'DRAFT') {
+        const isAuthor = session?.user.id === study.researcherId
         return (
-            <Link
-                href={Routes.studyEdit({ orgSlug: labSlug, studyId: study.id })}
-                aria-label={`Edit draft study ${study.title}`}
-            >
-                Edit
-            </Link>
+            <Group gap="xs" justify="center" wrap="nowrap">
+                <Link
+                    href={Routes.studyEdit({ orgSlug: labSlug, studyId: study.id })}
+                    aria-label={`Edit draft study ${study.title}`}
+                >
+                    Edit
+                </Link>
+                {isAuthor && <DeleteDraftButton study={study} />}
+            </Group>
         )
     }
 

--- a/src/database/migrations/1779100000000_add_deleted_at_to_study.ts
+++ b/src/database/migrations/1779100000000_add_deleted_at_to_study.ts
@@ -1,0 +1,9 @@
+import { type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+    await db.schema.alterTable('study').addColumn('deleted_at', 'timestamptz').execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+    await db.schema.alterTable('study').dropColumn('deleted_at').execute()
+}

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -211,6 +211,7 @@ export interface Study {
     createdAt: Generated<Timestamp>
     datasets: string[] | null
     dataSources: Generated<string[]>
+    deletedAt: Timestamp | null
     descriptionDocPath: string | null
     id: Generated<string>
     impact: Json | null

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -1826,7 +1826,7 @@ describe('softDeleteStudyAction', () => {
     it('returns not-found for a study that does not exist', async () => {
         await mockSessionWithTestData({ orgType: 'lab' })
         await expect(softDeleteStudyAction({ studyId: BLANK_UUID })).resolves.toMatchObject({
-            error: expect.any(String),
+            error: expect.objectContaining({ user: expect.stringMatching(/not found/i) }),
         })
     })
 })

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -1,6 +1,7 @@
 import logger from '@/lib/logger'
 import { deliver } from '@/server/mailgun'
 import {
+    BLANK_UUID,
     actionResult,
     buildFeedback,
     createTestProposalDraft,
@@ -21,10 +22,12 @@ import {
     ackAgreementsAction,
     approveStudyProposalAction,
     doesTestImageExistForStudyAction,
+    fetchStudiesForCurrentResearcherUserAction,
     fetchStudiesForOrgAction,
     getCodeReviewFeedbackAction,
     getStudyAction,
     rejectStudyProposalAction,
+    softDeleteStudyAction,
     submitCodeReviewDecisionAction,
     submitProposalReviewAction,
 } from './study.actions'
@@ -1751,3 +1754,79 @@ function validCriteriaFixture() {
         privacyProtection: 'yes',
     } as const
 }
+
+describe('softDeleteStudyAction', () => {
+    it('soft-deletes a DRAFT study and hides it from the researcher dashboard', async () => {
+        const { lab, studyId, user } = await createTestProposalDraft({
+            enclaveSlug: 'soft-delete-draft-enclave',
+            studyInfo: { title: 'Doomed Draft' },
+        })
+
+        // sanity: lab dashboard sees the draft before delete
+        const before = await fetchStudiesForOrgAction({ orgSlug: lab.slug })
+        expect(before).toEqual(expect.arrayContaining([expect.objectContaining({ id: studyId })]))
+
+        const result = await softDeleteStudyAction({ studyId })
+        expect(result).toMatchObject({ title: 'Doomed Draft' })
+
+        const row = await db
+            .selectFrom('study')
+            .select(['deletedAt', 'status'])
+            .where('id', '=', studyId)
+            .executeTakeFirstOrThrow()
+        expect(row.deletedAt).not.toBeNull()
+        expect(row.status).toBe('DRAFT') // status untouched, only deletedAt set
+
+        // lab dashboard no longer surfaces the deleted draft
+        const after = await fetchStudiesForOrgAction({ orgSlug: lab.slug })
+        expect(after).not.toEqual(expect.arrayContaining([expect.objectContaining({ id: studyId })]))
+
+        // user dashboard also drops it
+        const userView = await fetchStudiesForCurrentResearcherUserAction()
+        expect(Array.isArray(userView)).toBe(true)
+        if (Array.isArray(userView)) {
+            expect(userView.find((s) => s.id === studyId)).toBeUndefined()
+        }
+        // silence unused warning if user was destructured but not otherwise referenced
+        expect(user.id).toBeTruthy()
+    })
+
+    it('rejects non-DRAFT studies', async () => {
+        const { studyId } = await createTestProposalDraft({
+            enclaveSlug: 'soft-delete-non-draft-enclave',
+            studyInfo: { title: 'Submitted Study' },
+        })
+        await setTestStudyStatus(studyId, 'PENDING-REVIEW')
+
+        await expect(softDeleteStudyAction({ studyId })).resolves.toMatchObject({
+            error: expect.objectContaining({ study: expect.stringMatching(/only draft/i) }),
+        })
+
+        const row = await db.selectFrom('study').select('deletedAt').where('id', '=', studyId).executeTakeFirstOrThrow()
+        expect(row.deletedAt).toBeNull()
+    })
+
+    it('rejects a researcher who is not the draft author', async () => {
+        const { lab, studyId } = await createTestProposalDraft({
+            enclaveSlug: 'soft-delete-non-author-enclave',
+            studyInfo: { title: 'Colleague Draft' },
+        })
+
+        // Different lab member — passes view/delete CASL but is not the draft author
+        await mockSessionWithTestData({ orgSlug: lab.slug, orgType: 'lab' })
+
+        await expect(softDeleteStudyAction({ studyId })).resolves.toMatchObject({
+            error: expect.objectContaining({ user: expect.stringMatching(/only the draft author/i) }),
+        })
+
+        const row = await db.selectFrom('study').select('deletedAt').where('id', '=', studyId).executeTakeFirstOrThrow()
+        expect(row.deletedAt).toBeNull()
+    })
+
+    it('returns not-found for a study that does not exist', async () => {
+        await mockSessionWithTestData({ orgType: 'lab' })
+        await expect(softDeleteStudyAction({ studyId: BLANK_UUID })).resolves.toMatchObject({
+            error: expect.any(String),
+        })
+    })
+})

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -37,7 +37,12 @@ import { SIMULATE_CODE_BUILD } from '../config'
 import { bareExtension } from '@/lib/paths'
 import { Action, z } from './action'
 
-// NOT exported, for internal use by actions in this file
+// NOT exported, for internal use by actions in this file.
+// Soft-delete filter (`deletedAt IS NULL`) is intentionally scoped to dashboard listings via this helper.
+// Direct study reads by ID elsewhere — editor polling, agreements/code-review middlewares, getInfoForStudyId —
+// stay lifecycle-agnostic. Because soft-delete only applies to DRAFTs and a deleted DRAFT is no longer surfaced
+// on any dashboard, the studyId is effectively undiscoverable. Stale editor tabs / direct URL bookmarks remain
+// a known gap.
 function fetchStudyQuery(db: DBExecutor) {
     return db
         .selectFrom('study')

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -41,6 +41,7 @@ import { Action, z } from './action'
 function fetchStudyQuery(db: DBExecutor) {
     return db
         .selectFrom('study')
+        .where('study.deletedAt', 'is', null)
         .leftJoin(
             // Subquery to get the most recent study job for each study
             (eb) =>
@@ -221,6 +222,29 @@ export const ackAgreementsAction = new Action('ackAgreementsAction', { performsM
             .where('id', '=', studyId)
             .where(column, 'is', null)
             .execute()
+    })
+
+export const softDeleteStudyAction = new Action('softDeleteStudyAction', { performsMutations: true })
+    .params(z.object({ studyId: z.string() }))
+    .middleware(async ({ params: { studyId }, db }) => {
+        const study = await db
+            .selectFrom('study')
+            .select(['id', 'status', 'title', 'researcherId', 'orgId', 'submittedByOrgId'])
+            .where('id', '=', studyId)
+            .where('deletedAt', 'is', null)
+            .executeTakeFirstOrThrow(throwNotFound('study'))
+        return { study, orgId: study.orgId, submittedByOrgId: study.submittedByOrgId }
+    })
+    .requireAbilityTo('delete', 'Study')
+    .handler(async ({ db, study, params: { studyId }, session }) => {
+        if (study.status !== 'DRAFT') {
+            throw new ActionFailure({ study: 'only draft studies can be deleted' })
+        }
+        if (study.researcherId !== session.user.id) {
+            throw new ActionFailure({ user: 'only the draft author can delete this proposal' })
+        }
+        await db.updateTable('study').set({ deletedAt: new Date() }).where('id', '=', studyId).execute()
+        return { title: study.title }
     })
 
 async function approveJobCode({


### PR DESCRIPTION
Issue: [OTTER-565](https://openstax.atlassian.net/browse/OTTER-565)

## Summary

Adds a delete affordance for proposal drafts on the researcher dashboard. A trash icon now appears to the right of the **Edit** link on any row where `status === 'DRAFT'` **and** the current user is the draft's original author. Clicking it opens a confirmation modal; confirming soft-deletes the study so it disappears from all dashboards but the row is preserved in the database for audit/recovery.

## Changes

- **Migration** — `src/database/migrations/1779100000000_add_deleted_at_to_study.ts` adds a nullable `deleted_at timestamptz` column to `study`. Regenerated `src/database/types.ts` via `kysely-codegen`.
- **Server action** — new `softDeleteStudyAction` in `src/server/actions/study.actions.ts`. Guards: study must be `DRAFT`, caller must be the original `researcherId`, and the row must not already be soft-deleted. Sets `deleted_at = now()`.
- **Query filter** — `fetchStudyQuery` now filters `study.deleted_at IS NULL`, so soft-deleted drafts are hidden from `fetchStudiesForOrgAction`, `fetchStudiesForCurrentResearcherUserAction`, `fetchStudiesForCurrentReviewerAction`, and `getStudyAction` in one place.
- **UI**
  - New `DeleteDraftButton` (`src/components/dashboard/studies-table/delete-draft-button.tsx`) — phosphor `TrashIcon` inside a Mantine `ActionIcon`, wired to `softDeleteStudyAction` via `useMutation`. On success it invalidates the researcher dashboard queries and shows a green `Proposal draft {studyTitle} was successfully deleted` toast.
  - `StudyActionLink` (`src/components/dashboard/studies-table/study-action-link.tsx`) wraps Edit + trash in a `Group`, gating the trash on `study.status === 'DRAFT' && session.user.id === study.researcherId`.
  - Modal uses the existing `AppModal` wrapper with the spec copy and a `red.9` confirm button.

### Accessibility

- The modal's header X button was rendering without an accessible name. Added `closeButtonProps={{ 'aria-label': 'Close' }}` to the `AppModal` usage in `DeleteDraftButton` so screen readers can identify the close affordance.

### Test coverage

**Server action** (`src/server/actions/study.actions.test.ts` — `softDeleteStudyAction`)
- Soft-deletes a DRAFT and hides it from `fetchStudiesForOrgAction` + `fetchStudiesForCurrentResearcherUserAction`
- Rejects non-DRAFT statuses
- Rejects a researcher who is not the draft author
- Returns a not-found error for unknown study IDs

**Bin icon visibility** (`src/components/dashboard/studies-table/study-action-link.test.tsx`)
- Bin renders to the right of **Edit** for DRAFT studies authored by the current user (verified via `compareDocumentPosition`)
- Bin is hidden for DRAFT studies authored by a different user
- Bin is hidden for every non-DRAFT status (parametrized: PENDING-REVIEW, CHANGE-REQUESTED, APPROVED, REJECTED, ARCHIVED)

**Modal + delete behavior** (`src/components/dashboard/studies-table/delete-draft-button.test.tsx`)
- Clicking the bin opens the modal with the exact spec title and body copy
- Confirm button is rendered with `--button-bg: var(--mantine-color-red-9)`
- **X** closes the modal without deleting
- **Cancel** closes the modal without deleting
- **Yes, delete proposal draft** sets `study.deleted_at`, fires a green toast reading `Proposal draft {studyTitle} was successfully deleted`, and does not fire a red error toast
- An action failure (e.g. attempting to delete a non-DRAFT) fires the red error toast and never the green success toast

[OTTER-565]: https://openstax.atlassian.net/browse/OTTER-565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ