### PR TITLE
OTTER-538 follow-up: Fix researcher "Previous" navigation on results-stage Study Details page

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
@@ -314,5 +314,70 @@ describe('StudyReviewPage', () => {
             expect(page?.props.entries).toHaveLength(1)
             expect(page?.props.entries[0].decision).toBe('APPROVE')
         })
+
+        // Reachability tripwire for the latent blank-page path: PostFeedbackView returns null
+        // when entries[0].decision is null, and getCodeReviewFeedbackAction sorts newest-first
+        // with resubmission notes carrying decision: null. At a results status the approved job
+        // can itself be a resubmission, so a note (dated at job creation) coexists with the later
+        // APPROVE. This proves the APPROVE stays newest (entries[0]), so the page never blanks.
+        // If the ordering invariant ever regresses, entries[0] becomes the note and this fails
+        // (surfacing the OTTER-552-owned hardening rather than letting it silently break here).
+        it('keeps the APPROVE newest (non-blank) when a resubmission note coexists at a results status', async () => {
+            const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+            const { study, job } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'APPROVED',
+                jobStatus: 'CODE-SUBMITTED',
+            })
+
+            // The approved job is itself a resubmission: its note is dated at job creation and
+            // the reviewer's APPROVE lands a day later, mirroring the real resubmit -> approve flow.
+            await db
+                .updateTable('studyJob')
+                .set({
+                    createdAt: new Date('2026-03-01T00:00:00Z'),
+                    resubmissionNote: { root: { type: 'root', children: [{ text: 'fixed things' }] } },
+                })
+                .where('id', '=', job.id)
+                .execute()
+            await db
+                .insertInto('jobStatusChange')
+                .values({ status: 'RUN-COMPLETE', studyJobId: job.id, createdAt: new Date('2026-03-03T00:00:00Z') })
+                .execute()
+            await db
+                .insertInto('studyReviewComment')
+                .values({
+                    studyId: study.id,
+                    studyJobId: job.id,
+                    authorId: user.id,
+                    reviewKind: 'CODE',
+                    entryType: 'DECISION',
+                    decision: 'APPROVE',
+                    body: { root: { type: 'root', children: [] } },
+                    criteria: {
+                        proposalAlignment: 'yes',
+                        agreementCompliance: 'yes',
+                        securityChecks: 'yes',
+                        privacyProtection: 'yes',
+                    },
+                    createdAt: new Date('2026-03-02T00:00:00Z'),
+                })
+                .execute()
+
+            const page = await StudyReviewPage({
+                params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+                searchParams: Promise.resolve({ from: 'code-review' }),
+            })
+
+            expect(page?.type).toBe(PostFeedbackView)
+            expect(page?.props.kind).toBe('CODE')
+            // Newest-first: the APPROVE outranks the older note, so entries[0] is decision-bearing
+            // and PostFeedbackView does not return null. The note is still present for history.
+            expect(page?.props.entries[0].decision).toBe('APPROVE')
+            expect(page?.props.entries.some((e: { entryType: string }) => e.entryType === 'RESUBMISSION-NOTE')).toBe(
+                true,
+            )
+        })
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
@@ -268,5 +268,51 @@ describe('StudyReviewPage', () => {
                 expect(page?.type).toBe(StudyDetailsReviewer)
             },
         )
