### PR TITLE
OTTER-601: reuse the round's studyJob on submit

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/resubmit/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/resubmit/page.tsx
@@ -5,7 +5,7 @@ import { Routes } from '@/lib/routes'
 import { db } from '@/database'
 import { displayOrgName } from '@/lib/string'
 import { canResubmitStudyCode } from '@/lib/code-resubmission'
-import { fetchLatestCodeEnvForStudyIdOrNull, latestJobForStudyOrNull } from '@/server/db/queries'
+import { fetchLatestCodeEnvForStudyIdOrNull, latestSubmittedJobForStudy } from '@/server/db/queries'
 import { getCodeReviewFeedbackAction, getStudyAction } from '@/server/actions/study.actions'
 import { EditCodeResubmitProvider } from '@/contexts/edit-code-resubmit'
 import { EditStudyCodeView } from './edit-study-code-view'
@@ -18,7 +18,10 @@ export default async function ResubmitStudyCodePage(props: { params: Promise<{ s
         return notFound()
     }
 
-    const latestJob = await latestJobForStudyOrNull(studyId)
+    // Gate on the latest *submitted* job: opening this page begins a new round, and a file upload
+    // here creates a fresh INITIATED round job that would otherwise mask the prior submission and
+    // make canResubmitStudyCode fail (OTTER-601). The prior submission's status is what gates resubmit.
+    const latestJob = await latestSubmittedJobForStudy(studyId)
     const latestJobStatus = latestJob?.statusChanges.at(0)?.status ?? null
 
     if (!canResubmitStudyCode(latestJobStatus)) return notFound()

--- a/src/hooks/use-code-review-mutation.test.ts
+++ b/src/hooks/use-code-review-mutation.test.ts
@@ -101,7 +101,8 @@ describe('useCodeReviewMutation', () => {
         )
     })
 
-    it('reject broadcasts and rejects the study', async () => {
+    // OTTER-603: rejecting code fails the job only; the proposal stays APPROVED.
+    it('reject broadcasts and marks the code rejected, leaving the proposal approved', async () => {
         const { org, study, job } = await setApprovedStudyAndCodeSubmitted()
 
         const { result } = renderHook(
@@ -122,7 +123,15 @@ describe('useCodeReviewMutation', () => {
             .select('status')
             .where('id', '=', study.id)
             .executeTakeFirstOrThrow()
-        expect(updated.status).toBe('REJECTED')
+        expect(updated.status).toBe('APPROVED')
+
+        const jobRejected = await db
+            .selectFrom('jobStatusChange')
+            .select('id')
+            .where('studyJobId', '=', job.id)
+            .where('status', '=', 'CODE-REJECTED')
+            .executeTakeFirst()
+        expect(jobRejected).toBeTruthy()
         expect(handle.sendStateless).toHaveBeenCalledTimes(1)
     })
 

--- a/src/server/actions/study-request.test.ts
+++ b/src/server/actions/study-request.test.ts
@@ -29,6 +29,7 @@ import {
     submitStudyCodeAction,
 } from '@/server/actions/study-request'
 import { purgeProposalYjsDocsBeforeAt } from '@/server/db/yjs-cleanup'
+import { ensureRoundJobForLaunch } from '@/server/db/mutations'
 import { lexicalJson } from '@/lib/lexical'
 
 vi.mock('@/server/aws', async () => {
@@ -749,6 +750,138 @@ describe('Request Study Actions', () => {
 
             expect(result).toHaveProperty('error')
             expect((result as { error: string }).error).toContain('Main file not in file list')
+        })
+    })
+
+    // OTTER-601: one studyJob per submission round. Launch/upload opens the round's job; submit
+    // fills that same job in rather than minting a second that would mask the real submission.
+    describe('one-job-per-round (OTTER-601)', () => {
+        const jobCount = (studyId: string) =>
+            db
+                .selectFrom('studyJob')
+                .select((eb) => eb.fn.countAll<number>().as('n'))
+                .where('studyId', '=', studyId)
+                .executeTakeFirstOrThrow()
+                .then((r) => Number(r.n))
+
+        const codeFilesFor = async (studyId: string) => {
+            const job = await db
+                .selectFrom('studyJob')
+                .select('id')
+                .where('studyId', '=', studyId)
+                .orderBy('createdAt', 'desc')
+                .orderBy('id', 'desc')
+                .executeTakeFirstOrThrow()
+            return db
+                .selectFrom('studyJobFile')
+                .select(['name', 'fileType'])
+                .where('studyJobId', '=', job.id)
+                .where('fileType', 'in', ['MAIN-CODE', 'SUPPLEMENTAL-CODE'])
+                .orderBy('name')
+                .execute()
+        }
+
+        const submittedStatusCount = (studyId: string) =>
+            db
+                .selectFrom('studyJob')
+                .innerJoin('jobStatusChange', 'jobStatusChange.studyJobId', 'studyJob.id')
+                .select((eb) => eb.fn.countAll<number>().as('n'))
+                .where('studyJob.studyId', '=', studyId)
+                .where('jobStatusChange.status', '=', 'CODE-SUBMITTED')
+                .executeTakeFirstOrThrow()
+                .then((r) => Number(r.n))
+
+        const submitCode = (studyId: string, root: string, files: Record<string, string>, mainFileName: string) =>
+            writeWorkspaceFiles(root, studyId, files).then(() =>
+                actionResult(submitStudyCodeAction({ studyId, mainFileName, fileNames: Object.keys(files) })),
+            )
+
+        it('submit fills in the launch job instead of creating a second job', async () => {
+            const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+            const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
+            const root = await createWorkspaceDir('reuse-fill')
+            workspaceRoots.push(root)
+
+            // IDE launch opens the round's job
+            await ensureRoundJobForLaunch(db, study.id)
+            expect(await jobCount(study.id)).toBe(1)
+            const launchJob = await db
+                .selectFrom('studyJob')
+                .select('id')
+                .where('studyId', '=', study.id)
+                .executeTakeFirstOrThrow()
+
+            await submitCode(study.id, root, { 'main.R': 'print(1)', 'helper.R': 'print(2)' }, 'main.R')
+
+            // still one job — the launch job, now carrying the submission
+            expect(await jobCount(study.id)).toBe(1)
+            const afterJob = await db
+                .selectFrom('studyJob')
+                .select('id')
+                .where('studyId', '=', study.id)
+                .executeTakeFirstOrThrow()
+            expect(afterJob.id).toBe(launchJob.id)
+            expect(await codeFilesFor(study.id)).toEqual([
+                { name: 'helper.R', fileType: 'SUPPLEMENTAL-CODE' },
+                { name: 'main.R', fileType: 'MAIN-CODE' },
+            ])
+            expect(await submittedStatusCount(study.id)).toBe(1)
+        })
+
+        it('re-submitting before review overwrites files on the same job (no new job, no new version)', async () => {
+            const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+            const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
+            const root = await createWorkspaceDir('reuse-overwrite')
+            workspaceRoots.push(root)
+
+            await ensureRoundJobForLaunch(db, study.id)
+            await submitCode(study.id, root, { 'main.R': 'v1', 'helper.R': 'v1' }, 'main.R')
+            vi.mocked(aws.deleteFolderContents).mockClear()
+
+            // second submit drops helper.R, adds extra.R
+            await submitCode(study.id, root, { 'main.R': 'v2', 'extra.R': 'v2' }, 'main.R')
+
+            expect(await jobCount(study.id)).toBe(1)
+            expect(await codeFilesFor(study.id)).toEqual([
+                { name: 'extra.R', fileType: 'SUPPLEMENTAL-CODE' },
+                { name: 'main.R', fileType: 'MAIN-CODE' },
+            ])
+            // old S3 code objects cleared before re-upload
+            expect(aws.deleteFolderContents).toHaveBeenCalledTimes(1)
+            // still a single submission/version
+            expect(await submittedStatusCount(study.id)).toBe(1)
+        })
+
+        it('resubmitting after change-requested opens a new round (a second job/version)', async () => {
+            const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+            const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
+            const root = await createWorkspaceDir('reuse-resubmit')
+            workspaceRoots.push(root)
+
+            await ensureRoundJobForLaunch(db, study.id)
+            await submitCode(study.id, root, { 'main.R': 'round1' }, 'main.R')
+            const round1Job = await db
+                .selectFrom('studyJob')
+                .select('id')
+                .where('studyId', '=', study.id)
+                .executeTakeFirstOrThrow()
+            await db
+                .insertInto('jobStatusChange')
+                .values({ studyJobId: round1Job.id, status: 'CODE-CHANGES-REQUESTED' })
+                .execute()
+
+            await writeWorkspaceFiles(root, study.id, { 'main.R': 'round2' })
+            actionResult(
+                await resubmitStudyCodeAction({
+                    studyId: study.id,
+                    mainFileName: 'main.R',
+                    fileNames: ['main.R'],
+                    resubmissionNote: 'addressed the feedback and updated the code',
+                }),
+            )
+
+            expect(await jobCount(study.id)).toBe(2)
+            expect(await submittedStatusCount(study.id)).toBe(2)
         })
     })
 

--- a/src/server/actions/study-request.test.ts
+++ b/src/server/actions/study-request.test.ts
@@ -29,7 +29,7 @@ import {
     submitStudyCodeAction,
 } from '@/server/actions/study-request'
 import { purgeProposalYjsDocsBeforeAt } from '@/server/db/yjs-cleanup'
-import { ensureRoundJobForLaunch } from '@/server/db/mutations'
+import { ensureRoundJobForLaunch, ensureRoundJobForUpload } from '@/server/db/mutations'
 import { lexicalJson } from '@/lib/lexical'
 
 vi.mock('@/server/aws', async () => {
@@ -880,6 +880,45 @@ describe('Request Study Actions', () => {
                 }),
             )
 
+            expect(await jobCount(study.id)).toBe(2)
+            expect(await submittedStatusCount(study.id)).toBe(2)
+        })
+
+        // Regression: in the real flow the researcher uploads files on the resubmit page *before*
+        // submitting, which opens a fresh INITIATED round job. The resubmit guard must gate on the
+        // prior submitted job (CODE-CHANGES-REQUESTED), not that new INITIATED job, or it throws.
+        it('resubmit succeeds after a file upload opens the new round job first', async () => {
+            const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+            const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
+            const root = await createWorkspaceDir('reuse-resubmit-upload')
+            workspaceRoots.push(root)
+
+            await ensureRoundJobForLaunch(db, study.id)
+            await submitCode(study.id, root, { 'main.R': 'round1' }, 'main.R')
+            const round1Job = await db
+                .selectFrom('studyJob')
+                .select('id')
+                .where('studyId', '=', study.id)
+                .executeTakeFirstOrThrow()
+            await db
+                .insertInto('jobStatusChange')
+                .values({ studyJobId: round1Job.id, status: 'CODE-CHANGES-REQUESTED' })
+                .execute()
+
+            // Researcher uploads a file on the resubmit page → opens the round 2 INITIATED job.
+            await ensureRoundJobForUpload(db, study.id)
+            expect(await jobCount(study.id)).toBe(2)
+
+            await writeWorkspaceFiles(root, study.id, { 'main.R': 'round2' })
+            const result = await resubmitStudyCodeAction({
+                studyId: study.id,
+                mainFileName: 'main.R',
+                fileNames: ['main.R'],
+                resubmissionNote: 'addressed the feedback and updated the code',
+            })
+
+            expect(result).not.toHaveProperty('error')
+            // Still exactly the two rounds; the upload job became round 2, now CODE-SUBMITTED.
             expect(await jobCount(study.id)).toBe(2)
             expect(await submittedStatusCount(study.id)).toBe(2)
         })

--- a/src/server/actions/study-request.ts
+++ b/src/server/actions/study-request.ts
@@ -16,7 +16,7 @@ import {
     triggerScanForStudyJob,
 } from '@/server/aws'
 import { CODER_DISABLED, getConfigValue, SIMULATE_CODE_BUILD } from '@/server/config'
-import { nextVersionForStudyComment } from '@/server/db/mutations'
+import { getOrCreateCurrentRoundJob, nextVersionForStudyComment } from '@/server/db/mutations'
 import { getInfoForStudyId, getInfoForStudyJobId, getOrgIdFromSlug, latestJobForStudyOrNull } from '@/server/db/queries'
 import { db as database } from '@/database'
 import { deferred, onStudyReviewRequested, onStudyCodeSubmitted, onStudyCreated } from '@/server/events'
@@ -60,36 +60,42 @@ function triggerCodeScan(studyJobId: string, orgSlug: string, studyId: string) {
     }
 }
 
-async function addStudyJob(
+/**
+ * Attach the submitted code to the study's current submission round, reusing the job opened at IDE
+ * launch / file upload instead of minting a new one (OTTER-601). A new job is created only when the
+ * latest round has closed (resubmittable/terminal) — that's a genuine new submission round.
+ *
+ * The MAIN/SUPPLEMENTAL code file set is overwritten each time so a re-submit within an un-reviewed
+ * round (or after change-requested) reflects exactly the files now provided, with no leftovers from a
+ * prior attempt — in the DB and in S3.
+ */
+async function attachCodeToRoundJob(
     db: Kysely<DB>,
-    userId: string,
     studyId: string,
     orgSlug: string,
     mainCodeFileName: string,
     codeFileNames: string[],
 ) {
-    const studyJob = await db
-        .insertInto('studyJob')
-        .values({
-            studyId: studyId,
-        })
-        .returning('id')
-        .executeTakeFirstOrThrow()
+    const job = await getOrCreateCurrentRoundJob(db, studyId)
+    const studyJobId = job.id
 
-    await db
-        .insertInto('jobStatusChange')
-        .values({
-            studyJobId: studyJob.id,
-            status: 'INITIATED',
-        })
-        .executeTakeFirstOrThrow()
+    if (!job.created) {
+        // Reused round: drop any code files a prior attempt left on this job, in the DB and in S3,
+        // so a removed file does not linger in the reviewer's view.
+        await db
+            .deleteFrom('studyJobFile')
+            .where('studyJobId', '=', studyJobId)
+            .where('fileType', 'in', ['MAIN-CODE', 'SUPPLEMENTAL-CODE'])
+            .execute()
+        await deleteFolderContents(pathForStudyJobCode({ orgSlug, studyId, studyJobId }))
+    }
 
     await db
         .insertInto('studyJobFile')
         .values({
             name: mainCodeFileName,
-            path: pathForStudyJobCodeFile({ orgSlug, studyId, studyJobId: studyJob.id }, mainCodeFileName),
-            studyJobId: studyJob.id,
+            path: pathForStudyJobCodeFile({ orgSlug, studyId, studyJobId }, mainCodeFileName),
+            studyJobId,
             fileType: 'MAIN-CODE',
         })
         .executeTakeFirstOrThrow()
@@ -99,26 +105,33 @@ async function addStudyJob(
             .insertInto('studyJobFile')
             .values({
                 name: fileName,
-                path: pathForStudyJobCodeFile({ orgSlug, studyId, studyJobId: studyJob.id }, fileName),
-                studyJobId: studyJob.id,
+                path: pathForStudyJobCodeFile({ orgSlug, studyId, studyJobId }, fileName),
+                studyJobId,
                 fileType: 'SUPPLEMENTAL-CODE',
             })
             .executeTakeFirstOrThrow()
     }
 
-    const studyJobCodePath = pathForStudyJobCode({
-        orgSlug,
-        studyId,
-        studyJobId: studyJob.id,
-    })
+    // s3 signed url for client to upload
+    const urlForCodeUpload = await createSignedUploadUrl(pathForStudyJobCode({ orgSlug, studyId, studyJobId }))
 
-    // s3 signed urls for client to upload
-    const urlForCodeUpload = await createSignedUploadUrl(studyJobCodePath)
+    return { studyJobId, urlForCodeUpload }
+}
 
-    return {
-        studyJobId: studyJob.id,
-        urlForCodeUpload,
-    }
+/**
+ * Record CODE-SUBMITTED for a submission round exactly once. A re-submit within the same un-reviewed
+ * round overwrites the files but stays one submission/version, so we skip if the round's job already
+ * carries a CODE-SUBMITTED status (it may since have advanced to CODE-SCANNED, etc.).
+ */
+async function markCodeSubmitted(db: Kysely<DB>, { studyJobId, userId }: { studyJobId: string; userId: string }) {
+    const alreadySubmitted = await db
+        .selectFrom('jobStatusChange')
+        .select('id')
+        .where('studyJobId', '=', studyJobId)
+        .where('status', '=', 'CODE-SUBMITTED')
+        .executeTakeFirst()
+    if (alreadySubmitted) return
+    await db.insertInto('jobStatusChange').values({ studyJobId, userId, status: 'CODE-SUBMITTED' }).execute()
 }
 
 // Schema for creating a new draft
@@ -276,10 +289,10 @@ export const onSubmitDraftStudyAction = new Action('onSubmitDraftStudyAction', {
             throw new Error(`Cannot submit study: expected status DRAFT or APPROVED but got ${study.status}`)
         }
 
-        // Create the study job for the code files
-        const { studyJobId, urlForCodeUpload } = await addStudyJob(
+        // Attach the code to the study's current submission round. finalizeStudySubmissionAction
+        // adds the CODE-SUBMITTED status to this same job, so the two no longer diverge.
+        const { studyJobId, urlForCodeUpload } = await attachCodeToRoundJob(
             db,
-            userId,
             studyId,
             orgSlug,
             mainCodeFileName,
@@ -385,18 +398,35 @@ export const finalizeStudySubmissionAction = new Action('finalizeStudySubmission
             .where('study.id', '=', studyId)
             .executeTakeFirstOrThrow()
 
+        // The round job created by onSubmitDraftStudyAction (id tiebreaker keeps this deterministic
+        // when two jobs share a createdAt). Adding CODE-SUBMITTED here targets that same job.
         const latestJob = await db
             .selectFrom('studyJob')
-            .select('id')
-            .where('studyId', '=', studyId)
-            .orderBy('createdAt', 'desc')
+            .select((eb) => [
+                'studyJob.id as id',
+                eb
+                    .exists(
+                        eb
+                            .selectFrom('jobStatusChange')
+                            .select('jobStatusChange.id')
+                            .whereRef('jobStatusChange.studyJobId', '=', 'studyJob.id')
+                            .where('jobStatusChange.status', '=', 'CODE-SUBMITTED'),
+                    )
+                    .as('alreadySubmitted'),
+            ])
+            .where('studyJob.studyId', '=', studyId)
+            .orderBy('studyJob.createdAt', 'desc')
+            .orderBy('studyJob.id', 'desc')
+            .limit(1)
             .executeTakeFirst()
 
         if (latestJob) {
-            await db
-                .insertInto('jobStatusChange')
-                .values({ studyJobId: latestJob.id, userId, status: 'CODE-SUBMITTED' })
-                .execute()
+            if (!latestJob.alreadySubmitted) {
+                await db
+                    .insertInto('jobStatusChange')
+                    .values({ studyJobId: latestJob.id, userId, status: 'CODE-SUBMITTED' })
+                    .execute()
+            }
             triggerCodeScan(latestJob.id, orgSlug, studyId)
             onStudyReviewRequested({ studyJobId: latestJob.id })
         }
@@ -525,16 +555,15 @@ export const addJobToStudyAction = new Action('addJobToStudyAction', { performsM
     .handler(async ({ orgSlug, params: { studyId, mainCodeFileName, codeFileNames }, session, db }) => {
         const userId = session.user.id
 
-        const { studyJobId, urlForCodeUpload } = await addStudyJob(
+        const { studyJobId, urlForCodeUpload } = await attachCodeToRoundJob(
             db,
-            userId,
             studyId,
             orgSlug,
             mainCodeFileName,
             codeFileNames,
         )
 
-        await db.insertInto('jobStatusChange').values({ studyJobId, userId, status: 'CODE-SUBMITTED' }).execute()
+        await markCodeSubmitted(db, { studyJobId, userId })
 
         const now = new Date()
         await db
@@ -571,9 +600,8 @@ export const submitStudyCodeAction = new Action('submitStudyCodeAction', { perfo
         const sanitizedMainFileName = sanitizeFileName(mainFileName)
         const additionalFileNames = fileNames.filter((f) => f !== mainFileName).map((f) => sanitizeFileName(f))
 
-        const { studyJobId } = await addStudyJob(
+        const { studyJobId } = await attachCodeToRoundJob(
             db,
-            userId,
             studyId,
             orgSlug,
             sanitizedMainFileName,
@@ -594,7 +622,7 @@ export const submitStudyCodeAction = new Action('submitStudyCodeAction', { perfo
             await storeS3File({ orgSlug, studyId }, webStream, s3Path)
         }
 
-        await db.insertInto('jobStatusChange').values({ studyJobId, userId, status: 'CODE-SUBMITTED' }).execute()
+        await markCodeSubmitted(db, { studyJobId, userId })
 
         const now = new Date()
         await db
@@ -884,9 +912,10 @@ export const resubmitStudyCodeAction = new Action('resubmitStudyCodeAction', { p
         const sanitizedMainFileName = sanitizeFileName(mainFileName)
         const additionalFileNames = fileNames.filter((f) => f !== mainFileName).map((f) => sanitizeFileName(f))
 
-        const { studyJobId } = await addStudyJob(
+        // The canResubmitStudyCode guard above means the latest round has closed, so this opens a
+        // genuinely new round job (a new submission/version) rather than reusing the prior one.
+        const { studyJobId } = await attachCodeToRoundJob(
             db,
-            userId,
             studyId,
             orgSlug,
             sanitizedMainFileName,
@@ -906,7 +935,7 @@ export const resubmitStudyCodeAction = new Action('resubmitStudyCodeAction', { p
             await storeS3File({ orgSlug, studyId }, webStream, s3Path)
         }
 
-        await db.insertInto('jobStatusChange').values({ studyJobId, userId, status: 'CODE-SUBMITTED' }).execute()
+        await markCodeSubmitted(db, { studyJobId, userId })
 
         await db
             .updateTable('studyJob')

--- a/src/server/actions/study-request.ts
+++ b/src/server/actions/study-request.ts
@@ -17,7 +17,12 @@ import {
 } from '@/server/aws'
 import { CODER_DISABLED, getConfigValue, SIMULATE_CODE_BUILD } from '@/server/config'
 import { getOrCreateCurrentRoundJob, nextVersionForStudyComment } from '@/server/db/mutations'
-import { getInfoForStudyId, getInfoForStudyJobId, getOrgIdFromSlug, latestJobForStudyOrNull } from '@/server/db/queries'
+import {
+    getInfoForStudyId,
+    getInfoForStudyJobId,
+    getOrgIdFromSlug,
+    latestSubmittedJobForStudy,
+} from '@/server/db/queries'
 import { db as database } from '@/database'
 import { deferred, onStudyReviewRequested, onStudyCodeSubmitted, onStudyCreated } from '@/server/events'
 import { purgeProposalYjsDocsBeforeAt } from '@/server/db/yjs-cleanup'
@@ -899,7 +904,10 @@ export const resubmitStudyCodeAction = new Action('resubmitStudyCodeAction', { p
     .handler(async ({ orgSlug, params, session, db }) => {
         const { studyId, mainFileName, fileNames, resubmissionNote } = params
 
-        const latestJob = await latestJobForStudyOrNull(studyId)
+        // Gate on the latest *submitted* job, not the raw latest: a file upload during resubmit opens
+        // a fresh INITIATED round job that would otherwise mask the prior submission and fail this
+        // guard (OTTER-601). The prior submission's status is what determines resubmit eligibility.
+        const latestJob = await latestSubmittedJobForStudy(studyId)
         const latestStatus = latestJob?.statusChanges.at(0)?.status
         if (!canResubmitStudyCode(latestStatus)) {
             throw new Error(`Cannot resubmit study code: latest job status is ${latestStatus ?? 'none'}`)

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -1395,7 +1395,9 @@ describe('submitCodeReviewDecisionAction', () => {
         expect(latest.statusChanges.find((sc) => sc.status === 'CODE-APPROVED')).toBeTruthy()
     })
 
-    it('reject writes a code-review row, marks job CODE-REJECTED, and rejects the study', async () => {
+    // OTTER-603: rejecting code fails the job only; the proposal must stay APPROVED
+    // so the proposal page keeps showing "approved" rather than flipping to rejected.
+    it('reject writes a code-review row, marks job CODE-REJECTED, and leaves study.status APPROVED', async () => {
         const { user, org, study, job } = await setApprovedStudyAndCodeSubmitted()
 
         await submitCodeReviewDecisionAction({
@@ -1416,9 +1418,9 @@ describe('submitCodeReviewDecisionAction', () => {
             .select(['status', 'rejectedAt', 'approvedAt', 'reviewerId'])
             .where('id', '=', study.id)
             .executeTakeFirstOrThrow()
-        expect(updatedStudy.status).toBe('REJECTED')
-        expect(updatedStudy.rejectedAt).toBeTruthy()
-        expect(updatedStudy.approvedAt).toBeNull()
+        expect(updatedStudy.status).toBe('APPROVED')
+        expect(updatedStudy.approvedAt).toBeTruthy()
+        expect(updatedStudy.rejectedAt).toBeNull()
         expect(updatedStudy.reviewerId).toBe(user.id)
 
         const latest = await latestJobForStudy(study.id)

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -55,6 +55,10 @@ function fetchStudyQuery(db: DBExecutor) {
                     .distinctOn('studyId')
                     .orderBy('studyId')
                     .orderBy('createdAt', 'desc')
+                    // id (v7, insertion-ordered) breaks createdAt ties so the per-study job picked
+                    // here is deterministic when two jobs share a createdAt (e.g. inserted in one
+                    // transaction, where now() is constant). Mirrors latestJobForStudyQuery.
+                    .orderBy('studyJob.id', 'desc')
                     .as('latestStudyJob'),
             (join) => join.onRef('latestStudyJob.studyId', '=', 'study.id'),
         )

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -813,7 +813,20 @@ export const submitCodeReviewDecisionAction = new Action('submitCodeReviewDecisi
                 .execute()
             onStudyCodeApproved({ studyId, userId })
         } else if (decision === 'reject') {
-            await performStudyCodeRejection({ db, studyId, userId })
+            // Rejecting code only fails the job, not the proposal. Record
+            // CODE-REJECTED on the job and keep the study APPROVED so the
+            // proposal page keeps showing "approved" (OTTER-603). The study
+            // was already approved (approvedAt set) before code was reviewed.
+            await db
+                .insertInto('jobStatusChange')
+                .values({ userId, status: 'CODE-REJECTED', studyJobId: claimedJob.id })
+                .executeTakeFirstOrThrow()
+            await db
+                .updateTable('study')
+                .set({ status: 'APPROVED', rejectedAt: null, reviewerId: userId, lastUpdatedAt: new Date() })
+                .where('id', '=', studyId)
+                .execute()
+            onStudyCodeRejected({ studyId, userId })
         } else {
             // Clarification: append CODE-CHANGES-REQUESTED on the job (so the
             // pill flips to "Change requested") and move the study back to

--- a/src/server/actions/workspace-files.actions.ts
+++ b/src/server/actions/workspace-files.actions.ts
@@ -6,7 +6,7 @@ import { Action, z } from './action'
 import { CODER_DISABLED, getConfigValue } from '@/server/config'
 import { getInfoForStudyId } from '@/server/db/queries'
 import { sanitizeFileName } from '@/lib/utils'
-import { ensureBaselineJob } from '@/server/db/mutations'
+import { ensureRoundJobForUpload } from '@/server/db/mutations'
 
 async function getStudyFilesPath(studyId: string) {
     let coderFilesPath = await getConfigValue('CODER_FILES')
@@ -21,7 +21,7 @@ export const uploadWorkspaceFileAction = new Action('uploadWorkspaceFileAction',
     .middleware(async ({ params: { studyId } }) => await getInfoForStudyId(studyId))
     .requireAbilityTo('load', 'IDE')
     .handler(async ({ db, params: { studyId, file } }) => {
-        await ensureBaselineJob(db, studyId)
+        await ensureRoundJobForUpload(db, studyId)
 
         const coderFilesPath = await getStudyFilesPath(studyId)
         await fs.mkdir(coderFilesPath, { recursive: true })

--- a/src/server/actions/workspaces.actions.test.ts
+++ b/src/server/actions/workspaces.actions.test.ts
@@ -1,4 +1,4 @@
-import { mockSessionWithTestData, actionResult, insertTestStudyJobData } from '@/tests/unit.helpers'
+import { mockSessionWithTestData, actionResult, insertTestStudyJobData, db } from '@/tests/unit.helpers'
 import { describe, expect, test, afterEach, beforeEach, vi } from 'vitest'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
@@ -89,5 +89,103 @@ describe('Workspace Actions', () => {
         expect(result.files).toHaveLength(3) // main.py, README.md, data.csv
         expect(result.files[0]).toHaveProperty('size')
         expect(result.files[0]).toHaveProperty('mtime')
+    })
+
+    // OTTER-601: the submit-enable baseline must be the last *submission* time, not the round job's
+    // createdAt — otherwise relaunching an already-submitted study (which no longer mints a fresh
+    // job) re-enables Submit with no edits.
+    describe('getLastSubmissionInfoAction', () => {
+        test('with no submission, falls back to the round job createdAt and no files', async () => {
+            const { org, user } = await mockSessionWithTestData()
+            const { study, job } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'APPROVED',
+                jobStatus: 'INITIATED',
+            })
+
+            const { getLastSubmissionInfoAction } = await import('./workspaces.actions')
+            const result = actionResult(await getLastSubmissionInfoAction({ studyId: study.id }))
+
+            const jobRow = await db
+                .selectFrom('studyJob')
+                .select('createdAt')
+                .where('id', '=', job.id)
+                .executeTakeFirstOrThrow()
+            expect(result?.createdAt).toBe(jobRow.createdAt.toISOString())
+            expect(result?.fileNames).toEqual([])
+            expect(result?.mainFileName).toBeNull()
+        })
+
+        test('anchors on the CODE-SUBMITTED time and returns the submitted files', async () => {
+            const { org, user } = await mockSessionWithTestData()
+            const { study, job } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'PENDING-REVIEW',
+                jobStatus: 'INITIATED',
+            })
+            await db
+                .insertInto('studyJobFile')
+                .values([
+                    { studyJobId: job.id, name: 'main.r', path: `p/${job.id}/main.r`, fileType: 'MAIN-CODE' },
+                    {
+                        studyJobId: job.id,
+                        name: 'helper.r',
+                        path: `p/${job.id}/helper.r`,
+                        fileType: 'SUPPLEMENTAL-CODE',
+                    },
+                ])
+                .execute()
+            const submittedAt = new Date('2026-01-01T00:00:00.000Z')
+            await db
+                .insertInto('jobStatusChange')
+                .values({ studyJobId: job.id, status: 'CODE-SUBMITTED', createdAt: submittedAt })
+                .execute()
+
+            const { getLastSubmissionInfoAction } = await import('./workspaces.actions')
+            const result = actionResult(await getLastSubmissionInfoAction({ studyId: study.id }))
+
+            expect(result?.createdAt).toBe(submittedAt.toISOString())
+            expect(result?.mainFileName).toBe('main.r')
+            expect(result?.fileNames.sort()).toEqual(['helper.r', 'main.r'])
+        })
+
+        test('ignores a newer INITIATED round job and keeps the prior submission as the baseline', async () => {
+            const { org, user } = await mockSessionWithTestData()
+            const { study, job } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'APPROVED',
+                jobStatus: 'INITIATED',
+            })
+            const submittedAt = new Date('2026-01-01T00:00:00.000Z')
+            await db
+                .insertInto('studyJobFile')
+                .values({ studyJobId: job.id, name: 'main.r', path: `p/${job.id}/main.r`, fileType: 'MAIN-CODE' })
+                .execute()
+            await db
+                .insertInto('jobStatusChange')
+                .values([
+                    { studyJobId: job.id, status: 'CODE-SUBMITTED', createdAt: submittedAt },
+                    { studyJobId: job.id, status: 'CODE-CHANGES-REQUESTED', createdAt: submittedAt },
+                ])
+                .execute()
+
+            // A relaunch opens a fresh INITIATED round-2 job (newer) with no files.
+            const round2 = await db
+                .insertInto('studyJob')
+                .values({ studyId: study.id })
+                .returning('id')
+                .executeTakeFirstOrThrow()
+            await db.insertInto('jobStatusChange').values({ studyJobId: round2.id, status: 'INITIATED' }).execute()
+
+            const { getLastSubmissionInfoAction } = await import('./workspaces.actions')
+            const result = actionResult(await getLastSubmissionInfoAction({ studyId: study.id }))
+
+            // Baseline stays the prior submission, not the empty round-2 job.
+            expect(result?.createdAt).toBe(submittedAt.toISOString())
+            expect(result?.fileNames).toEqual(['main.r'])
+        })
     })
 })

--- a/src/server/actions/workspaces.actions.ts
+++ b/src/server/actions/workspaces.actions.ts
@@ -6,7 +6,7 @@ import { Action, z } from './action'
 import { createUserAndWorkspace, getCoderWorkspaceUrl } from '../coder'
 import { CODER_DISABLED, getConfigValue } from '@/server/config'
 import { getInfoForStudyId } from '@/server/db/queries'
-import { resetBaselineJob } from '@/server/db/mutations'
+import { ensureRoundJobForLaunch } from '@/server/db/mutations'
 import { initializeDevWorkspaceFiles } from '@/server/dev'
 
 const isMainFile = (filename: string): boolean => {
@@ -81,7 +81,7 @@ export const createUserAndWorkspaceAction = new Action('createUserAndWorkspaceAc
     .requireAbilityTo('load', 'IDE')
     .handler(async ({ db, params: { studyId }, session }) => {
         if (!session) throw new Error('Unauthorized')
-        await resetBaselineJob(db, studyId)
+        await ensureRoundJobForLaunch(db, studyId)
         if (CODER_DISABLED) {
             return {
                 success: true,

--- a/src/server/actions/workspaces.actions.ts
+++ b/src/server/actions/workspaces.actions.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path'
 import { Action, z } from './action'
 import { createUserAndWorkspace, getCoderWorkspaceUrl } from '../coder'
 import { CODER_DISABLED, getConfigValue } from '@/server/config'
-import { getInfoForStudyId } from '@/server/db/queries'
+import { getInfoForStudyId, latestSubmittedJobForStudy } from '@/server/db/queries'
 import { ensureRoundJobForLaunch } from '@/server/db/mutations'
 import { initializeDevWorkspaceFiles } from '@/server/dev'
 
@@ -139,24 +139,39 @@ export const getLastSubmissionInfoAction = new Action('getLastSubmissionInfoActi
     .middleware(async ({ params: { studyId } }) => await getInfoForStudyId(studyId))
     .requireAbilityTo('load', 'IDE')
     .handler(async ({ db, params: { studyId } }) => {
+        // Submit-enable compares workspace file mtimes against this baseline. Anchor it on the last
+        // *submission* (the CODE-SUBMITTED moment), not the current round job's createdAt: reusing a
+        // job means its createdAt no longer advances on relaunch, so anchoring there would let Submit
+        // re-enable with no edits after a study was already submitted (OTTER-601). Comparing against
+        // the submission time means Submit only lights up when a file actually changed since submit.
+        const submittedJob = await latestSubmittedJobForStudy(studyId)
+
+        if (submittedJob) {
+            const submittedAt = submittedJob.statusChanges.find((s) => s.status === 'CODE-SUBMITTED')?.createdAt
+            const codeFiles = submittedJob.files.filter(
+                (f) => f.fileType === 'MAIN-CODE' || f.fileType === 'SUPPLEMENTAL-CODE',
+            )
+            return {
+                createdAt: new Date(submittedAt ?? submittedJob.createdAt).toISOString(),
+                mainFileName: codeFiles.find((f) => f.fileType === 'MAIN-CODE')?.name ?? null,
+                fileNames: codeFiles.map((f) => f.name),
+            }
+        }
+
+        // No submission yet: fall back to the current round job's createdAt so the first submit
+        // enables once files are edited after the workspace was opened.
         const studyJob = await db
             .selectFrom('studyJob')
-            .select(['id', 'createdAt'])
+            .select(['createdAt'])
             .where('studyId', '=', studyId)
-            .orderBy('createdAt', 'desc')
+            .orderBy('id', 'desc')
             .executeTakeFirst()
 
         if (!studyJob) return null
 
-        const files = await db
-            .selectFrom('studyJobFile')
-            .select(['name', 'fileType'])
-            .where('studyJobId', '=', studyJob.id)
-            .execute()
-
         return {
             createdAt: studyJob.createdAt.toISOString(),
-            mainFileName: files.find((f) => f.fileType === 'MAIN-CODE')?.name ?? null,
-            fileNames: files.map((f) => f.name),
+            mainFileName: null,
+            fileNames: [],
         }
     })

--- a/src/server/db/mutations.test.ts
+++ b/src/server/db/mutations.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest'
+import { db } from '@/database'
+import { insertTestOrg, insertTestStudyJobData, insertTestStudyOnly } from '@/tests/unit.helpers'
+import type { StudyJobStatus } from '@/database/types'
+import { ensureRoundJobForLaunch, ensureRoundJobForUpload, getOrCreateCurrentRoundJob } from './mutations'
+
+const jobsForStudy = (studyId: string) =>
+    db.selectFrom('studyJob').select(['id', 'createdAt']).where('studyId', '=', studyId).orderBy('createdAt').execute()
+
+const addStatus = (studyJobId: string, status: StudyJobStatus) =>
+    db.insertInto('jobStatusChange').values({ studyJobId, status }).execute()
+
+const addFile = (studyJobId: string) =>
+    db
+        .insertInto('studyJobFile')
+        .values({ studyJobId, name: 'main.r', path: `path/${studyJobId}/main.r`, fileType: 'MAIN-CODE' })
+        .execute()
+
+describe('getOrCreateCurrentRoundJob (OTTER-601)', () => {
+    it('creates the first round job when the study has none', async () => {
+        const org = await insertTestOrg()
+        const { study } = await insertTestStudyOnly({ org })
+
+        const job = await getOrCreateCurrentRoundJob(db, study.id)
+
+        expect(job.created).toBe(true)
+        expect(job.latestStatus).toBe('INITIATED')
+        expect(await jobsForStudy(study.id)).toHaveLength(1)
+    })
+
+    it('reuses the open round job rather than creating a second one', async () => {
+        const org = await insertTestOrg()
+        const { study, job } = await insertTestStudyJobData({ org, studyStatus: 'APPROVED', jobStatus: 'INITIATED' })
+
+        const result = await getOrCreateCurrentRoundJob(db, study.id)
+
+        expect(result.created).toBe(false)
+        expect(result.id).toBe(job.id)
+        expect(await jobsForStudy(study.id)).toHaveLength(1)
+    })
+
+    it('reuses a submitted-but-undecided job (does not mask code under review)', async () => {
+        const org = await insertTestOrg()
+        const { study, job } = await insertTestStudyJobData({
+            org,
+            studyStatus: 'PENDING-REVIEW',
+            jobStatus: 'CODE-SUBMITTED',
+        })
+
+        const result = await getOrCreateCurrentRoundJob(db, study.id)
+
+        expect(result.created).toBe(false)
+        expect(result.id).toBe(job.id)
+        expect(result.latestStatus).toBe('CODE-SUBMITTED')
+        expect(await jobsForStudy(study.id)).toHaveLength(1)
+    })
+
+    it('opens a new round once the latest job is resubmittable (CODE-CHANGES-REQUESTED)', async () => {
+        const org = await insertTestOrg()
+        const { study, job } = await insertTestStudyJobData({
+            org,
+            studyStatus: 'APPROVED',
+            jobStatus: 'CODE-SUBMITTED',
+        })
+        await addFile(job.id)
+        await addStatus(job.id, 'CODE-CHANGES-REQUESTED')
+
+        const result = await getOrCreateCurrentRoundJob(db, study.id)
+
+        expect(result.created).toBe(true)
+        expect(result.id).not.toBe(job.id)
+        expect(await jobsForStudy(study.id)).toHaveLength(2)
+    })
+
+    it('does NOT open a new round after a terminal CODE-REJECTED (not resubmittable)', async () => {
+        const org = await insertTestOrg()
+        const { study, job } = await insertTestStudyJobData({
+            org,
+            studyStatus: 'APPROVED',
+            jobStatus: 'CODE-SUBMITTED',
+        })
+        await addFile(job.id)
+        await addStatus(job.id, 'CODE-REJECTED')
+
+        const result = await getOrCreateCurrentRoundJob(db, study.id)
+
+        expect(result.created).toBe(false)
+        expect(result.id).toBe(job.id)
+        expect(await jobsForStudy(study.id)).toHaveLength(1)
+    })
+})
+
+describe('ensureRoundJobForLaunch (OTTER-601)', () => {
+    it('creates the first job and re-anchors createdAt on a fresh open round', async () => {
+        const org = await insertTestOrg()
+        const { study } = await insertTestStudyOnly({ org })
+
+        await ensureRoundJobForLaunch(db, study.id)
+
+        expect(await jobsForStudy(study.id)).toHaveLength(1)
+    })
+
+    it('reuses the open round job and refreshes its createdAt (no stacking)', async () => {
+        const org = await insertTestOrg()
+        const { study, job } = await insertTestStudyJobData({ org, studyStatus: 'APPROVED', jobStatus: 'INITIATED' })
+        const [before] = await jobsForStudy(study.id)
+
+        const result = await ensureRoundJobForLaunch(db, study.id)
+
+        const after = await jobsForStudy(study.id)
+        expect(after).toHaveLength(1)
+        expect(after[0].id).toBe(job.id)
+        expect(result.id).toBe(job.id)
+        expect(after[0].createdAt.getTime()).toBeGreaterThanOrEqual(before.createdAt.getTime())
+    })
+
+    it('does NOT refresh createdAt of a submitted job under review', async () => {
+        const org = await insertTestOrg()
+        const { study, job } = await insertTestStudyJobData({
+            org,
+            studyStatus: 'PENDING-REVIEW',
+            jobStatus: 'CODE-SUBMITTED',
+        })
+        const [before] = await jobsForStudy(study.id)
+
+        await ensureRoundJobForLaunch(db, study.id)
+
+        const after = await jobsForStudy(study.id)
+        expect(after).toHaveLength(1)
+        expect(after[0].id).toBe(job.id)
+        expect(after[0].createdAt.getTime()).toBe(before.createdAt.getTime())
+    })
+
+    it('opens a new round when the latest job is resubmittable', async () => {
+        const org = await insertTestOrg()
+        const { study, job } = await insertTestStudyJobData({
+            org,
+            studyStatus: 'APPROVED',
+            jobStatus: 'CODE-SUBMITTED',
+        })
+        await addFile(job.id)
+        await addStatus(job.id, 'RUN-COMPLETE')
+
+        await ensureRoundJobForLaunch(db, study.id)
+
+        expect(await jobsForStudy(study.id)).toHaveLength(2)
+    })
+})
+
+describe('ensureRoundJobForUpload (OTTER-601)', () => {
+    it('creates a job when none exists', async () => {
+        const org = await insertTestOrg()
+        const { study } = await insertTestStudyOnly({ org })
+
+        await ensureRoundJobForUpload(db, study.id)
+
+        expect(await jobsForStudy(study.id)).toHaveLength(1)
+    })
+
+    it('reuses the open round job rather than stacking another', async () => {
+        const org = await insertTestOrg()
+        const { study, job } = await insertTestStudyJobData({ org, studyStatus: 'APPROVED', jobStatus: 'INITIATED' })
+
+        await ensureRoundJobForUpload(db, study.id)
+
+        const after = await jobsForStudy(study.id)
+        expect(after).toHaveLength(1)
+        expect(after[0].id).toBe(job.id)
+    })
+
+    it('does not mask a submitted job under review', async () => {
+        const org = await insertTestOrg()
+        const { study, job } = await insertTestStudyJobData({
+            org,
+            studyStatus: 'PENDING-REVIEW',
+            jobStatus: 'CODE-SUBMITTED',
+        })
+
+        await ensureRoundJobForUpload(db, study.id)
+
+        const after = await jobsForStudy(study.id)
+        expect(after).toHaveLength(1)
+        expect(after[0].id).toBe(job.id)
+    })
+})

--- a/src/server/db/mutations.test.ts
+++ b/src/server/db/mutations.test.ts
@@ -24,7 +24,7 @@ describe('getOrCreateCurrentRoundJob (OTTER-601)', () => {
         const job = await getOrCreateCurrentRoundJob(db, study.id)
 
         expect(job.created).toBe(true)
-        expect(job.latestStatus).toBe('INITIATED')
+        expect(job.hasSubmission).toBe(false)
         expect(await jobsForStudy(study.id)).toHaveLength(1)
     })
 
@@ -51,7 +51,7 @@ describe('getOrCreateCurrentRoundJob (OTTER-601)', () => {
 
         expect(result.created).toBe(false)
         expect(result.id).toBe(job.id)
-        expect(result.latestStatus).toBe('CODE-SUBMITTED')
+        expect(result.hasSubmission).toBe(true)
         expect(await jobsForStudy(study.id)).toHaveLength(1)
     })
 
@@ -70,6 +70,41 @@ describe('getOrCreateCurrentRoundJob (OTTER-601)', () => {
         expect(result.created).toBe(true)
         expect(result.id).not.toBe(job.id)
         expect(await jobsForStudy(study.id)).toHaveLength(2)
+    })
+
+    // Regression: the reuse-vs-new-round decision must not depend on jobStatusChange ordering.
+    // jobStatusChange.createdAt defaults to now() (constant within a transaction), so two statuses
+    // written together tie on createdAt and v7 ids aren't reliably monotonic within a millisecond.
+    // A "latest status" lookup over them is non-deterministic; this asserts the decision is stable
+    // when a non-resubmittable and a resubmittable status share an exact createdAt.
+    it('deterministically opens a new round when resubmittable and non-resubmittable statuses share a createdAt', async () => {
+        const org = await insertTestOrg()
+
+        // Fresh study per iteration so each decision runs against the same unchanged two-status state;
+        // an order-dependent implementation would flip the verdict across iterations.
+        for (let i = 0; i < 8; i++) {
+            const { study, job } = await insertTestStudyJobData({
+                org,
+                studyStatus: 'APPROVED',
+                jobStatus: 'CODE-SUBMITTED',
+            })
+            await addFile(job.id)
+            // Same exact timestamp for both rows — forces the createdAt tie the bug depended on, with
+            // a non-resubmittable (CODE-APPROVED) and a resubmittable (RUN-COMPLETE) status.
+            const tied = new Date()
+            await db
+                .insertInto('jobStatusChange')
+                .values([
+                    { studyJobId: job.id, status: 'CODE-APPROVED', createdAt: tied },
+                    { studyJobId: job.id, status: 'RUN-COMPLETE', createdAt: tied },
+                ])
+                .execute()
+
+            const result = await getOrCreateCurrentRoundJob(db, study.id)
+            expect(result.created).toBe(true)
+            expect(result.id).not.toBe(job.id)
+            expect(await jobsForStudy(study.id)).toHaveLength(2)
+        }
     })
 
     it('does NOT open a new round after a terminal CODE-REJECTED (not resubmittable)', async () => {

--- a/src/server/db/mutations.ts
+++ b/src/server/db/mutations.ts
@@ -1,7 +1,7 @@
 import { Action } from '../actions/action'
-import type { DB, StudyJobStatus } from '@/database/types'
+import type { DB } from '@/database/types'
 import { sql, type Kysely } from 'kysely'
-import { canResubmitStudyCode } from '@/lib/code-resubmission'
+import { CODE_RESUBMITTABLE_JOB_STATUSES } from '@/lib/code-resubmission'
 
 type SiUserOptionalAttrs = {
     firstName?: string | null
@@ -28,7 +28,14 @@ export const findOrCreateSiUserId = async (clerkId: string, attrs: SiUserOptiona
     return user.id
 }
 
-export type RoundJob = { id: string; createdAt: Date; latestStatus: StudyJobStatus | null; created: boolean }
+export type RoundJob = {
+    id: string
+    createdAt: Date
+    /** True once the round's job carries a real submission (any status beyond the initial INITIATED). */
+    hasSubmission: boolean
+    /** True when this call inserted a brand-new round job (vs. reusing the current one). */
+    created: boolean
+}
 
 async function createRoundJob(db: Kysely<DB>, studyId: string, createdAt: Date): Promise<RoundJob> {
     const studyJob = await db
@@ -42,7 +49,7 @@ async function createRoundJob(db: Kysely<DB>, studyId: string, createdAt: Date):
         .values({ studyJobId: studyJob.id, status: 'INITIATED' })
         .executeTakeFirstOrThrow()
 
-    return { id: studyJob.id, createdAt: studyJob.createdAt, latestStatus: 'INITIATED', created: true }
+    return { id: studyJob.id, createdAt: studyJob.createdAt, hasSubmission: false, created: true }
 }
 
 /**
@@ -65,15 +72,34 @@ export async function getOrCreateCurrentRoundJob(
     const latest = await db
         .selectFrom('studyJob')
         .select(['studyJob.id as id', 'studyJob.createdAt as createdAt'])
+        // Both flags are EXISTENCE checks, not "latest status" lookups, so they're independent of
+        // jobStatusChange ordering. jobStatusChange.createdAt defaults to now() (constant within a
+        // transaction), so two statuses written together tie on createdAt and v7 ids aren't reliably
+        // monotonic within a millisecond — ordering by them to pick "the latest status" is
+        // non-deterministic and could flip the reuse-vs-new-round decision. A resubmittable/terminal
+        // status is never followed by another status on the same job (resubmit opens a NEW job), so
+        // "has any resubmittable status" is an equivalent, order-independent test for a closed round.
         .select((eb) =>
             eb
-                .selectFrom('jobStatusChange')
-                .select('jobStatusChange.status')
-                .whereRef('jobStatusChange.studyJobId', '=', 'studyJob.id')
-                .orderBy('jobStatusChange.createdAt', 'desc')
-                .orderBy('jobStatusChange.id', 'desc')
-                .limit(1)
-                .as('latestStatus'),
+                .exists(
+                    eb
+                        .selectFrom('jobStatusChange')
+                        .select('jobStatusChange.id')
+                        .whereRef('jobStatusChange.studyJobId', '=', 'studyJob.id')
+                        .where('jobStatusChange.status', 'in', CODE_RESUBMITTABLE_JOB_STATUSES),
+                )
+                .as('roundClosed'),
+        )
+        .select((eb) =>
+            eb
+                .exists(
+                    eb
+                        .selectFrom('jobStatusChange')
+                        .select('jobStatusChange.id')
+                        .whereRef('jobStatusChange.studyJobId', '=', 'studyJob.id')
+                        .where('jobStatusChange.status', '!=', 'INITIATED'),
+                )
+                .as('hasSubmission'),
         )
         .where('studyJob.studyId', '=', studyId)
         // Order by id (v7 = insertion order), NOT createdAt: ensureRoundJobForUpload deliberately
@@ -84,11 +110,10 @@ export async function getOrCreateCurrentRoundJob(
         .limit(1)
         .executeTakeFirst()
 
-    const latestStatus = (latest?.latestStatus ?? null) as StudyJobStatus | null
-    if (!latest || canResubmitStudyCode(latestStatus)) {
+    if (!latest || latest.roundClosed) {
         return createRoundJob(db, studyId, new Date(Date.now() - backdateMs))
     }
-    return { id: latest.id, createdAt: latest.createdAt, latestStatus, created: false }
+    return { id: latest.id, createdAt: latest.createdAt, hasSubmission: Boolean(latest.hasSubmission), created: false }
 }
 
 // Submit is enabled when any workspace file's mtime > the current round job's createdAt.
@@ -101,7 +126,7 @@ export async function getOrCreateCurrentRoundJob(
  */
 export async function ensureRoundJobForLaunch(db: Kysely<DB>, studyId: string): Promise<RoundJob> {
     const job = await getOrCreateCurrentRoundJob(db, studyId)
-    if (job.created || job.latestStatus !== 'INITIATED') return job
+    if (job.created || job.hasSubmission) return job
     const reanchored = await db
         .updateTable('studyJob')
         .set({ createdAt: new Date() })

--- a/src/server/db/mutations.ts
+++ b/src/server/db/mutations.ts
@@ -76,7 +76,10 @@ export async function getOrCreateCurrentRoundJob(
                 .as('latestStatus'),
         )
         .where('studyJob.studyId', '=', studyId)
-        .orderBy('studyJob.createdAt', 'desc')
+        // Order by id (v7 = insertion order), NOT createdAt: ensureRoundJobForUpload deliberately
+        // backdates a new round job's createdAt (so uploaded files read as newer for submit-enable),
+        // which would otherwise rank it *behind* the prior submission and make us open yet another
+        // round. id is monotonic with insertion, so the most-recently-created job always wins.
         .orderBy('studyJob.id', 'desc')
         .limit(1)
         .executeTakeFirst()

--- a/src/server/db/mutations.ts
+++ b/src/server/db/mutations.ts
@@ -1,6 +1,7 @@
 import { Action } from '../actions/action'
-import type { DB } from '@/database/types'
+import type { DB, StudyJobStatus } from '@/database/types'
 import { sql, type Kysely } from 'kysely'
+import { canResubmitStudyCode } from '@/lib/code-resubmission'
 
 type SiUserOptionalAttrs = {
     firstName?: string | null
@@ -27,7 +28,9 @@ export const findOrCreateSiUserId = async (clerkId: string, attrs: SiUserOptiona
     return user.id
 }
 
-async function createBaselineJob(db: Kysely<DB>, studyId: string, createdAt: Date) {
+export type RoundJob = { id: string; createdAt: Date; latestStatus: StudyJobStatus | null; created: boolean }
+
+async function createRoundJob(db: Kysely<DB>, studyId: string, createdAt: Date): Promise<RoundJob> {
     const studyJob = await db
         .insertInto('studyJob')
         .values({ studyId, createdAt })
@@ -39,21 +42,78 @@ async function createBaselineJob(db: Kysely<DB>, studyId: string, createdAt: Dat
         .values({ studyJobId: studyJob.id, status: 'INITIATED' })
         .executeTakeFirstOrThrow()
 
-    return studyJob
+    return { id: studyJob.id, createdAt: studyJob.createdAt, latestStatus: 'INITIATED', created: true }
 }
 
-// Submit is enabled when any file's mtime > latest job's createdAt.
+/**
+ * A study accumulates one studyJob per submission *round*: a round opens when work begins (IDE launch
+ * or file upload) and closes once its job reaches a completed/resubmittable state. The latest job is
+ * the "current round" unless it has closed, in which case the next launch/submit starts a new round.
+ *
+ * This is the single source of truth for "which job does this study's in-progress work belong to" —
+ * shared by IDE launch, file upload, and code submission so they all converge on the same job instead
+ * of each minting its own (which is what let an empty IDE-init job mask a real submission, OTTER-601).
+ *
+ * `created` distinguishes a freshly-opened round from a reused one so callers can decide whether to
+ * re-anchor the submit-enable timestamp or overwrite a prior submission's files.
+ */
+export async function getOrCreateCurrentRoundJob(
+    db: Kysely<DB>,
+    studyId: string,
+    { backdateMs = 0 }: { backdateMs?: number } = {},
+): Promise<RoundJob> {
+    const latest = await db
+        .selectFrom('studyJob')
+        .select(['studyJob.id as id', 'studyJob.createdAt as createdAt'])
+        .select((eb) =>
+            eb
+                .selectFrom('jobStatusChange')
+                .select('jobStatusChange.status')
+                .whereRef('jobStatusChange.studyJobId', '=', 'studyJob.id')
+                .orderBy('jobStatusChange.createdAt', 'desc')
+                .orderBy('jobStatusChange.id', 'desc')
+                .limit(1)
+                .as('latestStatus'),
+        )
+        .where('studyJob.studyId', '=', studyId)
+        .orderBy('studyJob.createdAt', 'desc')
+        .orderBy('studyJob.id', 'desc')
+        .limit(1)
+        .executeTakeFirst()
 
-/** Creates a backdated job if none exists so uploaded files (written after) have newer mtime. */
-export async function ensureBaselineJob(db: Kysely<DB>, studyId: string) {
-    const existingJob = await db.selectFrom('studyJob').select('id').where('studyId', '=', studyId).executeTakeFirst()
-    if (existingJob) return
-    return createBaselineJob(db, studyId, new Date(Date.now() - 1000))
+    const latestStatus = (latest?.latestStatus ?? null) as StudyJobStatus | null
+    if (!latest || canResubmitStudyCode(latestStatus)) {
+        return createRoundJob(db, studyId, new Date(Date.now() - backdateMs))
+    }
+    return { id: latest.id, createdAt: latest.createdAt, latestStatus, created: false }
 }
 
-/** Always creates a fresh job for IDE launch. Starter files should have their mtime backdated. */
-export async function resetBaselineJob(db: Kysely<DB>, studyId: string) {
-    return createBaselineJob(db, studyId, new Date())
+// Submit is enabled when any workspace file's mtime > the current round job's createdAt.
+
+/**
+ * IDE launch: ensure the current round has a job. When the round is still open work (no submission
+ * yet — only INITIATED), re-anchor its createdAt to now so edits made after this launch enable Submit.
+ * A round whose job already carries a submission is left untouched. Reuses the round's job rather than
+ * stacking a new one (OTTER-601).
+ */
+export async function ensureRoundJobForLaunch(db: Kysely<DB>, studyId: string): Promise<RoundJob> {
+    const job = await getOrCreateCurrentRoundJob(db, studyId)
+    if (job.created || job.latestStatus !== 'INITIATED') return job
+    const reanchored = await db
+        .updateTable('studyJob')
+        .set({ createdAt: new Date() })
+        .where('id', '=', job.id)
+        .returning(['id', 'createdAt'])
+        .executeTakeFirstOrThrow()
+    return { ...job, createdAt: reanchored.createdAt }
+}
+
+/**
+ * File upload: ensure the current round has a job, backdated so files written immediately after still
+ * register as newer than its createdAt. Reuses the round's job rather than creating a new one.
+ */
+export async function ensureRoundJobForUpload(db: Kysely<DB>, studyId: string): Promise<RoundJob> {
+    return getOrCreateCurrentRoundJob(db, studyId, { backdateMs: 1000 })
 }
 
 /**

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -109,11 +109,15 @@ function latestJobForStudyQuery(studyId: string) {
         ])
         .where('studyJob.studyId', '=', studyId)
         .orderBy('createdAt', 'desc')
+        .orderBy('studyJob.id', 'desc')
         .limit(1)
 }
 
-// Skips baseline / IDE-init jobs (status sequence: just INITIATED) so callers
-// anchor on real submissions rather than a bare baseline with no files attached.
+// The latest job that has reached a real submission (any status beyond the initial INITIATED).
+// A study opens a fresh job when work on a new round begins (IDE launch / file upload after a
+// closed round); until that round is submitted its job is INITIATED-only. Reviewer/researcher
+// routing that must anchor on the *submitted* code uses this, not the raw latest job, so an
+// in-progress new round doesn't mask the submission still under review or showing results.
 function latestSubmittedJobForStudyQuery(studyId: string) {
     return latestJobForStudyQuery(studyId).where((eb) =>
         eb.exists(

--- a/tests/unit.helpers.tsx
+++ b/tests/unit.helpers.tsx
@@ -59,17 +59,42 @@ export const readTestSupportFile = (file: string) => {
     return fs.promises.readFile(path.join(__dirname, 'support', file), 'utf8')
 }
 
-export const createTestQueryClient = () =>
-    new QueryClient({
+// Every QueryClient minted for a test is tracked here and torn down in the global afterEach
+// (see resetTestQueryClients). Without this, a still-live client's scheduled work — most importantly
+// useWorkspaceFiles' refetchInterval timer — outlives its test and fires during the next one, reading
+// the process-global CODER_FILES (reassigned/deleted per test) and flipping a component's state. That
+// surfaced as "intermittent" study-code submit-button failures only under full-suite timing.
+const liveTestQueryClients = new Set<QueryClient>()
+
+// Background refetches (window-focus, mount, reconnect) are also disabled so queries only run when a
+// test explicitly invalidates them — interval polling is stopped by the teardown above.
+export const createTestQueryClient = () => {
+    const client = new QueryClient({
         defaultOptions: {
             queries: {
                 retry: false,
+                refetchOnMount: false,
+                refetchOnWindowFocus: false,
+                refetchOnReconnect: false,
             },
             mutations: {
                 retry: false,
             },
         },
     })
+    liveTestQueryClients.add(client)
+    return client
+}
+
+// Called from the global afterEach (tests/vitest.setup.ts) after RTL cleanup() has unmounted the
+// React trees: clear every test client so no cached data or in-flight refetch crosses into the next
+// test. Observers (and their interval timers) are already gone via cleanup().
+export const resetTestQueryClients = () => {
+    for (const client of liveTestQueryClients) {
+        client.clear()
+    }
+    liveTestQueryClients.clear()
+}
 
 // `renderHook(..., { wrapper: createTestQueryWrapper() })` for hooks that depend on
 // useMutation / useQuery. Each call gets a fresh QueryClient so cached state cannot

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -266,7 +266,12 @@ afterEach(async () => {
     delete process.env.UPLOAD_TMP_DIRECTORY
     const { __resetSharedYjsWebsocketForTests } = await import('@/lib/realtime/yjs-websocket-context')
     __resetSharedYjsWebsocketForTests()
+    // Unmount React trees first so query observers (and their refetchInterval timers) are removed,
+    // then clear every test QueryClient so no in-flight refetch or cached state crosses into the
+    // next test (which would read the per-test process.env.CODER_FILES after it's been reassigned).
     cleanup()
+    const { resetTestQueryClients } = await import('@/tests/unit.helpers')
+    resetTestQueryClients()
 })
 
 afterAll(async () => {


### PR DESCRIPTION
## OTTER-601 — [Baseline (IDE-init) jobs mask the latest submitted job](https://openstax.atlassian.net/browse/OTTER-601)

Every IDE launch / file upload minted a fresh empty `studyJob` (INITIATED, no files) and every code submit minted a *second* job, so one round of work produced two job rows. The newer empty job masked the real submission anywhere "the latest job" is read — wrong pages, dead-ends, hidden controls.

A study now carries **one `studyJob` per submission round**:

- `getOrCreateCurrentRoundJob` is the single source of truth for which job in-progress work belongs to. It reuses the latest job unless that job has reached a resubmittable/terminal state (a genuine new round) or none exists.
- IDE launch (`ensureRoundJobForLaunch`) and upload (`ensureRoundJobForUpload`) reuse the round's job rather than stacking. Launch re-anchors `createdAt` only while the round is still open work, never on a live submission.
- Submit (`attachCodeToRoundJob`) fills in that same job and overwrites its code files (DB + S3) so a re-submit before review reflects exactly the files now provided. `markCodeSubmitted` records `CODE-SUBMITTED` once per round.

`latestSubmittedJobForStudy` is kept: a new round legitimately opens a file-less job that reviewer/researcher routing must skip, so the per-route swaps the card listed (C/D/E/F/G) aren't needed.

## OTTER-603 — [Code rejection also rejects the proposal page](https://openstax.atlassian.net/browse/OTTER-603)

Rejecting code now fails the job only — records `CODE-REJECTED` and leaves the study `APPROVED`, so the proposal page no longer flips to rejected.

## Test harness

Clear every test `QueryClient` after each test and disable implicit refetches, so a lingering `refetchInterval` no longer reads the per-test `CODER_FILES` env across test boundaries (fixes nondeterministic study-code failures under full-suite runs).

Full suite: 1467 tests, green across repeated runs.