### PR TITLE
Open studies in their own tab

### DIFF
--- a/src/hooks/use-workspace-launcher.test.tsx
+++ b/src/hooks/use-workspace-launcher.test.tsx
@@ -142,7 +142,7 @@ describe('useWorkspaceLauncher', () => {
             })
 
             await waitFor(() => {
-                expect(mockWindowOpen).toHaveBeenCalledWith(workspaceUrl, 'child')
+                expect(mockWindowOpen).toHaveBeenCalledWith(workspaceUrl, `ide-for-study-${studyId}`)
                 expect(result.current.isLaunching).toBe(false)
             })
         })

--- a/src/hooks/use-workspace-launcher.tsx
+++ b/src/hooks/use-workspace-launcher.tsx
@@ -9,8 +9,8 @@ interface OpenResult {
     url: string
 }
 
-const openWorkspaceInNewTab = (url: string): OpenResult => {
-    const newWindow = window.open(url, 'child')
+const openWorkspaceInNewTab = (url: string, studyId: string): OpenResult => {
+    const newWindow = window.open(url, `ide-for-study-${studyId}`)
     const blocked = !newWindow || newWindow.closed || typeof newWindow.closed === 'undefined'
     return { success: !blocked, blocked, url }
 }
@@ -102,7 +102,7 @@ export function useWorkspaceLauncher({ studyId, onSuccess }: UseWorkspaceLaunche
         const url = workspaceQuery.data
         if (url) {
             setLaunchComplete(true)
-            const result = openWorkspaceInNewTab(url)
+            const result = openWorkspaceInNewTab(url, studyId)
             setLoading(false)
             if (result.blocked) {
                 setError(new Error('Popup blocked'))


### PR DESCRIPTION
## Summary
- Open each study's IDE in a dedicated browser tab keyed by `studyId` (`ide-for-study-${studyId}`) instead of a shared `child` target, so launching a second study no longer hijacks the tab of the first.

**Jira:** [OTTER-586](https://openstax.atlassian.net/browse/OTTER-586)

## Test plan
- [ ] Launch a study workspace — verify it opens in a new tab.
- [ ] Launch a second study from a separate row — verify it opens in its own tab and does not replace the first.
- [ ] Re-launch the same study — verify it reuses the existing tab for that study.
- [ ] Confirm popup-blocked path still surfaces the "Popup blocked" error.

[OTTER-586]: https://openstax.atlassian.net/browse/OTTER-586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