+
+        // OTTER-538 QA finding (DO): "Previous" from the results-stage Study Details page
+        // navigates to /review?from=code-review. After OTTER-552 that param routes to the
+        // post-code-feedback page. This proves the destination renders non-blank (the code
+        // APPROVE decision is present), rather than a null PostFeedbackView, at a results status.
+        it('renders the post-code-feedback page (kind=CODE, non-blank) when from=code-review at a results status', async () => {
+            const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+            const { study, job } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'APPROVED',
+                jobStatus: 'CODE-SUBMITTED',
+            })
+            await db
+                .insertInto('jobStatusChange')
+                .values({ status: 'RUN-COMPLETE', studyJobId: job.id, createdAt: new Date(Date.now() + 1000) })
+                .execute()
+            await db
+                .insertInto('studyReviewComment')
+                .values({
+                    studyId: study.id,
+                    studyJobId: job.id,
+                    authorId: user.id,
+                    reviewKind: 'CODE',
+                    entryType: 'DECISION',
+                    decision: 'APPROVE',
+                    body: { root: { type: 'root', children: [] } },
+                    criteria: {
+                        proposalAlignment: 'yes',
+                        agreementCompliance: 'yes',
+                        securityChecks: 'yes',
+                        privacyProtection: 'yes',
+                    },
+                })
+                .execute()
+
+            const page = await StudyReviewPage({
+                params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+                searchParams: Promise.resolve({ from: 'code-review' }),
+            })
+
+            expect(page?.type).toBe(PostFeedbackView)
+            expect(page?.props.kind).toBe('CODE')
+            expect(page?.props.entries).toHaveLength(1)
+            expect(page?.props.entries[0].decision).toBe('APPROVE')
+        })
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.test.tsx
@@ -58,7 +58,7 @@ async function setupSubmittedStudy() {
 function renderView(
     study: SelectedStudy,
     job: LatestJobForStudy,
-    overrides: { dashboardHref?: Route; reviewingOrgName?: string } = {},
+    overrides: { dashboardHref?: Route; reviewingOrgName?: string; isUnderReview?: boolean } = {},
 ) {
     renderWithProviders(
         <CodePostSubmissionView
@@ -67,6 +67,7 @@ function renderView(
             job={job}
             reviewingOrgName={overrides.reviewingOrgName ?? REVIEWING_ORG_NAME}
             dashboardHref={overrides.dashboardHref}
+            isUnderReview={overrides.isUnderReview}
         />,
     )
 }
@@ -111,6 +112,15 @@ describe('CodePostSubmissionView', () => {
 
             const banner = screen.getByTestId('code-under-review-banner')
             expect(banner).toHaveStyle({ backgroundColor: '#FFF9E5' })
+        })
+
+        it('hides the under-review banner when isUnderReview is false (reached via results-page Previous)', async () => {
+            const { study, job } = await setupSubmittedStudy()
+            renderView(study, job, { isUnderReview: false })
+
+            expect(screen.queryByTestId('code-under-review-banner')).not.toBeInTheDocument()
+            // The rest of the page still renders (e.g. the submitted timestamp).
+            expect(screen.getByTestId('code-submitted-timestamp')).toBeInTheDocument()
         })
     })
 

--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.tsx
@@ -20,6 +20,7 @@ interface CodePostSubmissionViewProps {
     job: LatestJobForStudy
     reviewingOrgName: string
     dashboardHref?: Route
+    isUnderReview?: boolean
 }
 
 function useExpandable(initial = false) {
@@ -40,6 +41,17 @@ const SubmittedTimestamp: FC<{ submittedOn: string | null }> = ({ submittedOn })
         <Text fz={12} c="charcoal.7" data-testid="code-submitted-timestamp">
             Submitted on {submittedOn}
         </Text>
+    )
+}
+
+const UnderReviewBanner: FC<{ isVisible: boolean; reviewingOrgName: string }> = ({ isVisible, reviewingOrgName }) => {
+    if (!isVisible) return null
+    return (
+        <Alert color="yellow" mt="md" bg="#FFF9E5" data-testid="code-under-review-banner">
+            Your study code has been submitted to {displayOrgName(reviewingOrgName)}. They will have access to your
+            study code and an AI-generated summary of its behavior. Please allow 7-10 business days for review.
+            You&apos;ll receive email notifications about updates.
+        </Alert>
     )
 }
 
