### PR TITLE
Instrument Coder workspace launch path for diagnosability

### DIFF
--- a/src/hooks/use-workspace-launcher.test.tsx
+++ b/src/hooks/use-workspace-launcher.test.tsx
@@ -18,6 +18,11 @@ vi.mock('@/server/actions/workspaces.actions', () => ({
     getWorkspaceUrlAction: vi.fn(),
 }))
 
+vi.mock('@/components/errors', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@/components/errors')>()),
+    reportError: vi.fn(),
+}))
+
 const mockWindowOpen = vi.fn()
 Object.defineProperty(window, 'open', {
     value: mockWindowOpen,
@@ -25,6 +30,7 @@ Object.defineProperty(window, 'open', {
 })
 
 import { createUserAndWorkspaceAction, getWorkspaceUrlAction } from '@/server/actions/workspaces.actions'
+import { reportError } from '@/components/errors'
 import { notifications } from '@mantine/notifications'
 
 const studyId = faker.string.uuid()
@@ -147,7 +153,10 @@ describe('useWorkspaceLauncher', () => {
             })
         })
 
-        it('should show notification and set error when popup is blocked', async () => {
+        // A blocked popup is not a launch failure: the workspace launched fine and the user gets a
+        // clickable fallback notification, so the hook must NOT surface it as `error` (which would
+        // render a misleading "Launch failed" state in the UI).
+        it('should show fallback notification without erroring when popup is blocked', async () => {
             const workspaceUrl = 'https://workspace.example.com'
             mockWindowOpen.mockReturnValue(null) // Simulate blocked popup
             ;(createUserAndWorkspaceAction as Mock).mockResolvedValue({
@@ -164,7 +173,6 @@ describe('useWorkspaceLauncher', () => {
             })
 
             await waitFor(() => {
-                expect(result.current.error?.message).toBe('Popup blocked')
                 expect(notifications.show).toHaveBeenCalledWith(
                     expect.objectContaining({
                         title: 'Popup blocked',
@@ -173,6 +181,7 @@ describe('useWorkspaceLauncher', () => {
                     }),
                 )
             })
+            expect(result.current.error).toBeNull()
         })
 
         it('should detect popup blocked when window.closed is true', async () => {
@@ -191,8 +200,11 @@ describe('useWorkspaceLauncher', () => {
             })
 
             await waitFor(() => {
-                expect(result.current.error?.message).toBe('Popup blocked')
+                expect(notifications.show).toHaveBeenCalledWith(
+                    expect.objectContaining({ title: 'Popup blocked', color: 'yellow' }),
+                )
             })
+            expect(result.current.error).toBeNull()
         })
     })
 
@@ -327,6 +339,69 @@ describe('useWorkspaceLauncher', () => {
             await waitFor(() => {
                 expect(result.current.error).toBeNull()
                 expect(result.current.isLaunching).toBe(true)
+            })
+        })
+    })
+
+    describe('error reporting', () => {
+        it('should report mutation failures to Sentry/notifications', async () => {
+            ;(createUserAndWorkspaceAction as Mock).mockResolvedValue({ error: 'boom' })
+
+            const { result } = renderHook(() => useWorkspaceLauncher({ studyId }), {
+                wrapper: createTestQueryWrapper(),
+            })
+
+            act(() => {
+                result.current.launchWorkspace()
+            })
+
+            await waitFor(() => {
+                expect(reportError).toHaveBeenCalledWith(expect.any(Error), 'Failed to launch IDE')
+            })
+        })
+
+        it('should report polling failures to Sentry/notifications', async () => {
+            ;(createUserAndWorkspaceAction as Mock).mockResolvedValue({ workspace: { id: 'workspace-456' } })
+            ;(getWorkspaceUrlAction as Mock).mockResolvedValue({ error: 'poll exploded' })
+
+            const { result } = renderHook(() => useWorkspaceLauncher({ studyId }), {
+                wrapper: createTestQueryWrapper(),
+            })
+
+            act(() => {
+                result.current.launchWorkspace()
+            })
+
+            await waitFor(() => {
+                expect(reportError).toHaveBeenCalledWith(expect.any(Error), 'Failed to launch IDE')
+            })
+        })
+    })
+
+    describe('clearError with a query error', () => {
+        it('should clear a polling error so the UI returns to a non-error state', async () => {
+            ;(createUserAndWorkspaceAction as Mock).mockResolvedValue({ workspace: { id: 'workspace-456' } })
+            ;(getWorkspaceUrlAction as Mock).mockResolvedValue({ error: 'Workspace not found' })
+
+            const { result } = renderHook(() => useWorkspaceLauncher({ studyId }), {
+                wrapper: createTestQueryWrapper(),
+            })
+
+            act(() => {
+                result.current.launchWorkspace()
+            })
+
+            await waitFor(() => {
+                expect(result.current.error).not.toBeNull()
+            })
+
+            act(() => {
+                result.current.clearError()
+            })
+
+            await waitFor(() => {
+                expect(result.current.error).toBeNull()
+                expect(result.current.isLaunching).toBe(false)
             })
         })
     })

--- a/src/hooks/use-workspace-launcher.tsx
+++ b/src/hooks/use-workspace-launcher.tsx
@@ -1,18 +1,37 @@
-import { useMutation, useQuery } from '@/common'
+import { useMutation, useQuery, useQueryClient } from '@/common'
+import { reportError } from '@/components/errors'
+import { ActionFailure } from '@/lib/errors'
 import { createUserAndWorkspaceAction, getWorkspaceUrlAction } from '@/server/actions/workspaces.actions'
 import { notifications } from '@mantine/notifications'
-import { useState, useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
-interface OpenResult {
-    success: boolean
-    blocked: boolean
-    url: string
+const LAUNCH_FAILED_MESSAGE = 'Failed to launch IDE'
+
+// The wrapped useQuery/useMutation throw an ActionFailure whose message is the raw `error` payload.
+// For an opaque (non-string) action error, surface a friendly fallback instead of leaking raw JSON.
+const toLaunchError = (err: Error | null): Error | null => {
+    if (!err) return null
+    if (err instanceof ActionFailure && typeof err.error !== 'string') return new Error(LAUNCH_FAILED_MESSAGE)
+    return err
 }
 
-const openWorkspaceInNewTab = (url: string, studyId: string): OpenResult => {
+const openWorkspaceInNewTab = (url: string, studyId: string): { blocked: boolean } => {
     const newWindow = window.open(url, `ide-for-study-${studyId}`)
     const blocked = !newWindow || newWindow.closed || typeof newWindow.closed === 'undefined'
-    return { success: !blocked, blocked, url }
+    return { blocked }
+}
+
+const notifyPopupBlocked = (url: string) => {
+    notifications.show({
+        title: 'Popup blocked',
+        message: (
+            <a href={url} target="_blank" rel="noopener noreferrer">
+                Click here to open your workspace
+            </a>
+        ),
+        color: 'yellow',
+        autoClose: false,
+    })
 }
 
 interface UseWorkspaceLauncherOptions {
@@ -22,7 +41,7 @@ interface UseWorkspaceLauncherOptions {
 
 interface UseWorkspaceLauncherReturn {
     launchWorkspace: () => void
-    /** True while the entire launch flow is in progress (from mutation start to workspace open) */
+    /** True while the entire launch flow is in progress (from mutation start until the workspace opens or fails) */
     isLaunching: boolean
     /** True only while the initial workspace creation mutation is in progress */
     isCreatingWorkspace: boolean
@@ -30,112 +49,69 @@ interface UseWorkspaceLauncherReturn {
     clearError: () => void
 }
 
+const WORKSPACE_STATUS_KEY = 'workspaceStatus'
+
 export function useWorkspaceLauncher({ studyId, onSuccess }: UseWorkspaceLauncherOptions): UseWorkspaceLauncherReturn {
-    const [workspaceId, setWorkspaceId] = useState<string | null>(null)
-    const [loading, setLoading] = useState(false)
-    const [error, setError] = useState<Error | null>(null)
-    const [launchComplete, setLaunchComplete] = useState(false)
-    const onSuccessRef = useRef(onSuccess)
+    const queryClient = useQueryClient()
 
-    useEffect(() => {
-        onSuccessRef.current = onSuccess
-    }, [onSuccess])
-
-    const mutation = useMutation({
-        mutationFn: async ({ studyId }: { studyId: string }) => {
-            const result = await createUserAndWorkspaceAction({ studyId })
-            if ('error' in result) {
-                throw new Error(typeof result.error === 'string' ? result.error : 'Failed to launch IDE')
-            }
-            return result
-        },
-        onMutate: () => {
-            setLoading(true)
-            setError(null)
-        },
-        onSuccess: (data) => {
-            const { id } = data.workspace
-            setWorkspaceId(id)
-        },
-        onError: (err) => {
-            setLoading(false)
-            const errorMessage = err instanceof Error ? err.message : 'Failed to launch IDE'
-            setError(new Error(errorMessage))
-        },
+    const creation = useMutation({
+        mutationFn: ({ studyId }: { studyId: string }) => createUserAndWorkspaceAction({ studyId }),
+        onError: (err) => reportError(err, LAUNCH_FAILED_MESSAGE),
     })
+    const workspaceId = creation.data?.workspace.id ?? null
 
-    const workspaceQuery = useQuery({
-        queryKey: ['coder', 'workspaceStatus', studyId, workspaceId],
-        enabled: !!workspaceId && !launchComplete,
+    // Once a workspace exists, poll until Coder hands back a URL (or the request errors out).
+    const urlQuery = useQuery({
+        queryKey: ['coder', WORKSPACE_STATUS_KEY, studyId, workspaceId],
+        enabled: !!workspaceId,
         refetchOnWindowFocus: false,
-        queryFn: async () => {
-            const result = await getWorkspaceUrlAction({
-                studyId,
-                workspaceId: workspaceId as string,
-            })
-            if (result && typeof result === 'object' && 'error' in result) {
-                throw new Error(typeof result.error === 'string' ? result.error : 'Failed to get workspace URL')
-            }
-            return result
-        },
-        refetchInterval: (query) => {
-            if (!workspaceId || launchComplete) return false
-            if (query.state.error || query.state.data) return false
-            return 5000
-        },
+        queryFn: () => getWorkspaceUrlAction({ studyId, workspaceId: workspaceId as string }),
+        refetchInterval: (query) => (query.state.data || query.state.error ? false : 5000),
     })
 
-    // Handle query results
+    // Opening the tab is a one-shot side effect fired when the poll resolves; the ref latches it to
+    // the current workspace so a re-render (or StrictMode double-invoke) can't open it twice.
+    const handledWorkspaceRef = useRef<string | null>(null)
     useEffect(() => {
-        if (launchComplete) return
+        const url = urlQuery.data
+        if (!url || !workspaceId || handledWorkspaceRef.current === workspaceId) return
 
-        if (workspaceQuery.error) {
-            // eslint-disable-next-line react-hooks/set-state-in-effect -- React Query v5 requires effects for query side effects
-            setLaunchComplete(true)
-            setLoading(false)
-            const errorMessage =
-                workspaceQuery.error instanceof Error ? workspaceQuery.error.message : 'Failed to get workspace URL'
-            setError(new Error(errorMessage))
-            return
+        handledWorkspaceRef.current = workspaceId
+        const { blocked } = openWorkspaceInNewTab(url, studyId)
+        if (blocked) notifyPopupBlocked(url)
+        onSuccess?.()
+    }, [urlQuery.data, workspaceId, studyId, onSuccess])
+
+    // Latch the report to the specific error so a StrictMode double-invoke (or re-render) can't
+    // fire two Sentry events / notifications for the same failure.
+    const reportedErrorRef = useRef<unknown>(null)
+    useEffect(() => {
+        if (urlQuery.error && reportedErrorRef.current !== urlQuery.error) {
+            reportedErrorRef.current = urlQuery.error
+            reportError(urlQuery.error, LAUNCH_FAILED_MESSAGE)
         }
-
-        const url = workspaceQuery.data
-        if (url) {
-            setLaunchComplete(true)
-            const result = openWorkspaceInNewTab(url, studyId)
-            setLoading(false)
-            if (result.blocked) {
-                setError(new Error('Popup blocked'))
-                notifications.show({
-                    title: 'Popup blocked',
-                    message: (
-                        <a href={url} target="_blank" rel="noopener noreferrer">
-                            Click here to open your workspace
-                        </a>
-                    ),
-                    color: 'yellow',
-                    autoClose: false,
-                })
-            }
-            onSuccessRef.current?.()
-        }
-    }, [workspaceQuery.data, workspaceQuery.error, launchComplete])
-
-    const launchWorkspace = useCallback(() => {
-        setError(null)
-        setLaunchComplete(false)
-        mutation.mutate({ studyId })
-    }, [mutation, studyId])
+    }, [urlQuery.error])
 
     const clearError = useCallback(() => {
-        setError(null)
-    }, [])
+        creation.reset()
+        handledWorkspaceRef.current = null
+        reportedErrorRef.current = null
+        queryClient.removeQueries({ queryKey: ['coder', WORKSPACE_STATUS_KEY, studyId] })
+    }, [creation, queryClient, studyId])
+
+    const launchWorkspace = useCallback(() => {
+        clearError()
+        creation.mutate({ studyId })
+    }, [clearError, creation, studyId])
+
+    const waitingForUrl = !!workspaceId && !urlQuery.data && !urlQuery.error
+    const isLaunching = creation.isPending || waitingForUrl
 
     return {
         launchWorkspace,
-        isLaunching: loading,
-        isCreatingWorkspace: mutation.isPending,
-        error: error || workspaceQuery.error || null,
+        isLaunching,
+        isCreatingWorkspace: creation.isPending,
+        error: toLaunchError(creation.error || urlQuery.error || null),
         clearError,
     }
 }

--- a/src/hooks/use-workspace-launcher.tsx
+++ b/src/hooks/use-workspace-launcher.tsx
@@ -61,10 +61,14 @@ export function useWorkspaceLauncher({ studyId, onSuccess }: UseWorkspaceLaunche
     const workspaceId = creation.data?.workspace.id ?? null
 
     // Once a workspace exists, poll until Coder hands back a URL (or the request errors out).
+    // The URL is permanent for a given workspace, so once resolved the result never goes stale and
+    // no refetch trigger (remount, reconnect, focus) should re-run the launch on the server.
     const urlQuery = useQuery({
         queryKey: ['coder', WORKSPACE_STATUS_KEY, studyId, workspaceId],
         enabled: !!workspaceId,
+        staleTime: Infinity,
         refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
         queryFn: () => getWorkspaceUrlAction({ studyId, workspaceId: workspaceId as string }),
         refetchInterval: (query) => (query.state.data || query.state.error ? false : 5000),
     })

--- a/src/server/coder.test.ts
+++ b/src/server/coder.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest'
 import {
+    coderFetch,
+    CoderApiError,
     createUserAndWorkspace,
     generateWorkspaceName,
     getCoderOrganizationId,
@@ -8,6 +10,7 @@ import {
     generateCoderUsername,
     shaHash,
 } from './coder'
+import logger from '@/lib/logger'
 import { getConfigValue } from './config'
 import { getStudyAndOrgDisplayInfo, siUser, fetchLatestCodeEnvForStudyId, getDataSourcesForOrg } from './db/queries'
 import { fetchFileContents } from './storage'
@@ -95,6 +98,7 @@ describe('getOrCreateCoderUser', () => {
                 Accept: 'application/json',
                 'Coder-Session-Token': 'https://api.coder.com',
             },
+            signal: expect.any(AbortSignal),
         })
     })
 
@@ -154,6 +158,7 @@ describe('getOrCreateCoderUser', () => {
                 user_status: 'active',
                 organization_ids: ['org'],
             }),
+            signal: expect.any(AbortSignal),
         })
     })
 
@@ -589,6 +594,7 @@ describe('getCoderTemplateId', () => {
                 Accept: 'application/json',
                 'Coder-Session-Token': 'token',
             },
+            signal: expect.any(AbortSignal),
         })
     })
 
@@ -604,6 +610,40 @@ describe('getCoderTemplateId', () => {
         getConfigValueMock.mockResolvedValueOnce('my-template')
 
         await expect(getCoderTemplateId()).rejects.toThrow('Failed to fetch templates data from Coder API')
+    })
+})
+
+describe('coderFetch instrumentation', () => {
+    const loggerErrorMock = logger.error as unknown as Mock
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        getConfigValueMock.mockResolvedValue('token')
+        getConfigValueMock.mockResolvedValueOnce('https://api.coder.com')
+    })
+
+    it('logs and throws CoderApiError on a non-ok response', async () => {
+        const mockFetch = global.fetch as unknown as Mock
+        mockFetch.mockResolvedValue({
+            ok: false,
+            status: 503,
+            text: vi.fn().mockResolvedValue('service unavailable'),
+        })
+
+        await expect(coderFetch('/api/v2/workspaces/abc')).rejects.toBeInstanceOf(CoderApiError)
+        expect(loggerErrorMock).toHaveBeenCalledWith(
+            expect.stringContaining('/api/v2/workspaces/abc -> 503: service unavailable'),
+        )
+    })
+
+    it('logs and rethrows when the request times out', async () => {
+        const mockFetch = global.fetch as unknown as Mock
+        const timeoutError = new Error('The operation timed out')
+        timeoutError.name = 'TimeoutError'
+        mockFetch.mockRejectedValue(timeoutError)
+
+        await expect(coderFetch('/api/v2/workspaces/abc')).rejects.toBe(timeoutError)
+        expect(loggerErrorMock).toHaveBeenCalledWith(expect.stringContaining('timed out'), timeoutError)
     })
 })
 

