### PR TITLE
OTTER-538 follow-up: fix do previous routing to post-code-feedback when code auto-approved

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
@@ -120,6 +120,20 @@ describe('StudyReviewPage', () => {
             studyStatus: 'APPROVED',
             jobStatus: 'CODE-SUBMITTED',
         })
+        // Proposal feedback so the from=code-review proposal fallback renders a real
+        // PostFeedbackView. With no feedback of any kind the page now falls through to active review.
+        await db
+            .insertInto('studyProposalComment')
+            .values({
+                studyId: study.id,
+                authorId: user.id,
+                authorRole: 'REVIEWER',
+                entryType: 'REVIEWER-FEEDBACK',
+                decision: 'APPROVE',
+                body: { root: { type: 'root', children: [] } },
+                version: 1,
+            })
+            .execute()
 
         const page = await StudyReviewPage({
             params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
@@ -204,6 +218,32 @@ describe('StudyReviewPage', () => {
         expect(page?.props.kind).toBeUndefined()
         expect(page?.props.entries).toHaveLength(1)
         expect(page?.props.entries[0].authorRole).toBe('REVIEWER')
+    })
+
+    it('falls through to active CodeReview (not a blank page) when from=code-review with no code-review, no CODE-APPROVED, and no proposal feedback', async () => {
+        // A study approved with zero feedback (approveStudyProposalAction writes no comment) whose
+        // code still awaits its first decision: the proposal fallback would otherwise render a blank
+        // PostFeedbackView (null on an empty list). Instead the page falls through to active review.
+        const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+        const { study } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'APPROVED',
+            jobStatus: 'CODE-SUBMITTED',
+        })
+        await db
+            .updateTable('study')
+            .set({ reviewerAgreementsAckedAt: new Date() })
+            .where('id', '=', study.id)
+            .execute()
+
+        const page = await StudyReviewPage({
+            params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+            searchParams: Promise.resolve({ from: 'code-review' }),
+        })
+
+        expect(page?.type).toBe(CodeReview)
+        expect(mockRedirect).not.toHaveBeenCalled()
     })
 
     it('renders ProposalReviewView for enclave without code', async () => {

--- a/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
@@ -540,6 +540,32 @@ describe('StudyReviewPage', () => {
             expect(page?.props.fallbackTimestamp).toBeTruthy()
         })
 
+        it('renders post-code-feedback (kind=CODE, fallback REJECT) when CODE-REJECTED has no code-review comment', async () => {
+            const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+            const { study, job } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'REJECTED',
+                jobStatus: 'CODE-SUBMITTED',
+            })
+            await db
+                .insertInto('jobStatusChange')
+                .values({ status: 'CODE-REJECTED', studyJobId: job.id, createdAt: new Date(Date.now() + 1000) })
+                .execute()
+
+            const page = await StudyReviewPage({
+                params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+                searchParams: Promise.resolve({}),
+            })
+
+            expect(page?.type).toBe(PostFeedbackView)
+            expect(page?.props.kind).toBe('CODE')
+            expect(page?.props.entries).toHaveLength(0)
+            expect(page?.props.fallbackDecision).toBe('REJECT')
+            expect(page?.props.fallbackTimestamp).toBeTruthy()
+            expect(mockRedirect).not.toHaveBeenCalled()
+        })
+
         it('uses the submitted job for fallback APPROVE when a newer baseline job exists', async () => {
             const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
             const { study, job } = await insertTestStudyJobData({

--- a/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
@@ -465,5 +465,39 @@ describe('StudyReviewPage', () => {
                 true,
             )
         })
+
+        // OTTER-538 QA (DO): a study approved via proposal approval auto-approves the code
+        // (CODE-APPROVED) WITHOUT writing a code-review comment. "Previous" from the results-stage
+        // Study Details page (?from=code-review) must still land on the post-code-feedback page,
+        // not the proposal "Review initial request" fallback. Renders kind=CODE via the APPROVE
+        // fallback derived from the CODE-APPROVED job status.
+        it('renders post-code-feedback (kind=CODE, fallback APPROVE) when from=code-review at results with CODE-APPROVED but no code-review comment', async () => {
+            const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+            const { study, job } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'APPROVED',
+                jobStatus: 'CODE-SUBMITTED',
+            })
+            await db
+                .insertInto('jobStatusChange')
+                .values({ status: 'CODE-APPROVED', studyJobId: job.id, createdAt: new Date(Date.now() + 1000) })
+                .execute()
+            await db
+                .insertInto('jobStatusChange')
+                .values({ status: 'RUN-COMPLETE', studyJobId: job.id, createdAt: new Date(Date.now() + 2000) })
+                .execute()
+
+            const page = await StudyReviewPage({
+                params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+                searchParams: Promise.resolve({ from: 'code-review' }),
+            })
+
+            expect(page?.type).toBe(PostFeedbackView)
+            expect(page?.props.kind).toBe('CODE')
+            expect(page?.props.entries).toHaveLength(0)
+            expect(page?.props.fallbackDecision).toBe('APPROVE')
+            expect(page?.props.fallbackTimestamp).toBeTruthy()
+        })
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
@@ -539,5 +539,39 @@ describe('StudyReviewPage', () => {
             expect(page?.props.fallbackDecision).toBe('APPROVE')
             expect(page?.props.fallbackTimestamp).toBeTruthy()
         })
+
+        it('uses the submitted job for fallback APPROVE when a newer baseline job exists', async () => {
+            const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+            const { study, job } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'APPROVED',
+                jobStatus: 'CODE-SUBMITTED',
+            })
+            await db
+                .insertInto('jobStatusChange')
+                .values({ status: 'CODE-APPROVED', studyJobId: job.id, createdAt: new Date(Date.now() + 1000) })
+                .execute()
+            await db
+                .insertInto('jobStatusChange')
+                .values({ status: 'RUN-COMPLETE', studyJobId: job.id, createdAt: new Date(Date.now() + 2000) })
+                .execute()
+            const baselineJob = await db
+                .insertInto('studyJob')
+                .values({ studyId: study.id, createdAt: new Date(Date.now() + 3000) })
+                .returning('id')
+                .executeTakeFirstOrThrow()
+            await db.insertInto('jobStatusChange').values({ status: 'INITIATED', studyJobId: baselineJob.id }).execute()
+
+            const page = await StudyReviewPage({
+                params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+                searchParams: Promise.resolve({ from: 'code-review' }),
+            })
+
+            expect(page?.type).toBe(PostFeedbackView)
+            expect(page?.props.kind).toBe('CODE')
+            expect(page?.props.job.id).toBe(job.id)
+            expect(page?.props.fallbackDecision).toBe('APPROVE')
+        })
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
@@ -536,8 +536,8 @@ describe('StudyReviewPage', () => {
             expect(page?.type).toBe(PostFeedbackView)
             expect(page?.props.kind).toBe('CODE')
             expect(page?.props.entries).toHaveLength(0)
-            expect(page?.props.fallbackDecision).toBe('APPROVE')
-            expect(page?.props.fallbackTimestamp).toBeTruthy()
+            expect(page?.props.fallback?.decision).toBe('APPROVE')
+            expect(page?.props.fallback?.timestamp).toBeTruthy()
         })
 
         it('renders post-code-feedback (kind=CODE, fallback REJECT) when CODE-REJECTED has no code-review comment', async () => {
@@ -561,8 +561,8 @@ describe('StudyReviewPage', () => {
             expect(page?.type).toBe(PostFeedbackView)
             expect(page?.props.kind).toBe('CODE')
             expect(page?.props.entries).toHaveLength(0)
-            expect(page?.props.fallbackDecision).toBe('REJECT')
-            expect(page?.props.fallbackTimestamp).toBeTruthy()
+            expect(page?.props.fallback?.decision).toBe('REJECT')
+            expect(page?.props.fallback?.timestamp).toBeTruthy()
             expect(mockRedirect).not.toHaveBeenCalled()
         })
 
@@ -597,7 +597,7 @@ describe('StudyReviewPage', () => {
             expect(page?.type).toBe(PostFeedbackView)
             expect(page?.props.kind).toBe('CODE')
             expect(page?.props.job.id).toBe(job.id)
-            expect(page?.props.fallbackDecision).toBe('APPROVE')
+            expect(page?.props.fallback?.decision).toBe('APPROVE')
         })
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/review/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.tsx
@@ -1,6 +1,7 @@
 'use server'
 
 import { AccessDeniedAlert, AlertNotFound } from '@/components/errors'
+import type { ReviewDecision } from '@/database/types'
 import { isActionError } from '@/lib/errors'
 import { isSubmittedProposalReviewStatus } from '@/lib/proposal-review'
 import { Routes } from '@/lib/routes'
@@ -20,6 +21,12 @@ import { ProposalReviewFromAgreementsView } from './proposal-review-from-agreeme
 import { PostFeedbackView } from './post-feedback-view'
 import { ProposalReviewView } from './proposal-review-view'
 import { StudyDetailsReviewer } from './study-details-reviewer'
+
+const CODE_DECISION_TO_REVIEW_DECISION: Record<string, ReviewDecision> = {
+    'CODE-APPROVED': 'APPROVE',
+    'CODE-CHANGES-REQUESTED': 'NEEDS-CLARIFICATION',
+    'CODE-REJECTED': 'REJECT',
+}
 
 export default async function StudyReviewPage(props: {
     params: Promise<{
@@ -81,12 +88,12 @@ export default async function StudyReviewPage(props: {
                 return <PostFeedbackView orgSlug={orgSlug} study={study} entries={codeEntries} kind="CODE" job={job} />
             }
 
-            // OTTER-538 QA: a study can reach the code-approved/results stage via proposal approval,
-            // which auto-approves the code (CODE-APPROVED) without writing a code-review comment.
+            // OTTER-538 QA: a study can reach a code-decision stage via proposal approve/reject,
+            // which writes a CODE-* job status without writing a code-review comment.
             // With no code-review rows we must still land the DO on the post-code-feedback page
-            // (approved code), not the proposal "Review initial request" fallback below.
-            const codeApprovedAt = job?.statusChanges.find((s) => s.status === 'CODE-APPROVED')?.createdAt
-            if (codeApprovedAt) {
+            // (code decision), not the proposal "Review initial request" fallback below.
+            const fallbackStatus = job?.statusChanges.find((s) => isCodeDecisionStatus(s.status))
+            if (fallbackStatus) {
                 return (
                     <PostFeedbackView
                         orgSlug={orgSlug}
@@ -94,8 +101,8 @@ export default async function StudyReviewPage(props: {
                         entries={[]}
                         kind="CODE"
                         job={job}
-                        fallbackDecision="APPROVE"
-                        fallbackTimestamp={codeApprovedAt}
+                        fallbackDecision={CODE_DECISION_TO_REVIEW_DECISION[fallbackStatus.status]}
+                        fallbackTimestamp={fallbackStatus.createdAt}
                     />
                 )
             }

--- a/src/app/[orgSlug]/study/[studyId]/review/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.tsx
@@ -12,7 +12,7 @@ import {
     getProposalFeedbackForStudyAction,
     getStudyAction,
 } from '@/server/actions/study.actions'
-import { currentReviewVersion, latestJobForStudyOrNull, latestSubmittedJobForStudy } from '@/server/db/queries'
+import { currentReviewVersion, latestSubmittedJobForStudy } from '@/server/db/queries'
 import { sessionFromClerk } from '@/server/clerk'
 import { redirect } from 'next/navigation'
 import { CodeReview } from './code-review'
@@ -54,14 +54,15 @@ export default async function StudyReviewPage(props: {
     }
 
     if (currentOrg.type === 'enclave') {
-        const codeSubmitted = studyHasJobStatus(study, 'CODE-SUBMITTED')
-
         // OTTER-552: once a code-review decision has been made, opening the study (e.g. via
         // the dashboard "View" link, which carries no `from` param) must land the DO on the
         // post-feedback code page — not the active code-review/decision page. We gate on the
         // *latest* job status so a subsequent resubmission (a fresh CODE-SUBMITTED after a
         // change request) reopens active review instead of sticking on the decision page.
         const latestDecisionJob = await latestSubmittedJobForStudy(studyId)
+        const codeSubmitted =
+            studyHasJobStatus(study, 'CODE-SUBMITTED') ||
+            (latestDecisionJob?.statusChanges.some((s) => s.status === 'CODE-SUBMITTED') ?? false)
         const decisionMade = isCodeDecisionStatus(latestDecisionJob?.statusChanges[0]?.status)
 
         // When a reviewer navigates back from the code review page, OR the code decision has
@@ -75,7 +76,7 @@ export default async function StudyReviewPage(props: {
             if (isActionError(codeEntries)) {
                 return <AlertNotFound title="Feedback could not be loaded" message="please refresh and try again" />
             }
-            const job = await latestJobForStudyOrNull(studyId)
+            const job = latestDecisionJob
             if (codeEntries.length > 0) {
                 return <PostFeedbackView orgSlug={orgSlug} study={study} entries={codeEntries} kind="CODE" job={job} />
             }

--- a/src/app/[orgSlug]/study/[studyId]/review/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.tsx
@@ -6,7 +6,7 @@ import { isActionError } from '@/lib/errors'
 import { isSubmittedProposalReviewStatus } from '@/lib/proposal-review'
 import { Routes } from '@/lib/routes'
 import { studyHasJobStatus } from '@/lib/studies'
-import { isCodeDecisionStatus, isStudyResultsStatus } from '@/lib/study-job-status'
+import { type CodeDecisionStatus, isCodeDecisionStatus, isStudyResultsStatus } from '@/lib/study-job-status'
 import { isSubmittedStudy } from '@/schema/study'
 import {
     getCodeReviewFeedbackAction,
@@ -22,7 +22,7 @@ import { PostFeedbackView } from './post-feedback-view'
 import { ProposalReviewView } from './proposal-review-view'
 import { StudyDetailsReviewer } from './study-details-reviewer'
 
-const CODE_DECISION_TO_REVIEW_DECISION: Record<string, ReviewDecision> = {
+const CODE_DECISION_TO_REVIEW_DECISION: Record<CodeDecisionStatus, ReviewDecision> = {
     'CODE-APPROVED': 'APPROVE',
     'CODE-CHANGES-REQUESTED': 'NEEDS-CLARIFICATION',
     'CODE-REJECTED': 'REJECT',
@@ -93,7 +93,12 @@ export default async function StudyReviewPage(props: {
             // With no code-review rows we must still land the DO on the post-code-feedback page
             // (code decision), not the proposal "Review initial request" fallback below.
             const fallbackStatus = job?.statusChanges.find((s) => isCodeDecisionStatus(s.status))
-            if (fallbackStatus) {
+            if (fallbackStatus && isCodeDecisionStatus(fallbackStatus.status)) {
+                const fallback = {
+                    decision: CODE_DECISION_TO_REVIEW_DECISION[fallbackStatus.status],
+                    timestamp: fallbackStatus.createdAt,
+                }
+
                 return (
                     <PostFeedbackView
                         orgSlug={orgSlug}
@@ -101,10 +106,7 @@ export default async function StudyReviewPage(props: {
                         entries={[]}
                         kind="CODE"
                         job={job}
-                        fallback={{
-                            decision: CODE_DECISION_TO_REVIEW_DECISION[fallbackStatus.status],
-                            timestamp: fallbackStatus.createdAt,
-                        }}
+                        fallback={fallback}
                     />
                 )
             }

--- a/src/app/[orgSlug]/study/[studyId]/review/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.tsx
@@ -101,8 +101,10 @@ export default async function StudyReviewPage(props: {
                         entries={[]}
                         kind="CODE"
                         job={job}
-                        fallbackDecision={CODE_DECISION_TO_REVIEW_DECISION[fallbackStatus.status]}
-                        fallbackTimestamp={fallbackStatus.createdAt}
+                        fallback={{
+                            decision: CODE_DECISION_TO_REVIEW_DECISION[fallbackStatus.status],
+                            timestamp: fallbackStatus.createdAt,
+                        }}
                     />
                 )
             }

--- a/src/app/[orgSlug]/study/[studyId]/review/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.tsx
@@ -103,7 +103,13 @@ export default async function StudyReviewPage(props: {
             if (isActionError(proposalEntries)) {
                 return <AlertNotFound title="Feedback could not be loaded" message="please refresh and try again" />
             }
-            return <PostFeedbackView orgSlug={orgSlug} study={study} entries={proposalEntries} />
+            // Only render the proposal post-feedback view when there is feedback to show. An empty
+            // list would blank the page (PostFeedbackView returns null with no decision). A study
+            // approved with no feedback (approveStudyProposalAction writes no comment) whose code is
+            // still awaiting a decision falls through to the active-review routing below instead.
+            if (proposalEntries.length > 0) {
+                return <PostFeedbackView orgSlug={orgSlug} study={study} entries={proposalEntries} />
+            }
         }
 
         // When a reviewer navigates back from the agreements step, show the proposal

--- a/src/app/[orgSlug]/study/[studyId]/review/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.tsx
@@ -75,10 +75,30 @@ export default async function StudyReviewPage(props: {
             if (isActionError(codeEntries)) {
                 return <AlertNotFound title="Feedback could not be loaded" message="please refresh and try again" />
             }
+            const job = await latestJobForStudyOrNull(studyId)
             if (codeEntries.length > 0) {
-                const job = await latestJobForStudyOrNull(studyId)
                 return <PostFeedbackView orgSlug={orgSlug} study={study} entries={codeEntries} kind="CODE" job={job} />
             }
+
+            // OTTER-538 QA: a study can reach the code-approved/results stage via proposal approval,
+            // which auto-approves the code (CODE-APPROVED) without writing a code-review comment.
+            // With no code-review rows we must still land the DO on the post-code-feedback page
+            // (approved code), not the proposal "Review initial request" fallback below.
+            const codeApprovedAt = job?.statusChanges.find((s) => s.status === 'CODE-APPROVED')?.createdAt
+            if (codeApprovedAt) {
+                return (
+                    <PostFeedbackView
+                        orgSlug={orgSlug}
+                        study={study}
+                        entries={[]}
+                        kind="CODE"
+                        job={job}
+                        fallbackDecision="APPROVE"
+                        fallbackTimestamp={codeApprovedAt}
+                    />
+                )
+            }
+
             const proposalEntries = await getProposalFeedbackForStudyAction({ studyId })
             if (isActionError(proposalEntries)) {
                 return <AlertNotFound title="Feedback could not be loaded" message="please refresh and try again" />

--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
@@ -435,18 +435,17 @@ describe('PostFeedbackView', () => {
         })
 
         // OTTER-538 QA: code auto-approved via proposal approval leaves a CODE-APPROVED job status
-        // but no code-review comment, so `entries` is empty. The fallback decision/timestamp keep
+        // but no code-review comment, so `entries` is empty. The fallback decision metadata keeps
         // the approved code page rendering instead of blanking out.
         describe('fallback decision (no code-review comment)', () => {
-            it('renders the approved code page from fallbackDecision/fallbackTimestamp when entries are empty', () => {
+            it('renders the approved code page from fallback when entries are empty', () => {
                 renderWithProviders(
                     <PostFeedbackView
                         orgSlug={ORG_SLUG}
                         study={study}
                         entries={[]}
                         kind="CODE"
-                        fallbackDecision="APPROVE"
-                        fallbackTimestamp={new Date('2026-04-21T10:00:00Z')}
+                        fallback={{ decision: 'APPROVE', timestamp: new Date('2026-04-21T10:00:00Z') }}
                     />,
                 )
 

--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
@@ -433,5 +433,35 @@ describe('PostFeedbackView', () => {
             await waitFor(() => expect(screen.getByTestId('study-code-body')).toBeInTheDocument())
             expect(toggle).toHaveTextContent('Hide full study code')
         })
+
+        // OTTER-538 QA: code auto-approved via proposal approval leaves a CODE-APPROVED job status
+        // but no code-review comment, so `entries` is empty. The fallback decision/timestamp keep
+        // the approved code page rendering instead of blanking out.
+        describe('fallback decision (no code-review comment)', () => {
+            it('renders the approved code page from fallbackDecision/fallbackTimestamp when entries are empty', () => {
+                renderWithProviders(
+                    <PostFeedbackView
+                        orgSlug={ORG_SLUG}
+                        study={study}
+                        entries={[]}
+                        kind="CODE"
+                        fallbackDecision="APPROVE"
+                        fallbackTimestamp={new Date('2026-04-21T10:00:00Z')}
+                    />,
+                )
+
+                expect(screen.getByText('Review study code')).toBeInTheDocument()
+                expect(screen.getByTestId('decision-banner-code-approved')).toBeInTheDocument()
+                expect(screen.getByTestId('proposal-timestamp')).toHaveTextContent('Approved on Apr 21, 2026')
+                // No code-review comments => no Feedback and notes section.
+                expect(screen.queryByTestId('feedback-and-notes-section')).not.toBeInTheDocument()
+            })
+
+            it('renders nothing when entries are empty and no fallback decision is provided', () => {
+                renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[]} kind="CODE" />)
+
+                expect(screen.queryByText('Review study code')).not.toBeInTheDocument()
+            })
+        })
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
@@ -23,6 +23,13 @@ type PostFeedbackViewProps = {
     entries: ProposalFeedbackEntry[] | CodeReviewFeedbackEntry[]
     kind?: PostFeedbackKind
     job?: LatestJobForStudy | null
+    /**
+     * Render the decision banner + timestamp from these when `entries` carries no decision. Code
+     * auto-approved via proposal approval leaves a CODE-APPROVED job status but no code-review
+     * comment, so the page would otherwise blank out; the fallback keeps the approved code page.
+     */
+    fallbackDecision?: ReviewDecision
+    fallbackTimestamp?: Date | string
 }
 
 type DecisionCopy = {
@@ -135,7 +142,7 @@ type CodeSectionProps = {
     job: LatestJobForStudy | null
     kindCopy: KindCopy
     timestampLabel: string
-    timestampDate: Date
+    timestampDate: Date | string | null
     banner: ReactNode
 }
 
@@ -208,16 +215,25 @@ function buildCrumbs({
     return [dashboard, proposalCrumb, current]
 }
 
-export function PostFeedbackView({ orgSlug, study, entries, kind = 'PROPOSAL', job = null }: PostFeedbackViewProps) {
+export function PostFeedbackView({
+    orgSlug,
+    study,
+    entries,
+    kind = 'PROPOSAL',
+    job = null,
+    fallbackDecision,
+    fallbackTimestamp,
+}: PostFeedbackViewProps) {
     const latest = entries[0]
-    if (!latest || latest.decision === null) {
+    const decision = latest?.decision ?? fallbackDecision ?? null
+    if (decision === null) {
         return null
     }
 
-    const decision = latest.decision
     const kindCopy = COPY_BY_KIND[kind]
     const decisionCopy = kindCopy.decisionCopy[decision]
     const timestampLabel = decisionCopy?.timestampLabel ?? PROPOSAL_DECISION_COPY[decision].timestampLabel
+    const timestampDate = latest?.createdAt ?? fallbackTimestamp ?? null
     const crumbs = buildCrumbs({ orgSlug, studyId: study.id, kind, crumbLast: kindCopy.crumbLast })
     const banner = <DecisionBanner decision={decision} kind={kind} />
     const isCode = kind === 'CODE'
@@ -235,7 +251,7 @@ export function PostFeedbackView({ orgSlug, study, entries, kind = 'PROPOSAL', j
                     job={job}
                     kindCopy={kindCopy}
                     timestampLabel={timestampLabel}
-                    timestampDate={latest.createdAt}
+                    timestampDate={timestampDate}
                     banner={banner}
                 />
                 <ProposalSection

--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
@@ -24,12 +24,14 @@ type PostFeedbackViewProps = {
     kind?: PostFeedbackKind
     job?: LatestJobForStudy | null
     /**
-     * Render the decision banner + timestamp from these when `entries` carries no decision. Code
-     * auto-approved via proposal approval leaves a CODE-APPROVED job status but no code-review
-     * comment, so the page would otherwise blank out; the fallback keeps the approved code page.
+     * Render the decision banner + timestamp from this when `entries` carries no decision. Proposal
+     * approve/reject can write a CODE-* job status without a code-review comment, so the page would
+     * otherwise blank out; the fallback keeps the code decision page.
      */
-    fallbackDecision?: ReviewDecision
-    fallbackTimestamp?: Date | string
+    fallback?: {
+        decision: ReviewDecision
+        timestamp: Date | string
+    }
 }
 
 type DecisionCopy = {
@@ -221,11 +223,11 @@ export function PostFeedbackView({
     entries,
     kind = 'PROPOSAL',
     job = null,
-    fallbackDecision,
-    fallbackTimestamp,
+    fallback,
 }: PostFeedbackViewProps) {
     const latest = entries[0]
-    const decision = latest?.decision ?? fallbackDecision ?? null
+    const latestDecision = latest?.decision ?? null
+    const decision = latestDecision ?? fallback?.decision ?? null
     if (decision === null) {
         return null
     }
@@ -233,7 +235,7 @@ export function PostFeedbackView({
     const kindCopy = COPY_BY_KIND[kind]
     const decisionCopy = kindCopy.decisionCopy[decision]
     const timestampLabel = decisionCopy?.timestampLabel ?? PROPOSAL_DECISION_COPY[decision].timestampLabel
-    const timestampDate = latest?.createdAt ?? fallbackTimestamp ?? null
+    const timestampDate = latestDecision ? latest?.createdAt : (fallback?.timestamp ?? null)
     const crumbs = buildCrumbs({ orgSlug, studyId: study.id, kind, crumbLast: kindCopy.crumbLast })
     const banner = <DecisionBanner decision={decision} kind={kind} />
     const isCode = kind === 'CODE'


### PR DESCRIPTION
see [OTTER-538 comment](https://openstax.atlassian.net/browse/OTTER-538?focusedCommentId=43317)

- Fixed the data organization reviewer's "Previous" link on the study results page so it now returns to the code feedback page instead of the initial proposal review page (the issue Malar reported on OTTER-538).
- This covers studies whose code was approved at the same time the proposal was approved, which left no separate code-review feedback on record and so previously sent the reviewer to the wrong page.
- Also fixed a similar low-probability case on this branch where the same navigation could land on a blank page when a study had no recorded feedback at all; it now falls through to the active code review page instead.
- Also handles the case where a newer baseline/IDE-init job exists after the submitted job, so the previous-link fallback still uses the submitted code job instead of skipping or looping.
- Added tests covering the corrected routing, the no-feedback fallback, and the newer baseline job case.