@@ -69,6 +81,7 @@ export function CodePostSubmissionView({
     job,
     reviewingOrgName,
     dashboardHref,
+    isUnderReview = true,
 }: CodePostSubmissionViewProps) {
     const { expanded, toggle, collapse } = useExpandable()
 
@@ -105,11 +118,7 @@ export function CodePostSubmissionView({
                         <SubmittedTimestamp submittedOn={submittedOn} />
                     </Group>
                     <Divider my="md" />
-                    <Alert color="yellow" mt="md" bg="#FFF9E5" data-testid="code-under-review-banner">
-                        Your study code has been submitted to {displayOrgName(reviewingOrgName)}. They will have access
-                        to your study code and an AI-generated summary of its behavior. Please allow 7-10 business days
-                        for review. You&apos;ll receive email notifications about updates.
-                    </Alert>
+                    <UnderReviewBanner isVisible={isUnderReview} reviewingOrgName={reviewingOrgName} />
                     <ExpandToggle isVisible={!expanded} onClick={toggle} />
                 </Paper>
 

--- a/src/app/[orgSlug]/study/[studyId]/view/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/page.test.tsx
@@ -371,5 +371,24 @@ describe('StudyViewPage', () => {
                 expect(page?.type).toBe(StudyDetailsResearcher)
             },
         )
+
+        it('renders CodePostSubmissionView with the banner hidden when from=code-submission at a results status', async () => {
+            const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+            const { study } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'APPROVED',
+                jobStatus: 'CODE-SUBMITTED',
+            })
+            await addJobStatus(study.id, 'RUN-COMPLETE')
+
+            const page = await StudyReviewPage({
+                params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+                searchParams: Promise.resolve({ from: 'code-submission' }),
+            })
+
+            expect(page?.type).toBe(CodePostSubmissionView)
+            expect(page?.props.isUnderReview).toBe(false)
+        })
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/view/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/page.test.tsx
@@ -393,5 +393,57 @@ describe('StudyViewPage', () => {
                 expect(page?.props.isUnderReview).toBe(false)
             },
         )
+
+        it('threads returnTo=org to StudyDetailsResearcher at a results status', async () => {
+            const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+            const { study } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'APPROVED',
+                jobStatus: 'CODE-SUBMITTED',
+            })
+            await addJobStatus(study.id, 'RUN-COMPLETE')
+
+            const page = await StudyReviewPage({
+                params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+                searchParams: Promise.resolve({ returnTo: 'org' }),
+            })
+
+            expect(page?.type).toBe(StudyDetailsResearcher)
+            expect(page?.props.returnTo).toBe('org')
+        })
+
+        // Fix 2 (PR #759): the from=code-submission branch is gated on isStudyResultsStatus, so a
+        // stray ?from=code-submission at a code-decision status falls through to CodePostDecisionView
+        // instead of short-circuiting to the post-submission view.
+        it('falls through to CodePostDecisionView when from=code-submission arrives at CODE-APPROVED', async () => {
+            const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+            const { study, job } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'APPROVED',
+                jobStatus: 'CODE-SUBMITTED',
+            })
+            await addJobStatus(study.id, 'CODE-APPROVED')
+            await db
+                .insertInto('studyReviewComment')
+                .values({
+                    studyId: study.id,
+                    studyJobId: job.id,
+                    authorId: user.id,
+                    reviewKind: 'CODE',
+                    entryType: 'DECISION',
+                    decision: 'APPROVE',
+                    body: { root: { type: 'root', children: [] } },
+                })
+                .execute()
+
+            const page = await StudyReviewPage({
+                params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+                searchParams: Promise.resolve({ from: 'code-submission' }),
+            })
+
+            expect(page?.type).toBe(CodePostDecisionView)
+        })
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/view/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/page.test.tsx
@@ -372,23 +372,26 @@ describe('StudyViewPage', () => {
             },
         )
 
