### PR TITLE
OTTER-552: route DO to post-feedback page on order-independent code decision

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
@@ -327,6 +327,71 @@ describe('StudyReviewPage', () => {
             },
         )
 
+        // OTTER-552 staging regression: the real submitCodeReviewDecisionAction writes the
+        // CODE-* decision in the same transaction as the CODE-SUBMITTED that opened the round, so
+        // jobStatusChange.createdAt ties (it defaults to now(), constant within a transaction) and
+        // v7 ids are not reliably monotonic within a millisecond. The decision could therefore sort
+        // *behind* CODE-SUBMITTED under `createdAt desc, id desc`, leaving the DO on the active
+        // code-review page. This test pins the single CODE-SUBMITTED and the decision to the SAME
+        // createdAt, with CODE-SUBMITTED inserted last so it wins the id tiebreak — the exact
+        // arrangement that broke the old statusChanges[0] check (which would read CODE-SUBMITTED as
+        // "latest" and route to active review). The count-based routing must still land on
+        // post-feedback: one submission, one decision.
+        it.each(['CODE-APPROVED', 'CODE-CHANGES-REQUESTED', 'CODE-REJECTED'] as const)(
+            'renders PostFeedbackView (kind=CODE) when a %s decision ties on createdAt with CODE-SUBMITTED',
+            async (jobStatus) => {
+                const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+                // Build the job by hand (no auto CODE-SUBMITTED) so the round has exactly one
+                // submission and one decision, both stamped at the same instant.
+                const { study, job } = await insertTestStudyJobData({
+                    org,
+                    researcherId: user.id,
+                    studyStatus: 'APPROVED',
+                    jobStatus: 'INITIATED',
+                })
+
+                const tiedAt = new Date('2026-06-01T00:00:00Z')
+                // Decision inserted first → lower id; CODE-SUBMITTED inserted last → higher id.
+                // Under `createdAt desc, id desc` the CODE-SUBMITTED sorts first, reproducing the
+                // non-deterministic staging order where the decision is no longer statusChanges[0].
+                await db
+                    .insertInto('jobStatusChange')
+                    .values({ status: jobStatus, studyJobId: job.id, createdAt: tiedAt })
+                    .execute()
+                await db
+                    .insertInto('jobStatusChange')
+                    .values({ status: 'CODE-SUBMITTED', studyJobId: job.id, createdAt: tiedAt })
+                    .execute()
+                await db
+                    .insertInto('studyReviewComment')
+                    .values({
+                        studyId: study.id,
+                        studyJobId: job.id,
+                        authorId: user.id,
+                        reviewKind: 'CODE',
+                        entryType: 'DECISION',
+                        decision: jobStatus === 'CODE-APPROVED' ? 'APPROVE' : 'REJECT',
+                        body: { root: { type: 'root', children: [] } },
+                        criteria: {
+                            proposalAlignment: 'yes',
+                            agreementCompliance: 'yes',
+                            securityChecks: 'yes',
+                            privacyProtection: 'yes',
+                        },
+                    })
+                    .execute()
+
+                const page = await StudyReviewPage({
+                    params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+                    searchParams: Promise.resolve({}),
+                })
+
+                expect(page?.type).toBe(PostFeedbackView)
+                expect(page?.props.kind).toBe('CODE')
+                expect(mockRedirect).not.toHaveBeenCalled()
+            },
+        )
+
         it('renders CodeReview (active review) when code was resubmitted after a change request', async () => {
             // CODE-CHANGES-REQUESTED followed by a fresh CODE-SUBMITTED means the researcher
             // resubmitted; the DO must return to active review, not the decision page. Gating
@@ -363,6 +428,64 @@ describe('StudyReviewPage', () => {
 
             expect(page?.type).toBe(CodeReview)
         })
+
+        // Execution window: approved code is provisioning/running in the enclave but no results
+        // exist yet. The DO must stay on the post-code-feedback page (mirroring the RL Code-approved
+        // page, view/page.tsx), NOT fall back to active code review — that fallback was the original
+        // OTTER-552 bug's failure mode. Results-status routing (OTTER-538) only takes over once a
+        // RUN-COMPLETE/FILES-*/JOB-ERRORED status exists.
+        it.each(['JOB-PROVISIONING', 'JOB-PACKAGING', 'JOB-READY', 'JOB-RUNNING'] as const)(
+            'renders PostFeedbackView (kind=CODE) while approved code is executing (%s, no results yet)',
+            async (runningStatus) => {
+                const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+                const { study, job } = await insertTestStudyJobData({
+                    org,
+                    researcherId: user.id,
+                    studyStatus: 'APPROVED',
+                    jobStatus: 'CODE-SUBMITTED',
+                })
+                await db
+                    .insertInto('jobStatusChange')
+                    .values({ status: 'CODE-APPROVED', studyJobId: job.id, createdAt: new Date(Date.now() + 1000) })
+                    .execute()
+                await db
+                    .insertInto('jobStatusChange')
+                    .values({ status: runningStatus, studyJobId: job.id, createdAt: new Date(Date.now() + 2000) })
+                    .execute()
+                await db
+                    .insertInto('studyReviewComment')
+                    .values({
+                        studyId: study.id,
+                        studyJobId: job.id,
+                        authorId: user.id,
+                        reviewKind: 'CODE',
+                        entryType: 'DECISION',
+                        decision: 'APPROVE',
+                        body: { root: { type: 'root', children: [] } },
+                        criteria: {
+                            proposalAlignment: 'yes',
+                            agreementCompliance: 'yes',
+                            securityChecks: 'yes',
+                            privacyProtection: 'yes',
+                        },
+                    })
+                    .execute()
+                await db
+                    .updateTable('study')
+                    .set({ reviewerAgreementsAckedAt: new Date() })
+                    .where('id', '=', study.id)
+                    .execute()
+
+                const page = await StudyReviewPage({
+                    params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+                    searchParams: Promise.resolve({}),
+                })
+
+                expect(page?.type).toBe(PostFeedbackView)
+                expect(page?.props.kind).toBe('CODE')
+                expect(mockRedirect).not.toHaveBeenCalled()
+            },
+        )
     })
 
     describe('study-details redesign (OTTER-538)', () => {

--- a/src/app/[orgSlug]/study/[studyId]/review/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.tsx
@@ -6,7 +6,12 @@ import { isActionError } from '@/lib/errors'
 import { isSubmittedProposalReviewStatus } from '@/lib/proposal-review'
 import { Routes } from '@/lib/routes'
 import { studyHasJobStatus } from '@/lib/studies'
-import { type CodeDecisionStatus, isCodeDecisionStatus, isStudyResultsStatus } from '@/lib/study-job-status'
+import {
+    type CodeDecisionStatus,
+    isCodeDecisionStatus,
+    isStudyResultsStatus,
+    latestSubmittedJobHasLiveCodeDecision,
+} from '@/lib/study-job-status'
 import { isSubmittedStudy } from '@/schema/study'
 import {
     getCodeReviewFeedbackAction,
@@ -63,14 +68,24 @@ export default async function StudyReviewPage(props: {
     if (currentOrg.type === 'enclave') {
         // OTTER-552: once a code-review decision has been made, opening the study (e.g. via
         // the dashboard "View" link, which carries no `from` param) must land the DO on the
-        // post-feedback code page — not the active code-review/decision page. We gate on the
-        // *latest* job status so a subsequent resubmission (a fresh CODE-SUBMITTED after a
-        // change request) reopens active review instead of sticking on the decision page.
+        // post-feedback code page — not the active code-review/decision page. The decision is
+        // detected order-independently (counting submissions vs decisions) so a subsequent
+        // resubmission reopens active review while a decision written in the same transaction as
+        // a sibling status still routes to post-feedback.
         const latestDecisionJob = await latestSubmittedJobForStudy(studyId)
+        const statusChanges = latestDecisionJob?.statusChanges ?? []
         const codeSubmitted =
-            studyHasJobStatus(study, 'CODE-SUBMITTED') ||
-            (latestDecisionJob?.statusChanges.some((s) => s.status === 'CODE-SUBMITTED') ?? false)
-        const decisionMade = isCodeDecisionStatus(latestDecisionJob?.statusChanges[0]?.status)
+            studyHasJobStatus(study, 'CODE-SUBMITTED') || statusChanges.some((s) => s.status === 'CODE-SUBMITTED')
+        // Order-independent: reading statusChanges[0] (the "latest" status) is non-deterministic
+        // for statuses written in the same transaction. See latestSubmittedJobHasLiveCodeDecision.
+        const hasLiveCodeDecision = latestSubmittedJobHasLiveCodeDecision(statusChanges)
+        // Once the job has reached a results stage (approve -> provisioning/run -> results) the
+        // dashboard "View" link must land on the results-only Study Details page (OTTER-538), not
+        // the post-feedback page. A CODE-APPROVED is always present at that point, so gate it out
+        // here. The explicit `from=code-review` "Previous" navigation still routes to post-feedback
+        // below regardless of results status.
+        const hasResultsStatus = statusChanges.some((s) => isStudyResultsStatus(s.status))
+        const decisionMade = hasLiveCodeDecision && !hasResultsStatus
 
         // When a reviewer navigates back from the code review page, OR the code decision has
         // already been made, show the post-feedback view. After a code-review decision exists,
@@ -142,10 +157,9 @@ export default async function StudyReviewPage(props: {
             }
 
             // OTTER-538: once the job has reached the results stage, render the
-            // redesigned results-only Study Details page.
-            const latestJobStatus = latestDecisionJob?.statusChanges[0]?.status
-
-            if (isStudyResultsStatus(latestJobStatus)) {
+            // redesigned results-only Study Details page. Existence check (not statusChanges[0])
+            // so a results status written alongside a sibling in one transaction still routes here.
+            if (hasResultsStatus) {
                 return <StudyDetailsReviewer orgSlug={orgSlug} study={study} />
             }
 

--- a/src/lib/study-job-status.test.ts
+++ b/src/lib/study-job-status.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import type { StudyJobStatus } from '@/database/types'
+import { latestSubmittedJobHasLiveCodeDecision } from './study-job-status'
+
+const changes = (...statuses: StudyJobStatus[]) => statuses.map((status) => ({ status }))
+
+describe('latestSubmittedJobHasLiveCodeDecision', () => {
+    it('is false when no decision exists yet', () => {
+        expect(latestSubmittedJobHasLiveCodeDecision(changes('CODE-SUBMITTED'))).toBe(false)
+        expect(latestSubmittedJobHasLiveCodeDecision(changes('CODE-SUBMITTED', 'CODE-SCANNED'))).toBe(false)
+        expect(latestSubmittedJobHasLiveCodeDecision([])).toBe(false)
+    })
+
+    it.each(['CODE-APPROVED', 'CODE-CHANGES-REQUESTED', 'CODE-REJECTED'] as const)(
+        'is true when a %s decision follows a submission',
+        (decision) => {
+            expect(latestSubmittedJobHasLiveCodeDecision(changes('CODE-SUBMITTED', decision))).toBe(true)
+        },
+    )
+
+    // The bug: jobStatusChange rows written in the same transaction tie on createdAt and v7 ids
+    // are not reliably monotonic within a millisecond, so "latest status" ordering can put
+    // CODE-SUBMITTED ahead of the decision. The count is order-independent, so the array order
+    // here (decision *before* the submission it decides) must not change the result.
+    it.each(['CODE-APPROVED', 'CODE-CHANGES-REQUESTED', 'CODE-REJECTED'] as const)(
+        'is true for a %s decision regardless of array order (same-millisecond tie)',
+        (decision) => {
+            expect(latestSubmittedJobHasLiveCodeDecision(changes(decision, 'CODE-SUBMITTED'))).toBe(true)
+        },
+    )
+
+    it('is false again once a resubmission adds an un-decided CODE-SUBMITTED', () => {
+        // Round 1 decided (changes requested), round 2 resubmitted and awaiting review.
+        expect(
+            latestSubmittedJobHasLiveCodeDecision(
+                changes('CODE-SUBMITTED', 'CODE-CHANGES-REQUESTED', 'CODE-SUBMITTED'),
+            ),
+        ).toBe(false)
+    })
+
+    it('is true again once the resubmission is itself decided', () => {
+        expect(
+            latestSubmittedJobHasLiveCodeDecision(
+                changes('CODE-SUBMITTED', 'CODE-CHANGES-REQUESTED', 'CODE-SUBMITTED', 'CODE-APPROVED'),
+            ),
+        ).toBe(true)
+    })
+
+    it('treats CODE-SCANNED as part of a submission, not a new one', () => {
+        expect(latestSubmittedJobHasLiveCodeDecision(changes('CODE-SUBMITTED', 'CODE-SCANNED', 'CODE-APPROVED'))).toBe(
+            true,
+        )
+    })
+})

--- a/src/lib/study-job-status.ts
+++ b/src/lib/study-job-status.ts
@@ -47,3 +47,28 @@ export const CODE_DECISION_JOB_STATUSES: readonly CodeDecisionStatus[] = [
 
 export const isCodeDecisionStatus = (status: StudyJobStatus | undefined): status is CodeDecisionStatus =>
     !!status && CODE_DECISION_JOB_STATUSES.includes(status as CodeDecisionStatus)
+
+// OTTER-552: "does the current round have a live code-review decision?"
+//
+// The obvious test — isCodeDecisionStatus(statusChanges[0]) — reads the *latest* status, but
+// that ordering is non-deterministic: jobStatusChange.createdAt defaults to now() (constant
+// within a transaction) so statuses written together tie on createdAt, and v7 ids are not
+// reliably monotonic within a millisecond (see mutations.ts getOrCreateCurrentRoundJob). On
+// staging a CODE-APPROVED/REJECTED/CHANGES-REQUESTED row written alongside a sibling status
+// could sort *behind* it, so the DO fell through to the active code-review page instead of
+// the post-feedback page.
+//
+// Each review round is CODE-SUBMITTED → (decision). Counting is order-independent: when at
+// least as many decisions as submissions exist, the latest submission has been decided and the
+// DO belongs on the post-feedback page. A resubmission adds a CODE-SUBMITTED with no following
+// decision — either on a brand-new job (the current resubmission model, where this job is no
+// longer the latest submitted job) or appended to the same job (legacy) — tipping the count
+// back so the DO returns to active review. CODE-SCANNED is an automated step between submit and
+// decision, not a fresh submission, so it is excluded from the submitted count.
+export const latestSubmittedJobHasLiveCodeDecision = (
+    statusChanges: ReadonlyArray<{ status: StudyJobStatus }>,
+): boolean => {
+    const submittedCount = statusChanges.filter((s) => s.status === 'CODE-SUBMITTED').length
+    const decisionCount = statusChanges.filter((s) => isCodeDecisionStatus(s.status)).length
+    return decisionCount > 0 && decisionCount >= submittedCount
+}


### PR DESCRIPTION
## Problem

When a DO opens a study with a code decision (approved / changes-requested / rejected) from the dashboard, they sometimes land on the **active code-review page** instead of the read-only post-code-feedback page. Reported still failing on Staging and flagged as a June-release showstopper.

Root cause: the routing detected a decision via the *latest* job status (`statusChanges[0]`). That ordering is non-deterministic — `jobStatusChange` rows written in the same transaction tie on `createdAt` (defaults to `now()`), and v7 ids aren't reliably monotonic within a millisecond (the hazard already documented in `mutations.ts`). A `CODE-*` decision could sort behind a sibling status, so `decisionMade` came out false.

## Fix

- New order-independent helper `latestSubmittedJobHasLiveCodeDecision` — counts submissions vs decisions on the latest submitted job instead of reading "the latest status". A resubmission's un-decided `CODE-SUBMITTED` tips it back to active review.
- `review/page.tsx` uses the helper, and gates the post-feedback branch on an existence check for results-stage statuses (`hasResultsStatus`) so an approved-and-running study still lands on the OTTER-538 Study Details page. This mirrors the RL-side pattern in `view/page.tsx`.

## Behavior (matches OTTER-552 + OTTER-538)

- Decision recorded, no results yet (incl. while approved code is provisioning/running) → post-code-feedback page.
- Results exist (`RUN-COMPLETE`/`FILES-*`/`JOB-ERRORED`) → Study Details results page; "Previous" returns to the post-feedback page via `from=code-review`.

## Tests

- `study-job-status.test.ts` — 10 helper unit cases (incl. reversed-order ties, resubmission rounds).
- `review/page.test.tsx` — same-millisecond-tie regression (3 statuses) + execution-window cases (4 running statuses). Verified to fail against the old `statusChanges[0]` logic.