### PR TITLE
ci: cache SonarQube scanner and Trivy to harden infosec job

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -63,12 +63,22 @@ jobs:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
               with:
                   persist-credentials: false
+            # Trivy downloads its binary (via setup-trivy) and vulnerability DB on
+            # every run, so it flakes the same way the SonarQube scanner did when
+            # those fetches hit a transient upstream outage. trivy-action enables
+            # its built-in actions/cache by default; we make that cache effective by
+            # (1) pinning the binary `version` so the cache key is stable across runs
+            # instead of drifting, and (2) pointing both scan steps at one shared
+            # `cache-dir` so the DB is fetched at most once per run and reused on
+            # subsequent runs. A version bump naturally busts the cache.
             - name: Run Trivy vulnerability scanner in fs mode
               uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
               with:
                   scan-type: 'fs'
                   scan-ref: '.'
                   trivy-config: trivy.yaml
+                  version: v0.70.0
+                  cache-dir: ${{ github.workspace }}/.cache/trivy
             - name: Run Trivy license scanner
               uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
               with:
@@ -78,6 +88,8 @@ jobs:
                   severity: 'HIGH,CRITICAL'
                   exit-code: '1'
                   trivyignores: '.trivyignore.yaml'
+                  version: v0.70.0
+                  cache-dir: ${{ github.workspace }}/.cache/trivy
             # Cache the SonarScanner CLI and analysis cache (downloaded into
             # SONAR_USER_HOME by the scan step below). This makes the job resilient
             # to intermittent failures fetching the scanner from

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -78,6 +78,18 @@ jobs:
                   severity: 'HIGH,CRITICAL'
                   exit-code: '1'
                   trivyignores: '.trivyignore.yaml'
+            # Cache the SonarScanner CLI and analysis cache (downloaded into
+            # SONAR_USER_HOME by the scan step below). This makes the job resilient
+            # to intermittent failures fetching the scanner from
+            # binaries.sonarsource.com: on a cache hit the binary is reused instead
+            # of re-downloaded. Keyed on the scanner version pin so a bump busts it.
+            - name: Cache SonarQube scanner
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+              with:
+                  path: ${{ github.workspace }}/.sonar
+                  key: ${{ runner.os }}-sonar-7006c4492b2e0ee0f816d36501671557c97f5995
+                  restore-keys: |
+                      ${{ runner.os }}-sonar-
             - name: Run SonarQube SAST Scan
               # SONAR_TOKEN is scoped to this single step (not the job env) so that
               # any future steps added above cannot accidentally read it. Keep it here.
@@ -85,6 +97,7 @@ jobs:
               env:
                   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
                   SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+                  SONAR_USER_HOME: ${{ github.workspace }}/.sonar
 
     test:
         timeout-minutes: 20


### PR DESCRIPTION
## Problem

The `infosec` CI job fails intermittently when one of its scan steps can't fetch a tool or database from upstream. Two independent download paths cause this:

- **SonarQube** — the scan step downloads the Sonar Scanner CLI from `binaries.sonarsource.com` on every run, so any transient SonarSource outage fails the job.
- **Trivy** — `trivy-action` downloads the Trivy **binary** (via `setup-trivy`) and the **vulnerability DB** on every run, so it flakes the same way when those fetches hit a transient upstream outage.

## Change

Harden both download paths so a cache hit avoids the network entirely.

### SonarQube scanner cache

Add an `actions/cache` step (same pinned SHA already used elsewhere in `checks.yml`) that caches `SONAR_USER_HOME`, redirected into the workspace via the env var so the cache actually covers the scanner install:

- **Cache hit** → the scanner binary is reused instead of re-downloaded.
- **Key** is pinned to the `sonarqube-scan-action` SHA, so bumping the action version automatically busts the cache and pulls the matching scanner.
- **`restore-keys`** provides a warm fallback from the most recent prior cache.

### Trivy binary + DB cache

`trivy-action` already enables its built-in `actions/cache` by default, but that cache only helps if the key is stable and the cache dir is shared. So on both Trivy scan steps:

- **Pin the binary `version`** (`v0.70.0`, the action's own default for this pinned SHA — behavior unchanged, now explicit) so the cache key no longer drifts run-to-run.
- **Share one `cache-dir`** (`${{ github.workspace }}/.cache/trivy`) across both steps, so the vuln DB is fetched at most once per run and reused on subsequent runs.
- A version bump naturally busts the cache.

## Security note

This respects the OTTER-545 security comment block on the job: the cache steps add no PR-controlled code execution, and `SONAR_TOKEN` stays scoped to the single scan step.
