### PR TITLE
Fix invitation signup MFA dead-end for new accounts

### DIFF
--- a/src/app/account/invitation/[inviteId]/signup/page.tsx
+++ b/src/app/account/invitation/[inviteId]/signup/page.tsx
@@ -16,8 +16,6 @@ import { useRouter } from 'next/navigation'
 import { FC, use, useState } from 'react'
 import { getOrgInfoForInviteAction, onCreateAccountAction, onPendingUserLoginAction } from '../create-account.action'
 import { Routes } from '@/lib/routes'
-import { RequestMFA } from '@/app/account/signin/mfa'
-import { type MFAState } from '@/app/account/signin/logic'
 
 const formSchema = z
     .object({
@@ -50,14 +48,10 @@ type InviteData = {
     orgName: string
 }
 
-type SignupStep = 'form' | 'mfa'
-
 const SetupAccountForm: FC<InviteData> = ({ inviteId, email, orgName }) => {
     const { setActive, signIn } = useSignIn()
     const theme = useMantineTheme()
     const router = useRouter()
-    const [step, setStep] = useState<SignupStep>('form')
-    const [mfaState, setMfaState] = useState<MFAState>(false)
     const [termsAccepted, setTermsAccepted] = useState(false)
 
     const form = useForm({
@@ -94,8 +88,14 @@ const SetupAccountForm: FC<InviteData> = ({ inviteId, email, orgName }) => {
                     await onPendingUserLoginAction({ inviteId })
                     router.push(Routes.accountMfa)
                 } else if (attempt.status === 'needs_second_factor') {
-                    setMfaState({ signIn: attempt, usingSMS: false })
-                    setStep('mfa')
+                    // A freshly-created account has no MFA factors enrolled, so a second-factor
+                    // challenge here is unsatisfiable — handing this state to <RequestMFA> would
+                    // strand the user on the "No MFA factors are configured" dead-end screen.
+                    // The instance-level Clerk MFA policy must allow first sign-in to complete
+                    // so the user can reach /account/mfa to enroll.
+                    reportError(
+                        'Your account was created, but multi-factor authentication is required before you can sign in. Please contact your administrator.',
+                    )
                 } else {
                     console.error(
                         'Sign-in status:',
@@ -111,10 +111,6 @@ const SetupAccountForm: FC<InviteData> = ({ inviteId, email, orgName }) => {
             }
         },
     })
-
-    if (step === 'mfa' && mfaState) {
-        return <RequestMFA mfa={mfaState} />
-    }
 
     return (
         <Paper bg="white" p="xxl" radius="sm" w={600} my={{ base: '1rem', lg: 0 }}>


### PR DESCRIPTION
## Bug

A newly-invited user who entered their name and password on the invitation signup page was being shown:

> **Multi-Factor Authentication required**
> No MFA factors are configured for your account. Please contact your administrator to set up MFA, or use a recovery code if you have one.
> [Try recovery code]

…before they had any chance to enroll a factor — a dead end (no recovery code either).

## Root cause

The post-create sign-in attempt in \`src/app/account/invitation/[inviteId]/signup/page.tsx\` can return \`status === 'needs_second_factor'\` when the Clerk instance requires MFA at sign-in. Commit \`d62fab78\` (Dec 22) added a branch that hands that state to \`<RequestMFA>\`, the second-factor *challenge* UI. But a freshly-created account has no factors enrolled — \`supportedSecondFactors\` is empty — so \`<RequestMFA>\` falls into its \`hasNoFactors\` branch and renders the dead-end screen.

The branch is unreachable-by-design for fresh accounts: \`setActive\` cannot succeed while \`needs_second_factor\` is pending, so we can't get the user into an active session to reach \`/account/mfa\` and enroll a factor either.

## Fix

Remove the broken branch and surface an actionable error notification instead. The user no longer hits the dead-end screen; they get a clear message telling them what to do.

## Follow-up (not in this PR)

The real remedy is at the Clerk instance level: first sign-in for a freshly-created user must reach \`status === 'complete'\` so the existing redirect to \`/account/mfa\` can enroll a factor. Worth confirming whether the Clerk MFA policy was recently switched to \"required at sign-in\" — if so, that's likely what started triggering this code path. The signup flow inherently can't enroll MFA before the user is signed in.

## Verification

- \`npm run typecheck\` — passes
- \`npm run lint\` (via lint-staged on commit) — passes
- \`npx vitest run src/app/account/signin src/app/account/invitation\` — 17/17 pass

There is no existing unit test for \`signup/page.tsx\`; this PR doesn't add one because the change is a deletion of a broken branch plus a string error message.