### PR TITLE
fix: address DAST security-header findings (SIINFOSEC-769/771/772)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,7 +9,15 @@ const securityHeaders = [
     // and we have no in-app frame usage.
     { key: 'X-Frame-Options', value: 'DENY' },
     // Defense-in-depth equivalent of X-Frame-Options for modern browsers.
-    { key: 'Content-Security-Policy', value: "frame-ancestors 'none'" },
+    // frame-ancestors/form-action/base-uri have no fallback to default-src, so they
+    // must be listed explicitly (SIINFOSEC-769, ZAP-10055). We intentionally do not
+    // set script-src/default-src here: Clerk and Sentry inject scripts/connect to
+    // their own origins at runtime, and a restrictive policy would break auth and
+    // error reporting without a nonce-based setup.
+    {
+        key: 'Content-Security-Policy',
+        value: ["frame-ancestors 'none'", "form-action 'self'", "base-uri 'self'"].join('; '),
+    },
     // Prevent MIME-sniffing-based content-type confusion.
     { key: 'X-Content-Type-Options', value: 'nosniff' },
     // Limit referrer leakage to cross-origin destinations.
@@ -18,6 +26,8 @@ const securityHeaders = [
 
 const nextConfig: NextConfig = {
     cacheComponents: false,
+    // Don't advertise the framework in responses (SIINFOSEC-771, ZAP-40025).
+    poweredByHeader: false,
     productionBrowserSourceMaps: true,
     assetPrefix: isDev ? undefined : '/assets/',
     output: 'standalone',
@@ -35,6 +45,11 @@ const nextConfig: NextConfig = {
         optimizePackageImports: ['@phosphor-icons/react'],
         serverActions: {
             bodySizeLimit: '6mb',
+        },
+        // Emit Subresource Integrity (integrity=) hashes on Next's own script tags
+        // (SIINFOSEC-772, ZAP-90003).
+        sri: {
+            algorithm: 'sha256',
         },
     },
 }


### PR DESCRIPTION
## Summary

The OWASP ZAP DAST scan (build #113, 2026-06-04) against `app.staging.safeinsights.org` opened 5 `HIGH` tickets on the SIINFOSEC board. This PR fixes the three that are addressable in `management-app`'s own config, all in `next.config.ts`:

| Ticket | ZAP rule | Fix |
|--------|----------|-----|
| **SIINFOSEC-769** | 10055 — CSP missing a no-fallback directive | Added `form-action 'self'` and `base-uri 'self'` to the CSP (these don't fall back to `default-src`). |
| **SIINFOSEC-771** | 40025 — proxy/framework fingerprinting | Set `poweredByHeader: false` to drop the `X-Powered-By` header. |
| **SIINFOSEC-772** | 90003 — missing Subresource Integrity | Enabled `experimental.sri` (`sha256`) so Next emits `integrity=` on its own script tags. |

### Why CSP stays minimal
I deliberately did **not** add `script-src`/`default-src`. Clerk (auth) and Sentry (error reporting) inject scripts and open connections to their own origins at runtime; a restrictive policy would break them without a nonce-based CSP setup. The added directives (`frame-ancestors`, `form-action`, `base-uri`) are exactly the no-fallback directives ZAP-10055 checks, and are safe.

## Not addressed here (need infra / not actionable in this repo)

- **SIINFOSEC-770** (ZAP-30003, "integer overflow" on `/login?__clerk_handshake=…`) — **false positive**. This is a Clerk auth-handshake redirect with no integer input; the remediation text ("recompile the backend executable") doesn't apply to a Next.js app.
- **SIINFOSEC-773** (ZAP-40039, web cache deception) — mitigation is cache-key/`Cache-Control` behavior at the CDN/load-balancer layer, not app config.
- **SIINFOSEC-771** also calls for disabling `TRACE`/`OPTIONS` at the proxy — that's an infra/load-balancer change, out of scope for this repo. This PR covers the app-level `X-Powered-By` portion.

## Verification

- `pnpm typecheck` ✅
- `eslint` + `prettier` ✅
- `pnpm build` (full production build) ✅ — confirms the SRI emission and config changes don't break the build.

DAST findings can only be confirmed resolved by the next ZAP scan against staging after deploy.