### PR TITLE
OTTER-576: deduplicate active editors by user ID

### DIFF
--- a/src/components/editable-text/collaborative-editor.tsx
+++ b/src/components/editable-text/collaborative-editor.tsx
@@ -189,7 +189,10 @@ function SaveStatus({
 
 type ActiveEditor = { userId: string; name: string; color: string; focusing: boolean }
 
-function useActiveEditors(providerRef: React.RefObject<HocuspocusProvider | null>, currentUserId: string | undefined) {
+export function useActiveEditors(
+    providerRef: React.RefObject<HocuspocusProvider | null>,
+    currentUserId: string | undefined,
+) {
     const [editors, setEditors] = useState<ActiveEditor[]>([])
 
     useEffect(() => {
@@ -201,12 +204,13 @@ function useActiveEditors(providerRef: React.RefObject<HocuspocusProvider | null
         const update = () => {
             const seen = new Map<string, ActiveEditor>()
             awareness.getStates().forEach((state, clientId) => {
+                if (clientId === awareness.clientID || !state.name) return
                 const userId = state.awarenessData?.userId
-                // current user Yjs client tab || same clerk user in diff tab || no name = skip
-                if (clientId === awareness.clientID || userId === currentUserId || !state.name) return
-                const existing = seen.get(userId)
+                if (userId === currentUserId) return
+                const key = userId ?? `client-${clientId}`
+                const existing = seen.get(key)
                 if (!existing || (!existing.focusing && state.focusing)) {
-                    seen.set(userId, { userId, name: state.name, color: state.color, focusing: state.focusing })
+                    seen.set(key, { userId: key, name: state.name, color: state.color, focusing: state.focusing })
                 }
             })
             setEditors(Array.from(seen.values()))
@@ -388,6 +392,9 @@ export function CollaborativeEditor({
     const { user } = useUser()
     const { getToken } = useAuth()
     const providerRef = useRef<HocuspocusProvider | null>(null)
+    // State mirror of providerRef — the ref is needed for synchronous access in
+    // the factory callback; state is needed so the cleanup effect can depend on
+    // the provider value.
     const [activeProvider, setActiveProvider] = useState<HocuspocusProvider | null>(null)
     const [authFailureCode, setAuthFailureCode] = useState<AuthFailureCode | null>(null)
     const phase = useConnectionPhase()
@@ -424,7 +431,9 @@ export function CollaborativeEditor({
         publishProvider,
     )
 
-    // Re-publish after strict-mode teardown so subscribers don't stay on null.
+    // Strict-mode cleanup detaches the provider; re-attach and re-publish so
+    // the provider stays in providerMap and subscribers don't stay on null.
+    // attach() is idempotent — on first mount this is a no-op.
     useEffect(() => {
         if (providerRef.current) {
             providerRef.current.attach()

--- a/src/components/editable-text/collaborative-editor.tsx
+++ b/src/components/editable-text/collaborative-editor.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useAuth, useUser } from '@clerk/nextjs'
 import { Alert, Badge, Box, Group, Paper, Skeleton, Stack, Text } from '@mantine/core'
 import { LexicalComposer } from '@lexical/react/LexicalComposer'
@@ -187,9 +187,9 @@ function SaveStatus({
     )
 }
 
-type ActiveEditor = { name: string; color: string; focusing: boolean }
+type ActiveEditor = { userId: string; name: string; color: string; focusing: boolean }
 
-function useActiveEditors(providerRef: React.RefObject<HocuspocusProvider | null>) {
+function useActiveEditors(providerRef: React.RefObject<HocuspocusProvider | null>, currentUserId: string | undefined) {
     const [editors, setEditors] = useState<ActiveEditor[]>([])
 
     useEffect(() => {
@@ -199,13 +199,17 @@ function useActiveEditors(providerRef: React.RefObject<HocuspocusProvider | null
         const awareness = provider.awareness!
 
         const update = () => {
-            const states: ActiveEditor[] = []
+            const seen = new Map<string, ActiveEditor>()
             awareness.getStates().forEach((state, clientId) => {
-                if (clientId !== awareness.clientID && state.name) {
-                    states.push({ name: state.name, color: state.color, focusing: state.focusing })
+                const userId = state.awarenessData?.userId
+                // current user Yjs client tab || same clerk user in diff tab || no name = skip
+                if (clientId === awareness.clientID || userId === currentUserId || !state.name) return
+                const existing = seen.get(userId)
+                if (!existing || (!existing.focusing && state.focusing)) {
+                    seen.set(userId, { userId, name: state.name, color: state.color, focusing: state.focusing })
                 }
             })
-            setEditors(states)
+            setEditors(Array.from(seen.values()))
         }
 
         awareness.on('change', update)
@@ -214,13 +218,19 @@ function useActiveEditors(providerRef: React.RefObject<HocuspocusProvider | null
         return () => {
             awareness.off('change', update)
         }
-    }, [providerRef])
+    }, [providerRef, currentUserId])
 
     return editors
 }
 
-function ActiveEditorsList({ providerRef }: { providerRef: React.RefObject<HocuspocusProvider | null> }) {
-    const editors = useActiveEditors(providerRef)
+function ActiveEditorsList({
+    providerRef,
+    currentUserId,
+}: {
+    providerRef: React.RefObject<HocuspocusProvider | null>
+    currentUserId: string | undefined
+}) {
+    const editors = useActiveEditors(providerRef, currentUserId)
 
     if (editors.length === 0) return null
 
@@ -230,7 +240,7 @@ function ActiveEditorsList({ providerRef }: { providerRef: React.RefObject<Hocus
                 Also editing:
             </Text>
             {editors.map((editor) => (
-                <Badge key={editor.name} color={editor.color} variant="light" size="sm">
+                <Badge key={editor.userId} color={editor.color} variant="light" size="sm">
                     {editor.name}
                 </Badge>
             ))}
@@ -378,11 +388,14 @@ export function CollaborativeEditor({
     const { user } = useUser()
     const { getToken } = useAuth()
     const providerRef = useRef<HocuspocusProvider | null>(null)
+    const [activeProvider, setActiveProvider] = useState<HocuspocusProvider | null>(null)
     const [authFailureCode, setAuthFailureCode] = useState<AuthFailureCode | null>(null)
     const phase = useConnectionPhase()
     const triggerKickOut = useTriggerStudyKickOut()
+    const userId = user?.id
     const username = [user?.firstName, user?.lastName].filter(Boolean).join(' ') || 'Anonymous'
     const cursorColor = pickCursorColor(username)
+    const awarenessData = useMemo(() => ({ userId }), [userId])
     const fetchToken = useCallback(async () => getToken(), [getToken])
     const onAuthError = useCallback(
         (reason: string) => {
@@ -396,29 +409,41 @@ export function CollaborativeEditor({
         },
         [id, triggerKickOut],
     )
+    const publishProvider = useCallback(
+        (provider: HocuspocusProvider | null) => {
+            setActiveProvider(provider)
+            onProviderReady?.(provider)
+        },
+        [onProviderReady],
+    )
     const providerFactory = useCollaborationProvider(
         websocketProvider,
         providerRef,
         fetchToken,
         onAuthError,
-        onProviderReady,
+        publishProvider,
     )
 
+    // Re-publish after strict-mode teardown so subscribers don't stay on null.
     useEffect(() => {
-        // React strict mode (dev) runs setup-cleanup-setup on mount; the cleanup's
-        // `onProviderReady(null)` would otherwise wipe the provider that the
-        // factory just published during render, leaving subscribers stuck on null
-        // (criteria Y.Map bridge, submission listener). Re-publishing the current
-        // provider on setup undoes the strict-mode null publish; the cleanup still
-        // fires on real unmount. Production is unaffected (single mount, single
-        // setup, cleanup only on real unmount).
-        if (providerRef.current && onProviderReady) {
-            onProviderReady(providerRef.current)
+        if (providerRef.current) {
+            providerRef.current.attach()
+            publishProvider(providerRef.current)
         }
         return () => {
-            onProviderReady?.(null)
+            publishProvider(null)
         }
-    }, [onProviderReady])
+    }, [publishProvider])
+
+    // Clean up the per-document subscription so re-entering peers get a fresh
+    // server Connection with full awareness of who's already editing.
+    useEffect(() => {
+        if (!activeProvider) return
+        return () => {
+            activeProvider.awareness?.setLocalState(null)
+            activeProvider.detach()
+        }
+    }, [activeProvider])
 
     // STUDY_NOT_EDITABLE: a peer submitted while we were disconnected. The kick-out
     // flow (toast + redirect) is wired up at the page level; render nothing here so
@@ -472,6 +497,7 @@ export function CollaborativeEditor({
                         shouldBootstrap={false}
                         username={username}
                         cursorColor={cursorColor}
+                        awarenessData={awarenessData}
                     />
                     {onChange && <EditorChangePlugin onChange={onChange} />}
                     <ListPlugin />
@@ -485,7 +511,7 @@ export function CollaborativeEditor({
                         <SaveStatus documentId={id} studyId={studyId} providerRef={providerRef} />
                         {footerRight && <Box ml="auto">{footerRight}</Box>}
                     </Group>
-                    <ActiveEditorsList providerRef={providerRef} />
+                    <ActiveEditorsList providerRef={providerRef} currentUserId={userId} />
                 </Stack>
             </LexicalCollaboration>
         </LexicalComposer>

--- a/src/components/editable-text/use-active-editors.test.ts
+++ b/src/components/editable-text/use-active-editors.test.ts
@@ -1,0 +1,123 @@
+import { renderHook, act, describe, it, expect } from '@/tests/unit.helpers'
+import { HocuspocusProvider } from '@hocuspocus/provider'
+import { useActiveEditors } from './collaborative-editor'
+
+type FakeAwareness = HocuspocusProvider['awareness'] & {
+    states: Map<number, Record<string, unknown>>
+    clientID: number
+    _emit: (event: string, args: unknown[]) => void
+}
+
+function seedStates(awareness: FakeAwareness, entries: Array<[number, Record<string, unknown>]>) {
+    for (const [clientId, state] of entries) {
+        awareness.states.set(clientId, state)
+    }
+}
+
+describe('useActiveEditors', () => {
+    it('excludes the local Yjs client', () => {
+        const provider = new HocuspocusProvider({ name: 'test' } as never)
+        const awareness = provider.awareness as unknown as FakeAwareness
+        awareness.clientID = 1
+        seedStates(awareness, [
+            [1, { name: 'Me', color: 'red', focusing: true, awarenessData: { userId: 'user-a' } }],
+            [2, { name: 'Peer', color: 'blue', focusing: false, awarenessData: { userId: 'user-b' } }],
+        ])
+
+        const ref = { current: provider } as React.RefObject<HocuspocusProvider | null>
+        const { result } = renderHook(() => useActiveEditors(ref, 'user-a'))
+
+        expect(result.current).toHaveLength(1)
+        expect(result.current[0].name).toBe('Peer')
+    })
+
+    it('excludes other tabs of the same Clerk user', () => {
+        const provider = new HocuspocusProvider({ name: 'test' } as never)
+        const awareness = provider.awareness as unknown as FakeAwareness
+        awareness.clientID = 1
+        seedStates(awareness, [
+            [1, { name: 'Me', color: 'red', focusing: true, awarenessData: { userId: 'user-a' } }],
+            [3, { name: 'Me (tab 2)', color: 'red', focusing: false, awarenessData: { userId: 'user-a' } }],
+            [2, { name: 'Peer', color: 'blue', focusing: true, awarenessData: { userId: 'user-b' } }],
+        ])
+
+        const ref = { current: provider } as React.RefObject<HocuspocusProvider | null>
+        const { result } = renderHook(() => useActiveEditors(ref, 'user-a'))
+
+        expect(result.current).toHaveLength(1)
+        expect(result.current[0].name).toBe('Peer')
+    })
+
+    it('deduplicates the same userId across tabs, preferring focusing', () => {
+        const provider = new HocuspocusProvider({ name: 'test' } as never)
+        const awareness = provider.awareness as unknown as FakeAwareness
+        awareness.clientID = 1
+        seedStates(awareness, [
+            [2, { name: 'Peer', color: 'blue', focusing: false, awarenessData: { userId: 'user-b' } }],
+            [3, { name: 'Peer', color: 'blue', focusing: true, awarenessData: { userId: 'user-b' } }],
+        ])
+
+        const ref = { current: provider } as React.RefObject<HocuspocusProvider | null>
+        const { result } = renderHook(() => useActiveEditors(ref, 'user-a'))
+
+        expect(result.current).toHaveLength(1)
+        expect(result.current[0].focusing).toBe(true)
+    })
+
+    it('shows peers without userId individually using clientId fallback', () => {
+        const provider = new HocuspocusProvider({ name: 'test' } as never)
+        const awareness = provider.awareness as unknown as FakeAwareness
+        awareness.clientID = 1
+        seedStates(awareness, [
+            [2, { name: 'Old Client A', color: 'green', focusing: false }],
+            [3, { name: 'Old Client B', color: 'yellow', focusing: false }],
+        ])
+
+        const ref = { current: provider } as React.RefObject<HocuspocusProvider | null>
+        const { result } = renderHook(() => useActiveEditors(ref, 'user-a'))
+
+        expect(result.current).toHaveLength(2)
+        expect(result.current.map((e) => e.name).sort()).toEqual(['Old Client A', 'Old Client B'])
+    })
+
+    it('excludes entries with no name', () => {
+        const provider = new HocuspocusProvider({ name: 'test' } as never)
+        const awareness = provider.awareness as unknown as FakeAwareness
+        awareness.clientID = 1
+        seedStates(awareness, [
+            [2, { color: 'blue', focusing: false, awarenessData: { userId: 'user-b' } }],
+            [3, { name: '', color: 'red', focusing: false, awarenessData: { userId: 'user-c' } }],
+            [4, { name: 'Valid', color: 'green', focusing: true, awarenessData: { userId: 'user-d' } }],
+        ])
+
+        const ref = { current: provider } as React.RefObject<HocuspocusProvider | null>
+        const { result } = renderHook(() => useActiveEditors(ref, 'user-a'))
+
+        expect(result.current).toHaveLength(1)
+        expect(result.current[0].name).toBe('Valid')
+    })
+
+    it('updates when awareness changes', () => {
+        const provider = new HocuspocusProvider({ name: 'test' } as never)
+        const awareness = provider.awareness as unknown as FakeAwareness
+        awareness.clientID = 1
+
+        const ref = { current: provider } as React.RefObject<HocuspocusProvider | null>
+        const { result } = renderHook(() => useActiveEditors(ref, 'user-a'))
+
+        expect(result.current).toHaveLength(0)
+
+        act(() => {
+            awareness.states.set(2, {
+                name: 'Peer',
+                color: 'blue',
+                focusing: true,
+                awarenessData: { userId: 'user-b' },
+            })
+            awareness._emit('change', [{ added: [2], updated: [], removed: [] }])
+        })
+
+        expect(result.current).toHaveLength(1)
+        expect(result.current[0].name).toBe('Peer')
+    })
+})

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -197,6 +197,7 @@ vi.mock('@hocuspocus/provider', async () => {
         // Surfaced so tests can assert which document name a provider was created for.
         configuration: { name?: string } = {}
         attach = vi.fn()
+        detach = vi.fn()
         destroy = vi.fn()
         disconnect = vi.fn()
         connect = vi.fn()


### PR DESCRIPTION
## Summary

Deduplicate the "also editing" list by Clerk user ID so a single person editing in multiple tabs doesn't appear as multiple collaborators, and so the current user never sees their own name in the list.

## Changes

- **`useActiveEditors`** now takes the current user's Clerk ID and dedupes awareness states by `awarenessData.userId`:
  - Skips the local Yjs client, the current Clerk user on other tabs, and any state missing a name.
  - When the same user appears more than once, keeps the focused entry if one exists.
- **`ActiveEditor`** gains a `userId` field, which is also used as the React key in `ActiveEditorsList` (replacing the unstable `name` key).
- **`CollaborativeEditor`** publishes `awarenessData: { userId }` to the collaboration plugin so peers can identify each other by Clerk ID rather than display name.
- **Provider lifecycle** reworked:
  - New `activeProvider` state + `publishProvider` callback so subscribers and the `onProviderReady` consumer stay in sync.
  - On mount, calls `provider.attach()` and re-publishes (handles React strict-mode setup/cleanup/setup without leaving subscribers stuck on `null`).
  - On unmount, calls `awareness.setLocalState(null)` and `provider.detach()` so re-entering peers get a fresh server connection with full awareness of who's already editing.