### PR TITLE
upgrade to vitest 4.1.x as minimum

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.56.1",
         "vite-tsconfig-paths": "^6.1.1",
-        "vitest": "^4.1.6",
+        "vitest": ">=4.1.6",
         "vitest-monocart-coverage": "^4.0.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.56.1",
         "vite-tsconfig-paths": "^6.1.1",
-        "vitest": "*",
+        "vitest": "^4.1.6",
         "vitest-monocart-coverage": "^4.0.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
         "tsx": "4.21.0",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.56.1",
-        "vite-tsconfig-paths": "^6.1.1",
+        "vite": ">=8.0.0",
         "vitest": ">=4.1.6",
         "vitest-monocart-coverage": "^4.0.1"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,9 +351,9 @@ importers:
       typescript-eslint:
         specifier: ^8.56.1
         version: 8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      vite-tsconfig-paths:
-        specifier: ^6.1.1
-        version: 6.1.1(typescript@5.9.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vite:
+        specifier: '>=8.0.0'
+        version: 8.0.13(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: '>=4.1.6'
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(@vitest/coverage-v8@4.1.6)(happy-dom@20.9.0)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -3904,9 +3904,6 @@ packages:
     resolution: {integrity: sha512-wiSuFQLZ+urS9x2gGPl1H5drc5twabmm4m2gTR27XDFyjUHJUNsS8o/2aKyIF6IoBaR630atdher0XJ5g6OMmA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -6000,11 +5997,6 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
-
-  vite-tsconfig-paths@6.1.1:
-    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
-    peerDependencies:
-      vite: '*'
 
   vite@8.0.13:
     resolution: {integrity: sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==}
@@ -10375,8 +10367,6 @@ snapshots:
       merge2: 1.4.1
       slash: 4.0.0
 
-  globrex@0.1.2: {}
-
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -12501,16 +12491,6 @@ snapshots:
   validator@13.15.35: {}
 
   vary@1.1.2: {}
-
-  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
-    dependencies:
-      debug: 4.4.3
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@5.9.3)
-      vite: 8.0.13(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vite@8.0.13(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,7 +355,7 @@ importers:
         specifier: ^6.1.1
         version: 6.1.1(typescript@5.9.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest:
-        specifier: '*'
+        specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(@vitest/coverage-v8@4.1.6)(happy-dom@20.9.0)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest-monocart-coverage:
         specifier: ^4.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,7 +355,7 @@ importers:
         specifier: ^6.1.1
         version: 6.1.1(typescript@5.9.3)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest:
-        specifier: ^4.1.6
+        specifier: '>=4.1.6'
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.6)(@vitest/coverage-v8@4.1.6)(happy-dom@20.9.0)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest-monocart-coverage:
         specifier: ^4.0.1

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -17,206 +17,225 @@ declare module 'vitest' {
 
 expect.extend(matchers)
 
-const Headers = new Map()
-
 // Deferred callbacks (via next/server's `after`) are fire-and-forget async operations.
 // In production they run after the response. In tests we must:
 //  1. Track their promises so we can await them before rolling back the transaction
 //  2. Mock `sleep` to be instant (otherwise simulateJobScan waits 1s, completeFakeCodeScan waits 30s)
-// Without this, callbacks outlive the test transaction and cause FK violations — non-deterministically
+// Without this, callbacks outlive the test transaction and cause FK violations, non-deterministically
 // depending on machine speed (works on fast local machines, fails on slow CI).
-const pendingDeferredCallbacks: Promise<unknown>[] = []
+const mockState = vi.hoisted(() => {
+    const headers = new Map()
+    const pendingDeferredCallbacks: Promise<unknown>[] = []
+    let runWithLocalStorage: ((cb: () => void) => void) | undefined
 
-function runDeferredTestCallback(cb: () => void | Promise<void>) {
-    localStorageContext.run({ db: undefined as never }, () => {
-        const result = cb()
-        if (result && typeof (result as Promise<unknown>).then === 'function') {
-            pendingDeferredCallbacks.push(result as Promise<unknown>)
+    return {
+        headers,
+        pendingDeferredCallbacks,
+        setRunWithLocalStorage(run: (cb: () => void) => void) {
+            runWithLocalStorage = run
+        },
+        runDeferredTestCallback(cb: () => void | Promise<void>) {
+            if (!runWithLocalStorage) throw new Error('Test local storage context is not initialized')
+
+            runWithLocalStorage(() => {
+                const result = cb()
+                if (result && typeof (result as Promise<unknown>).then === 'function') {
+                    pendingDeferredCallbacks.push(result as Promise<unknown>)
+                }
+            })
+        },
+    }
+})
+
+mockState.setRunWithLocalStorage((cb) => {
+    localStorageContext.run({ db: undefined as never }, cb)
+})
+
+// vi.mock calls must live at the module top level. Vitest hoists them above imports,
+// so any values referenced by a factory must come from vi.hoisted instead of ordinary
+// module-scope declarations.
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+vi.mock('next/router', () => require('next-router-mock'))
+vi.mock('next/server', async (importOriginal) => ({
+    ...(await importOriginal()),
+    after: mockState.runDeferredTestCallback,
+}))
+
+// https://github.com/scottrippey/next-router-mock/issues/67#issuecomment-1564906960
+vi.mock('next/navigation', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mockRouter = require('next-router-mock')
+    const useRouter = mockRouter.useRouter
+
+    return {
+        ...mockRouter,
+        notFound: vi.fn(),
+        redirect: vi.fn().mockImplementation((url: string) => {
+            mockRouter.memoryRouter.setCurrentUrl(url)
+        }),
+        usePathname: () => {
+            const router = useRouter()
+            return router.asPath.split('?')[0]
+        },
+        useParams: vi.fn(() => ({})),
+        useSearchParams: () => {
+            const router = useRouter()
+            const path = router.query
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            return new URLSearchParams(path as any)
+        },
+    }
+})
+vi.mock('next/cache')
+vi.mock('next/headers', async () => ({ headers: async () => mockState.headers }))
+
+// Clerk SDK mocks - configured via mockClerkSession() in unit.helpers.tsx
+vi.mock('@clerk/nextjs')
+vi.mock('@clerk/nextjs/server')
+
+// Partial mock: only mock Clerk mutation functions, keep read functions real
+vi.mock('@/server/clerk', async (importOriginal) => ({
+    ...(await importOriginal()),
+    updateClerkUserName: vi.fn(),
+    updateClerkUserMetadata: vi.fn(),
+    findOrCreateClerkOrganization: vi.fn(),
+}))
+
+vi.mock('@/components/page-breadcrumbs', () => ({
+    OrgBreadcrumbs: () => null,
+    ResearcherBreadcrumbs: () => null,
+    PageBreadcrumbs: () => null,
+}))
+
+vi.mock('@mantine/notifications', () => ({
+    notifications: {
+        show: vi.fn(),
+        hide: vi.fn(),
+    },
+    showNotification: vi.fn(),
+    Notifications: () => null,
+}))
+
+// Stub out the Hocuspocus client so unit tests don't open real websockets to
+// the editor service. The fake provider exposes enough of the Yjs/awareness
+// surface for @lexical/yjs's CollaborationPlugin to mount without crashing.
+vi.mock('@hocuspocus/provider', async () => {
+    const Y = await import('yjs')
+    const websocketCtorSpy = vi.fn()
+    const websocketInstances: FakeHocuspocusProviderWebsocket[] = []
+    class FakeHocuspocusProviderWebsocket {
+        providerMap = new Map()
+        // Tests treat the socket as already connected so the editor renders fully
+        // without each test having to wire up a status sequence. Tests that need
+        // to drive the reconnect/failed paths can set `socket.status` and call
+        // `__emit('status', { status })`.
+        status: 'connecting' | 'connected' | 'disconnected' = 'connected'
+        _observers = new Map<string, Set<(...args: unknown[]) => void>>()
+        destroy = vi.fn()
+        attach = vi.fn()
+        detach = vi.fn()
+        on(event: string, fn: (...args: unknown[]) => void) {
+            if (!this._observers.has(event)) this._observers.set(event, new Set())
+            this._observers.get(event)!.add(fn)
         }
-    })
-}
+        off(event: string, fn: (...args: unknown[]) => void) {
+            this._observers.get(event)?.delete(fn)
+        }
+        // Test helper: drives the connection-phase state machine in unit tests.
+        __emit(event: string, ...args: unknown[]) {
+            this._observers.get(event)?.forEach((fn) => fn(...args))
+        }
+        constructor(...args: unknown[]) {
+            websocketCtorSpy(...args)
+            websocketInstances.push(this)
+        }
+        static __ctor = websocketCtorSpy
+        static __instances = websocketInstances
+    }
+    class FakeAwareness {
+        clientID = 1
+        states = new Map<number, Record<string, unknown>>()
+        meta = new Map()
+        _localState: Record<string, unknown> | null = null
+        _observers = new Map<string, Set<(...args: unknown[]) => void>>()
+        getStates() {
+            return this.states
+        }
+        getLocalState() {
+            return this._localState
+        }
+        setLocalState(state: Record<string, unknown> | null) {
+            this._localState = state
+            if (state) this.states.set(this.clientID, state)
+            else this.states.delete(this.clientID)
+            this._emit('change', [{ added: [], updated: [this.clientID], removed: [] }, 'local'])
+            this._emit('update', [{ added: [], updated: [this.clientID], removed: [] }, 'local'])
+        }
+        setLocalStateField(field: string, value: unknown) {
+            this.setLocalState({ ...(this._localState ?? {}), [field]: value })
+        }
+        on(event: string, fn: (...args: unknown[]) => void) {
+            if (!this._observers.has(event)) this._observers.set(event, new Set())
+            this._observers.get(event)!.add(fn)
+        }
+        off(event: string, fn: (...args: unknown[]) => void) {
+            this._observers.get(event)?.delete(fn)
+        }
+        _emit(event: string, args: unknown[]) {
+            this._observers.get(event)?.forEach((fn) => fn(...args))
+        }
+        destroy() {}
+    }
+    const providerCtorSpy = vi.fn()
+    const providerInstances: FakeHocuspocusProvider[] = []
+    class FakeHocuspocusProvider {
+        document: InstanceType<typeof Y.Doc>
+        awareness = new FakeAwareness()
+        isSynced = false
+        unsyncedChanges = 0
+        // Surfaced so tests can assert which document name a provider was created for.
+        configuration: { name?: string } = {}
+        attach = vi.fn()
+        destroy = vi.fn()
+        disconnect = vi.fn()
+        connect = vi.fn()
+        on = vi.fn()
+        off = vi.fn()
+        send = vi.fn()
+        sendStateless = vi.fn()
+        constructor(opts?: { document?: InstanceType<typeof Y.Doc>; name?: string }) {
+            this.document = opts?.document ?? new Y.Doc()
+            this.configuration = { name: opts?.name }
+            providerCtorSpy(opts)
+            providerInstances.push(this)
+        }
+        static __ctor = providerCtorSpy
+        static __instances = providerInstances
+    }
+    return {
+        HocuspocusProviderWebsocket: FakeHocuspocusProviderWebsocket,
+        HocuspocusProvider: FakeHocuspocusProvider,
+        WebSocketStatus: {
+            Connecting: 'connecting',
+            Connected: 'connected',
+            Disconnected: 'disconnected',
+        },
+    }
+})
+
+// Make sleep instant so deferred simulation callbacks (simulateJobScan, completeFakeCodeScan)
+// complete within the test transaction instead of firing real 1s/30s timers.
+vi.mock('@/lib/utils', async (importOriginal) => ({
+    ...(await importOriginal()),
+    sleep: vi.fn().mockResolvedValue(undefined),
+}))
 
 beforeAll(async () => {
     // Defense layer: clear Clerk credentials to prevent real API calls if mocks fail
     delete process.env.CLERK_SECRET_KEY
     delete process.env.CLERK_PUBLISHABLE_KEY
     delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
-
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    vi.mock('next/router', () => require('next-router-mock'))
-    vi.mock('next/server', async (importOriginal) => ({
-        ...(await importOriginal()),
-        after: runDeferredTestCallback,
-    }))
-
-    // https://github.com/scottrippey/next-router-mock/issues/67#issuecomment-1564906960
-    vi.mock('next/navigation', () => {
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        const mockRouter = require('next-router-mock')
-        const useRouter = mockRouter.useRouter
-
-        return {
-            ...mockRouter,
-            notFound: vi.fn(),
-            redirect: vi.fn().mockImplementation((url: string) => {
-                mockRouter.memoryRouter.setCurrentUrl(url)
-            }),
-            usePathname: () => {
-                const router = useRouter()
-                return router.asPath.split('?')[0]
-            },
-            useParams: vi.fn(() => ({})),
-            useSearchParams: () => {
-                const router = useRouter()
-                const path = router.query
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                return new URLSearchParams(path as any)
-            },
-        }
-    })
-    vi.mock('next/cache')
-    vi.mock('next/headers', async () => ({ headers: async () => Headers }))
-
-    // Clerk SDK mocks - configured via mockClerkSession() in unit.helpers.tsx
-    vi.mock('@clerk/nextjs')
-    vi.mock('@clerk/nextjs/server')
-
-    // Partial mock: only mock Clerk mutation functions, keep read functions real
-    vi.mock('@/server/clerk', async (importOriginal) => ({
-        ...(await importOriginal()),
-        updateClerkUserName: vi.fn(),
-        updateClerkUserMetadata: vi.fn(),
-        findOrCreateClerkOrganization: vi.fn(),
-    }))
-
-    vi.mock('@/components/page-breadcrumbs', () => ({
-        OrgBreadcrumbs: () => null,
-        ResearcherBreadcrumbs: () => null,
-        PageBreadcrumbs: () => null,
-    }))
-
-    vi.mock('@mantine/notifications', () => ({
-        notifications: {
-            show: vi.fn(),
-            hide: vi.fn(),
-        },
-        showNotification: vi.fn(),
-        Notifications: () => null,
-    }))
-
-    // Stub out the Hocuspocus client so unit tests don't open real websockets to
-    // the editor service. The fake provider exposes enough of the Yjs/awareness
-    // surface for @lexical/yjs's CollaborationPlugin to mount without crashing.
-    vi.mock('@hocuspocus/provider', async () => {
-        const Y = await import('yjs')
-        const websocketCtorSpy = vi.fn()
-        const websocketInstances: FakeHocuspocusProviderWebsocket[] = []
-        class FakeHocuspocusProviderWebsocket {
-            providerMap = new Map()
-            // Tests treat the socket as already connected so the editor renders fully
-            // without each test having to wire up a status sequence. Tests that need
-            // to drive the reconnect/failed paths can set `socket.status` and call
-            // `__emit('status', { status })`.
-            status: 'connecting' | 'connected' | 'disconnected' = 'connected'
-            _observers = new Map<string, Set<(...args: unknown[]) => void>>()
-            destroy = vi.fn()
-            attach = vi.fn()
-            detach = vi.fn()
-            on(event: string, fn: (...args: unknown[]) => void) {
-                if (!this._observers.has(event)) this._observers.set(event, new Set())
-                this._observers.get(event)!.add(fn)
-            }
-            off(event: string, fn: (...args: unknown[]) => void) {
-                this._observers.get(event)?.delete(fn)
-            }
-            // Test helper: drives the connection-phase state machine in unit tests.
-            __emit(event: string, ...args: unknown[]) {
-                this._observers.get(event)?.forEach((fn) => fn(...args))
-            }
-            constructor(...args: unknown[]) {
-                websocketCtorSpy(...args)
-                websocketInstances.push(this)
-            }
-            static __ctor = websocketCtorSpy
-            static __instances = websocketInstances
-        }
-        class FakeAwareness {
-            clientID = 1
-            states = new Map<number, Record<string, unknown>>()
-            meta = new Map()
-            _localState: Record<string, unknown> | null = null
-            _observers = new Map<string, Set<(...args: unknown[]) => void>>()
-            getStates() {
-                return this.states
-            }
-            getLocalState() {
-                return this._localState
-            }
-            setLocalState(state: Record<string, unknown> | null) {
-                this._localState = state
-                if (state) this.states.set(this.clientID, state)
-                else this.states.delete(this.clientID)
-                this._emit('change', [{ added: [], updated: [this.clientID], removed: [] }, 'local'])
-                this._emit('update', [{ added: [], updated: [this.clientID], removed: [] }, 'local'])
-            }
-            setLocalStateField(field: string, value: unknown) {
-                this.setLocalState({ ...(this._localState ?? {}), [field]: value })
-            }
-            on(event: string, fn: (...args: unknown[]) => void) {
-                if (!this._observers.has(event)) this._observers.set(event, new Set())
-                this._observers.get(event)!.add(fn)
-            }
-            off(event: string, fn: (...args: unknown[]) => void) {
-                this._observers.get(event)?.delete(fn)
-            }
-            _emit(event: string, args: unknown[]) {
-                this._observers.get(event)?.forEach((fn) => fn(...args))
-            }
-            destroy() {}
-        }
-        const providerCtorSpy = vi.fn()
-        const providerInstances: FakeHocuspocusProvider[] = []
-        class FakeHocuspocusProvider {
-            document: InstanceType<typeof Y.Doc>
-            awareness = new FakeAwareness()
-            isSynced = false
-            unsyncedChanges = 0
-            // Surfaced so tests can assert which document name a provider was created for.
-            configuration: { name?: string } = {}
-            attach = vi.fn()
-            destroy = vi.fn()
-            disconnect = vi.fn()
-            connect = vi.fn()
-            on = vi.fn()
-            off = vi.fn()
-            send = vi.fn()
-            sendStateless = vi.fn()
-            constructor(opts?: { document?: InstanceType<typeof Y.Doc>; name?: string }) {
-                this.document = opts?.document ?? new Y.Doc()
-                this.configuration = { name: opts?.name }
-                providerCtorSpy(opts)
-                providerInstances.push(this)
-            }
-            static __ctor = providerCtorSpy
-            static __instances = providerInstances
-        }
-        return {
-            HocuspocusProviderWebsocket: FakeHocuspocusProviderWebsocket,
-            HocuspocusProvider: FakeHocuspocusProvider,
-            WebSocketStatus: {
-                Connecting: 'connecting',
-                Connected: 'connected',
-                Disconnected: 'disconnected',
-            },
-        }
-    })
-
-    // Make sleep instant so deferred simulation callbacks (simulateJobScan, completeFakeCodeScan)
-    // complete within the test transaction instead of firing real 1s/30s timers.
-    vi.mock('@/lib/utils', async (importOriginal) => ({
-        ...(await importOriginal()),
-        sleep: vi.fn().mockResolvedValue(undefined),
-    }))
 
     testTransaction.start()
 })
@@ -239,9 +258,9 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-    Headers.clear()
-    await Promise.allSettled(pendingDeferredCallbacks)
-    pendingDeferredCallbacks.length = 0
+    mockState.headers.clear()
+    await Promise.allSettled(mockState.pendingDeferredCallbacks)
+    mockState.pendingDeferredCallbacks.length = 0
     await testTransaction.rollback()
     await fs.promises.rm(tmpDir, { recursive: true })
     delete process.env.UPLOAD_TMP_DIRECTORY

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,14 +1,16 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { testsCoverageSourceFilter } from './tests/coverage.mjs'
 
 const IS_CI = !!process.env.CI
 
 // https://vitejs.dev/config/
 export default defineConfig({
-    plugins: [react(), tsconfigPaths()],
+    plugins: [react()],
     resolve: {
+        // Resolve tsconfig.json `paths` (@/*, @/tests/*) natively. Vite 8 added
+        // this, replacing the vite-tsconfig-paths plugin.
+        tsconfigPaths: true,
         // Force single Lexical/Yjs module instances across the test tree.
         // Without this, services/editor's nested node_modules and the root
         // node_modules load separate constructors, which breaks identity checks


### PR DESCRIPTION
## What's this about

If you've looked at the unit test job in CI lately, you've probably noticed it got really noisy. The [`test` job on the Checks workflow](https://github.com/safeinsights/management-app/actions/runs/26520079462/job/78112042756) spews a wall of warnings before the tests even start running:

```
Importing from "vitest/coverage" is deprecated since Vitest 4.1. Please use "vitest/node" instead.
Warning: A vi.mock("next/router") call in tests/vitest.setup.ts is not at the top level of the module. Although it appears nested, it will be hoisted and executed before any tests run. Move it to the top level to reflect its actual execution order. This will become an error in a future version.
Warning: A vi.mock("next/server") call ... (and one for every other vi.mock, ~12 in total)
The plugin "vite-tsconfig-paths" is detected. Vite now supports tsconfig paths resolution natively via the resolve.tsconfigPaths option. You can remove the plugin and set resolve.tsconfigPaths: true in your Vite config instead.
```

The tests themselves still passed, but the output was hard to read and one of those warnings literally says *"this will become an error in a future version"*, so it's worth dealing with now rather than waiting for it to break.

## Why it started happening

The root cause was in `package.json`:

```json
"vitest": "*"
```

A wildcard version. Whenever the lockfile gets regenerated (which the pnpm migration did), it floats to whatever the latest Vitest is. That's how we silently jumped onto **Vitest 4.1** (and **Vite 8** alongside it, since Vitest pulls Vite in), which shipped in May 2026 ("Test Tags, Native Node.js Execution and AI Agent Reporter") and surfaced three things in our setup:

1. **The `vi.mock` hoisting warning.** Vitest transforms any file containing `vi.mock` so it can hoist those calls to the very top and rewrite static imports into dynamic ones, guaranteeing mocks register before the modules they replace are imported. Our `tests/vitest.setup.ts` had all of its `vi.mock` calls nested inside a `beforeAll(...)`. Vitest was hoisting them out anyway, so the placement was misleading, and 4.1 now warns about it (and plans to make it a hard error in a later major).

2. **The `vitest/coverage` deprecation.** In 4.1 the coverage base class moved to `vitest/node` and `vitest/coverage` became a deprecated shim. This one isn't ours: it comes from the `vitest-monocart-coverage` package (latest 4.0.2 still imports the old path), and it only appears when coverage is enabled, which is why it shows up in CI but not in a plain local run.

3. **The `vite-tsconfig-paths` plugin warning.** Vite 8 added native tsconfig `paths` resolution via `resolve.tsconfigPaths`, so the `vite-tsconfig-paths` plugin we used in `vitest.config.ts` is now redundant and Vite nudges you to drop it.

This is also the answer to "why don't I see this locally?" The wildcard meant local dev images could be on an older cached Vitest, and the coverage warning is coverage-only.

## What this PR does

- **Pins Vitest to `>=4.1.6`** instead of `*`. The wildcard had no floor at all, so the lockfile could resolve to anything (including versions older than the top-level `vi.mock` requirement). `>=4.1.6` guarantees we never drop below 4.1.6 while still accepting future minor and major releases. The resolved version is unchanged (4.1.6), so this is really just the lockfile spec catching up to reality. Note: because this also accepts new majors, a future lockfile regen could move us onto Vitest 5+; CI installing with a frozen lockfile keeps us on 4.1.6 until that bump is done deliberately.
- **Moves all `vi.mock` calls in `tests/vitest.setup.ts` to the module top level**, which is what Vitest wanted. Because the mock factories need values that aren't safe to touch at hoist time (the deferred-callback tracking and the fake `headers` map, which depend on a real import), those are now built with `vi.hoisted(...)` and the import-dependent piece is wired in via a normal top-level call afterwards. Behavior is identical to before, just expressed in the way 4.1's hoisting model expects.
- **Replaces the `vite-tsconfig-paths` plugin with Vite 8's native `resolve.tsconfigPaths: true`** and removes the plugin dependency. Our `tsconfig.json` only uses plain `compilerOptions.paths` (`@/*`, `@/tests/*`), which the native boolean option covers fully (no `projects`/`root`/`loose`/`baseUrl`-only features that the native option lacks). To make sure we can actually rely on this, I also added a direct **`"vite": ">=8.0.0"`** dependency: Vitest's own peer range is `^6 || ^7 || ^8`, so without an explicit floor the lockfile could legally resolve Vite back down to 6 or 7, where `resolve.tsconfigPaths` doesn't exist.

## What this PR deliberately does NOT do

The `vitest/coverage` deprecation is left as-is. It's entirely upstream in `vitest-monocart-coverage`, it's harmless (the shim still works and Vitest documents no removal version), and the only ways to silence it from our side are a fragile pnpm patch or a fork. I've reported it upstream instead: [cenfun/vitest-monocart-coverage#17](https://github.com/cenfun/vitest-monocart-coverage/issues/17). We'll pick up the fix for free once they publish a release that imports from `vitest/node`.

## Verification

Ran the full unit suite in Docker against Vitest 4.1.6 / Vite 8.0.13 (same versions CI uses):

- **151 test files / 1368 tests pass**, exit 0, same counts as before, none skipped
- the `vi.mock` "not at the top level" warnings are gone (12 → 0)
- the `vite-tsconfig-paths` plugin warning is gone, with **zero `@/` import-resolution errors** (the `@/*` and `@/tests/*` aliases are imported across ~all test files, so a path-resolution regression couldn't pass silently)
- `tsc --noEmit`, ESLint, and Prettier are clean on the changed files

## Files changed

- `package.json` — pin `vitest` to `>=4.1.6`, drop `vite-tsconfig-paths`, add `vite >=8.0.0`
- `pnpm-lock.yaml` — spec updates + plugin removal (resolved versions unchanged)
- `tests/vitest.setup.ts` — hoist `vi.mock` calls to top level
- `vitest.config.ts` — use native `resolve.tsconfigPaths`, drop the plugin
