### PR TITLE
Fix booting a fresh env in Docker

### DIFF
--- a/bin/docker-dev-init
+++ b/bin/docker-dev-init
@@ -5,7 +5,7 @@
 
 set -e
 
-pnpm install --frozen-lockfile
+pnpm install --config.confirm-modules-purge=false --frozen-lockfile
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,23 +118,20 @@ services:
             - AWS_ACCOUNT_ID=000000000000
             - AWS_REGION=us-east-1
             - CLAUDE_API_KEY=$CLAUDE_API_KEY
+            # Cap Turbopack's heap so next-server can't balloon past the Docker VM's
+            # memory and get OOM-killed mid-compile (kernel SIGKILL, not a container OOM).
+            - NODE_OPTIONS=--max-old-space-size=4096
         build:
             context: .
             dockerfile: ./Dockerfile.dev
         volumes:
             - ./:/app/
             - node_modules:/app/node_modules
-        restart: always
+        restart: unless-stopped
         networks:
             - mgmnt-app
         ports:
             - 4000:4000
-        healthcheck:
-            test: ['CMD-SHELL', 'curl -sf http://localhost:4000/about']
-            interval: 30s
-            retries: 5
-            start_period: 45s
-            timeout: 30s
 networks:
     mgmnt-app:
 volumes:

--- a/src/server/user-sync.test.ts
+++ b/src/server/user-sync.test.ts
@@ -40,6 +40,27 @@ describe('syncUserToDatabase', () => {
         expect(user.lastName).toBe('User')
     })
 
+    it('should create new user when metadataUserId is set but matches no existing user', async () => {
+        const attrs = {
+            clerkId: faker.string.alpha(10),
+            firstName: 'Test',
+            lastName: 'User',
+            email: faker.internet.email({ provider: 'test.com' }),
+            metadataUserId: faker.string.uuid(),
+        }
+
+        const result = await db.transaction().execute(async (trx) => {
+            return syncUserToDatabase(attrs, trx)
+        })
+
+        expect(result.id).toBeDefined()
+        expect(result.id).not.toBe(attrs.metadataUserId)
+
+        const user = await db.selectFrom('user').selectAll('user').where('id', '=', result.id).executeTakeFirstOrThrow()
+        expect(user.clerkId).toBe(attrs.clerkId)
+        expect(user.email).toBe(attrs.email)
+    })
+
     it('should update existing user when clerkId exists', async () => {
         const org = await insertTestOrg()
         const { user: existingUser } = await insertTestUser({ org })

--- a/src/server/user-sync.ts
+++ b/src/server/user-sync.ts
@@ -122,7 +122,16 @@ export async function syncUserToDatabase(attrs: UserSyncAttrs, executor: DBExecu
     }
 
     // Create the new user
-    const user = await executor.insertInto('user').values(attrs).returning(['id']).executeTakeFirstOrThrow()
+    const user = await executor
+        .insertInto('user')
+        .values({
+            clerkId: attrs.clerkId,
+            firstName: attrs.firstName,
+            lastName: attrs.lastName,
+            email: attrs.email,
+        })
+        .returning(['id'])
+        .executeTakeFirstOrThrow()
 
     return {
         id: user.id,


### PR DESCRIPTION
Two fixes needed to boot a fresh environment in Docker.

## 1. pnpm purge no longer prompts

Without this you occasionally get launch errors like:

```
mgmnt-app | Scope: all 2 workspace projects
mgmnt-app | [ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY] Aborted removal of modules directory due to no TTY
mgmnt-app |
mgmnt-app | If you are running pnpm in CI, set the CI environment variable to "true", or set "confirmModulesPurge" to "false".
mgmnt-app exited with code 1
```

## 2. User sync no longer references a non-existent column

On a fresh DB, the first login hit:

```
kysely:error: error: column "metadata_user_id" of relation "user" does not exist
```

The create-user path in `syncUserToDatabase` spread the full `attrs` object into `insertInto('user')`. `attrs` carries a transient `metadataUserId` field (used only for the non-prod lookup), which Kysely turned into a `metadata_user_id` column in the INSERT. Existing users hit the update branches that `.set()` explicit columns, so only the fresh-create path was broken. Fix inserts the real columns only, and adds a test covering the `metadataUserId`-set-but-no-match case.