### PR TITLE
OTTER 537: polish the post-submission study code page and add a per-file download icon

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/study-code-files.test.ts
+++ b/src/app/[orgSlug]/study/[studyId]/review/study-code-files.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import type { StudyJobFileType } from '@/database/types'
+import { filterAndOrderCodeFiles, type CodeFile } from './study-code-files'
+
+const file = (name: string, fileType: StudyJobFileType): CodeFile => ({ name, fileType })
+
+describe('filterAndOrderCodeFiles', () => {
+    it('drops non-code file types (security scan logs, encrypted artifacts, results)', () => {
+        const result = filterAndOrderCodeFiles([
+            file('main.R', 'MAIN-CODE'),
+            file('helper.R', 'SUPPLEMENTAL-CODE'),
+            file('security-scan.txt', 'SECURITY-SCAN-LOG'),
+            file('encrypted-logs.zip', 'ENCRYPTED-SECURITY-SCAN-LOG'),
+            file('result.csv', 'APPROVED-RESULT'),
+            file('packaging-error.log', 'PACKAGING-ERROR-LOG'),
+        ])
+
+        expect(result.map((f) => f.name)).toEqual(['main.R', 'helper.R'])
+    })
+
+    it('puts MAIN-CODE first and sorts SUPPLEMENTAL-CODE alphabetically regardless of input order', () => {
+        const result = filterAndOrderCodeFiles([
+            file('zeta.R', 'SUPPLEMENTAL-CODE'),
+            file('alpha.R', 'SUPPLEMENTAL-CODE'),
+            file('main.R', 'MAIN-CODE'),
+            file('beta.R', 'SUPPLEMENTAL-CODE'),
+        ])
+
+        expect(result.map((f) => f.name)).toEqual(['main.R', 'alpha.R', 'beta.R', 'zeta.R'])
+    })
+
+    it('returns an empty array when no code files are present', () => {
+        const result = filterAndOrderCodeFiles([
+            file('security-scan.txt', 'SECURITY-SCAN-LOG'),
+            file('result.csv', 'APPROVED-RESULT'),
+        ])
+
+        expect(result).toEqual([])
+    })
+
+    it('preserves extra fields on the input element (generic shape)', () => {
+        const created = new Date('2026-01-15T10:00:00Z')
+        const input = [
+            { name: 'main.R', fileType: 'MAIN-CODE' as const, createdAt: created, sizeBytes: 1234 },
+            { name: 'helper.R', fileType: 'SUPPLEMENTAL-CODE' as const, createdAt: created, sizeBytes: 567 },
+            { name: 'scan.txt', fileType: 'SECURITY-SCAN-LOG' as const, createdAt: created, sizeBytes: 42 },
+        ]
+
+        const result = filterAndOrderCodeFiles(input)
+
+        expect(result).toEqual([
+            { name: 'main.R', fileType: 'MAIN-CODE', createdAt: created, sizeBytes: 1234 },
+            { name: 'helper.R', fileType: 'SUPPLEMENTAL-CODE', createdAt: created, sizeBytes: 567 },
+        ])
+        expect(result[0].createdAt).toBe(created)
+        expect(result[0].sizeBytes).toBe(1234)
+    })
+})

--- a/src/app/[orgSlug]/study/[studyId]/review/study-code-files.ts
+++ b/src/app/[orgSlug]/study/[studyId]/review/study-code-files.ts
@@ -1,17 +1,17 @@
 import type { StudyJobFileType } from '@/database/types'
-import type { LatestJobForStudy } from '@/server/db/queries'
 
 export type CodeFile = { name: string; fileType: StudyJobFileType }
 
 const CODE_FILE_TYPES: StudyJobFileType[] = ['MAIN-CODE', 'SUPPLEMENTAL-CODE']
 
