### PR TITLE
Restyle code review criteria banner to match mockup

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-criteria.ts
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-criteria.ts
@@ -11,3 +11,10 @@ export const CODE_REVIEW_CRITERIA: readonly CodeReviewCriterion[] = [
     { key: 'securityChecks', label: 'Security and vulnerability checks passed' },
     { key: 'privacyProtection', label: 'No risk of PII exposure expected in outputs' },
 ]
+
+export const CODE_REVIEW_BANNER_CRITERIA: readonly { label: string; description: string }[] = [
+    { label: 'Proposal alignment', description: 'Does the code align with the approved research proposal?' },
+    { label: 'Agreement compliance', description: 'Does the code comply with all the agreements?' },
+    { label: 'Security checks', description: 'Have security and vulnerability checks been passed?' },
+    { label: 'Privacy protection', description: 'Is there any risk of PII exposure expected in the outputs?' },
+]

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.test.tsx
@@ -101,9 +101,9 @@ describe('CodeReviewRedesignView', () => {
         renderWithProviders(await CodeReviewRedesignView({ orgSlug: ORG_SLUG, study }))
 
         const criteria = screen.getByTestId('code-review-criteria')
-        expect(criteria).toHaveTextContent('Code aligns with approved research proposal')
-        expect(criteria).toHaveTextContent('Code aligns with all the agreements')
-        expect(criteria).toHaveTextContent('Security and vulnerability checks passed')
-        expect(criteria).toHaveTextContent('No risk of PII exposure expected in outputs')
+        expect(criteria).toHaveTextContent('Proposal alignment: Does the code align with the approved research proposal?')
+        expect(criteria).toHaveTextContent('Agreement compliance: Does the code comply with all the agreements?')
+        expect(criteria).toHaveTextContent('Security checks: Have security and vulnerability checks been passed?')
+        expect(criteria).toHaveTextContent('Privacy protection: Is there any risk of PII exposure expected in the outputs?')
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.test.tsx
@@ -101,9 +101,13 @@ describe('CodeReviewRedesignView', () => {
         renderWithProviders(await CodeReviewRedesignView({ orgSlug: ORG_SLUG, study }))
 
         const criteria = screen.getByTestId('code-review-criteria')
-        expect(criteria).toHaveTextContent('Proposal alignment: Does the code align with the approved research proposal?')
+        expect(criteria).toHaveTextContent(
+            'Proposal alignment: Does the code align with the approved research proposal?',
+        )
         expect(criteria).toHaveTextContent('Agreement compliance: Does the code comply with all the agreements?')
         expect(criteria).toHaveTextContent('Security checks: Have security and vulnerability checks been passed?')
-        expect(criteria).toHaveTextContent('Privacy protection: Is there any risk of PII exposure expected in the outputs?')
+        expect(criteria).toHaveTextContent(
+            'Privacy protection: Is there any risk of PII exposure expected in the outputs?',
+        )
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-redesign-view.tsx
@@ -8,7 +8,7 @@ import { getStudyReviewForJob, jobScanResultForJob, latestJobForStudyOrNull } fr
 import { Box, Stack, Title } from '@mantine/core'
 import type { SelectedStudy } from '@/server/actions/study.actions'
 import { CodeReviewClient } from './code-review-client'
-import { CODE_REVIEW_CRITERIA } from './code-review-criteria'
+import { CODE_REVIEW_BANNER_CRITERIA } from './code-review-criteria'
 import { SubmittedCodeSection } from './submitted-code-section'
 
 type CodeReviewRedesignViewProps = {
@@ -28,7 +28,7 @@ function CodeReviewStatusBanner({ labName }: { labName: string }) {
                     code based on these criteria:
                 </>
             }
-            criteria={CODE_REVIEW_CRITERIA}
+            criteria={CODE_REVIEW_BANNER_CRITERIA}
         />
     )
 }


### PR DESCRIPTION
Issue: [OTTER-559](https://openstax.atlassian.net/browse/OTTER-559)

## Summary
- Restyle the review criteria banner on the code review page so each criterion renders as a bold short label followed by a question (e.g. **Proposal alignment:** Does the code align with the approved research proposal?), matching the latest design mockup.
- Add a new `CODE_REVIEW_BANNER_CRITERIA` constant scoped to the banner display, leaving the existing `CODE_REVIEW_CRITERIA` (used by the evaluation section's radio rows) untouched.

[OTTER-559]: https://openstax.atlassian.net/browse/OTTER-559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