### PR TITLE
Fix SWC JSX-whitespace bug: replace HTML entities in JSX text

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -55,6 +55,9 @@ const eslintConfig = [
             // broken in prod. Use the literal character instead (e.g. ’ ” &).
             // Remove this rule once @next/swc ships the fix; see
             // src/lib/swc-jsx-entity-whitespace.test.ts.
+            // NOTE: extend this array to add more restricted-syntax patterns — do NOT add a
+            // second 'no-restricted-syntax' key in this block, it would silently overwrite
+            // these selectors (object-key collision) and disable the entity guard with no error.
             'no-restricted-syntax': [
                 'error',
                 {
@@ -65,6 +68,8 @@ const eslintConfig = [
                         'Do not use HTML character entities (e.g. &apos;, &rsquo;, &amp;) in JSX text — they trigger an SWC whitespace bug (swc#11392). Use the literal character instead (e.g. ’ ” &).',
                 },
                 {
+                    // Numeric refs need their own selector because the named pattern above stops at
+                    // `#` (not a `\w`). `&#\w+;` covers both decimal (&#39;) and hex (&#x27;) forms.
                     selector: 'JSXText[raw=/&#\\w+;/]',
                     message:
                         'Do not use numeric HTML character references (e.g. &#39;) in JSX text — they trigger an SWC whitespace bug (swc#11392). Use the literal character instead.',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,6 +49,27 @@ const eslintConfig = [
             ...reactHooksPlugin.configs.recommended.rules,
             // Disable prop-types for TypeScript projects
             'react/prop-types': 'off',
+            // Ban HTML character entities in JSX text. Our production compiler (SWC)
+            // drops the space between an inline element and adjacent JSX text when that
+            // text contains an entity (swc#11392) — invisible in unit tests (Babel),
+            // broken in prod. Use the literal character instead (e.g. ’ ” &).
+            // Remove this rule once @next/swc ships the fix; see
+            // src/lib/swc-jsx-entity-whitespace.test.ts.
+            'no-restricted-syntax': [
+                'error',
+                {
+                    // typescript-eslint exposes the source text (with entities) on `raw`;
+                    // `value` is already entity-decoded, so it must be `raw` here.
+                    selector: 'JSXText[raw=/&\\w+;/]',
+                    message:
+                        'Do not use HTML character entities (e.g. &apos;, &rsquo;, &amp;) in JSX text — they trigger an SWC whitespace bug (swc#11392). Use the literal character instead (e.g. ’ ” &).',
+                },
+                {
+                    selector: 'JSXText[raw=/&#\\w+;/]',
+                    message:
+                        'Do not use numeric HTML character references (e.g. &#39;) in JSX text — they trigger an SWC whitespace bug (swc#11392). Use the literal character instead.',
+                },
+            ],
         },
         settings: {
             react: {

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/edit-initial-request-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/edit-initial-request-section.tsx
@@ -106,7 +106,7 @@ export const EditInitialRequestSection: FC<EditInitialRequestSectionProps> = ({
                 <Box>
                     <FormFieldLabel label="Dataset(s) of interest" required inputId="datasets" />
                     <Text size="xs" mb="xs" c="charcoal.7">
-                        Select the dataset(s) you&apos;d like to use for your research.
+                        Select the dataset(s) you’d like to use for your research.
                     </Text>
                     <Group align="center" gap="xxl">
                         <Box w="50%">

--- a/src/app/[orgSlug]/study/[studyId]/proposal/form.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/form.tsx
@@ -130,8 +130,8 @@ export const ProposalForm: FC<ProposalFormProps> = ({
                             <Box>
                                 <FormFieldLabel label="Dataset(s) of interest" required inputId="datasets" />
                                 <Text size="xs" mb="xs" c="charcoal.7">
-                                    Select the dataset(s) you&apos;d like to use for your research. You&apos;ll find
-                                    options based on the selected Data Organization in Step 1 and its data availability.
+                                    Select the dataset(s) you’d like to use for your research. You’ll find options based
+                                    on the selected Data Organization in Step 1 and its data availability.
                                 </Text>
                                 <Group align="center" gap="xxl">
                                     <Box w="50%">

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-feedback-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-feedback-section.tsx
@@ -48,11 +48,11 @@ type CodeReviewFeedbackSectionProps = {
 function FeedbackIntro({ labName }: { labName: string }) {
     return (
         <Text fz={16} c="charcoal.9">
-            Share your feedback on this code submission with {labName}. Your comments should address the code&rsquo;s
+            Share your feedback on this code submission with {labName}. Your comments should address the code’s
             alignment with the approved study proposal/initial request and all the agreements, whether the security log
             surfaced issues, and whether the analysis code risks exposing PII. You can also request clarifications about
-            the researchers&rsquo; approach and flag potential risks or misconceptions about your dataset(s) before the
-            code is approved to run.
+            the researchers’ approach and flag potential risks or misconceptions about your dataset(s) before the code
+            is approved to run.
         </Text>
     )
 }

--- a/src/app/[orgSlug]/study/[studyId]/review/review-feedback-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/review-feedback-section.tsx
@@ -81,9 +81,9 @@ export function ReviewFeedbackSection({
                 <Stack gap="md">
                     <Text fz={16} c="charcoal.9">
                         Share your feedback on this request directly with {submittingLabName}. Consider addressing the
-                        initial request&apos;s feasibility given your data and infrastructure, its potential to advance
-                        the understanding of teaching and learning, and any questions or clarifications you need from
-                        the research team.
+                        initial request’s feasibility given your data and infrastructure, its potential to advance the
+                        understanding of teaching and learning, and any questions or clarifications you need from the
+                        research team.
                     </Text>
                     <FeedbackEditor feedback={feedback} studyId={studyId} reviewVersion={reviewVersion} />
                 </Stack>

--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.tsx
@@ -61,7 +61,7 @@ const UnderReviewBanner: FC<{ isVisible: boolean; reviewingOrgName: string; isRe
     return (
         <Alert color="yellow" mt="md" bg="#FFF9E5" data-testid="code-under-review-banner">
             Your study code {verb} {displayOrgName(reviewingOrgName)}. They will have access to your study code and an
-            AI-generated summary of its behavior. Please allow 7-10 business days for review. You&apos;ll receive email
+            AI-generated summary of its behavior. Please allow 7-10 business days for review. You’ll receive email
             notifications about updates.
         </Alert>
     )

--- a/src/app/account/invitation/[inviteId]/page.tsx
+++ b/src/app/account/invitation/[inviteId]/page.tsx
@@ -82,12 +82,12 @@ export default async function AcceptInvitePage({ params }: { params: Promise<{ i
         <Paper bg="white" p="xxl" radius="sm" w={600} my={{ base: '1rem', lg: 0 }}>
             <Flex direction="column" maw={500} mx="auto" pb="xxl" gap="md">
                 <Title order={3} ta="center">
-                    You&apos;ve been invited to join SafeInsights!
+                    You’ve been invited to join SafeInsights!
                 </Title>
                 <Text size="md" my="xs">
                     {invitingUserName} has invited you to join {orgName} as a {isAdmin ? 'admin' : 'contributor'}. Since
-                    we couldn&apos;t find an existing account associated with this email, please select one of the
-                    options below:
+                    we couldn’t find an existing account associated with this email, please select one of the options
+                    below:
                 </Text>
                 <Text size="md" fw={600} ta="center">
                     Already have a SafeInsights account?

--- a/src/app/account/invitation/[inviteId]/signup/page.tsx
+++ b/src/app/account/invitation/[inviteId]/signup/page.tsx
@@ -121,8 +121,7 @@ const SetupAccountForm: FC<InviteData> = ({ inviteId, email, orgName }) => {
                         Welcome To SafeInsights!
                     </Title>
                     <Text size="md">
-                        You&apos;ve been invited to join {orgName}. Please fill out the details below to create your
-                        account.
+                        You’ve been invited to join {orgName}. Please fill out the details below to create your account.
                     </Text>
                     <TextInput
                         label="Email"

--- a/src/app/account/keys/generate-keys.tsx
+++ b/src/app/account/keys/generate-keys.tsx
@@ -170,8 +170,8 @@ const ConfirmationModal: FC<{ onClose: () => void; isOpen: boolean; keys: Keys; 
             <Stack>
                 <Text size="md">Make sure you have securely saved your reviewer key. </Text>
                 <Text size="sm" c="red.9">
-                    <b>Note:</b> SafeInsights does not store your reviewer key. If you lose your key, you won&apos;t be
-                    able to access study results and will need to generate a new key.
+                    <b>Note:</b> SafeInsights does not store your reviewer key. If you lose your key, you won’t be able
+                    to access study results and will need to generate a new key.
                 </Text>
                 <Text size="md" mb="md">
                     Do you want to proceed?

--- a/src/app/account/mfa/app/add-app-mfa.tsx
+++ b/src/app/account/mfa/app/add-app-mfa.tsx
@@ -106,7 +106,7 @@ function AddTotpScreenContent({
                 Authenticator app verification
             </Title>
             <Text size="md">
-                Open your authenticator app and scan the QR code to link your account. If you&apos;re unable to scan the
+                Open your authenticator app and scan the QR code to link your account. If you’re unable to scan the
                 code, you can enter the setup key manually.
             </Text>
             <Text size="md" mb="xs">

--- a/src/app/account/mfa/manage-mfa.tsx
+++ b/src/app/account/mfa/manage-mfa.tsx
@@ -41,8 +41,7 @@ export function ManageMFA() {
                     Secure your account with <br /> Multi-Factor Authentication
                 </Title>
                 <Text size="md">
-                    To enhance the security of your account, we&apos;re enforcing two-factor verification at
-                    SafeInsights.
+                    To enhance the security of your account, we’re enforcing two-factor verification at SafeInsights.
                 </Text>
                 <Text size="md" mb="xs">
                     You can choose to receive verification codes via text message (SMS) or use an authenticator app.

--- a/src/app/account/mfa/sms/add-sms-mfa.tsx
+++ b/src/app/account/mfa/sms/add-sms-mfa.tsx
@@ -259,7 +259,7 @@ export function AddSMSMFA() {
                                         </Button>
                                         <Group>
                                             <Text fz="md" c="grey.7">
-                                                Didn&apos;t receive a code?{' '}
+                                                Didn’t receive a code?{' '}
                                                 <Anchor component="button" onClick={resendCode}>
                                                     Resend code
                                                 </Anchor>

--- a/src/app/account/signin/mfa.tsx
+++ b/src/app/account/signin/mfa.tsx
@@ -204,7 +204,7 @@ export const RequestMFA: FC<{ mfa: MFAState }> = ({ mfa }) => {
                             </Stack>
                             <Divider my="xs" c="charcoal.1" />
                             <Text size="md" c="grey.7">
-                                Can&apos;t access your MFA device?
+                                Can’t access your MFA device?
                             </Text>
                             <Button
                                 w="100%"

--- a/src/app/account/signin/sms-verification.tsx
+++ b/src/app/account/signin/sms-verification.tsx
@@ -54,7 +54,7 @@ export const SmsVerification = ({ signIn, phoneNumber, form, isVerifyingCode }: 
             </Button>
             <Group>
                 <Text fz="sm" c="grey.7">
-                    Didn&apos;t receive a code?{' '}
+                    Didn’t receive a code?{' '}
                     <Anchor
                         component="button"
                         type="button"

--- a/src/components/cancel-button.tsx
+++ b/src/components/cancel-button.tsx
@@ -25,8 +25,8 @@ export function CancelButton({ isDirty, disabled }: { isDirty: boolean; disabled
             <AppModal isOpen={isOpen} onClose={() => setIsOpen(false)} title="Cancel proposal?">
                 <Stack>
                     <Text size="md">
-                        You&apos;re about to cancel this study proposal draft. On cancel, the current proposal will be
-                        deleted and you won&apos;t be able to retrieve it in the future.
+                        You’re about to cancel this study proposal draft. On cancel, the current proposal will be
+                        deleted and you won’t be able to retrieve it in the future.
                     </Text>
                     <Text size="md">Do you want to proceed?</Text>
                     <Group>

--- a/src/components/editable-text/collaborative-editor.tsx
+++ b/src/components/editable-text/collaborative-editor.tsx
@@ -335,8 +335,7 @@ export type CollaborativeEditorProps = {
 function EditorUnavailable() {
     return (
         <Alert color="red" title="Editor unavailable">
-            We couldn&apos;t connect to the collaboration server. Try refreshing the page — your last saved draft is
-            safe.
+            We couldn’t connect to the collaboration server. Try refreshing the page — your last saved draft is safe.
         </Alert>
     )
 }

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -52,7 +52,7 @@ export class ErrorBoundary extends Component<Props, State> {
                                     Something Went Wrong
                                 </Title>
                                 <Text size="md" fw={400} c="grey.6" mt="md">
-                                    We&apos;re experiencing a technical issue. <br /> Please try again in a few minutes.
+                                    We’re experiencing a technical issue. <br /> Please try again in a few minutes.
                                 </Text>
                                 {this.state.eventId && (
                                     <Text size="sm" fw={600} c="grey.5" mt="sm">

--- a/src/components/researcher-profile/position-form.tsx
+++ b/src/components/researcher-profile/position-form.tsx
@@ -64,7 +64,7 @@ export function PositionForm({
                 <div>
                     <FormFieldLabel label="Link to your profile page" inputId="profileUrl" />
                     <Text size="sm" mb={6}>
-                        Add a link to your personal institutional or organization&apos;s profile page, if available.
+                        Add a link to your personal institutional or organization’s profile page, if available.
                     </Text>
                     <TextInput
                         id="profileUrl"

--- a/src/components/study/review-uploaded-files.tsx
+++ b/src/components/study/review-uploaded-files.tsx
@@ -80,8 +80,7 @@ export const ReviewUploadedFiles: FC<ReviewUploadedFilesProps> = ({
                 <Divider />
 
                 <Text size="sm">
-                    If you&apos;re uploading multiple files, please select your main file (i.e., the script that runs
-                    first)
+                    If you’re uploading multiple files, please select your main file (i.e., the script that runs first)
                 </Text>
 
                 <Table>

--- a/src/components/study/study-code-review-view.tsx
+++ b/src/components/study/study-code-review-view.tsx
@@ -72,8 +72,8 @@ export function StudyCodeReviewView({
             <Stack gap={4}>
                 <Text fw={600}>Review files</Text>
                 <Text size="sm" c="dimmed">
-                    If you&apos;re creating or uploading multiple files, please select your main file (i.e., the script
-                    that runs first).
+                    If you’re creating or uploading multiple files, please select your main file (i.e., the script that
+                    runs first).
                 </Text>
             </Stack>
 

--- a/src/lib/swc-jsx-entity-whitespace.test.ts
+++ b/src/lib/swc-jsx-entity-whitespace.test.ts
@@ -34,12 +34,29 @@ import { beforeAll, describe, expect, it } from 'vitest'
  */
 
 // Internal Next compiler API — no public types, but stable enough for a canary.
+// If a future Next relocates this path, require() throws here; rather than crashing
+// the whole suite at module load (which reads as "something broke" instead of
+// "investigate the canary"), capture the failure and skip with an explanatory message.
 const require = createRequire(import.meta.url)
-const swc = require('next/dist/build/swc')
+let swc: { transform: (src: string, opts: unknown) => Promise<{ code: string }>; loadBindings: () => Promise<void> }
+let swcLoadError: unknown = null
+try {
+    swc = require('next/dist/build/swc')
+} catch (err) {
+    swcLoadError = err
+    console.warn(
+        "[swc-jsx-entity-whitespace canary] Could not load 'next/dist/build/swc' — skipping. " +
+            'Next likely relocated this internal entrypoint; re-point the require above and ' +
+            `re-enable the canary. Original error: ${err instanceof Error ? err.message : String(err)}`,
+    )
+}
 
 // Compiles a <p> whose text run after `<b>Note:</b>` starts with " SafeInsights"
-// and contains `token`. Returns the compiled JS so we can check whether the
-// leading space before "SafeInsights" survived.
+// and contains `token`. SWC emits that run as its own string-literal arg, so the
+// leading space (when preserved) shows up as `"<space>SafeInsights`. Matching the
+// opening quote directly pins the assertion to *that* run's leading whitespace
+// rather than any space elsewhere in the compiled output.
+const SPACE_BEFORE_RUN = /"\s+SafeInsights/
 const compile = async (token: string): Promise<string> => {
     const source =
         `const x = (<p>\n` +
@@ -48,12 +65,17 @@ const compile = async (token: string): Promise<string> => {
         `</p>)`
     const { code } = await swc.transform(source, {
         filename: 'probe.tsx',
-        jsc: { parser: { syntax: 'typescript', tsx: true }, transform: { react: { runtime: 'classic', pragma: 'h' } } },
+        // Automatic runtime to mirror the production build (which is what actually breaks). The
+        // whitespace trimming is in SWC's shared JSX transform, so the runtime choice doesn't
+        // affect the result — but matching prod keeps the canary honest.
+        jsc: { parser: { syntax: 'typescript', tsx: true }, transform: { react: { runtime: 'automatic' } } },
     })
     return code
 }
 
-describe('SWC JSX entity whitespace (regression canary — see file header)', () => {
+// Skip (don't error) if the internal SWC entrypoint moved — the canary can't run, but that's a
+// "go re-point this at the new path" signal, not a real failure. The warning makes the skip visible.
+describe.skipIf(swcLoadError != null)('SWC JSX entity whitespace (regression canary — see file header)', () => {
     beforeAll(async () => {
         await swc.loadBindings()
     })
@@ -61,7 +83,7 @@ describe('SWC JSX entity whitespace (regression canary — see file header)', ()
     it('canary: SWC still drops the space when the text run contains an HTML entity', async () => {
         const code = await compile('won&apos;t store it')
         expect(
-            code.includes(' SafeInsights'),
+            SPACE_BEFORE_RUN.test(code),
             'SWC appears to have FIXED the JSX-entity whitespace bug (swc#11392). ' +
                 'Remove this test and the no-restricted-syntax JSX-entity guard in eslint.config.mjs; ' +
                 'HTML entities in JSX text are safe again.',
@@ -70,6 +92,6 @@ describe('SWC JSX entity whitespace (regression canary — see file header)', ()
 
     it('literal apostrophe keeps the space (this is why replacing entities fixes the render)', async () => {
         const code = await compile('won’t store it')
-        expect(code.includes(' SafeInsights')).toBe(true)
+        expect(SPACE_BEFORE_RUN.test(code)).toBe(true)
     })
 })

--- a/src/lib/swc-jsx-entity-whitespace.test.ts
+++ b/src/lib/swc-jsx-entity-whitespace.test.ts
@@ -1,0 +1,75 @@
+import { createRequire } from 'node:module'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * REGRESSION CANARY — SWC JSX whitespace bug (swc-project/swc#11392).
+ *
+ * THE BUG
+ *   Next's SWC compiler drops the significant space between an inline element
+ *   (e.g. `</b>`) and an adjacent JSX text run *when that text run contains any
+ *   HTML character reference* — named (`&apos;`, `&amp;`, `&rsquo;`) or numeric
+ *   (`&#39;`). Babel, tsc, and esbuild all preserve the space; only SWC drops it,
+ *   so it is invisible in our unit tests (vitest compiles with Babel) and only
+ *   shows up in the production build. It silently rendered, e.g.,
+ *   "Note: SafeInsights ..." as "Note:SafeInsights ...".
+ *
+ *   Root cause (see babel#17683): SWC decodes the HTML entity *before* trimming
+ *   JSX whitespace instead of after, which corrupts the adjacent-space handling.
+ *
+ * THE WORKAROUND (this repo)
+ *   We replaced HTML entities in JSX text with literal characters (e.g.
+ *   `&apos;` -> `’`). An ESLint guard (`no-restricted-syntax` on `JSXText` in
+ *   eslint.config.mjs) prevents reintroducing them.
+ *
+ * UPSTREAM STATUS
+ *   Fixed in swc-core 1.15.11 (swc PR #11474) but NOT yet in our bundled
+ *   `@next/swc` (see the failing assertion below for the live check).
+ *
+ * >>> WHEN THE "canary" TEST BELOW FAILS <<<
+ *   It asserts the *current, buggy* behavior. A failure means a newer
+ *   `@next/swc` has shipped the fix. At that point you can:
+ *     1. delete this test,
+ *     2. remove the `no-restricted-syntax` JSX-entity guard in eslint.config.mjs,
+ *     3. (optionally) use HTML entities in JSX text again.
+ */
+
+// Internal Next compiler API — no public types, but stable enough for a canary.
+const require = createRequire(import.meta.url)
+const swc = require('next/dist/build/swc')
+
+// Compiles a <p> whose text run after `<b>Note:</b>` starts with " SafeInsights"
+// and contains `token`. Returns the compiled JS so we can check whether the
+// leading space before "SafeInsights" survived.
+const compile = async (token: string): Promise<string> => {
+    const source =
+        `const x = (<p>\n` +
+        `    <b>Note:</b> SafeInsights ${token} and the text keeps going so it\n` +
+        `    wraps onto a second line here.\n` +
+        `</p>)`
+    const { code } = await swc.transform(source, {
+        filename: 'probe.tsx',
+        jsc: { parser: { syntax: 'typescript', tsx: true }, transform: { react: { runtime: 'classic', pragma: 'h' } } },
+    })
+    return code
+}
+
+describe('SWC JSX entity whitespace (regression canary — see file header)', () => {
+    beforeAll(async () => {
+        await swc.loadBindings()
+    })
+
+    it('canary: SWC still drops the space when the text run contains an HTML entity', async () => {
+        const code = await compile('won&apos;t store it')
+        expect(
+            code.includes(' SafeInsights'),
+            'SWC appears to have FIXED the JSX-entity whitespace bug (swc#11392). ' +
+                'Remove this test and the no-restricted-syntax JSX-entity guard in eslint.config.mjs; ' +
+                'HTML entities in JSX text are safe again.',
+        ).toBe(false)
+    })
+
+    it('literal apostrophe keeps the space (this is why replacing entities fixes the render)', async () => {
+        const code = await compile('won’t store it')
+        expect(code.includes(' SafeInsights')).toBe(true)
+    })
+})


### PR DESCRIPTION
## TL;DR
HTML character entities (`&apos;`, `&rsquo;`, `&#39;`, `&amp;`, …) in **JSX text** trigger a bug in SWC (our production compiler) that **drops the space between an inline element and the adjacent text**. This PR replaces those entities with literal characters, adds a lint guard so they can't come back, and adds a canary test that will tell us when the upstream SWC fix lands so we can revert the workaround.

## The symptom
On the "Have you stored your reviewer key?" modal, the production build rendered:

> **Note:**SafeInsights does not store your reviewer key…   ← no space after "Note:"

even though the source is correct:
```tsx
<b>Note:</b> SafeInsights does not store your reviewer key. If you lose your key, you won&apos;t be …
```

<img width="593" height="306" alt="image" src="https://github.com/user-attachments/assets/9d2979f7-5a5c-4a68-8cbe-545e73958a09" />


## Why this is esoteric (and why it slipped through)
The space is present in the source, and it survives **every** layer except the production compile:

| stage | keeps the space? |
|---|---|
| source on disk | ✅ (verified at the byte level) |
| Babel (what **vitest** uses to compile components) | ✅ |
| React render / Mantine SSR | ✅ |
| Sentry `reactComponentAnnotation` transform | ✅ |
| **Next SWC (`@next/swc`) — the production build** | ❌ **drops it** |

Because our unit tests compile with **Babel**, a normal render test shows the space and passes — while production (SWC) is broken. That's the trap.

## Root cause (controlled proof)
The trigger is an **HTML character entity in the adjacent text run**. Identical text, only the token varies, compiled with Next's SWC:

| token in the text run | SWC result |
|---|---|
| plain / `'` (straight) / `’` (unicode) | space preserved ✅ |
| `&apos;` | **stripped** ❌ |
| `&#39;` (numeric) | **stripped** ❌ |
| `&amp;` | **stripped** ❌ |
| `&quot;` | **stripped** ❌ |
| `&rsquo;` | **stripped** ❌ |

SWC decodes the entity **before** trimming JSX whitespace instead of after, which corrupts the adjacent-space handling. References:
- swc-project/swc#11392 (this bug) — fixed in **swc-core 1.15.11** (PR #11474)
- babel/babel#17683 (root-cause writeup: "decode after trimming, not before")
- swc-project/swc#542 (the older, *non-entity* variant — fixed long ago in v1.1.11, which is why non-entity text is fine today)

## Why this fix (and not the alternatives)
- **Not** a Next/SWC upgrade — `@next/swc` is a **version-locked vendored binary** (can't bump SWC alone), and the latest stable Next (16.2.7) doesn't include the fix yet.
- **Not** a custom build-time loader — possible (Sentry does it), but it'd need to be registered for **both** webpack and Turbopack (dev/prod parity trap) and is hidden machinery. Literal characters aren't worse source than entities anyway.

So we remove the **trigger**: literal characters in JSX text. `&apos;`/`&rsquo;` → `’` (typographic apostrophe — renders identically, and `react/no-unescaped-entities` is happy with it).

## What's in this PR
1. **19 files**: every `&apos;`/`&rsquo;` in JSX text → literal `’`. (Prettier re-flowed a few lines since `’` is shorter than `&apos;`.)
2. **ESLint guard** (`eslint.config.mjs`): `no-restricted-syntax` on `JSXText[raw=/&\w+;/]` (and numeric) — bans HTML entities in JSX text, with a message explaining the SWC bug. (Note: it matches `raw`, since typescript-eslint already entity-decodes `value`.)
3. **Regression canary** (`src/lib/swc-jsx-entity-whitespace.test.ts`): compiles a snippet with Next's SWC and asserts the **current buggy** behavior. **When `@next/swc` ships the fix, this test fails** — that's the signal to delete the workaround, the guard, and the test. A second assertion (literal ⇒ space kept) documents why the fix works.

## Verification
- `pnpm lint` (eslint + prettier) — clean, and the new guard catches any reintroduced entity repo-wide.
- The canary test passes today (bug present) and is designed to fail when SWC is fixed.