### PR TITLE
OTTER-572: resume drafts on Step 2 when Step 2 fields exist

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/edit/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit/page.test.tsx
@@ -20,8 +20,8 @@ beforeEach(() => {
     })
 })
 
-const renderRoute = (orgSlug: string, studyId: string) =>
-    StudyEditPage({ params: Promise.resolve({ orgSlug, studyId }) })
+const renderRoute = (orgSlug: string, studyId: string, searchParams: { from?: string } = {}) =>
+    StudyEditPage({ params: Promise.resolve({ orgSlug, studyId }), searchParams: Promise.resolve(searchParams) })
 
 const setupDraft = async () => {
     const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
@@ -103,5 +103,26 @@ describe('StudyEditPage', () => {
                 expect(mockRedirect).toHaveBeenCalledWith(`/${org.slug}/study/${study.id}/proposal`)
             },
         )
+    })
+
+    // Step 2's "Previous" footer button saves the form (which writes Step-2 fields) then
+    // navigates here with ?from=step2. Without this override, the draftHasStep2Progress
+    // check would bounce the researcher right back to /proposal — the page they were
+    // trying to leave — creating a dead Previous button.
+    it('renders Step 1 when arriving from Step 2 Previous, even with Step 2 fields populated', async () => {
+        const { org, study } = await setupDraft()
+        const { user: piUser } = await insertTestUser({ org })
+        await db
+            .updateTable('study')
+            .set({ piUserId: piUser.id, datasets: ['students'] })
+            .where('id', '=', study.id)
+            .execute()
+        ;(useParams as Mock).mockReturnValue({ orgSlug: org.slug, studyId: study.id })
+
+        const page = await renderRoute(org.slug, study.id, { from: 'step2' })
+        renderWithProviders(<StudyRequestProvider submittingOrgSlug={org.slug}>{page!}</StudyRequestProvider>)
+
+        expect(mockRedirect).not.toHaveBeenCalled()
+        expect(screen.getByRole('button', { name: /Proceed to Step 2/i })).toBeInTheDocument()
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/edit/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit/page.test.tsx
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { redirect, useParams } from 'next/navigation'
+import { StudyRequestProvider } from '@/contexts/study-request'
+import {
+    db,
+    insertTestStudyJobData,
+    insertTestUser,
+    mockSessionWithTestData,
+    renderWithProviders,
+    screen,
+    type Mock,
+} from '@/tests/unit.helpers'
+import StudyEditPage from './page'
+
+const mockRedirect = vi.mocked(redirect)
+
+beforeEach(() => {
+    mockRedirect.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT')
+    })
+})
+
+const renderRoute = (orgSlug: string, studyId: string) =>
+    StudyEditPage({ params: Promise.resolve({ orgSlug, studyId }) })
+
+const setupDraft = async () => {
+    const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+    const { study } = await insertTestStudyJobData({
+        org,
+        researcherId: user.id,
+        studyStatus: 'DRAFT',
+        jobStatus: 'JOB-READY',
+    })
+    return { org, user, study }
+}
+
+const LEXICAL_BODY = JSON.stringify({ root: { children: [{ type: 'paragraph', children: [] }] } })
+
+describe('StudyEditPage', () => {
+    it('renders the Step 1 form when the draft has no Step 2 fields populated', async () => {
+        const { org, study } = await setupDraft()
+        // <StudyProposal /> calls useStudyRequest(); production wires the provider in
+        // /[orgSlug]/study/layout.tsx (which the test render does not exercise).
+        ;(useParams as Mock).mockReturnValue({ orgSlug: org.slug, studyId: study.id })
+
+        const page = await renderRoute(org.slug, study.id)
+        renderWithProviders(<StudyRequestProvider submittingOrgSlug={org.slug}>{page!}</StudyRequestProvider>)
+
+        expect(mockRedirect).not.toHaveBeenCalled()
+        // The Step 1 form's "Proceed to Step 2" footer button is the cheapest, most stable proof
+        // that we rendered <StudyProposal /> (Step 1) rather than redirecting away.
+        expect(screen.getByRole('button', { name: /Proceed to Step 2/i })).toBeInTheDocument()
+    })
+
+    it('shows the not-found message for non-DRAFT studies', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+        const { study } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'APPROVED',
+        })
+
+        const page = await renderRoute(org.slug, study.id)
+        renderWithProviders(page!)
+
+        expect(screen.getByText(/Only studies that are in DRAFT status can be edited/i)).toBeInTheDocument()
+        expect(mockRedirect).not.toHaveBeenCalled()
+    })
+
+    describe('redirects to Step 2 when the draft has Step 2 progress', () => {
+        it('redirects when a PI user has been selected', async () => {
+            const { org, study } = await setupDraft()
+            const { user: piUser } = await insertTestUser({ org })
+            await db.updateTable('study').set({ piUserId: piUser.id }).where('id', '=', study.id).execute()
+
+            await expect(renderRoute(org.slug, study.id)).rejects.toThrow('NEXT_REDIRECT')
+            expect(mockRedirect).toHaveBeenCalledWith(`/${org.slug}/study/${study.id}/proposal`)
+        })
+
+        it('redirects when datasets have been picked', async () => {
+            const { org, study } = await setupDraft()
+            await db
+                .updateTable('study')
+                .set({ datasets: ['students'] })
+                .where('id', '=', study.id)
+                .execute()
+
+            await expect(renderRoute(org.slug, study.id)).rejects.toThrow('NEXT_REDIRECT')
+            expect(mockRedirect).toHaveBeenCalledWith(`/${org.slug}/study/${study.id}/proposal`)
+        })
+
+        it.each(['researchQuestions', 'projectSummary', 'impact', 'additionalNotes'] as const)(
+            'redirects when %s has been saved',
+            async (field) => {
+                const { org, study } = await setupDraft()
+                await db
+                    .updateTable('study')
+                    .set({ [field]: JSON.parse(LEXICAL_BODY) })
+                    .where('id', '=', study.id)
+                    .execute()
+
+                await expect(renderRoute(org.slug, study.id)).rejects.toThrow('NEXT_REDIRECT')
+                expect(mockRedirect).toHaveBeenCalledWith(`/${org.slug}/study/${study.id}/proposal`)
+            },
+        )
+    })
+})

