### PR TITLE
fix(invite-signup): surface Clerk 422 validation errors inline

### DIFF
--- a/src/app/account/invitation/[inviteId]/create-account.action.test.ts
+++ b/src/app/account/invitation/[inviteId]/create-account.action.test.ts
@@ -86,6 +86,54 @@ describe('Create Account Actions', () => {
         expect(result).toEqual({ error: expect.objectContaining({ invite: 'not found' }) })
     })
 
+    it('onCreateAccountAction surfaces Clerk validation errors inline', async () => {
+        const client = clerkClient as unknown as Mock
+        client.mockResolvedValue({
+            users: {
+                // no existing Clerk user, so the handler attempts to create one
+                getUserList: vi.fn(async () => ({ totalCount: 0, data: [] })),
+                createUser: vi.fn(async () => {
+                    throw {
+                        errors: [
+                            {
+                                code: 'form_password_pwned',
+                                message: 'Password has been found in an online data breach.',
+                                longMessage:
+                                    'Password has been found in an online data breach. For account safety, please use a different password.',
+                            },
+                        ],
+                    }
+                }),
+            },
+        })
+
+        const invite = await db
+            .insertInto('pendingUser')
+            .values({
+                orgId: org.id,
+                email: faker.internet.email({ provider: 'test.com' }),
+                isAdmin: false,
+                invitedByUserId: invitingUser.user.id,
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        const form = {
+            firstName: 'Test',
+            lastName: 'User',
+            password: 'hunter2',
+            confirmPassword: 'hunter2',
+        }
+
+        const result = await onCreateAccountAction({ inviteId: invite.id, form })
+        expect(result).toEqual({
+            error: {
+                code: 'form_password_pwned',
+                form: 'Password has been found in an online data breach. For account safety, please use a different password.',
+            },
+        })
+    })
+
     it('onCreateAccountAction rejects existing user', async () => {
         const { user } = await insertTestUser({ org })
 

--- a/src/app/account/invitation/[inviteId]/create-account.action.ts
+++ b/src/app/account/invitation/[inviteId]/create-account.action.ts
@@ -4,6 +4,7 @@ import { Action, ActionFailure, z } from '@/server/actions/action'
 import { updateClerkUserMetadata } from '@/server/clerk'
 import { getReviewerPublicKey } from '@/server/db/queries'
 import { onUserAcceptInvite } from '@/server/events'
+import { extractClerkCodeAndMessage, isClerkApiError } from '@/lib/errors'
 import { clerkClient } from '@clerk/nextjs/server'
 
 export const onPendingUserLoginAction = new Action('onPendingUserLoginAction')
@@ -187,13 +188,26 @@ export const onCreateAccountAction = new Action('onCreateAccountAction')
         } else {
             const createdByCIJobId = process.env.GITHUB_JOB
             const privateMetadata = createdByCIJobId ? { createdByCIJobId } : undefined
-            const clerkUser = await clerk.users.createUser({
-                firstName: form.firstName,
-                lastName: form.lastName,
-                emailAddress: [invite.email],
-                password: form.password,
-                privateMetadata,
-            })
+            let clerkUser
+            try {
+                clerkUser = await clerk.users.createUser({
+                    firstName: form.firstName,
+                    lastName: form.lastName,
+                    emailAddress: [invite.email],
+                    password: form.password,
+                    privateMetadata,
+                })
+            } catch (error) {
+                // Clerk rejects weak/compromised passwords (and other invalid input) with a 422.
+                // Surface the human-readable reason inline instead of the opaque "Unprocessable
+                // Entity" toast. The signup form renders the `form` key as a dedicated alert and
+                // uses `code` to pick an appropriate title (e.g. "Compromised Password").
+                if (isClerkApiError(error)) {
+                    const { code, message } = extractClerkCodeAndMessage(error)
+                    throw new ActionFailure({ form: message, code })
+                }
+                throw error
+            }
             clerkId = clerkUser.id
 
             const primaryEmail = clerkUser.emailAddresses.find((e) => e.emailAddress === invite.email)

--- a/src/app/account/invitation/[inviteId]/signup/page.tsx
+++ b/src/app/account/invitation/[inviteId]/signup/page.tsx
@@ -6,6 +6,7 @@ import {
     usePasswordRequirements,
 } from '@/app/account/reset-password/password-requirements'
 import { useMutation, useQuery, z, zodResolver } from '@/common'
+import { CLERK_ERROR_TITLES } from '@/components/clerk-errors'
 import { handleMutationErrorsWithForm, InputError, reportError } from '@/components/errors'
 import { LoadingMessage } from '@/components/loading'
 import { useAuth, useSignIn } from '@clerk/nextjs'
@@ -182,7 +183,7 @@ const SetupAccountForm: FC<InviteData> = ({ inviteId, email, orgName }) => {
                     {form.errors.form && (
                         <Alert
                             color="red"
-                            title="Compromised Password"
+                            title={CLERK_ERROR_TITLES[String(form.errors.code)]?.title || 'Could not create account'}
                             withCloseButton
                             onClose={() => form.clearFieldError('form')}
                         >

--- a/src/components/errors.tsx
+++ b/src/components/errors.tsx
@@ -31,7 +31,9 @@ export function handleMutationErrorsWithForm(form: FormErrorHandler) {
             } else {
                 const formErrorKeys = Object.keys(failure)
                 const fieldKeys = Object.keys(form.values)
-                const nonFieldKeys = formErrorKeys.filter((k) => k !== 'form')
+                // `form` is the catch-all alert key; `code` is a reserved companion that lets
+                // callers pass an error code (e.g. a Clerk code) to drive an alert title.
+                const nonFieldKeys = formErrorKeys.filter((k) => k !== 'form' && k !== 'code')
 
                 const unknownKeys = difference(nonFieldKeys, fieldKeys)
 


### PR DESCRIPTION
## Problem

Sentry [#7473887468](https://github.com/safeinsights/management-app) — an `a: Unprocessable Entity` error on `POST /account/invitation/[inviteId]/signup` (staging, Mobile Safari).

Clerk's `users.createUser()` rejects invalid input — most commonly a **weak or breached password** — with a `422 ClerkAPIResponseError`. The invitation signup action (`onCreateAccountAction`) didn't catch it, so:

1. The action wrapper returned the raw error's `.message` — the bare string `"Unprocessable Entity"` — giving the user (and Sentry) no idea *what* was wrong.
2. Because the failure was a **string**, `handleMutationErrorsWithForm` routed it to a generic error **toast** instead of the form's purpose-built inline alert:

> An error occurred — Unprocessable Entity Reference: 340d9389…

## Fix

- **`create-account.action.ts`** — wrap `clerk.users.createUser()`; on a Clerk API error, rethrow as `ActionFailure({ form: longMessage, code })` using the existing `isClerkApiError` / `extractClerkCodeAndMessage` helpers.
- **`errors.tsx`** — `handleMutationErrorsWithForm` now treats `code` as a reserved companion key (alongside `form`) so the object-shaped failure routes **inline** rather than falling back to a toast. No regression for MFA forms that use `code` as a real field.
- **`signup/page.tsx`** — the inline alert title is now derived from the Clerk code via `CLERK_ERROR_TITLES` (e.g. `form_password_pwned` → "Compromised Password"), falling back to "Could not create account" for other 422s. The body shows Clerk's real `longMessage`.

## Tests

- Added a unit test asserting a Clerk `form_password_pwned` 422 yields `{ error: { code, form } }`.
- `errors.test.tsx`: 18/18 pass; tsc + eslint clean.

> Note: the DB-backed action tests (including the new one) require a Postgres test DB and run in CI; they couldn't execute in my local sandbox (env/ARN not configured).