-        it('renders CodePostSubmissionView with the banner hidden when from=code-submission at a results status', async () => {
-            const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
-            const { study } = await insertTestStudyJobData({
-                org,
-                researcherId: user.id,
-                studyStatus: 'APPROVED',
-                jobStatus: 'CODE-SUBMITTED',
-            })
-            await addJobStatus(study.id, 'RUN-COMPLETE')
+        it.each(['RUN-COMPLETE', 'FILES-APPROVED', 'FILES-REJECTED', 'JOB-ERRORED'] as const)(
+            'renders CodePostSubmissionView with the banner hidden when from=code-submission at %s',
+            async (jobStatus) => {
+                const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+                const { study } = await insertTestStudyJobData({
+                    org,
+                    researcherId: user.id,
+                    studyStatus: 'APPROVED',
+                    jobStatus: 'CODE-SUBMITTED',
+                })
+                await addJobStatus(study.id, jobStatus)
 
-            const page = await StudyReviewPage({
-                params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
-                searchParams: Promise.resolve({ from: 'code-submission' }),
-            })
+                const page = await StudyReviewPage({
+                    params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+                    searchParams: Promise.resolve({ from: 'code-submission' }),
+                })
 
-            expect(page?.type).toBe(CodePostSubmissionView)
-            expect(page?.props.isUnderReview).toBe(false)
-        })
+                expect(page?.type).toBe(CodePostSubmissionView)
+                expect(page?.props.isUnderReview).toBe(false)
+            },
+        )
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/view/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/page.tsx
@@ -34,7 +34,8 @@ export default async function StudyReviewPage(props: {
 
     const job = await latestJobForStudyOrNull(studyId)
 
-    const dashboardHref = searchParams.returnTo === 'org' ? Routes.orgDashboard({ orgSlug }) : Routes.dashboard
+    const returnTo = searchParams.returnTo === 'org' ? 'org' : undefined
+    const dashboardHref = returnTo ? Routes.orgDashboard({ orgSlug }) : Routes.dashboard
 
     const fromAgreements = searchParams.from === 'agreements'
     const fromCodeSubmission = searchParams.from === 'code-submission'
@@ -49,8 +50,10 @@ export default async function StudyReviewPage(props: {
 
         // RL "Previous" from the results-stage Study Details page returns here with ?from=code-submission.
         // Once results exist the under-review branch no longer fires, so render the OTTER-537 post-submission
-        // page explicitly. The "code under review" banner is hidden because review has already concluded.
-        if (fromCodeSubmission) {
+        // page explicitly. Gate on the results status (not the query param alone) so a stray
+        // ?from=code-submission at a code-decision/under-review status falls through to the correct branch
+        // below. The "code under review" banner is hidden because review has already concluded.
+        if (isStudyResultsStatus(latestJobStatus) && fromCodeSubmission) {
             const reviewingOrgName = await getOrgNameFromId(study.orgId)
             return (
                 <CodePostSubmissionView
@@ -104,7 +107,15 @@ export default async function StudyReviewPage(props: {
         // OTTER-538: once results exist, render the redesigned Study Details page
         // (no code section, results-only) instead of the legacy CodeOnlyView.
         if (isStudyResultsStatus(latestJobStatus)) {
-            return <StudyDetailsResearcher orgSlug={orgSlug} study={study} job={job} dashboardHref={dashboardHref} />
+            return (
+                <StudyDetailsResearcher
+                    orgSlug={orgSlug}
+                    study={study}
+                    job={job}
+                    dashboardHref={dashboardHref}
+                    returnTo={returnTo}
+                />
+            )
         }
         return <CodeOnlyView orgSlug={orgSlug} study={study} job={job} dashboardHref={dashboardHref} />
     }
@@ -119,7 +130,7 @@ export default async function StudyReviewPage(props: {
             ? Routes.studyAgreements({
                   orgSlug,
                   studyId,
-                  returnTo: searchParams.returnTo === 'org' ? 'org' : undefined,
+                  returnTo,
               })
             : undefined
         return (

--- a/src/app/[orgSlug]/study/[studyId]/view/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/page.tsx
@@ -37,6 +37,7 @@ export default async function StudyReviewPage(props: {
     const dashboardHref = searchParams.returnTo === 'org' ? Routes.orgDashboard({ orgSlug }) : Routes.dashboard
 
     const fromAgreements = searchParams.from === 'agreements'
+    const fromCodeSubmission = searchParams.from === 'code-submission'
 
     // Only show code views if code was actually submitted (not just a baseline job from IDE launch).
     // When the researcher navigates back from agreements (?from=agreements), show the read-only
@@ -45,6 +46,23 @@ export default async function StudyReviewPage(props: {
     if (job && codeSubmitted && !fromAgreements) {
         const latestJobStatus = job.statusChanges[0]?.status
         const isUnderReview = study.status === 'PENDING-REVIEW' && isUnderReviewStatus(latestJobStatus)
+
+        // RL "Previous" from the results-stage Study Details page returns here with ?from=code-submission.
+        // Once results exist the under-review branch no longer fires, so render the OTTER-537 post-submission
+        // page explicitly. The "code under review" banner is hidden because review has already concluded.
+        if (fromCodeSubmission) {
+            const reviewingOrgName = await getOrgNameFromId(study.orgId)
+            return (
+                <CodePostSubmissionView
+                    orgSlug={orgSlug}
+                    study={study}
+                    job={job}
+                    reviewingOrgName={reviewingOrgName}
+                    dashboardHref={dashboardHref}
+                    isUnderReview={false}
+                />
+            )
+        }
 
         if (isCodeDecisionStatus(latestJobStatus)) {
             const entries = await getCodeReviewFeedbackAction({ studyId })

--- a/src/app/[orgSlug]/study/[studyId]/view/study-details-researcher.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/study-details-researcher.test.tsx
@@ -27,4 +27,15 @@ describe('StudyDetailsResearcher', () => {
             expect.stringContaining(`/${org.slug}/study/${study.id}/view?from=code-submission`),
         )
     })
+
+    it('preserves org-dashboard context on the Previous link when returnTo=org', async () => {
+        const { org, study, latestJob } = await setupStudyAction({ orgSlug: 'openstax', orgType: 'lab' })
+
+        renderWithProviders(<StudyDetailsResearcher orgSlug={org.slug} study={study} job={latestJob!} returnTo="org" />)
+
+        const previous = screen.getByRole('link', { name: /previous/i })
+        const href = previous.getAttribute('href') ?? ''
+        expect(href).toContain('from=code-submission')
+        expect(href).toContain('returnTo=org')
+    })
 })

--- a/src/app/[orgSlug]/study/[studyId]/view/study-details-researcher.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/study-details-researcher.test.tsx
@@ -16,12 +16,15 @@ describe('StudyDetailsResearcher', () => {
         expect(screen.getByText('Study Status')).toBeInTheDocument()
     })
 
-    it('renders a Previous link', async () => {
+    it('renders a Previous link back to the OTTER-537 code-submission page', async () => {
         const { org, study, latestJob } = await setupStudyAction({ orgSlug: 'openstax', orgType: 'lab' })
 
         renderWithProviders(<StudyDetailsResearcher orgSlug={org.slug} study={study} job={latestJob!} />)
 
         const previous = screen.getByRole('link', { name: /previous/i })
-        expect(previous).toBeInTheDocument()
+        expect(previous).toHaveAttribute(
+            'href',
+            expect.stringContaining(`/${org.slug}/study/${study.id}/view?from=code-submission`),
+        )
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/view/study-details-researcher.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/study-details-researcher.tsx
@@ -19,10 +19,11 @@ type StudyDetailsResearcherProps = {
     study: SelectedStudy
     job: LatestJobForStudy
     dashboardHref?: Route
+    returnTo?: 'org'
 }
 
-export function StudyDetailsResearcher({ orgSlug, study, job, dashboardHref }: StudyDetailsResearcherProps) {
-    const previousHref = Routes.studyView({ orgSlug, studyId: study.id, from: 'code-submission' })
+export function StudyDetailsResearcher({ orgSlug, study, job, dashboardHref, returnTo }: StudyDetailsResearcherProps) {
+    const previousHref = Routes.studyView({ orgSlug, studyId: study.id, from: 'code-submission', returnTo })
 
     return (
         <Stack px="xl" gap="xl">

--- a/src/app/[orgSlug]/study/[studyId]/view/study-details-researcher.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/study-details-researcher.tsx
@@ -9,9 +9,10 @@ import type { LatestJobForStudy } from '@/server/db/queries'
 import type { SelectedStudy } from '@/server/actions/study.actions'
 
 // OTTER-538: Study Details page (RL) — removes the "Study Code" section.
-// "Previous" goes back to the dashboard since the OTTER-537 post-code-submission
-// page only renders while the job is in CODE-SUBMITTED/CODE-SCANNED status; once
-// results exist that page is no longer routable.
+// "Previous" returns to the OTTER-537 post-code-submission page. That page only
+// renders at /view while the job is in CODE-SUBMITTED/CODE-SCANNED status; once
+// results exist it is otherwise unroutable, so we reach it via ?from=code-submission,
+// which page.tsx routes to CodePostSubmissionView with the under-review banner hidden.
 
 type StudyDetailsResearcherProps = {
     orgSlug: string
@@ -21,7 +22,7 @@ type StudyDetailsResearcherProps = {
 }
 
 export function StudyDetailsResearcher({ orgSlug, study, job, dashboardHref }: StudyDetailsResearcherProps) {
-    const previousHref = dashboardHref ?? Routes.dashboard
+    const previousHref = Routes.studyView({ orgSlug, studyId: study.id, from: 'code-submission' })
 
     return (
         <Stack px="xl" gap="xl">

--- a/src/lib/routes/definitions.ts
+++ b/src/lib/routes/definitions.ts
@@ -99,7 +99,16 @@ export const Routes = {
 
     studyRequest: makeRoute(({ orgSlug }) => `/${orgSlug}/study/request`, OrgParams),
 
-    studyView: makeRoute(({ orgSlug, studyId }) => `/${orgSlug}/study/${studyId}/view`, StudyParams),
+    studyView: makeRoute(
+        ({ orgSlug, studyId, from }) => {
+            const base = `/${orgSlug}/study/${studyId}/view`
+            const params = new URLSearchParams()
+            if (from) params.set('from', from)
+            const qs = params.toString()
+            return qs ? `${base}?${qs}` : base
+        },
+        StudyParams.extend({ from: z.string().optional() }),
+    ),
 
     studyEdit: makeRoute(({ orgSlug, studyId }) => `/${orgSlug}/study/${studyId}/edit`, StudyParams),
 

--- a/src/lib/routes/definitions.ts
+++ b/src/lib/routes/definitions.ts
@@ -100,14 +100,15 @@ export const Routes = {
     studyRequest: makeRoute(({ orgSlug }) => `/${orgSlug}/study/request`, OrgParams),
 
     studyView: makeRoute(
-        ({ orgSlug, studyId, from }) => {
+        ({ orgSlug, studyId, from, returnTo }) => {
             const base = `/${orgSlug}/study/${studyId}/view`
             const params = new URLSearchParams()
             if (from) params.set('from', from)
+            if (returnTo) params.set('returnTo', returnTo)
             const qs = params.toString()
             return qs ? `${base}?${qs}` : base
         },
-        StudyParams.extend({ from: z.string().optional() }),
+        StudyParams.extend({ from: z.string().optional(), returnTo: z.string().optional() }),
     ),
 
     studyEdit: makeRoute(({ orgSlug, studyId }) => `/${orgSlug}/study/${studyId}/edit`, StudyParams),


### PR DESCRIPTION
see comments of [OTTER-538](https://openstax.atlassian.net/browse/OTTER-538)

- Fixed the researcher "Previous" button on the results-stage Study Details page so it returns to the post-code-submission page instead of the dashboard.
- Hid the "code under review" notice on that page once results exist, since the review has already concluded.
- Added a regression test confirming the reviewer "Previous" button lands on the post-code-feedback page rather than a blank screen.
- Added tests covering the corrected researcher navigation and the hidden review notice.

[OTTER-538]: https://openstax.atlassian.net/browse/OTTER-538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