### PR TITLE
fix: stop Coverage Diff from failing on every push to main

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -256,16 +256,20 @@ jobs:
                   cat test-results/coverage/coverage-summary.md >> $GITHUB_STEP_SUMMARY
                   cat test-results/coverage/coverage-details.md >> $GITHUB_STEP_SUMMARY
             - name: Coverage Diff
+              # Only run on pull_request. On the default branch the action
+              # switches to "baseline update" mode and pushes the coverage
+              # summary to the repo .wiki, which needs `contents: write`, a
+              # permission we deliberately withhold from this PR-code-running
+              # job (OTTER-545). That push 403s on every push to main, so we
+              # skip it there. On PRs the action only reads the baseline and
+              # posts the delta comment, which needs no extra permission.
+              if: github.event_name == 'pull_request'
               uses: bultkrantz/coverage-diff-action@4b5175f210f33024e9725a59f6be6ba407bec8cd # v5.0.1
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   base-summary-filename: base-summary.json
                   coverage-filename: test-results/coverage/coverage-summary.json
                   allowed-to-fail: true
-                  # Disable badge / wiki publish: pushing to the .wiki repo
-                  # requires `contents: write`, which we deliberately do not
-                  # grant this PR-code-running job (OTTER-545). PR comment
-                  # still works without it.
                   badge-enabled: false
             - name: Display server log
               run: if [ -f server_output.log ]; then cat server_output.log; fi


### PR DESCRIPTION
## Problem

The `Coverage Diff` step in the `test` job fails on **every push to `main`**, while it passes fine on pull requests. Example failing run on main: https://github.com/safeinsights/management-app/actions/runs/27175011114/job/80221967952

The failure is an uncaught error from `bultkrantz/coverage-diff-action`:

```
Running on default branch
Saving json-summary report into the repo wiki
GitError: Pushing to https://github.com/safeinsights/management-app.wiki.git
remote: Permission to safeinsights/management-app.wiki.git denied to github-actions[bot].
fatal: unable to access '.../management-app.wiki.git/': The requested URL returned error: 403
```

## Root cause

This action behaves differently depending on the branch:

- **On `pull_request`** it only *reads* the coverage baseline from the repo wiki and posts a delta comment. No push, so it succeeds.
- **On the default branch (`push` to `main`)** it switches to "baseline update" mode and *pushes* the json-summary to `management-app.wiki.git`. That push requires `contents: write`.

The `test` job's `GITHUB_TOKEN` only has `pull-requests: write`. The `contents: write` (and `pages: write`) permissions were intentionally dropped in #674 (OTTER-545 CI hardening), because this job runs PR-controlled code and must not be able to push commits or modify the repo. So the wiki push correctly gets a 403 on every push to main.

A previous attempt to silence this (`badge-enabled: false`) was incomplete: that flag only suppresses the coverage **badge**, not the json-summary **baseline** push, and there is no input flag on the action to disable the baseline wiki storage.

`allowed-to-fail: true` does not help either, that only controls the coverage-threshold verdict, not an uncaught git error, so the step hard-fails.

## Fix

Gate the `Coverage Diff` step to pull requests only:

```yaml
- name: Coverage Diff
  if: github.event_name == 'pull_request'
  ...
```

This is the smallest change that resolves the failure while fully preserving the OTTER-545 security posture:

- **No new permissions.** We do not reintroduce `contents: write` to a job that runs untrusted PR code. The alternative (a default-branch baseline-update job with `contents: write`) would either reopen that hole or require a duplicate full coverage run on every merge.
- **Nothing functional is lost.** The wiki baseline has been frozen since the last successful push on 2026-05-06 (when #674 merged), so PR comments have already been comparing against that fixed baseline. Skipping the step on push-to-main only removes the recurring red X; it does not degrade anything currently working.

The misleading `badge-enabled` comment is replaced with one that documents the real reason the step is PR-only.

## Validation

- `pnpm run validate-actions` passes
- Workflow YAML parses cleanly