--- a/src/app/[orgSlug]/study/[studyId]/edit/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit/page.tsx
@@ -5,8 +5,12 @@ import { Routes } from '@/lib/routes'
 import { draftHasStep2Progress } from '@/lib/studies'
 import { StudyProposal } from '../../request/proposal'
 
-export default async function StudyEditPage(props: { params: Promise<{ studyId: string; orgSlug: string }> }) {
+export default async function StudyEditPage(props: {
+    params: Promise<{ studyId: string; orgSlug: string }>
+    searchParams: Promise<{ from?: string }>
+}) {
     const params = await props.params
+    const searchParams = await props.searchParams
     const { studyId, orgSlug } = params
 
     // TODO: validate that member from clerk session matches memberId from url
@@ -43,8 +47,10 @@ export default async function StudyEditPage(props: { params: Promise<{ studyId: 
     }
 
     // OTTER-572: drafts that already reached Step 2 reopen on Step 2 instead of
-    // always sending the researcher back to the Step 1 data-org picker.
-    if (draftHasStep2Progress(study)) {
+    // always sending the researcher back to the Step 1 data-org picker. Step 2's
+    // "Previous" button must remain a working escape hatch, so it navigates here
+    // with ?from=step2 to explicitly request the Step 1 form.
+    if (searchParams.from !== 'step2' && draftHasStep2Progress(study)) {
         redirect(Routes.studyProposal({ orgSlug, studyId }))
     }
 

--- a/src/app/[orgSlug]/study/[studyId]/edit/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit/page.tsx
@@ -1,10 +1,13 @@
+import { redirect } from 'next/navigation'
 import { db } from '@/database'
 import { AlertNotFound } from '@/components/errors'
+import { Routes } from '@/lib/routes'
+import { draftHasStep2Progress } from '@/lib/studies'
 import { StudyProposal } from '../../request/proposal'
 
-export default async function StudyEditPage(props: { params: Promise<{ studyId: string }> }) {
+export default async function StudyEditPage(props: { params: Promise<{ studyId: string; orgSlug: string }> }) {
     const params = await props.params
-    const { studyId } = params
+    const { studyId, orgSlug } = params
 
     // TODO: validate that member from clerk session matches memberId from url
     const study = await db
@@ -15,11 +18,17 @@ export default async function StudyEditPage(props: { params: Promise<{ studyId: 
             'study.status',
             'study.title',
             'study.piName',
+            'study.piUserId',
             'study.language',
             'study.descriptionDocPath',
             'study.irbDocPath',
             'study.agreementDocPath',
             'study.dataSources',
+            'study.datasets',
+            'study.researchQuestions',
+            'study.projectSummary',
+            'study.impact',
+            'study.additionalNotes',
             'study.containerLocation',
             'study.outputMimeType',
             'org.slug as orgSlug',
@@ -31,6 +40,12 @@ export default async function StudyEditPage(props: { params: Promise<{ studyId: 
         return (
             <AlertNotFound title="Study was not found" message="Only studies that are in DRAFT status can be edited." />
         )
+    }
+
+    // OTTER-572: drafts that already reached Step 2 reopen on Step 2 instead of
+    // always sending the researcher back to the Step 1 data-org picker.
+    if (draftHasStep2Progress(study)) {
+        redirect(Routes.studyProposal({ orgSlug, studyId }))
     }
 
     return (

--- a/src/app/[orgSlug]/study/[studyId]/proposal/footer.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/footer.tsx
@@ -34,7 +34,10 @@ export const ProposalFooter: FC<ProposalFooterProps> = ({ researcherName, resear
 
     const handlePrevious = async () => {
         const saved = await saveDraft()
-        if (saved) router.push(Routes.studyEdit({ orgSlug, studyId }))
+        // Tell the Edit page this nav is the explicit Step 2 → Step 1 back-step
+        // so it skips the OTTER-572 "resume on Step 2" redirect, which would
+        // otherwise bounce the user straight back to the page they just left.
+        if (saved) router.push(Routes.studyEdit({ orgSlug, studyId, from: 'step2' }))
     }
 
     return (

--- a/src/lib/routes/definitions.ts
+++ b/src/lib/routes/definitions.ts
@@ -101,7 +101,16 @@ export const Routes = {
 
     studyView: makeRoute(({ orgSlug, studyId }) => `/${orgSlug}/study/${studyId}/view`, StudyParams),
 
-    studyEdit: makeRoute(({ orgSlug, studyId }) => `/${orgSlug}/study/${studyId}/edit`, StudyParams),
+    studyEdit: makeRoute(
+        ({ orgSlug, studyId, from }) => {
+            const base = `/${orgSlug}/study/${studyId}/edit`
+            const params = new URLSearchParams()
+            if (from) params.set('from', from)
+            const qs = params.toString()
+            return qs ? `${base}?${qs}` : base
+        },
+        StudyParams.extend({ from: z.string().optional() }),
+    ),
 
     studyReview: makeRoute(
         ({ orgSlug, studyId, from }) => {

--- a/src/lib/studies.test.ts
+++ b/src/lib/studies.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { ProposalFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
-import { decisionTimestampForProposalHeader } from './studies'
+import { decisionTimestampForProposalHeader, draftHasStep2Progress } from './studies'
 
 const submittedAt = new Date('2025-04-16T10:00:00Z')
 const approvedAt = new Date('2026-04-20T10:00:00Z')
@@ -120,4 +120,41 @@ describe('decisionTimestampForProposalHeader', () => {
             'submittedAt is required for proposal header timestamp',
         )
     })
+})
+
+const emptyDraftStep2 = {
+    piUserId: null,
+    datasets: null,
+    researchQuestions: null,
+    projectSummary: null,
+    impact: null,
+    additionalNotes: null,
+}
+
+describe('draftHasStep2Progress', () => {
+    it('returns false when no Step 2 field has been written', () => {
+        expect(draftHasStep2Progress(emptyDraftStep2)).toBe(false)
+    })
+
+    it('returns false when datasets is an empty array', () => {
+        // An empty array means "explicitly cleared" rather than "never touched";
+        // until a dataset is actually picked the researcher has nothing to resume on Step 2.
+        expect(draftHasStep2Progress({ ...emptyDraftStep2, datasets: [] })).toBe(false)
+    })
+
+    it('returns true once a PI user has been selected', () => {
+        expect(draftHasStep2Progress({ ...emptyDraftStep2, piUserId: 'user-123' })).toBe(true)
+    })
+
+    it('returns true once a dataset has been picked', () => {
+        expect(draftHasStep2Progress({ ...emptyDraftStep2, datasets: ['students'] })).toBe(true)
+    })
+
+    it.each([['researchQuestions'], ['projectSummary'], ['impact'], ['additionalNotes']] as const)(
+        'returns true once the %s lexical field has been saved',
+        (field) => {
+            const lexicalJson = { root: { children: [{ type: 'text', text: 'hi' }] } }
+            expect(draftHasStep2Progress({ ...emptyDraftStep2, [field]: lexicalJson })).toBe(true)
+        },
+    )
 })

--- a/src/lib/studies.ts
+++ b/src/lib/studies.ts
@@ -27,7 +27,7 @@ type DraftStep2Fields = {
 // `piName`, and document paths. Step 2 is the first time any of the columns
 // below are written, so any one being non-empty means the researcher has
 // reached Step 2. Used to route a "resume draft" entry to the step where
-// they last left off instead of always landing on Step 1.
+// they last left off instead of always landing on Step 1. Step 1 never writes these columns
 export function draftHasStep2Progress(study: DraftStep2Fields): boolean {
     if (study.piUserId) return true
     if (study.datasets && study.datasets.length > 0) return true

--- a/src/lib/studies.ts
+++ b/src/lib/studies.ts
@@ -1,4 +1,4 @@
-import type { StudyJobStatus } from '@/database/types'
+import type { Json, StudyJobStatus } from '@/database/types'
 import type { ProposalFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
 
 type StudyWithJobStatuses = {
@@ -12,6 +12,30 @@ export function studyHasJobStatus(study: StudyWithJobStatuses, status: StudyJobS
 export function deriveStudyVersion(entries: { version: number }[]): number {
     if (entries.length === 0) return 1
     return Math.max(...entries.map((e) => e.version))
+}
+
+type DraftStep2Fields = {
+    piUserId: string | null
+    datasets: string[] | null
+    researchQuestions: Json | null
+    projectSummary: Json | null
+    impact: Json | null
+    additionalNotes: Json | null
+}
+
+// Step 1 (data org + language + docs) saves `orgSlug`, `language`, `title`,
+// `piName`, and document paths. Step 2 is the first time any of the columns
+// below are written, so any one being non-empty means the researcher has
+// reached Step 2. Used to route a "resume draft" entry to the step where
+// they last left off instead of always landing on Step 1.
+export function draftHasStep2Progress(study: DraftStep2Fields): boolean {
+    if (study.piUserId) return true
+    if (study.datasets && study.datasets.length > 0) return true
+    if (study.researchQuestions != null) return true
+    if (study.projectSummary != null) return true
+    if (study.impact != null) return true
+    if (study.additionalNotes != null) return true
+    return false
 }
 
 /** Returns the timestamp of the latest decision for the submitted proposal header. */


### PR DESCRIPTION
Summary

Today the "Edit" link on a draft always re-routes the researcher to Step 1 (the data-org + language picker) regardless of how far they had gotten. This PR redirects the researcher back to whichever step they last edited — Step 2 if any of the Step-2-only columns have been written, Step 1 otherwise.
Detection is a pure helper, draftHasStep2Progress(study) in src/lib/studies.ts. It returns true when piUserId is set, when datasets is a non-empty array, or when any of researchQuestions, projectSummary, impact, or additionalNotes is non-null. Step 1 only writes orgSlug / language / title / piName / document paths, so a write to any of those columns is a strong signal that the researcher reached Step 2.

src/app/[orgSlug]/study/[studyId]/edit/page.tsx widens its SELECT to include the Step-2 columns and calls redirect(Routes.studyProposal({ orgSlug, studyId })) when draftHasStep2Progress(study) is true; fresh drafts still render the existing Step 1 <StudyProposal> form. The DRAFT-status guard and not-found alert are unchanged.

Adds unit tests for the helper (each Step-2 field individually triggers true; empty array does not) and for the route (fresh draft → Step 1, non-DRAFT → not-found alert, each Step-2 field individually → redirect to /[orgSlug]/study/[studyId]/proposal).