### PR TITLE
OTTER-546: route code review Back button to agreements page

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-client.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-client.test.tsx
@@ -1,5 +1,4 @@
 import { vi } from 'vitest'
-import type { Route } from 'next'
 import { memoryRouter } from 'next-router-mock'
 import {
     actionResult,
@@ -14,6 +13,7 @@ import {
     userEvent,
     waitFor,
 } from '@/tests/unit.helpers'
+import { Routes } from '@/lib/routes'
 import { getStudyAction, type SelectedStudy } from '@/server/actions/study.actions'
 import { latestJobForStudy } from '@/server/db/queries'
 import { CodeReviewClient } from './code-review-client'
@@ -44,7 +44,8 @@ async function setupValidReviewableJob(labName = 'Rice University') {
     const study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
     const job = await latestJobForStudy(study.id)
     const studyWithLab: SelectedStudy = { ...study, submittingLabName: labName }
-    return { study: studyWithLab, job, orgSlug: org.slug }
+    const previousHref = Routes.studyAgreements({ orgSlug: org.slug, studyId: study.id, from: 'previous' })
+    return { study: studyWithLab, job, orgSlug: org.slug, previousHref }
 }
 
 async function fillAllCriteria(user: ReturnType<typeof userEvent.setup>) {
@@ -76,14 +77,14 @@ describe('CodeReviewClient decision selector', () => {
     })
 
     it('renders all three decision options with their titles and descriptions', async () => {
-        const { study, job, orgSlug } = await setupValidReviewableJob('Rice University')
+        const { study, job, orgSlug, previousHref } = await setupValidReviewableJob('Rice University')
         renderWithProviders(
             <CodeReviewClient
                 orgSlug={orgSlug}
                 study={study}
                 job={job}
                 latestJobStatus="CODE-SUBMITTED"
-                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous` as Route}
+                previousHref={previousHref}
             />,
         )
 
@@ -115,14 +116,14 @@ describe('CodeReviewClient decision selector', () => {
 
     it('disables Submit when no decision is selected even with valid feedback and criteria', async () => {
         const user = userEvent.setup()
-        const { study, job, orgSlug } = await setupValidReviewableJob()
+        const { study, job, orgSlug, previousHref } = await setupValidReviewableJob()
         renderWithProviders(
             <CodeReviewClient
                 orgSlug={orgSlug}
                 study={study}
                 job={job}
                 latestJobStatus="CODE-SUBMITTED"
-                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous` as Route}
+                previousHref={previousHref}
             />,
         )
 
@@ -137,14 +138,14 @@ describe('CodeReviewClient decision selector', () => {
         ['code-review-decision-reject'],
     ])('enables Submit when %s is selected with valid feedback and criteria', async (decisionTestId) => {
         const user = userEvent.setup()
-        const { study, job, orgSlug } = await setupValidReviewableJob()
+        const { study, job, orgSlug, previousHref } = await setupValidReviewableJob()
         renderWithProviders(
             <CodeReviewClient
                 orgSlug={orgSlug}
                 study={study}
                 job={job}
                 latestJobStatus="CODE-SUBMITTED"
-                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous` as Route}
+                previousHref={previousHref}
             />,
         )
 
@@ -156,14 +157,14 @@ describe('CodeReviewClient decision selector', () => {
 
     it('opens the non-destructive confirmation modal when submitting with needs-clarification', async () => {
         const user = userEvent.setup()
-        const { study, job, orgSlug } = await setupValidReviewableJob()
+        const { study, job, orgSlug, previousHref } = await setupValidReviewableJob()
         renderWithProviders(
             <CodeReviewClient
                 orgSlug={orgSlug}
                 study={study}
                 job={job}
                 latestJobStatus="CODE-SUBMITTED"
-                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous` as Route}
+                previousHref={previousHref}
             />,
         )
 
@@ -181,14 +182,14 @@ describe('CodeReviewClient decision selector', () => {
 
     it('opens the destructive reject modal with the warning paragraph when submitting with reject', async () => {
         const user = userEvent.setup()
-        const { study, job, orgSlug } = await setupValidReviewableJob()
+        const { study, job, orgSlug, previousHref } = await setupValidReviewableJob()
         renderWithProviders(
             <CodeReviewClient
                 orgSlug={orgSlug}
                 study={study}
                 job={job}
                 latestJobStatus="CODE-SUBMITTED"
-                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous` as Route}
+                previousHref={previousHref}
             />,
         )
 
@@ -206,14 +207,14 @@ describe('CodeReviewClient decision selector', () => {
 
     it('calls submitReview with decision=needs-clarification on confirm', async () => {
         const user = userEvent.setup()
-        const { study, job, orgSlug } = await setupValidReviewableJob()
+        const { study, job, orgSlug, previousHref } = await setupValidReviewableJob()
         renderWithProviders(
             <CodeReviewClient
                 orgSlug={orgSlug}
                 study={study}
                 job={job}
                 latestJobStatus="CODE-SUBMITTED"
-                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous` as Route}
+                previousHref={previousHref}
             />,
         )
 
@@ -240,8 +241,7 @@ describe('CodeReviewClient decision selector', () => {
 
     it('Back button navigates to the agreements page (previousHref), not the dashboard', async () => {
         const user = userEvent.setup()
-        const { study, job, orgSlug } = await setupValidReviewableJob()
-        const previousHref = `/${orgSlug}/study/${study.id}/agreements?from=previous` as Route
+        const { study, job, orgSlug, previousHref } = await setupValidReviewableJob()
         memoryRouter.setCurrentUrl(`/${orgSlug}/study/${study.id}/review`)
         renderWithProviders(
             <CodeReviewClient

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-client.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-client.test.tsx
@@ -1,4 +1,5 @@
 import { vi } from 'vitest'
+import { memoryRouter } from 'next-router-mock'
 import {
     actionResult,
     beforeEach,
@@ -76,7 +77,13 @@ describe('CodeReviewClient decision selector', () => {
     it('renders all three decision options with their titles and descriptions', async () => {
         const { study, job, orgSlug } = await setupValidReviewableJob('Rice University')
         renderWithProviders(
-            <CodeReviewClient orgSlug={orgSlug} study={study} job={job} latestJobStatus="CODE-SUBMITTED" />,
+            <CodeReviewClient
+                orgSlug={orgSlug}
+                study={study}
+                job={job}
+                latestJobStatus="CODE-SUBMITTED"
+                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous`}
+            />,
         )
 
         expect(screen.getByTestId('code-review-decision-approve')).toBeInTheDocument()
@@ -109,7 +116,13 @@ describe('CodeReviewClient decision selector', () => {
         const user = userEvent.setup()
         const { study, job, orgSlug } = await setupValidReviewableJob()
         renderWithProviders(
-            <CodeReviewClient orgSlug={orgSlug} study={study} job={job} latestJobStatus="CODE-SUBMITTED" />,
+            <CodeReviewClient
+                orgSlug={orgSlug}
+                study={study}
+                job={job}
+                latestJobStatus="CODE-SUBMITTED"
+                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous`}
+            />,
         )
 
         await fillAllCriteria(user)
@@ -125,7 +138,13 @@ describe('CodeReviewClient decision selector', () => {
         const user = userEvent.setup()
         const { study, job, orgSlug } = await setupValidReviewableJob()
         renderWithProviders(
-            <CodeReviewClient orgSlug={orgSlug} study={study} job={job} latestJobStatus="CODE-SUBMITTED" />,
+            <CodeReviewClient
+                orgSlug={orgSlug}
+                study={study}
+                job={job}
+                latestJobStatus="CODE-SUBMITTED"
+                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous`}
+            />,
         )
 
         await fillAllCriteria(user)
@@ -138,7 +157,13 @@ describe('CodeReviewClient decision selector', () => {
         const user = userEvent.setup()
         const { study, job, orgSlug } = await setupValidReviewableJob()
         renderWithProviders(
-            <CodeReviewClient orgSlug={orgSlug} study={study} job={job} latestJobStatus="CODE-SUBMITTED" />,
+            <CodeReviewClient
+                orgSlug={orgSlug}
+                study={study}
+                job={job}
+                latestJobStatus="CODE-SUBMITTED"
+                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous`}
+            />,
         )
 
         await fillAllCriteria(user)
@@ -157,7 +182,13 @@ describe('CodeReviewClient decision selector', () => {
         const user = userEvent.setup()
         const { study, job, orgSlug } = await setupValidReviewableJob()
         renderWithProviders(
-            <CodeReviewClient orgSlug={orgSlug} study={study} job={job} latestJobStatus="CODE-SUBMITTED" />,
+            <CodeReviewClient
+                orgSlug={orgSlug}
+                study={study}
+                job={job}
+                latestJobStatus="CODE-SUBMITTED"
+                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous`}
+            />,
         )
 
         await fillAllCriteria(user)
@@ -176,7 +207,13 @@ describe('CodeReviewClient decision selector', () => {
         const user = userEvent.setup()
         const { study, job, orgSlug } = await setupValidReviewableJob()
         renderWithProviders(
-            <CodeReviewClient orgSlug={orgSlug} study={study} job={job} latestJobStatus="CODE-SUBMITTED" />,
+            <CodeReviewClient
+                orgSlug={orgSlug}
+                study={study}
+                job={job}
+                latestJobStatus="CODE-SUBMITTED"
+                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous`}
+            />,
         )
 
         await fillAllCriteria(user)
@@ -197,6 +234,28 @@ describe('CodeReviewClient decision selector', () => {
                     privacyProtection: 'yes',
                 },
             })
+        })
+    })
+
+    it('Back button navigates to the agreements page (previousHref), not the dashboard', async () => {
+        const user = userEvent.setup()
+        const { study, job, orgSlug } = await setupValidReviewableJob()
+        const previousHref = `/${orgSlug}/study/${study.id}/agreements?from=previous`
+        memoryRouter.setCurrentUrl(`/${orgSlug}/study/${study.id}/review`)
+        renderWithProviders(
+            <CodeReviewClient
+                orgSlug={orgSlug}
+                study={study}
+                job={job}
+                latestJobStatus="CODE-SUBMITTED"
+                previousHref={previousHref}
+            />,
+        )
+
+        await user.click(screen.getByRole('button', { name: /back/i }))
+
+        await waitFor(() => {
+            expect(memoryRouter.asPath).toBe(previousHref)
         })
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-client.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-client.test.tsx
@@ -1,4 +1,5 @@
 import { vi } from 'vitest'
+import type { Route } from 'next'
 import { memoryRouter } from 'next-router-mock'
 import {
     actionResult,
@@ -82,7 +83,7 @@ describe('CodeReviewClient decision selector', () => {
                 study={study}
                 job={job}
                 latestJobStatus="CODE-SUBMITTED"
-                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous`}
+                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous` as Route}
             />,
         )
 
@@ -121,7 +122,7 @@ describe('CodeReviewClient decision selector', () => {
                 study={study}
                 job={job}
                 latestJobStatus="CODE-SUBMITTED"
-                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous`}
+                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous` as Route}
             />,
         )
 
@@ -143,7 +144,7 @@ describe('CodeReviewClient decision selector', () => {
                 study={study}
                 job={job}
                 latestJobStatus="CODE-SUBMITTED"
-                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous`}
+                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous` as Route}
             />,
         )
 
@@ -162,7 +163,7 @@ describe('CodeReviewClient decision selector', () => {
                 study={study}
                 job={job}
                 latestJobStatus="CODE-SUBMITTED"
-                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous`}
+                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous` as Route}
             />,
         )
 
@@ -187,7 +188,7 @@ describe('CodeReviewClient decision selector', () => {
                 study={study}
                 job={job}
                 latestJobStatus="CODE-SUBMITTED"
-                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous`}
+                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous` as Route}
             />,
         )
 
@@ -212,7 +213,7 @@ describe('CodeReviewClient decision selector', () => {
                 study={study}
                 job={job}
                 latestJobStatus="CODE-SUBMITTED"
-                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous`}
+                previousHref={`/${orgSlug}/study/${study.id}/agreements?from=previous` as Route}
             />,
         )
 
@@ -240,7 +241,7 @@ describe('CodeReviewClient decision selector', () => {
     it('Back button navigates to the agreements page (previousHref), not the dashboard', async () => {
         const user = userEvent.setup()
         const { study, job, orgSlug } = await setupValidReviewableJob()
-        const previousHref = `/${orgSlug}/study/${study.id}/agreements?from=previous`
+        const previousHref = `/${orgSlug}/study/${study.id}/agreements?from=previous` as Route
         memoryRouter.setCurrentUrl(`/${orgSlug}/study/${study.id}/review`)
         renderWithProviders(
             <CodeReviewClient

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-client.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-client.tsx
@@ -33,7 +33,7 @@ type Props = {
     study: SelectedStudy
     job: LatestJobForStudy
     latestJobStatus: StudyJobStatus | null
-    previousHref: string
+    previousHref: Route
 }
 
 const isCodeReviewEditable = ({ status, latestJobStatus }: EditableSnapshot): boolean =>
@@ -56,7 +56,7 @@ function useCodeReview({
     studyId: string
     jobId: string
     tabSessionId: string
-    previousHref: string
+    previousHref: Route
 }) {
     const feedback = useReviewFeedback({ maxWords: CODE_REVIEW_FEEDBACK_MAX_WORDS })
     const decision = useReviewDecision()
@@ -84,7 +84,7 @@ function useCodeReview({
     const { submitReview, isPending } = useCodeReviewMutation({ studyId, jobId, orgSlug, tabSessionId })
 
     const handleBack = () => {
-        router.push(previousHref as Route)
+        router.push(previousHref)
     }
 
     const handleSubmit = () => {

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-client.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-client.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { Alert, Box, Button, Group, Stack, Text } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { useForm } from '@mantine/form'
+import type { Route } from 'next'
 import { useRouter } from 'next/navigation'
 import { CaretLeftIcon } from '@phosphor-icons/react'
 
@@ -16,7 +17,6 @@ import { CodeReviewFeedbackProviderShare } from '@/lib/realtime/code-review-feed
 import { REVIEWABLE_CODE_JOB_STATUSES } from '@/lib/code-review-status'
 import { CODE_REVIEW_FEEDBACK_MAX_WORDS } from '@/lib/proposal-review'
 import type { Decision } from '@/lib/review-decision'
-import { Routes } from '@/lib/routes'
 import type { SelectedStudy } from '@/server/actions/study.actions'
 import type { LatestJobForStudy } from '@/server/db/queries'
 import type { StudyJobStatus } from '@/database/types'
@@ -33,6 +33,7 @@ type Props = {
     study: SelectedStudy
     job: LatestJobForStudy
     latestJobStatus: StudyJobStatus | null
+    previousHref: string
 }
 
 const isCodeReviewEditable = ({ status, latestJobStatus }: EditableSnapshot): boolean =>
@@ -49,11 +50,13 @@ function useCodeReview({
     studyId,
     jobId,
     tabSessionId,
+    previousHref,
 }: {
     orgSlug: string
     studyId: string
     jobId: string
     tabSessionId: string
+    previousHref: string
 }) {
     const feedback = useReviewFeedback({ maxWords: CODE_REVIEW_FEEDBACK_MAX_WORDS })
     const decision = useReviewDecision()
@@ -77,12 +80,11 @@ function useCodeReview({
     const hasDecision = decision.selected !== null
 
     const canSubmit = feedback.isValid && hasDecision && criteriaComplete
-    const backPath = Routes.orgDashboard({ orgSlug })
 
     const { submitReview, isPending } = useCodeReviewMutation({ studyId, jobId, orgSlug, tabSessionId })
 
     const handleBack = () => {
-        router.push(backPath)
+        router.push(previousHref as Route)
     }
 
     const handleSubmit = () => {
@@ -204,7 +206,7 @@ function NonEditableBody({ isVisible, job, onBack }: NonEditableBodyProps) {
     )
 }
 
-export function CodeReviewClient({ orgSlug, study, job, latestJobStatus }: Props) {
+export function CodeReviewClient({ orgSlug, study, job, latestJobStatus, previousHref }: Props) {
     const [tabSessionId] = useState(() => crypto.randomUUID())
 
     const {
@@ -220,7 +222,7 @@ export function CodeReviewClient({ orgSlug, study, job, latestJobStatus }: Props
         closeReject,
         handleConfirmSubmit,
         isPending,
-    } = useCodeReview({ orgSlug, studyId: study.id, jobId: job.id, tabSessionId })
+    } = useCodeReview({ orgSlug, studyId: study.id, jobId: job.id, tabSessionId, previousHref })
 
     const initiallyEditable = isCodeReviewEditable({ status: study.status, latestJobStatus })
     const labName = study.submittingLabName ?? study.submittedByOrgSlug

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review.tsx
@@ -103,6 +103,7 @@ export async function CodeReview({ orgSlug, study, entries }: CodeReviewProps) {
 
     const [review, scan] = await Promise.all([getStudyReviewForJob(job.id), jobScanResultForJob(job.id)])
     const proposalHref = `${Routes.studyReview({ orgSlug, studyId: study.id })}?from=code-review`
+    const previousHref = Routes.studyAgreements({ orgSlug, studyId: study.id, from: 'previous' })
     const latestJobStatus = job.statusChanges.at(0)?.status ?? null
 
     const version = deriveCodeReviewVersion(entries)
@@ -136,7 +137,13 @@ export async function CodeReview({ orgSlug, study, entries }: CodeReviewProps) {
                     codeInitiallyExpanded={!isResubmission}
                 />
                 {isResubmission && <FeedbackAndNotesSection entries={entries} />}
-                <CodeReviewClient orgSlug={orgSlug} study={study} job={job} latestJobStatus={latestJobStatus} />
+                <CodeReviewClient
+                    orgSlug={orgSlug}
+                    study={study}
+                    job={job}
+                    latestJobStatus={latestJobStatus}
+                    previousHref={previousHref}
+                />
             </Stack>
         </Box>
     )

--- a/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
@@ -87,6 +87,7 @@ describe('StudyReviewPage', () => {
         })
         expect(page?.type).toBe(ProposalReviewFromAgreementsView)
         expect(page?.props.agreementsHref).toContain('/agreements')
+        expect(page?.props.agreementsHref).toContain('from=previous')
     })
 
     it('renders CodeReview when agreements already acknowledged (no redirect)', async () => {

--- a/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.test.tsx
@@ -81,6 +81,9 @@ describe('StudyReviewPage', () => {
             jobStatus: 'CODE-SUBMITTED',
         })
 
+        // from=agreements: reviewer clicked Previous on the Agreements page, landing on the proposal view.
+        // The outgoing agreementsHref ("Proceed to Step 2") must carry from=previous so the Agreements
+        // page doesn't auto-redirect back to /review when reviewerAgreementsAckedAt is already set.
         const page = await StudyReviewPage({
             params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
             searchParams: Promise.resolve({ from: 'agreements' }),

--- a/src/app/[orgSlug]/study/[studyId]/review/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/page.tsx
@@ -145,7 +145,7 @@ export default async function StudyReviewPage(props: {
                 <ProposalReviewFromAgreementsView
                     orgSlug={orgSlug}
                     study={study}
-                    agreementsHref={Routes.studyAgreements({ orgSlug, studyId })}
+                    agreementsHref={Routes.studyAgreements({ orgSlug, studyId, from: 'previous' })}
                 />
             )
         }


### PR DESCRIPTION
## Summary

- Code review page's **Back** button now navigates to the study's agreements page (with `?from=previous`) instead of the org dashboard, matching the linear step flow Proposal → Agreements → Code Review.
- `ProposalReviewFromAgreementsView` link to agreements now also carries`?from=previous`, so reviewers who already acknowledged agreements aren't auto-redirected back to the review page.
- `CodeReviewClient` gains a required `previousHref: Route` prop, computed server-side in `code-review.tsx` via `Routes.studyAgreements({ from: 'previous'})`.