### PR TITLE
fix: preserve symlinks when zipping standalone Lambda package

### DIFF
--- a/bin/build-app
+++ b/bin/build-app
@@ -20,6 +20,13 @@ set -euo pipefail
 
 cp bin/prod.run.sh .next/standalone/run.sh
 
+# -y preserves symlinks instead of following them. Next's standalone output
+# under pnpm keeps node_modules/next (and other deps) as symlinks into the
+# .pnpm store; their transitive deps (@next/env, @swc/helpers, …) only resolve
+# through that symlink graph. Without -y, zip dereferences node_modules/next
+# into real files but strands its .pnpm-nested deps, so the Lambda fails at
+# startup with `Cannot find module '@next/env'` / '@swc/helpers'. Preserving the
+# symlinks keeps the graph intact end to end.
 pushd .next/standalone/
-zip -q -r ../../lambda-server-package.zip .
+zip -q -r -y ../../lambda-server-package.zip .
 popd

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "@mantine/notifications": "^8.3",
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/nextjs": "^10.41.0",
+        "@swc/helpers": "0.5.15",
         "@tanstack/react-query": "^5.90.21",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/papaparse": "^5.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       '@sentry/nextjs':
         specifier: ^10.41.0
         version: 10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.106.2(esbuild@0.27.7)(postcss@8.5.15))
+      '@swc/helpers':
+        specifier: 0.5.15
+        version: 0.5.15
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.100.11(react@19.2.4)


### PR DESCRIPTION
## Problem

After the pnpm migration, the management-app Lambda fails at startup with cascading missing-module errors — first `@swc/helpers`, then `@next/env`:

```
Error: Cannot find module '@next/env'
Require stack:
- /var/task/node_modules/next/dist/server/config.js
- /var/task/node_modules/next/dist/server/next.js
- /var/task/server.js
```

Both are transitive dependencies of next's own runtime.

## Root cause

Next's `output: 'standalone'` under pnpm keeps `node_modules/next` (and most deps) as **symlinks** into the `.pnpm` store; their transitive deps resolve only through that symlink graph.

`bin/build-app` packaged the bundle with `zip -r` (no `-y`), so zip **followed** the `next` symlink and wrote next's files as real files at the top level — while leaving its `.pnpm`-nested deps (`@next/env`, `@swc/helpers`, …) stranded under `node_modules/.pnpm/`. In the unpacked Lambda, `node_modules/next` is real files with no sibling `@next/env`, so resolution fails.

This is why declaring `@swc/helpers` as a direct dep (an earlier revision of this PR) only moved the failure to the next stranded package — it was whack-a-mole against a packaging bug. Confirmed by pulling the deployed `build.zip` from S3: `next` stored as real files, deps present only under `.pnpm/`, no top-level `@next/env`.

## Fix

Add `-y` to the `zip` so symlinks are stored as symlinks. AWS Lambda preserves them on extract, the `.pnpm` graph stays intact end to end, and every transitive dep resolves exactly as it does locally — fixing the whole class of errors at once.

```diff
-zip -q -r ../../lambda-server-package.zip .
+zip -q -r -y ../../lambda-server-package.zip .
```

## Verification

Built locally, zipped with `-y`, clean-room extracted into a fresh dir (simulating `/var/task`), and confirmed both previously-failing modules load with no `MODULE_NOT_FOUND`:

- `require('next/dist/server/config.js')` ✓ (resolves `@next/env`)
- `require('next/dist/shared/lib/constants.js')` ✓ (resolves `@swc/helpers`)

Ref: [vercel/next.js discussion #35437](https://github.com/vercel/next.js/discussions/35437) — *"copying with cp -P and zipping with zip -y worked… preserving symlinks"*