--- a/src/server/coder/client.ts
+++ b/src/server/coder/client.ts
@@ -1,4 +1,10 @@
 import { getConfigValue } from '../config'
+import logger from '@/lib/logger'
+
+// Coder API calls had no timeout: a hung request leaves the launch poll
+// pending forever, which surfaces as an endless UI spinner with no error.
+// Bound it so a stall becomes a logged, throwable failure instead.
+const CODER_FETCH_TIMEOUT_MS = 15_000
 
 export interface CoderFetchOptions {
     method?: RequestInit['method']
@@ -32,14 +38,26 @@ export async function coderFetch<T>(path: string, options: CoderFetchOptions = {
         headers['Content-Type'] = 'application/json'
     }
 
-    const response = await fetch(`${coderApiEndpoint}${path}`, {
-        method,
-        headers,
-        body: body ? JSON.stringify(body) : undefined,
-    })
+    let response: Response
+    try {
+        response = await fetch(`${coderApiEndpoint}${path}`, {
+            method,
+            headers,
+            body: body ? JSON.stringify(body) : undefined,
+            signal: AbortSignal.timeout(CODER_FETCH_TIMEOUT_MS),
+        })
+    } catch (error) {
+        const timedOut = error instanceof Error && error.name === 'TimeoutError'
+        logger.error(
+            `Coder API ${method} ${path} ${timedOut ? `timed out after ${CODER_FETCH_TIMEOUT_MS}ms` : 'request failed'}:`,
+            error,
+        )
+        throw error
+    }
 
     if (!response.ok) {
         const errorText = await response.text()
+        logger.error(`Coder API ${method} ${path} -> ${response.status}: ${errorText}`)
         throw new CoderApiError(`${errorMessage}: ${response.status} ${errorText}`, response.status, errorText)
     }
 

--- a/src/server/coder/workspaces.ts
+++ b/src/server/coder/workspaces.ts
@@ -30,46 +30,77 @@ async function generateWorkspaceUrl(studyId: string): Promise<string> {
     const workspaceName = generateWorkspaceName(studyId)
     const user = await getCoderUser(studyId)
     if (!user) {
+        logger.error(`[coder-launch study=${studyId}] Coder user not found for workspace ${workspaceName}`)
         throw new Error('Coder user not found')
     }
     return `${coderApiEndpoint}${coderWorkspacePath(user.username, workspaceName)}`
 }
 
-function isWorkspaceReady(event: CoderWorkspaceEvent): boolean {
-    if (!event) return false
-    const resources = event.latest_build?.resources
-    if (!resources || resources.length === 0) return false
+// Returns readiness plus a short human-readable reason. The reason is logged
+// while polling so a workspace that never becomes ready leaves a trail of
+// exactly which gate (build status, agent lifecycle, code-server health) is
+// holding it up, instead of an opaque stream of nulls.
+function describeReadiness(event: CoderWorkspaceEvent): { ready: boolean; reason: string } {
+    if (!event) return { ready: false, reason: 'no workspace event' }
 
+    const buildStatus = event.latest_build?.status ?? 'unknown'
+    const resources = event.latest_build?.resources
+    if (!resources || resources.length === 0) {
+        return { ready: false, reason: `build status=${buildStatus}, no resources yet` }
+    }
+
+    const agentStates: string[] = []
     for (const resource of resources) {
         for (const agent of resource.agents ?? []) {
             const lifecycle = (agent.lifecycle_state ?? '').toLowerCase()
             const status = (agent.status ?? '').toLowerCase()
 
             const agentReady = lifecycle === 'ready' || status === 'ready' || status === 'connected'
-            const codeServerHealthy = (agent.apps ?? []).some(
-                (app) => app.slug === 'code-server' && (app.health ?? '').toLowerCase() === 'healthy',
-            )
+            const codeServer = (agent.apps ?? []).find((app) => app.slug === 'code-server')
+            const codeServerHealth = (codeServer?.health ?? 'absent').toLowerCase()
+            const codeServerHealthy = codeServerHealth === 'healthy'
 
             if (agentReady && codeServerHealthy) {
-                return true
+                return { ready: true, reason: `agent lifecycle=${lifecycle} status=${status}, code-server=healthy` }
             }
+            agentStates.push(`{lifecycle=${lifecycle || '∅'} status=${status || '∅'} code-server=${codeServerHealth}}`)
         }
     }
 
-    return false
+    return { ready: false, reason: `build status=${buildStatus}, agents not ready: ${agentStates.join(', ')}` }
 }
 
 export async function getCoderWorkspaceUrl(studyId: string, workspaceId: string): Promise<string | null> {
-    const workspace = await coderFetch<CoderWorkspaceEvent>(`/api/v2/workspaces/${workspaceId}`, {
-        errorMessage: 'Failed to get workspace status',
-    })
+    const logCtx = `[coder-launch study=${studyId} workspace=${workspaceId}]`
 
-    if (isWorkspaceReady(workspace)) {
+    let step = 'fetch-workspace-status'
+    try {
+        const workspace = await coderFetch<CoderWorkspaceEvent>(`/api/v2/workspaces/${workspaceId}`, {
+            errorMessage: 'Failed to get workspace status',
+        })
+
+        const readiness = describeReadiness(workspace)
+        if (!readiness.ready) {
+            logger.info(`${logCtx} not ready yet, polling again: ${readiness.reason}`)
+            return null
+        }
+        logger.info(`${logCtx} workspace ready (${readiness.reason}), initializing code files`)
+
+        step = 'initialize-code-files'
         await initializeWorkspaceCodeFiles(studyId)
-        return await generateWorkspaceUrl(studyId)
-    }
+        logger.info(`${logCtx} code files initialized, generating workspace url`)
 
-    return null
+        step = 'generate-workspace-url'
+        const url = await generateWorkspaceUrl(studyId)
+        logger.info(`${logCtx} launch complete, returning workspace url`)
+        return url
+    } catch (error) {
+        // A throw here leaves the client polling forever (the UI spinner), so
+        // make the failing step a loud, Sentry-reported signal rather than a
+        // bare rejection the client can only render as a generic error.
+        logger.error(`${logCtx} FAILED at step "${step}":`, error)
+        throw error
+    }
 }
 
 async function startWorkspace(workspaceId: string): Promise<void> {
@@ -228,16 +259,23 @@ async function studyDirHasFiles(dir: string): Promise<boolean> {
 }
 
 const initializeWorkspaceCodeFiles = async (studyId: string): Promise<void> => {
+    const logCtx = `[coder-init study=${studyId}]`
     const coderBaseFilePath = await getConfigValue('CODER_FILES')
     const studyDir = path.join(coderBaseFilePath, studyId)
 
     // Idempotent: only copy starter files when the directory is empty.
     // Skips repeat calls (ready-polling) and avoids clobbering user edits across sessions.
-    if (await studyDirHasFiles(studyDir)) return
+    if (await studyDirHasFiles(studyDir)) {
+        logger.info(`${logCtx} ${studyDir} already has files, skipping starter-code copy`)
+        return
+    }
 
     const codeEnv = await fetchLatestCodeEnvForStudyId(studyId)
-
-    logger.info(`Initializing workspace with starter code for study ${studyId} ...`)
+    const starterFiles = codeEnv.starterCodeFileNames ?? []
+    logger.info(
+        `${logCtx} initializing into ${studyDir} from codeEnv=${codeEnv.identifier} (id=${codeEnv.id}), ` +
+            `${starterFiles.length} starter file(s): [${starterFiles.join(', ')}]`,
+    )
 
     // Backdate starter-file mtime relative to the baseline studyJob rather than wall-clock.
     // Wall-clock backdating breaks when Coder provisioning takes longer than the backdate window:
@@ -247,16 +285,27 @@ const initializeWorkspaceCodeFiles = async (studyId: string): Promise<void> => {
     const baselineCreatedAt = await latestStudyJobCreatedAt(db, studyId)
     const pastDate = baselineCreatedAt ? new Date(baselineCreatedAt.getTime() - 1000) : new Date(Date.now() - 60_000)
 
-    for (const fileName of codeEnv.starterCodeFileNames) {
+    for (const fileName of starterFiles) {
         const filePath = pathForStarterCode({ orgSlug: codeEnv.slug, codeEnvId: codeEnv.id, fileName })
-        const fileData = await fetchFileContents(filePath)
         const targetFilePath = path.join(studyDir, fileName)
 
-        logger.info(`Writing ${fileName} to ${targetFilePath} for study ${studyId}`)
+        let fileData
+        try {
+            fileData = await fetchFileContents(filePath)
+        } catch (error) {
+            logger.error(`${logCtx} failed fetching starter file from s3://${filePath}:`, error)
+            throw error
+        }
 
-        await fs.mkdir(path.dirname(targetFilePath), { recursive: true })
-        await fs.writeFile(targetFilePath, Buffer.from(await fileData.arrayBuffer()))
-        await fs.utimes(targetFilePath, pastDate, pastDate)
+        try {
+            await fs.mkdir(path.dirname(targetFilePath), { recursive: true })
+            await fs.writeFile(targetFilePath, Buffer.from(await fileData.arrayBuffer()))
+            await fs.utimes(targetFilePath, pastDate, pastDate)
+        } catch (error) {
+            logger.error(`${logCtx} failed writing starter file to ${targetFilePath}:`, error)
+            throw error
+        }
+        logger.info(`${logCtx} wrote ${fileName} to ${targetFilePath}`)
     }
 
     // Initialize claude.md
@@ -266,8 +315,15 @@ const initializeWorkspaceCodeFiles = async (studyId: string): Promise<void> => {
 
     let combinedContextString = ''
     for (const contextName of workspaceContexts) {
-        const response = await getAgentContext(database.db, { name: contextName, orgId: null })
+        let response
+        try {
+            response = await getAgentContext(database.db, { name: contextName, orgId: null })
+        } catch (error) {
+            logger.error(`${logCtx} failed fetching agent context "${contextName}":`, error)
+            throw error
+        }
         if (isActionError(response)) {
+            logger.error(`${logCtx} agent context "${contextName}" returned error: ${errorToString(response)}`)
             throw new Error(errorToString(response))
         }
         if (response.content) combinedContextString += response.content + '\n'
@@ -278,9 +334,13 @@ const initializeWorkspaceCodeFiles = async (studyId: string): Promise<void> => {
     const targetContextFileName = 'CLAUDE.md'
     const targetContextPath = path.join(coderBaseFilePath, studyId, targetContextFileName)
 
-    logger.info(`Writing ${targetContextFileName} to ${targetContextPath} for study ${studyId}`)
-
-    await fs.mkdir(path.dirname(targetContextPath), { recursive: true })
-    await fs.writeFile(targetContextPath, combinedContextString, 'utf-8')
-    await fs.utimes(targetContextPath, pastDate, pastDate)
+    try {
+        await fs.mkdir(path.dirname(targetContextPath), { recursive: true })
+        await fs.writeFile(targetContextPath, combinedContextString, 'utf-8')
+        await fs.utimes(targetContextPath, pastDate, pastDate)
+    } catch (error) {
+        logger.error(`${logCtx} failed writing ${targetContextFileName} to ${targetContextPath}:`, error)
+        throw error
+    }
+    logger.info(`${logCtx} wrote ${targetContextFileName} (${combinedContextString.length} bytes), init complete`)
 }


### PR DESCRIPTION
## Why

A failed or hung IDE launch currently surfaces **only as an endless UI spinner** with no server-side signal — we can't tell which step broke. While investigating a prod launch where Coder reported the workspace running but the management-app UI kept spinning, the lack of breadcrumbs made the root cause impossible to pin down from logs alone (the readiness gate passed, but nothing downstream was logged).

This adds step-level breadcrumbs and loud, Sentry-reported error logging across the entire launch path so the next occurrence leaves a clear trail.

## What

**`src/server/coder/workspaces.ts`**
- **`getCoderWorkspaceUrl`** — tracks the active step (`fetch-workspace-status` / `initialize-code-files` / `generate-workspace-url`) and logs a `logger.error` naming the failing step on any throw (→ console **and Sentry**), plus milestone info logs. Every line is prefixed `[coder-launch study=… workspace=…]` for easy grepping.
- **`isWorkspaceReady` → `describeReadiness`** — now returns `{ ready, reason }`. A not-yet-ready poll logs *which* gate is holding it (build status, agent lifecycle/status, code-server health) instead of an opaque stream of nulls.
- **`initializeWorkspaceCodeFiles`** — logs the already-populated early return, the resolved code env + starter-file list, and per-file success; distinguishes **S3-fetch** vs **local-write** vs **agent-context** failures. Also made null-safe on `starterCodeFileNames`.
- **`generateWorkspaceUrl`** — logs the "Coder user not found" case.

**`src/server/coder/client.ts`**
- **`coderFetch`** — added a **15s timeout** (`AbortSignal.timeout`) so a hung Coder request becomes a logged, throwable error rather than a forever-pending poll (a prime suspect for the spinner), plus `logger.error` on non-ok responses and timeouts.

## Behavior change

The only functional change is the **15s timeout** on Coder API calls — everything else is logging. A previously-hanging request now rejects after 15s, which the client renders as an error instead of spinning indefinitely.

## Tests

- Updated existing `coderFetch` assertions for the new `AbortSignal`.
- Added `coderFetch instrumentation` coverage: non-ok → logs + throws `CoderApiError`; timeout → logs + rethrows.
- `coder.test.ts` + `workspaces.actions.test.ts`: 34 passing. `tsc` + `eslint` clean.

---

## Client-side follow-up: `use-workspace-launcher` refactor

While the server changes make a hung/failed launch *diagnosable*, the client hook that drives the launch handled errors poorly and obscured failures. Refactored `src/hooks/use-workspace-launcher.tsx` to be robust and to surface what the new server logging now reports.

**Problems addressed**
- Rolled its own state machine (`loading` / `error` / `launchComplete` / `workspaceId` `useState`s + a `setState`-in-effect latch) that mirrored React Query's own state and drifted out of sync.
- **Swallowed failures into local state with no Sentry/notification reporting** — a failed launch left the user with a generic error and no breadcrumb, undercutting the server-side instrumentation.
- Redundantly re-implemented `'error' in result` unwrapping that the `@/common` `useQuery`/`useMutation` wrappers already do (they throw `ActionFailure`).
- A blocked popup was surfaced as `error`, rendering a misleading **"Launch failed"** button even though the workspace launched fine.
- `clearError` never actually cleared poll errors.

**Changes**
- State now **derives from the creation mutation + URL poll** — no mirrored `useState`. `workspaceId` reads from `creation.data`.
- Mutation and poll failures are reported via `reportError` (**Sentry + notification**), each latched so a StrictMode double-invoke can't double-report.
- `toLaunchError` keeps a friendly fallback for opaque (non-string) action errors instead of leaking raw JSON.
- Popup-blocked shows the clickable fallback notification **only** — no longer a fake `error`.
- `clearError` fully clears poll errors via `queryClient.removeQueries`.
- Dropped the `react-hooks/set-state-in-effect` eslint-disable.

**Tests** — updated popup-blocked expectations; added coverage for error reporting (mutation + poll) and clearing a polling error. 16/16 in-file, 105/105 across `src/hooks/`. `tsc` + `eslint` + `prettier` clean.
