### PR TITLE
OTTER-607: scope study/job mutations to the owning lab

### DIFF
--- a/src/lib/permission-types.ts
+++ b/src/lib/permission-types.ts
@@ -41,7 +41,7 @@ type Abilities =
     | Ability<'OrgStudies', 'view', { orgType: 'enclave' | 'lab'; orgId?: UUID; submittedByOrgId?: UUID }>
     | Ability<'Study', 'view' | 'create', { orgId?: UUID; submittedByOrgId?: UUID }>
     | Ability<'Study', 'review' | 'approve' | 'reject' | 'update' | 'delete', { orgId?: UUID; submittedByOrgId?: UUID }>
-    | Ability<'StudyJob', 'view' | 'create' | 'delete', { orgId?: UUID; submittedByOrgId?: UUID }>
+    | Ability<'StudyJob', 'view' | 'create', { orgId?: UUID; submittedByOrgId?: UUID }>
     | Ability<'ReviewerKey', 'view' | 'update', object>
     | Ability<'Org', 'view' | 'update' | 'create' | 'delete', { orgId?: UUID; orgSlug?: string }>
     | Ability<'OrgMembers', 'view', { orgId?: UUID; orgSlug?: string }>

--- a/src/lib/permissions.test.ts
+++ b/src/lib/permissions.test.ts
@@ -41,16 +41,28 @@ test('reviewer role', () => {
 
 test('researcher role', () => {
     const { ability, session } = createAbilty({}, 'lab')
+    const ownLabId = session.orgs.test.id
+    const otherLabId = faker.string.uuid()
 
     expect(
         // researchers cannot approve studies
-        ability.can('approve', toRecord('Study', { orgId: session.orgs.test.id })),
+        ability.can('approve', toRecord('Study', { orgId: ownLabId })),
     ).toBe(false)
 
     expect(ability.can('create', 'Study')).toBe(true)
 
+    // update/delete are scoped to studies the researcher's own lab submitted
+    expect(ability.can('update', toRecord('Study', { submittedByOrgId: ownLabId }))).toBe(true)
+    expect(ability.can('delete', toRecord('Study', { submittedByOrgId: ownLabId }))).toBe(true)
+    expect(ability.can('create', toRecord('StudyJob', { submittedByOrgId: ownLabId }))).toBe(true)
+
+    // ...but not studies submitted by a different lab
+    expect(ability.can('update', toRecord('Study', { submittedByOrgId: otherLabId }))).toBe(false)
+    expect(ability.can('delete', toRecord('Study', { submittedByOrgId: otherLabId }))).toBe(false)
+    expect(ability.can('create', toRecord('StudyJob', { submittedByOrgId: otherLabId }))).toBe(false)
+
     // Researchers cannot invite users to their org (not admins)
-    expect(ability.can('invite', toRecord('User', { orgId: session.orgs.test.id }))).toBe(false)
+    expect(ability.can('invite', toRecord('User', { orgId: ownLabId }))).toBe(false)
 })
 
 test('admin role', () => {

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -49,13 +49,16 @@ export function defineAbilityFor(session: UserSession) {
     permit('view', 'Study', { submittedByOrgId: { $in: usersResearcherOrgIds } })
     permit('view', 'StudyJob', { submittedByOrgId: { $in: usersResearcherOrgIds } })
 
-    // users who belong to any research orgs can create studies for ANY org
+    // users who belong to any research orgs can create studies for ANY org.
+    // create is unconditioned: a new draft has no submittedByOrgId yet — the
+    // submitting lab is chosen in the handler from the user's own orgs. update,
+    // delete, and job mutations are scoped to studies the user's lab submitted,
+    // so a lab member can't mutate another lab's study by guessing its id.
     if (usersResearcherOrgIds.length) {
         permit('create', 'Study')
-        permit('update', 'Study')
-        permit('delete', 'Study')
-        permit('create', 'StudyJob')
-        permit('delete', 'StudyJob')
+        permit('update', 'Study', { submittedByOrgId: { $in: usersResearcherOrgIds } })
+        permit('delete', 'Study', { submittedByOrgId: { $in: usersResearcherOrgIds } })
+        permit('create', 'StudyJob', { submittedByOrgId: { $in: usersResearcherOrgIds } })
         permit('load', 'IDE')
     }
 

--- a/src/server/actions/study-request.test.ts
+++ b/src/server/actions/study-request.test.ts
@@ -211,6 +211,19 @@ describe('Request Study Actions', () => {
         expect(aws.deleteFolderContents).toHaveBeenCalledWith(`studies/${org.slug}/${studyId}`)
     })
 
+    it('onDeleteStudyAction rejects a cross-lab user and leaves the study intact', async () => {
+        const { org: labA } = await mockSessionWithTestData({ orgSlug: 'lab-delete-cross-A', orgType: 'lab' })
+        const { studyId } = await insertTestStudyData({ org: labA })
+
+        // A member of a different lab must not be able to delete labA's study by id.
+        await mockSessionWithTestData({ orgSlug: 'lab-delete-cross-B', orgType: 'lab' })
+        const result = await onDeleteStudyAction({ studyId })
+        expect(result).toHaveProperty('error')
+
+        const study = await db.selectFrom('study').select('id').where('id', '=', studyId).executeTakeFirst()
+        expect(study?.id).toBe(studyId)
+    })
+
     // DRAFT → PENDING-REVIEW is a first-time proposal submission, sends "new study proposal" email
     it('finalizeStudySubmissionAction calls onStudyCreated for DRAFT studies', async () => {
         const enclave = await insertTestOrg({ type: 'enclave', slug: 'test-evt-draft' })
@@ -925,9 +938,13 @@ describe('Request Study Actions', () => {
     })
 
     describe('saveCodeResubmissionNoteDraftAction', () => {
-        it('persists the draft note on the study row', async () => {
+        it('persists the draft note on a CHANGE-REQUESTED study for a same-lab user', async () => {
             const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
-            const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
+            const { study } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'CHANGE-REQUESTED',
+            })
 
             const result = actionResult(
                 await saveCodeResubmissionNoteDraftAction({ studyId: study.id, note: 'A draft note' }),
@@ -944,11 +961,66 @@ describe('Request Study Actions', () => {
 
         it('rejects payloads larger than 10kb', async () => {
             const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
-            const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
+            const { study } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'CHANGE-REQUESTED',
+            })
 
             const tooLong = 'x'.repeat(10_001)
             const result = await saveCodeResubmissionNoteDraftAction({ studyId: study.id, note: tooLong })
             expect(result).toHaveProperty('error')
+        })
+
+        it('rejects a cross-lab save attempt instead of silently no-op (OTTER-607)', async () => {
+            const { org: labA, user: ownerA } = await mockSessionWithTestData({
+                orgSlug: 'lab-code-note-cross-A',
+                orgType: 'lab',
+            })
+            const { study } = await insertTestStudyJobData({
+                org: labA,
+                researcherId: ownerA.id,
+                studyStatus: 'CHANGE-REQUESTED',
+            })
+
+            // Switch session to a user in a different lab and try to save the draft.
+            await mockSessionWithTestData({ orgSlug: 'lab-code-note-cross-B', orgType: 'lab' })
+            const result = await saveCodeResubmissionNoteDraftAction({
+                studyId: study.id,
+                note: 'cross-lab attempt',
+            })
+            // Without the 0-row UPDATE check the client would render the autosave
+            // indicator as "All changes saved" while nothing was persisted.
+            expect('error' in result).toBe(true)
+
+            const row = await db
+                .selectFrom('study')
+                .select('codeResubmissionNoteDraft')
+                .where('id', '=', study.id)
+                .executeTakeFirstOrThrow()
+            expect(row.codeResubmissionNoteDraft).toBeNull()
+        })
+
+        it('rejects a save attempt when the study is not CHANGE-REQUESTED (OTTER-607)', async () => {
+            const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+            const { study } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'PENDING-REVIEW',
+            })
+
+            const result = await saveCodeResubmissionNoteDraftAction({
+                studyId: study.id,
+                note: 'wrong-status attempt',
+            })
+            expect('error' in result).toBe(true)
+
+            const row = await db
+                .selectFrom('study')
+                .select('codeResubmissionNoteDraft')
+                .where('id', '=', study.id)
+                .executeTakeFirstOrThrow()
+            expect(row.codeResubmissionNoteDraft).toBeNull()
         })
     })
 

--- a/src/server/actions/study-request.ts
+++ b/src/server/actions/study-request.ts
@@ -17,12 +17,7 @@ import {
 } from '@/server/aws'
 import { CODER_DISABLED, getConfigValue, SIMULATE_CODE_BUILD } from '@/server/config'
 import { getOrCreateCurrentRoundJob, nextVersionForStudyComment } from '@/server/db/mutations'
-import {
-    getInfoForStudyId,
-    getInfoForStudyJobId,
-    getOrgIdFromSlug,
-    latestSubmittedJobForStudy,
-} from '@/server/db/queries'
+import { getInfoForStudyId, getOrgIdFromSlug, latestSubmittedJobForStudy } from '@/server/db/queries'
 import { db as database } from '@/database'
 import { deferred, onStudyReviewRequested, onStudyCodeSubmitted, onStudyCreated } from '@/server/events'
 import { purgeProposalYjsDocsBeforeAt } from '@/server/db/yjs-cleanup'
@@ -514,22 +509,6 @@ export const getDraftStudyAction = new Action('getDraftStudyAction')
         }
     })
 
-export const onDeleteStudyJobAction = new Action('onDeleteStudyJobAction', { performsMutations: true })
-    .params(z.object({ studyJobId: z.string() }))
-    .middleware(async ({ params: { studyJobId } }) => await getInfoForStudyJobId(studyJobId))
-    .requireAbilityTo('delete', 'StudyJob') // will use orgId from above
-    .handler(async ({ db, studyId, orgSlug, params: { studyJobId } }) => {
-        await db.deleteFrom('jobStatusChange').where('studyJobId', '=', studyJobId).execute()
-        await db.deleteFrom('studyJobFile').where('studyJobId', '=', studyJobId).execute()
-        await db.deleteFrom('studyJob').where('id', '=', studyJobId).execute()
-
-        try {
-            await deleteFolderContents(pathForStudyJobCode({ orgSlug, studyJobId, studyId }))
-        } catch (err) {
-            logger.error(`Failed to delete S3 files for job ${studyJobId}: ${err}`)
-        }
-    })
-
 export const onDeleteStudyAction = new Action('onDeleteStudyAction', { performsMutations: true })
     .params(z.object({ studyId: z.string() }))
     .middleware(async ({ params: { studyId } }) => await getInfoForStudyId(studyId))
@@ -845,8 +824,29 @@ export const saveCodeResubmissionNoteDraftAction = new Action('saveCodeResubmiss
     .params(z.object({ studyId: z.string().uuid(), note: z.string().max(10_000) }))
     .middleware(async ({ params: { studyId } }) => await getInfoForStudyId(studyId))
     .requireAbilityTo('update', 'Study')
-    .handler(async ({ db, params: { studyId, note } }) => {
-        await db.updateTable('study').set({ codeResubmissionNoteDraft: note }).where('id', '=', studyId).execute()
+    .handler(async ({ db, params: { studyId, note }, session }) => {
+        const userLabOrgIds = Object.values(session.orgs)
+            .filter((org) => org.type === 'lab')
+            .map((org) => org.id)
+
+        // Mirrors saveProposalResubmissionNoteDraftAction (OTTER-607): the
+        // status + lab guard stops a cross-lab member from writing a draft onto
+        // another lab's study, and the 0-row check turns a wrong-status / wrong-lab
+        // attempt into a hard ActionFailure instead of letting the client's
+        // autosave indicator report "saved" when nothing persisted.
+        const saved = await db
+            .updateTable('study')
+            .set({ codeResubmissionNoteDraft: note })
+            .where('id', '=', studyId)
+            .where('status', '=', 'CHANGE-REQUESTED')
+            .where('submittedByOrgId', 'in', userLabOrgIds.length > 0 ? userLabOrgIds : [''])
+            .returning(['id'])
+            .executeTakeFirst()
+
+        if (!saved) {
+            throw new ActionFailure({ submission: 'Study is not editable or you do not have access' })
+        }
+
         return { studyId, savedAt: new Date().toISOString() }
     })
 


### PR DESCRIPTION
[OTTER-607](https://safeinsights.atlassian.net/browse/OTTER-607)

The lab-researcher rules in `permissions.ts` granted `update`/`delete` Study and `create` StudyJob unconditionally, so CASL was a no-op for those — the only thing stopping a lab member from mutating another lab's study by id was whatever ad-hoc SQL guard each handler happened to include, and some were missing it (notably the code resubmission note draft, the card's subject).

## Changes
- **permissions.ts**: scope `update`/`delete` Study and `create` StudyJob to `{ submittedByOrgId in user's lab orgs }`. `create` Study stays unconditioned — a new draft has no `submittedByOrgId` yet; the submitting lab is set in the handler from the user's own orgs.
- **saveCodeResubmissionNoteDraftAction**: add the `status = 'CHANGE-REQUESTED'` + lab SQL guard and a 0-row `ActionFailure`, mirroring its proposal twin. Previously a cross-lab member could write a draft onto another lab's study, and the client's autosave reported "saved" when nothing persisted.
- Remove the unused `onDeleteStudyJobAction` (no callers anywhere) and its orphaned `delete StudyJob` ability.

## Tests
- Cross-lab + wrong-status rejection and same-lab success for the code resubmission note draft and study delete.
- Researcher CASL scoping (own-lab allowed, other-lab denied) in `permissions.test.ts`.

All affected suites pass; lint and typecheck clean.

[OTTER-607]: https://openstax.atlassian.net/browse/OTTER-607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