-// MAIN-CODE files first, then SUPPLEMENTAL-CODE alphabetized — keeps the entry
-// point file pinned to the leftmost tab regardless of insertion order.
-export function filterAndOrderCodeFiles(files: LatestJobForStudy['files']): CodeFile[] {
+// MAIN-CODE files first, then SUPPLEMENTAL-CODE alphabetized. Generic on the
+// input element so callers that need the full file shape (e.g. for createdAt)
+// get it back, while callers typed against the narrower CodeFile still work.
+export function filterAndOrderCodeFiles<T extends CodeFile>(files: readonly T[]): T[] {
     const codeFiles = files.filter((f) => CODE_FILE_TYPES.includes(f.fileType))
     const main = codeFiles.filter((f) => f.fileType === 'MAIN-CODE')
     const supplemental = codeFiles
         .filter((f) => f.fileType === 'SUPPLEMENTAL-CODE')
         .sort((a, b) => a.name.localeCompare(b.name))
-    return [...main, ...supplemental].map((f) => ({ name: f.name, fileType: f.fileType }))
+    return [...main, ...supplemental]
 }

--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.test.tsx
@@ -181,6 +181,59 @@ describe('CodePostSubmissionView', () => {
 
             expect(toggle).toHaveAttribute('aria-expanded', 'false')
         })
+
+        it('excludes non-code files (security scan logs, encrypted logs) from the submitted code table', async () => {
+            const { org, user } = await mockSessionWithTestData({ orgSlug: ORG_SLUG, orgType: 'lab' })
+            const { study: dbStudy, job } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'PENDING-REVIEW',
+                jobStatus: 'CODE-SUBMITTED',
+                title: 'Mixed Files Study',
+            })
+            await db
+                .insertInto('studyJobFile')
+                .values([
+                    {
+                        studyJobId: job.id,
+                        name: 'main.R',
+                        path: `${org.slug}/${dbStudy.id}/${job.id}/main.R`,
+                        fileType: 'MAIN-CODE',
+                    },
+                    {
+                        studyJobId: job.id,
+                        name: 'helper.R',
+                        path: `${org.slug}/${dbStudy.id}/${job.id}/helper.R`,
+                        fileType: 'SUPPLEMENTAL-CODE',
+                    },
+                    {
+                        studyJobId: job.id,
+                        name: 'encrypted-logs.zip',
+                        path: `${org.slug}/${dbStudy.id}/${job.id}/encrypted-logs.zip`,
+                        fileType: 'ENCRYPTED-SECURITY-SCAN-LOG',
+                    },
+                    {
+                        studyJobId: job.id,
+                        name: 'security-scan-log.txt',
+                        path: `${org.slug}/${dbStudy.id}/${job.id}/security-scan-log.txt`,
+                        fileType: 'SECURITY-SCAN-LOG',
+                    },
+                ])
+                .execute()
+
+            const study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+            const latestJob = (await latestJobForStudy(dbStudy.id)) as LatestJobForStudy
+            ;(useParams as Mock).mockReturnValue({ orgSlug: ORG_SLUG, studyId: study.id })
+            renderView(study, latestJob)
+
+            const interact = userEvent.setup()
+            await interact.click(screen.getByTestId('study-code-toggle'))
+
+            expect(screen.getByText('main.R')).toBeInTheDocument()
+            expect(screen.getByText('helper.R')).toBeInTheDocument()
+            expect(screen.queryByText('encrypted-logs.zip')).not.toBeInTheDocument()
+            expect(screen.queryByText('security-scan-log.txt')).not.toBeInTheDocument()
+        })
     })
 
     describe('navigation', () => {

--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.test.tsx
@@ -94,14 +94,15 @@ describe('CodePostSubmissionView', () => {
     })
 
     describe('banner', () => {
-        it('renders the yellow status banner with the data org name and the 7-10 days copy', async () => {
+        it('renders the yellow status banner with the data org name and the Figma copy', async () => {
             const { study, job } = await setupSubmittedStudy()
             renderView(study, job, { reviewingOrgName: REVIEWING_ORG_NAME })
 
             const banner = screen.getByTestId('code-under-review-banner')
             expect(banner).toHaveTextContent(REVIEWING_ORG_NAME)
-            expect(banner).toHaveTextContent(/7-10 days/)
-            expect(banner).toHaveTextContent(/successfully submitted/)
+            expect(banner).toHaveTextContent(/AI-generated summary of its behavior/)
+            expect(banner).toHaveTextContent(/7-10 business days/)
+            expect(banner).toHaveTextContent(/email notifications about updates/)
         })
 
         it('renders the banner with the AC-specified background color #FFF9E5', async () => {
@@ -128,7 +129,8 @@ describe('CodePostSubmissionView', () => {
             const interact = userEvent.setup()
             await interact.click(screen.getByTestId('study-code-toggle'))
 
-            expect(screen.getByTestId('study-code-toggle')).toHaveAttribute('aria-expanded', 'true')
+            // The outer "View full study code" toggle unmounts once expanded.
+            expect(screen.queryByTestId('study-code-toggle')).not.toBeInTheDocument()
             expect(screen.getByTestId('submitted-code-table')).toBeInTheDocument()
             expect(
                 screen.getByText('View the code files that you uploaded to run against the dataset.'),
@@ -167,19 +169,15 @@ describe('CodePostSubmissionView', () => {
             renderView(study, job)
 
             const interact = userEvent.setup()
-            const toggle = screen.getByTestId('study-code-toggle')
-            await interact.click(toggle)
-            expect(toggle).toHaveAttribute('aria-expanded', 'true')
+            await interact.click(screen.getByTestId('study-code-toggle'))
 
-            // When expanded, "Hide full study code" appears twice: once as the top toggle's
-            // label, once as the in-section anchor at the bottom of the collapse. Click the
-            // in-section one (the entry that is not the toggle button).
-            const hideLabels = screen.getAllByText('Hide full study code')
-            const inSectionHide = hideLabels.find((el) => el.closest('[data-testid="study-code-toggle"]') === null)
-            expect(inSectionHide).toBeDefined()
-            await interact.click(inSectionHide!)
+            // After expansion the outer "View full study code" toggle unmounts; only the
+            // in-section "Hide full study code" anchor remains.
+            expect(screen.queryByTestId('study-code-toggle')).not.toBeInTheDocument()
 
-            expect(toggle).toHaveAttribute('aria-expanded', 'false')
+            await interact.click(screen.getByText('Hide full study code'))
+
+            expect(screen.getByTestId('study-code-toggle')).toHaveAttribute('aria-expanded', 'false')
         })
 
         it('excludes non-code files (security scan logs, encrypted logs) from the submitted code table', async () => {

--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.tsx
@@ -62,9 +62,6 @@ export function CodePostSubmissionView({
         ['Study code'],
     ]
 
-    const toggleLabel = expanded ? 'Hide full study code' : 'View full study code'
-    const caretRotation = expanded ? 'rotate(-90deg)' : 'rotate(0deg)'
-
     const codeFiles = job.files.filter((f) => f.fileType === 'MAIN-CODE' || f.fileType === 'SUPPLEMENTAL-CODE')
 
     return (
@@ -88,34 +85,43 @@ export function CodePostSubmissionView({
                     </Group>
                     <Divider my="md" />
                     <Alert color="yellow" mt="md" bg="#FFF9E5" data-testid="code-under-review-banner">
-                        Your study code has been successfully submitted to {displayOrgName(reviewingOrgName)}. They will
-                        review it and respond with feedback, follow-up questions, or a decision. You&apos;ll receive
-                        email notifications as your code progresses through the review process. Please allow an
-                        estimated 7-10 days for a complete code review. Review timelines vary by data organization.
+                        Your study code has been submitted to {displayOrgName(reviewingOrgName)}. They will have access
+                        to your study code and an AI-generated summary of its behavior. Please allow 7-10 business days
+                        for review. You&apos;ll receive email notifications about updates.
                     </Alert>
-                    <Anchor
-                        component="button"
-                        size="sm"
-                        fw={700}
-                        onClick={toggle}
-                        mt="md"
-                        display="inline-flex"
-                        style={{ alignItems: 'center', gap: 4 }}
-                        aria-expanded={expanded}
-                        data-testid="study-code-toggle"
-                    >
-                        {toggleLabel}
-                        <CaretRightIcon size={12} style={{ transition: 'transform 200ms', transform: caretRotation }} />
-                    </Anchor>
+                    {!expanded && (
+                        <Anchor
+                            component="button"
+                            size="sm"
+                            fw={700}
+                            onClick={toggle}
+                            mt="md"
+                            display="inline-flex"
+                            style={{ alignItems: 'center', gap: 4 }}
+                            aria-expanded={expanded}
+                            data-testid="study-code-toggle"
+                        >
+                            View full study code
+                            <CaretRightIcon size={12} />
+                        </Anchor>
+                    )}
                 </Paper>
 
                 <Collapse in={expanded}>
                     <Paper p="xxl">
                         <Stack gap="md">
-                            <Title order={5}>Submitted code</Title>
-                            <Anchor href={proposalHref} target="_blank" rel="noopener noreferrer" fw={700} size="sm">
-                                View approved initial request
-                            </Anchor>
+                            <Group justify="space-between" align="center">
+                                <Title order={5}>Submitted code</Title>
+                                <Anchor
+                                    href={proposalHref}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    fw={700}
+                                    size="sm"
+                                >
+                                    View approved initial request
+                                </Anchor>
+                            </Group>
                             <Divider />
                             <Text>View the code files that you uploaded to run against the dataset.</Text>
                             <SubmittedCodeTable jobId={job.id} files={codeFiles} />

--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.tsx
@@ -65,6 +65,8 @@ export function CodePostSubmissionView({
     const toggleLabel = expanded ? 'Hide full study code' : 'View full study code'
     const caretRotation = expanded ? 'rotate(-90deg)' : 'rotate(0deg)'
 
+    const codeFiles = job.files.filter((f) => f.fileType === 'MAIN-CODE' || f.fileType === 'SUPPLEMENTAL-CODE')
+
     return (
         <Stack p="xl" gap="xl">
             <PageBreadcrumbs crumbs={breadcrumbs} />
@@ -116,7 +118,7 @@ export function CodePostSubmissionView({
                             </Anchor>
                             <Divider />
                             <Text>View the code files that you uploaded to run against the dataset.</Text>
-                            <SubmittedCodeTable jobId={job.id} files={job.files} />
+                            <SubmittedCodeTable jobId={job.id} files={codeFiles} />
                             <Anchor
                                 component="button"
                                 size="sm"

--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.tsx
@@ -12,6 +12,7 @@ import { Routes } from '@/lib/routes'
 import { SubmittedCodeTable } from '@/components/study/submitted-code-table'
 import type { LatestJobForStudy } from '@/server/db/queries'
 import type { SelectedStudy } from '@/server/actions/study.actions'
+import { filterAndOrderCodeFiles } from '@/app/[orgSlug]/study/[studyId]/review/study-code-files'
 
 interface CodePostSubmissionViewProps {
     orgSlug: string
@@ -42,6 +43,26 @@ const SubmittedTimestamp: FC<{ submittedOn: string | null }> = ({ submittedOn })
     )
 }
 
+const ExpandToggle: FC<{ isVisible: boolean; onClick: () => void }> = ({ isVisible, onClick }) => {
+    if (!isVisible) return null
+    return (
+        <Anchor
+            component="button"
+            size="sm"
+            fw={700}
+            onClick={onClick}
+            mt="md"
+            display="inline-flex"
+            style={{ alignItems: 'center', gap: 4 }}
+            aria-expanded={false}
+            data-testid="study-code-toggle"
+        >
+            View full study code
+            <CaretRightIcon size={12} />
+        </Anchor>
+    )
+}
+
 export function CodePostSubmissionView({
     orgSlug,
     study,
@@ -62,7 +83,7 @@ export function CodePostSubmissionView({
         ['Study code'],
     ]
 
-    const codeFiles = job.files.filter((f) => f.fileType === 'MAIN-CODE' || f.fileType === 'SUPPLEMENTAL-CODE')
+    const codeFiles = filterAndOrderCodeFiles(job.files)
 
     return (
         <Stack p="xl" gap="xl">
@@ -89,22 +110,7 @@ export function CodePostSubmissionView({
                         to your study code and an AI-generated summary of its behavior. Please allow 7-10 business days
                         for review. You&apos;ll receive email notifications about updates.
                     </Alert>
-                    {!expanded && (
-                        <Anchor
-                            component="button"
-                            size="sm"
-                            fw={700}
-                            onClick={toggle}
-                            mt="md"
-                            display="inline-flex"
-                            style={{ alignItems: 'center', gap: 4 }}
-                            aria-expanded={expanded}
-                            data-testid="study-code-toggle"
-                        >
-                            View full study code
-                            <CaretRightIcon size={12} />
-                        </Anchor>
-                    )}
+                    <ExpandToggle isVisible={!expanded} onClick={toggle} />
                 </Paper>
 
                 <Collapse in={expanded}>

--- a/src/components/study/submitted-code-table.test.tsx
+++ b/src/components/study/submitted-code-table.test.tsx
@@ -56,6 +56,21 @@ describe('SubmittedCodeTable', () => {
         expect(screen.getByText(/print/)).toBeInTheDocument()
     })
 
+    it('renders a download anchor per row pointing at the /dl/study-code route', () => {
+        const files = [
+            buildFile({ name: 'main.py', fileType: 'MAIN-CODE' }),
+            buildFile({ name: 'helper.py', fileType: 'SUPPLEMENTAL-CODE' }),
+        ]
+        renderWithProviders(<SubmittedCodeTable jobId="job-1" files={files} />)
+
+        const main = screen.getByRole('link', { name: 'Download main.py' })
+        expect(main).toHaveAttribute('href', '/dl/study-code/job-1/main.py')
+        expect(main).toHaveAttribute('download', 'main.py')
+
+        const helper = screen.getByRole('link', { name: 'Download helper.py' })
+        expect(helper).toHaveAttribute('href', '/dl/study-code/job-1/helper.py')
+    })
+
     it('closes the modal when onClose is fired', async () => {
         mockFetch.mockResolvedValue({ fileName: 'main.py', contents: 'x = 1' })
 

--- a/src/components/study/submitted-code-table.tsx
+++ b/src/components/study/submitted-code-table.tsx
@@ -2,11 +2,12 @@
 
 import { useState, type FC } from 'react'
 import { ActionIcon, Divider, Group, Table, Text, Tooltip } from '@mantine/core'
-import { EyeIcon, StarIcon } from '@phosphor-icons/react/dist/ssr'
+import { DownloadSimpleIcon, EyeIcon, StarIcon } from '@phosphor-icons/react/dist/ssr'
 import { useQuery } from '@/common'
 import { fetchStudyJobCodeFileAction } from '@/server/actions/study-job.actions'
 import type { LatestJobForStudy } from '@/server/db/queries'
 import { FilePreviewModal } from '@/components/file-preview-modal'
+import { studyCodeURL } from '@/lib/paths'
 
 type SubmittedFile = LatestJobForStudy['files'][number]
 
@@ -23,10 +24,11 @@ const formatUpdatedAt = (date: Date | string) =>
         minute: '2-digit',
     })
 
-const SubmittedCodeRow: FC<{ file: SubmittedFile; onPreview: (file: SubmittedFile) => void }> = ({
-    file,
-    onPreview,
-}) => {
+const SubmittedCodeRow: FC<{
+    file: SubmittedFile
+    jobId: string
+    onPreview: (file: SubmittedFile) => void
+}> = ({ file, jobId, onPreview }) => {
     const isMain = file.fileType === 'MAIN-CODE'
     const starWeight = isMain ? 'fill' : 'regular'
     const starColor = isMain ? 'var(--mantine-color-indigo-6)' : 'var(--mantine-color-gray-5)'
@@ -61,6 +63,16 @@ const SubmittedCodeRow: FC<{ file: SubmittedFile; onPreview: (file: SubmittedFil
                     >
                         <EyeIcon weight="fill" />
                     </ActionIcon>
+                    <ActionIcon
+                        component="a"
+                        href={studyCodeURL(jobId, file.name)}
+                        download={file.name}
+                        variant="subtle"
+                        color="gray"
+                        aria-label={`Download ${file.name}`}
+                    >
+                        <DownloadSimpleIcon weight="fill" />
+                    </ActionIcon>
                 </Group>
             </Table.Td>
         </Table.Tr>
@@ -90,7 +102,7 @@ export const SubmittedCodeTable: FC<SubmittedCodeTableProps> = ({ jobId, files }
         : null
 
     const rowElements = files.map((file) => (
-        <SubmittedCodeRow key={file.name} file={file} onPreview={(f) => setPreviewFileName(f.name)} />
+        <SubmittedCodeRow key={file.name} file={file} jobId={jobId} onPreview={(f) => setPreviewFileName(f.name)} />
     ))
 
     return (


### PR DESCRIPTION
see [OTTER-537 comments](https://openstax.atlassian.net/browse/OTTER-537)

- Update the post-submission status banner copy to match the Figma design.
- Hide encrypted scan logs and other non-code artifacts from the submitted code table so only files the researcher uploaded show up.
- Remove the duplicate "Hide full study code" toggle so the show/hide control only appears once.
- Move the "View approved initial request" link to the top-right of the submitted code section header.
- Add a one-click download icon next to the eye icon for each submitted file.