### PR TITLE
fix(e2e): assert invitation signup MFA-required error

### DIFF
--- a/tests/org-admin.spec.ts
+++ b/tests/org-admin.spec.ts
@@ -79,7 +79,10 @@ test.describe('Organization Admin', () => {
         // Submit the form
         await submitBtn.click()
 
-        await expect(page.getByRole('heading', { name: /multi-factor authentication/i })).toBeVisible()
+        // The CI Clerk instance enforces a second factor at first sign-in, so the freshly-created
+        // account's sign-in returns `needs_second_factor` rather than completing. The signup page
+        // surfaces an actionable error for that case instead of stranding the user (see PR #742).
+        await expect(page.getByText(/multi-factor authentication is required before you can sign in/i)).toBeVisible()
     })
 
     test('org admin can create and edit code environment starter code', async ({ page }) => {


### PR DESCRIPTION

## Root cause

When an invited user creates an account, the post-create `signIn.create()` returns `status === 'needs_second_factor'` because the CI Clerk instance enforces a second factor at first sign-in. #742 deliberately changed that branch to surface an actionable error toast instead of navigating to `/account/mfa`:

> Your account was created, but multi-factor authentication is required before you can sign in. Please contact your administrator.

The test still expected the MFA enrollment heading (`/multi-factor authentication/i`), so it timed out after 30s on all 3 retries.

I confirmed from the failing run's trace that the rendered alert was the #742 error string and that the page remained on the signup form.

## Fix

Update the test's final assertion to match #742's intended behavior — assert the error message for the `needs_second_factor` case, with a comment explaining why.

## Follow-up (not in this PR)

Per #742's own description, the real remedy is a **Clerk instance-level** config change so first sign-in for a freshly-created user reaches `status === 'complete'`, letting invited users actually enroll MFA. That's an ops change outside this repo.

## Verification

- `npx tsc --noEmit` — passes
- `npx eslint tests/org-admin.spec.ts` — passes