### PR TITLE
Remove unused Playwright browser install from Docker build

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,9 +8,6 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml panda.config.ts ./
 
 RUN pnpm install --frozen-lockfile
 
-RUN pnpm exec playwright install chromium
-RUN pnpm exec playwright install-deps chromium
-
 #COPY .gitignore .editorconfig next.config.mjs tsconfig.json kysely.config.ts .eslintrc.json .prettierrc.json .
 
 # Next.js collects completely anonymous telemetry data about general usage. Learn more here: https://nextjs.org/telemetry

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,8 +8,8 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml panda.config.ts ./
 
 RUN pnpm install --frozen-lockfile
 
-RUN pnpm exec playwright install
-RUN pnpm exec playwright install-deps
+RUN pnpm exec playwright install chromium
+RUN pnpm exec playwright install-deps chromium
 
 #COPY .gitignore .editorconfig next.config.mjs tsconfig.json kysely.config.ts .eslintrc.json .prettierrc.json .
 


### PR DESCRIPTION
## Summary

`Dockerfile.dev` ran `pnpm exec playwright install` (+ `install-deps`), which
downloaded all three browsers (Chromium, Firefox, WebKit) on every build, often
taking several minutes. That image only runs the Next.js dev server (`mgmnt-app`)
and the Vitest/happy-dom unit-test runner (`test-runner`) — neither launches a
browser, so the binaries were pure waste. This removes both install lines.

## Why it's safe

Playwright e2e tests run on the host, not in Docker (see the README "E2E Testing
with Playwright" section; CI installs Chromium on the runner host, not in the image).
The `@playwright/test` package stays via `pnpm install`, so typecheck/lint of the
spec files in-container is unaffected — it only needs browser binaries at run time,
which never happens here.

## Notes

- An intermediate step trimmed the install to Chromium only, but since no browser
  is ever launched in this image, the install was dropped entirely.
- If we ever want to run e2e inside Docker, the install is one line to re-add
  (ideally in a dedicated e2e image rather than this dev one).

## Changes

- `Dockerfile.dev`: remove `RUN pnpm exec playwright install` and
  `RUN pnpm exec playwright install-deps`.