### PR TITLE
fix: prevent empty orgSlug from 500-ing the study request page

### DIFF
--- a/src/components/study/programming-language-section.test.tsx
+++ b/src/components/study/programming-language-section.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { FC } from 'react'
+import { ProgrammingLanguageSection } from './programming-language-section'
+import { getLanguagesForOrgAction } from '@/server/actions/org.actions'
+import { TestingProviders, useTestStudyProposalForm } from '@/tests/providers'
+
+vi.mock('@/server/actions/org.actions', () => ({
+    getLanguagesForOrgAction: vi.fn(() =>
+        Promise.resolve({
+            orgName: 'Test Organization',
+            languages: [{ value: 'R', label: 'R', starterCodeUrls: [], commandLines: {} }],
+        }),
+    ),
+}))
+
+interface FormWrapperProps {
+    orgSlug?: string
+}
+
+const FormWrapper: FC<FormWrapperProps> = ({ orgSlug = '' }) => {
+    const form = useTestStudyProposalForm({ orgSlug })
+
+    return (
+        <TestingProviders>
+            <ProgrammingLanguageSection form={form} />
+        </TestingProviders>
+    )
+}
+
+describe('ProgrammingLanguageSection', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    // OTTER: a stale session can leave orgSlug empty when a newly created org is
+    // missing from the user's JWT. The languages query must stay disabled rather
+    // than fire with '' and trigger an opaque "no result" throw server-side.
+    it('does not query for languages when orgSlug is empty', async () => {
+        render(<FormWrapper orgSlug="" />)
+
+        // give react-query a tick to (not) fire
+        await new Promise((resolve) => setTimeout(resolve, 50))
+        expect(getLanguagesForOrgAction).not.toHaveBeenCalled()
+    })
+
+    it('queries for languages once an orgSlug is selected', async () => {
+        render(<FormWrapper orgSlug="test-org" />)
+
+        await waitFor(() => {
+            expect(getLanguagesForOrgAction).toHaveBeenCalledWith({ orgSlug: 'test-org' })
+        })
+        expect(await screen.findByText('R')).toBeInTheDocument()
+    })
+})

--- a/src/components/study/programming-language-section.tsx
+++ b/src/components/study/programming-language-section.tsx
@@ -18,6 +18,10 @@ export const ProgrammingLanguageSection: React.FC<Props> = ({ form }) => {
     const { data, isLoading } = useQuery({
         queryKey: ['languages-for-org', selectedOrgSlug],
         queryFn: () => getLanguagesForOrgAction({ orgSlug: selectedOrgSlug }),
+        // A stale session can leave orgSlug empty (new org missing from the
+        // user's JWT). Without this guard the query fires with '' and the org
+        // lookup throws "no result", 500-ing the whole request page.
+        enabled: !!selectedOrgSlug,
     })
 
     const orgName = data?.orgName ?? ''

--- a/src/server/actions/org.actions.test.ts
+++ b/src/server/actions/org.actions.test.ts
@@ -282,5 +282,14 @@ describe('Org Actions', () => {
                 ]),
             )
         })
+
+        // OTTER: a stale session can leave the form's orgSlug empty when a newly
+        // created org is missing from the user's JWT. An empty slug must fail
+        // validation rather than reach the org lookup, which would otherwise
+        // throw an opaque "no result" and 500 the study-request page.
+        it('rejects an empty orgSlug with a validation error', async () => {
+            const result = await getLanguagesForOrgAction({ orgSlug: '' })
+            expect(result).toEqual({ error: expect.stringContaining('Validation error') })
+        })
     })
 })

--- a/src/server/actions/org.actions.ts
+++ b/src/server/actions/org.actions.ts
@@ -101,7 +101,7 @@ type LanguageOption = {
 
 export const getLanguagesForOrgAction = new Action('getLanguagesForOrgAction')
     .requireAbilityTo('view', 'Orgs')
-    .params(z.object({ orgSlug: z.string() }))
+    .params(z.object({ orgSlug: z.string().min(1) }))
     .handler(async ({ db, params: { orgSlug } }) => {
         const { languageLabels } = await import('@/lib/languages')
         const { signedUrlForFile } = await import('@/server/aws')


### PR DESCRIPTION
## Problem

Sentry caught `Error: no result` on `POST /[orgSlug]/study/request` (issue 7171187694) — researchers on a newly set-up org couldn't create studies.

The throw is `getLanguagesForOrgAction` → `SELECT name, id FROM org WHERE slug = $orgSlug` → `executeTakeFirstOrThrow()` returning nothing. The slug it received was an **empty string**.

## Root cause

`ProgrammingLanguageSection` registers the languages query unconditionally:

```ts
const { data } = useQuery({
    queryKey: ['languages-for-org', selectedOrgSlug],
    queryFn: () => getLanguagesForOrgAction({ orgSlug: selectedOrgSlug }),
})
// ...
if (!selectedOrgSlug) return null   // guards RENDER, not the query
```

The `if (!selectedOrgSlug) return null` guard sits **below** the hook, so it only stops rendering — the query still fires. When a stale session JWT omits a newly created org, the form's `orgSlug` is never seeded and stays `''`. The action's param schema was `z.string()`, which accepts `''`, so it reached the DB lookup → `WHERE slug = ''` → `executeTakeFirstOrThrow()` throws "no result" → the whole request page 500s.

## Fix

Two layers:

1. **Client** — `enabled: !!selectedOrgSlug` so the query never runs with an empty slug.
2. **Server** — `z.string().min(1)` so an empty slug fails validation cleanly instead of an opaque Kysely throw.

## Tests

- New `programming-language-section.test.tsx`: asserts the query stays disabled when `orgSlug` is empty and fires once a slug is selected. (Verified it fails without the `enabled` guard.)
- `org.actions.test.ts`: empty `orgSlug` → validation error.

## Scope

This fixes the **crash**. It does not address the upstream trigger (a stale session JWT that omits a newly created org); a user in that state will see the org absent from the picker until their metadata refreshes (re-login), but will no longer get a 500.