### PR TITLE
OTTER-517: My Dashboard - Inconsistencies with dual roles

### DIFF
--- a/src/app/dashboard/user-studies.test.tsx
+++ b/src/app/dashboard/user-studies.test.tsx
@@ -62,7 +62,7 @@ describe('UserStudiesDashboard', () => {
         renderWithProviders(<UserStudiesDashboard />)
 
         expect(await screen.findByText('My dashboard')).toBeDefined()
-        expect(await screen.findByText('You have not started a study yet')).toBeDefined()
+        expect(await screen.findByText("You haven't yet participated in a study")).toBeDefined()
         expect(screen.getByRole('radio', { name: 'Reviewer' })).toBeDefined()
         expect(screen.getByRole('radio', { name: 'Researcher' })).toBeDefined()
 
@@ -90,7 +90,7 @@ describe('UserStudiesDashboard', () => {
 
         await userEvent.click(screen.getByRole('radio', { name: 'Reviewer' }))
 
-        expect(await screen.findByText('You currently do not have any studies to review')).toBeDefined()
+        expect(await screen.findByText("You haven't yet participated in reviewing a study")).toBeDefined()
         expect(screen.getByRole('radio', { name: 'Reviewer' })).toBeDefined()
         expect(screen.getByRole('radio', { name: 'Researcher' })).toBeDefined()
     })
@@ -100,7 +100,7 @@ describe('UserStudiesDashboard', () => {
 
         renderWithProviders(<UserStudiesDashboard />)
 
-        expect(await screen.findByText('You have not started a study yet')).toBeDefined()
+        expect(await screen.findByText("You haven't yet participated in a study")).toBeDefined()
         expect(screen.queryByRole('radio', { name: 'Reviewer' })).toBeNull()
         expect(screen.queryByRole('radio', { name: 'Researcher' })).toBeNull()
     })
@@ -110,7 +110,7 @@ describe('UserStudiesDashboard', () => {
 
         renderWithProviders(<UserStudiesDashboard />)
 
-        expect(await screen.findByText('You currently do not have any studies to review')).toBeDefined()
+        expect(await screen.findByText("You haven't yet participated in reviewing a study")).toBeDefined()
         expect(screen.queryByRole('radio', { name: 'Reviewer' })).toBeNull()
         expect(screen.queryByRole('radio', { name: 'Researcher' })).toBeNull()
     })

--- a/src/app/dashboard/user-studies.test.tsx
+++ b/src/app/dashboard/user-studies.test.tsx
@@ -1,0 +1,117 @@
+import {
+    db,
+    insertTestUser,
+    mockDualRoleSessionWithTestData,
+    mockPathname,
+    mockSessionWithTestData,
+    renderWithProviders,
+    screen,
+    userEvent,
+    beforeEach,
+    describe,
+    expect,
+    it,
+} from '@/tests/unit.helpers'
+import UserStudiesDashboard from './user-studies'
+
+type InsertStudyOptions = {
+    orgId: string
+    submittedByOrgId: string
+    researcherId: string
+    reviewerId?: string | null
+    title: string
+}
+
+const insertStudy = ({ orgId, submittedByOrgId, researcherId, reviewerId = null, title }: InsertStudyOptions) =>
+    db
+        .insertInto('study')
+        .values({
+            orgId,
+            submittedByOrgId,
+            researcherId,
+            reviewerId,
+            containerLocation: 'test-container',
+            title,
+            piName: 'PI',
+            status: 'PENDING-REVIEW',
+            dataSources: ['all'],
+            outputMimeType: 'text/csv',
+            language: 'R',
+            submittedAt: new Date(),
+        })
+        .execute()
+
+beforeEach(() => {
+    mockPathname('/dashboard')
+})
+
+describe('UserStudiesDashboard', () => {
+    it('keeps the toggle visible when the default researcher tab is empty and reviewer has rows', async () => {
+        const { user, labOrg, enclaveOrg } = await mockDualRoleSessionWithTestData()
+        // A study authored by someone else but assigned to our user as the reviewer: it
+        // surfaces under Reviewer but not Researcher, so the default researcher tab is empty.
+        const { user: otherResearcher } = await insertTestUser({ org: { ...labOrg, type: 'lab' } })
+        await insertStudy({
+            orgId: enclaveOrg.id,
+            submittedByOrgId: labOrg.id,
+            researcherId: otherResearcher.id,
+            reviewerId: user.id,
+            title: 'Reviewer Study',
+        })
+
+        renderWithProviders(<UserStudiesDashboard />)
+
+        expect(await screen.findByText('My dashboard')).toBeDefined()
+        expect(await screen.findByText('You have not started a study yet')).toBeDefined()
+        expect(screen.getByRole('radio', { name: 'Reviewer' })).toBeDefined()
+        expect(screen.getByRole('radio', { name: 'Researcher' })).toBeDefined()
+
+        await userEvent.click(screen.getByRole('radio', { name: 'Reviewer' }))
+
+        expect(await screen.findByText('Reviewer Study')).toBeDefined()
+        expect(screen.getByRole('radio', { name: 'Reviewer' })).toBeDefined()
+        expect(screen.getByRole('radio', { name: 'Researcher' })).toBeDefined()
+    })
+
+    it('keeps the toggle visible after switching from a populated researcher tab to an empty reviewer tab', async () => {
+        const { user, labOrg, enclaveOrg } = await mockDualRoleSessionWithTestData()
+        // Our user authored the study (Researcher tab) but is not assigned as a reviewer, so
+        // the Reviewer tab is empty.
+        await insertStudy({
+            orgId: enclaveOrg.id,
+            submittedByOrgId: labOrg.id,
+            researcherId: user.id,
+            title: 'Researcher Study',
+        })
+
+        renderWithProviders(<UserStudiesDashboard />)
+
+        expect(await screen.findByText('Researcher Study')).toBeDefined()
+
+        await userEvent.click(screen.getByRole('radio', { name: 'Reviewer' }))
+
+        expect(await screen.findByText('You currently do not have any studies to review')).toBeDefined()
+        expect(screen.getByRole('radio', { name: 'Reviewer' })).toBeDefined()
+        expect(screen.getByRole('radio', { name: 'Researcher' })).toBeDefined()
+    })
+
+    it('does not show the toggle for a single-role researcher', async () => {
+        await mockSessionWithTestData({ orgType: 'lab' })
+
+        renderWithProviders(<UserStudiesDashboard />)
+
+        expect(await screen.findByText('You have not started a study yet')).toBeDefined()
+        expect(screen.queryByRole('radio', { name: 'Reviewer' })).toBeNull()
+        expect(screen.queryByRole('radio', { name: 'Researcher' })).toBeNull()
+    })
+
+    it('does not show the toggle for a single-role reviewer', async () => {
+        await mockSessionWithTestData({ orgType: 'enclave' })
+
+        renderWithProviders(<UserStudiesDashboard />)
+
+        expect(await screen.findByText('You currently do not have any studies to review')).toBeDefined()
+        expect(screen.queryByRole('radio', { name: 'Reviewer' })).toBeNull()
+        expect(screen.queryByRole('radio', { name: 'Researcher' })).toBeNull()
+    })
+})

--- a/src/app/dashboard/user-studies.test.tsx
+++ b/src/app/dashboard/user-studies.test.tsx
@@ -39,7 +39,8 @@ const insertStudy = ({ orgId, submittedByOrgId, researcherId, reviewerId = null,
             language: 'R',
             submittedAt: new Date(),
         })
-        .execute()
+        .returning('id')
+        .executeTakeFirstOrThrow()
 
 beforeEach(() => {
     mockPathname('/dashboard')
@@ -48,16 +49,24 @@ beforeEach(() => {
 describe('UserStudiesDashboard', () => {
     it('keeps the toggle visible when the default researcher tab is empty and reviewer has rows', async () => {
         const { user, labOrg, enclaveOrg } = await mockDualRoleSessionWithTestData()
-        // A study authored by someone else but assigned to our user as the reviewer: it
+        // A study authored by someone else but approved by our user as the reviewer: it
         // surfaces under Reviewer but not Researcher, so the default researcher tab is empty.
         const { user: otherResearcher } = await insertTestUser({ org: { ...labOrg, type: 'lab' } })
-        await insertStudy({
+        const study = await insertStudy({
             orgId: enclaveOrg.id,
             submittedByOrgId: labOrg.id,
             researcherId: otherResearcher.id,
-            reviewerId: user.id,
             title: 'Reviewer Study',
         })
+        const job = await db
+            .insertInto('studyJob')
+            .values({ studyId: study.id })
+            .returning('id')
+            .executeTakeFirstOrThrow()
+        await db
+            .insertInto('jobStatusChange')
+            .values({ studyJobId: job.id, userId: user.id, status: 'CODE-APPROVED' })
+            .execute()
 
         renderWithProviders(<UserStudiesDashboard />)
 

--- a/src/components/dashboard/studies-table/empty-state.tsx
+++ b/src/components/dashboard/studies-table/empty-state.tsx
@@ -1,13 +1,23 @@
 import { Stack, Text } from '@mantine/core'
-import { Audience } from './types'
+import { Audience, Scope } from './types'
 
-export function EmptyState({ audience }: { audience: Audience }) {
-    const message =
-        audience === 'reviewer' ? 'You currently do not have any studies to review' : 'You have not started a study yet'
+// 'My dashboard' (user scope) uses participation-focused copy so dual-role users get a
+// role-specific empty state (OTTER-517). The org dashboards keep their existing copy.
+const MESSAGES: Record<Scope, Record<Audience, string>> = {
+    user: {
+        reviewer: "You haven't yet participated in reviewing a study",
+        researcher: "You haven't yet participated in a study",
+    },
+    org: {
+        reviewer: 'You have no studies to review.',
+        researcher: "You haven't started a study yet",
+    },
+}
 
+export function EmptyState({ audience, scope }: { audience: Audience; scope: Scope }) {
     return (
         <Stack align="center" gap="md">
-            <Text>{message}</Text>
+            <Text>{MESSAGES[scope][audience]}</Text>
         </Stack>
     )
 }

--- a/src/components/dashboard/studies-table/empty-state.tsx
+++ b/src/components/dashboard/studies-table/empty-state.tsx
@@ -1,29 +1,13 @@
-import { ButtonLink } from '@/components/links'
-import { Routes } from '@/lib/routes'
-import { Stack, Text, Title } from '@mantine/core'
-import { PlusIcon } from '@phosphor-icons/react/dist/ssr'
+import { Stack, Text } from '@mantine/core'
 import { Audience } from './types'
 
-type EmptyStateProps = {
-    audience: Audience
-    orgSlug: string
-    showNewStudyButton: boolean
-}
+export function EmptyState({ audience }: { audience: Audience }) {
+    const message =
+        audience === 'reviewer' ? 'You currently do not have any studies to review' : 'You have not started a study yet'
 
-export function EmptyState({ audience, orgSlug, showNewStudyButton }: EmptyStateProps) {
-    if (audience === 'reviewer') {
-        return <Title order={5}>You have no studies to review.</Title>
-    }
-
-    // Researcher empty state
     return (
         <Stack align="center" gap="md">
-            <Text>You haven&apos;t started a study yet</Text>
-            {showNewStudyButton && (
-                <ButtonLink leftSection={<PlusIcon />} href={Routes.studyRequest({ orgSlug })} data-testid="new-study">
-                    Propose New Study
-                </ButtonLink>
-            )}
+            <Text>{message}</Text>
         </Stack>
     )
 }

--- a/src/components/dashboard/studies-table/empty-state.tsx
+++ b/src/components/dashboard/studies-table/empty-state.tsx
@@ -9,7 +9,7 @@ const MESSAGES: Record<Scope, Record<Audience, string>> = {
         researcher: "You haven't yet participated in a study",
     },
     org: {
-        reviewer: 'You have no studies to review.',
+        reviewer: 'You have no studies to review',
         researcher: "You haven't started a study yet",
     },
 }

--- a/src/components/dashboard/studies-table/index.tsx
+++ b/src/components/dashboard/studies-table/index.tsx
@@ -185,7 +185,7 @@ function StudiesTableBody({ isError, error, isEmpty, studies, audience, scope, o
     }
 
     if (isEmpty) {
-        return <EmptyState audience={audience} />
+        return <EmptyState audience={audience} scope={scope} />
     }
 
     return (

--- a/src/components/dashboard/studies-table/index.tsx
+++ b/src/components/dashboard/studies-table/index.tsx
@@ -89,6 +89,7 @@ export function StudiesTable({
         data: studies = [],
         refetch,
         isError,
+        error,
         isFetching,
         isRefetching,
         isLoading,
@@ -148,7 +149,7 @@ export function StudiesTable({
             {description && <Text mb="md">{description}</Text>}
             <StudiesTableBody
                 isError={isError}
-                error={errorToString(studies)}
+                error={errorToString(error)}
                 isEmpty={displayedStudies.length === 0}
                 studies={displayedStudies}
                 audience={audience}

--- a/src/components/dashboard/studies-table/index.tsx
+++ b/src/components/dashboard/studies-table/index.tsx
@@ -109,22 +109,15 @@ export function StudiesTable({
         return <TableSkeleton showActionButton={showNewStudyButton} paperWrapper={paperWrapper} />
     }
 
-    // Error state
-    if (isError) {
-        return <ErrorAlert error={`Failed to load studies: ${errorToString(studies)}`} />
-    }
-
     // Apply client-side filtering for user scope
     const displayedStudies =
         scope === 'user' && userId
             ? filterStudiesForUser(studies as StudyRowType[], audience, userId)
             : (studies as StudyRowType[])
 
-    // Empty state
-    if (!displayedStudies.length) {
-        return <EmptyState audience={audience} orgSlug={effectiveOrgSlug} showNewStudyButton={showNewStudyButton} />
-    }
-
+    // The header (title, toggle, refresher, CTA) must always render so dual-role users keep
+    // their audience toggle even when the selected role has no studies. Only the body below
+    // reflects error / empty / populated state.
     const shouldShowRefresher = showRefresher && needsRefresh(displayedStudies)
 
     const content = (
@@ -153,20 +146,15 @@ export function StudiesTable({
             </Group>
             <Divider c="charcoal.1" />
             {description && <Text mb="md">{description}</Text>}
-            <Table layout="fixed" verticalSpacing="md" highlightOnHover stickyHeader>
-                <TableHeader audience={audience} scope={scope} />
-                <TableTbody>
-                    {displayedStudies.map((study) => (
-                        <StudyRow
-                            key={study.id}
-                            study={study}
-                            audience={audience}
-                            scope={scope}
-                            orgSlug={effectiveOrgSlug}
-                        />
-                    ))}
-                </TableTbody>
-            </Table>
+            <StudiesTableBody
+                isError={isError}
+                error={errorToString(studies)}
+                isEmpty={displayedStudies.length === 0}
+                studies={displayedStudies}
+                audience={audience}
+                scope={scope}
+                orgSlug={effectiveOrgSlug}
+            />
         </Stack>
     )
 
@@ -179,4 +167,35 @@ export function StudiesTable({
     }
 
     return content
+}
+
+type StudiesTableBodyProps = {
+    isError: boolean
+    error: string
+    isEmpty: boolean
+    studies: StudyRowType[]
+    audience: Audience
+    scope: Scope
+    orgSlug: string
+}
+
+function StudiesTableBody({ isError, error, isEmpty, studies, audience, scope, orgSlug }: StudiesTableBodyProps) {
+    if (isError) {
+        return <ErrorAlert error={`Failed to load studies: ${error}`} />
+    }
+
+    if (isEmpty) {
+        return <EmptyState audience={audience} />
+    }
+
+    return (
+        <Table layout="fixed" verticalSpacing="md" highlightOnHover stickyHeader>
+            <TableHeader audience={audience} scope={scope} />
+            <TableTbody>
+                {studies.map((study) => (
+                    <StudyRow key={study.id} study={study} audience={audience} scope={scope} orgSlug={orgSlug} />
+                ))}
+            </TableTbody>
+        </Table>
+    )
 }

--- a/src/components/dashboard/studies-table/studies-table.test.tsx
+++ b/src/components/dashboard/studies-table/studies-table.test.tsx
@@ -131,7 +131,61 @@ describe('Studies Table', () => {
             />,
         )
 
-        expect(await screen.findByText(/You have no studies to review/i)).toBeDefined()
+        expect(await screen.findByText(/You currently do not have any studies to review/i)).toBeDefined()
+    })
+
+    it('renders header actions when the table is empty', async () => {
+        vi.mocked(fetchStudiesForOrgAction).mockResolvedValueOnce([])
+        renderWithProviders(
+            <StudiesTable
+                audience="reviewer"
+                scope="org"
+                orgSlug="test-org"
+                title="Review Studies"
+                showRefresher
+                paperWrapper
+                headerActions={<button type="button">Toggle Placeholder</button>}
+            />,
+        )
+
+        expect(await screen.findByText(/You currently do not have any studies to review/i)).toBeDefined()
+        expect(screen.getByText('Review Studies')).toBeDefined()
+        expect(screen.getByText('Toggle Placeholder')).toBeDefined()
+    })
+
+    it('renders researcher empty state copy', async () => {
+        vi.mocked(fetchStudiesForOrgAction).mockResolvedValueOnce([])
+        renderWithProviders(
+            <StudiesTable audience="researcher" scope="org" orgSlug="test-org" title="Proposed Studies" paperWrapper />,
+        )
+
+        expect(await screen.findByText(/You have not started a study yet/i)).toBeDefined()
+    })
+
+    it('renders reviewer empty state copy', async () => {
+        vi.mocked(fetchStudiesForOrgAction).mockResolvedValueOnce([])
+        renderWithProviders(
+            <StudiesTable audience="reviewer" scope="org" orgSlug="test-org" title="Review Studies" paperWrapper />,
+        )
+
+        expect(await screen.findByText(/You currently do not have any studies to review/i)).toBeDefined()
+    })
+
+    it('does not duplicate the new study button on an empty lab org dashboard', async () => {
+        vi.mocked(fetchStudiesForOrgAction).mockResolvedValueOnce([])
+        renderWithProviders(
+            <StudiesTable
+                audience="researcher"
+                scope="org"
+                orgSlug="test-org"
+                title="Proposed Studies"
+                showNewStudyButton
+                paperWrapper
+            />,
+        )
+
+        await screen.findByText(/You have not started a study yet/i)
+        expect(screen.getAllByTestId('new-study')).toHaveLength(1)
     })
 
     it('renders the table when studies exist', async () => {

--- a/src/components/dashboard/studies-table/studies-table.test.tsx
+++ b/src/components/dashboard/studies-table/studies-table.test.tsx
@@ -188,6 +188,16 @@ describe('Studies Table', () => {
         expect(screen.getAllByTestId('new-study')).toHaveLength(1)
     })
 
+    it('does not show the new study button on an empty enclave org dashboard', async () => {
+        vi.mocked(fetchStudiesForOrgAction).mockResolvedValueOnce([])
+        renderWithProviders(
+            <StudiesTable audience="reviewer" scope="org" orgSlug="test-org" title="Review Studies" paperWrapper />,
+        )
+
+        await screen.findByText(/You currently do not have any studies to review/i)
+        expect(screen.queryByTestId('new-study')).toBeNull()
+    })
+
     it('renders the table when studies exist', async () => {
         renderWithProviders(
             <StudiesTable

--- a/src/components/dashboard/studies-table/studies-table.test.tsx
+++ b/src/components/dashboard/studies-table/studies-table.test.tsx
@@ -131,7 +131,7 @@ describe('Studies Table', () => {
             />,
         )
 
-        expect(await screen.findByText(/You currently do not have any studies to review/i)).toBeDefined()
+        expect(await screen.findByText(/You have no studies to review/i)).toBeDefined()
     })
 
     it('renders header actions when the table is empty', async () => {
@@ -148,7 +148,7 @@ describe('Studies Table', () => {
             />,
         )
 
-        expect(await screen.findByText(/You currently do not have any studies to review/i)).toBeDefined()
+        expect(await screen.findByText(/You have no studies to review/i)).toBeDefined()
         expect(screen.getByText('Review Studies')).toBeDefined()
         expect(screen.getByText('Toggle Placeholder')).toBeDefined()
     })
@@ -159,7 +159,7 @@ describe('Studies Table', () => {
             <StudiesTable audience="researcher" scope="org" orgSlug="test-org" title="Proposed Studies" paperWrapper />,
         )
 
-        expect(await screen.findByText(/You have not started a study yet/i)).toBeDefined()
+        expect(await screen.findByText(/You haven't started a study yet/i)).toBeDefined()
     })
 
     it('renders reviewer empty state copy', async () => {
@@ -168,7 +168,7 @@ describe('Studies Table', () => {
             <StudiesTable audience="reviewer" scope="org" orgSlug="test-org" title="Review Studies" paperWrapper />,
         )
 
-        expect(await screen.findByText(/You currently do not have any studies to review/i)).toBeDefined()
+        expect(await screen.findByText(/You have no studies to review/i)).toBeDefined()
     })
 
     it('does not duplicate the new study button on an empty lab org dashboard', async () => {
@@ -184,7 +184,7 @@ describe('Studies Table', () => {
             />,
         )
 
-        await screen.findByText(/You have not started a study yet/i)
+        await screen.findByText(/You haven't started a study yet/i)
         expect(screen.getAllByTestId('new-study')).toHaveLength(1)
     })
 
@@ -194,7 +194,7 @@ describe('Studies Table', () => {
             <StudiesTable audience="reviewer" scope="org" orgSlug="test-org" title="Review Studies" paperWrapper />,
         )
 
-        await screen.findByText(/You currently do not have any studies to review/i)
+        await screen.findByText(/You have no studies to review/i)
         expect(screen.queryByTestId('new-study')).toBeNull()
     })
 

--- a/src/components/dashboard/studies-table/studies-table.test.tsx
+++ b/src/components/dashboard/studies-table/studies-table.test.tsx
@@ -198,6 +198,16 @@ describe('Studies Table', () => {
         expect(screen.queryByTestId('new-study')).toBeNull()
     })
 
+    it('surfaces the query error message when loading fails', async () => {
+        vi.mocked(fetchStudiesForOrgAction).mockRejectedValueOnce(new Error('boom'))
+        renderWithProviders(
+            <StudiesTable audience="reviewer" scope="org" orgSlug="test-org" title="Review Studies" paperWrapper />,
+        )
+
+        expect(await screen.findByText(/Failed to load studies: .*boom/i)).toBeDefined()
+        expect(screen.getByText('Review Studies')).toBeDefined()
+    })
+
     it('renders the table when studies exist', async () => {
         renderWithProviders(
             <StudiesTable

--- a/tests/unit.helpers.tsx
+++ b/tests/unit.helpers.tsx
@@ -435,6 +435,10 @@ type MockSession = {
     orgType?: 'enclave' | 'lab'
     isSiAdmin?: boolean
     twoFactorEnabled?: boolean
+    // Additional org memberships beyond the primary `orgSlug`, e.g. to mock a dual-role
+    // user who belongs to both a lab and an enclave. Ids must match real DB org ids when
+    // the mocked session drives server actions that query by org id.
+    extraOrgs?: Array<{ slug: string; id?: string; type?: 'enclave' | 'lab'; isAdmin?: boolean }>
 }
 
 export type ClerkMocks = ReturnType<typeof mockClerkSession>
@@ -475,6 +479,15 @@ export const mockClerkSession = (values: MockSession | null) => {
             slug: CLERK_ADMIN_ORG_SLUG,
             type: 'enclave',
             isAdmin: true,
+        }
+    }
+
+    for (const extra of values.extraOrgs ?? []) {
+        orgs[extra.slug] = {
+            id: extra.id,
+            slug: extra.slug,
+            type: extra.type ?? 'enclave',
+            isAdmin: extra.isAdmin ?? false,
         }
     }
     // Flattened structure - no environment nesting
@@ -611,6 +624,37 @@ export async function mockSessionWithTestData(options: MockSessionWithTestDataOp
     const session = { user, org: { id: org.id, slug: org.slug } }
 
     return { session, org, user, orgUser, ...mocks }
+}
+
+type MockDualRoleSessionOptions = {
+    labSlug?: string
+    enclaveSlug?: string
+    twoFactorEnabled?: boolean
+}
+
+// Creates a real lab org + enclave org and a single user who is a member of BOTH (a
+// "dual-role" user: researcher via the lab, reviewer via the enclave). The Clerk mock's
+// publicMetadata carries both real org ids, so server actions resolve the same dual-role
+// session the real app would. Use for My dashboard Reviewer/Researcher toggle tests.
+export async function mockDualRoleSessionWithTestData(options: MockDualRoleSessionOptions = {}) {
+    const labOrg = await insertTestOrg({ slug: options.labSlug ?? faker.string.alpha(10), type: 'lab' })
+    const enclaveOrg = await insertTestOrg({ slug: options.enclaveSlug ?? faker.string.alpha(10), type: 'enclave' })
+
+    const { user } = await insertTestUser({ org: { id: labOrg.id, slug: labOrg.slug, type: 'lab' } })
+    await findOrCreateOrgMembership({ userId: user.id, slug: enclaveOrg.slug, isAdmin: false })
+
+    const mocks = mockClerkSession({
+        userId: user.id,
+        clerkUserId: user.clerkId,
+        email: user.email ?? undefined,
+        orgSlug: labOrg.slug,
+        orgId: labOrg.id,
+        orgType: 'lab',
+        twoFactorEnabled: options.twoFactorEnabled,
+        extraOrgs: [{ slug: enclaveOrg.slug, id: enclaveOrg.id, type: 'enclave' }],
+    })
+
+    return { user, labOrg, enclaveOrg, ...mocks }
 }
 
 type CreateTestProposalDraftOptions = {


### PR DESCRIPTION
see [OTTER-517](https://openstax.atlassian.net/browse/OTTER-517)

**Why this happens:** The Reviewer/Researcher toggle is rendered inside `StudiesTable`'s header, but `StudiesTable` had early `return`s for the empty (and error) states that fired *before* the header was built. So whenever the selected role had zero rows, the component returned just the empty message and the whole header, including the toggle, disappeared. The effective condition for showing the toggle became "dual-role **and** the selected tab has rows" instead of just "dual-role." That produced both reported symptoms: a new dual-role user lands on the empty Researcher tab and gets stuck with no toggle (Issue 1), and switching to an empty Reviewer tab makes the toggle vanish (Issue 2). Issue 3 was simply hardcoded empty-state copy that didn't match the per-audience wording.

**Fix:** the header always renders once studies load; only the body below it reflects empty/error/table state, and the empty copy is now audience-specific.

[OTTER-517]: https://openstax.atlassian.net/browse/OTTER-517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