### PR TITLE
OTTER-556 follow-up: fix gaps in tests and code

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
         "@types/react": "19.2.14",
         "@vitejs/plugin-react": "^5.1.4",
         "aws-sdk-client-mock": "^4.1.0",
-        "concurrently": "^9.2.1",
+        "concurrently": "^10.0.3",
         "dotenv": "*",
         "esbuild": "^0.27.7",
         "eslint": "^9.39.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,8 +283,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       concurrently:
-        specifier: ^9.2.1
-        version: 9.2.1
+        specifier: ^10.0.3
+        version: 10.0.3
       dotenv:
         specifier: '*'
         version: 17.4.2
@@ -3116,6 +3116,10 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   child_process@1.0.2:
     resolution: {integrity: sha512-Wmza/JzL0SiWz7kl6MhIKT5ceIlnFPJX+lwUGj7Clhy5MMldsSoJR0+uvRzOS5Kv45Mq7t1PoE8TsOA9bzvb6g==}
 
@@ -3157,9 +3161,9 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
-  cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -3200,9 +3204,9 @@ packages:
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
-  concurrently@9.2.1:
-    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
-    engines: {node: '>=18'}
+  concurrently@10.0.3:
+    resolution: {integrity: sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==}
+    engines: {node: '>=22'}
     hasBin: true
 
   confbox@0.2.4:
@@ -5338,10 +5342,6 @@ packages:
   remeda@2.34.1:
     resolution: {integrity: sha512-k5iIF3lHm2NQ+2bNGDvZTD5jZl/JZkCS6AQOfGjYBd7V4rbb3K5whHvab0/O7CqPI43vYzbnIVCQXQJqmOyI6w==}
 
-  require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
-
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -5465,8 +5465,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   si-encryption@https://codeload.github.com/safeinsights/encryption/tar.gz/2e35d3bb56f02bfc0e6d5cd9d83c54637ed0ac20:
@@ -5657,6 +5657,10 @@ packages:
         optional: true
       babel-plugin-macros:
         optional: true
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -6153,10 +6157,6 @@ packages:
     resolution: {integrity: sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==}
     engines: {node: '>=12.17'}
 
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
-
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
@@ -6213,13 +6213,13 @@ packages:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
 
-  yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
-  yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
-    engines: {node: '>=12'}
+  yargs@18.0.0:
+    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yjs@13.6.30:
     resolution: {integrity: sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==}
@@ -9451,6 +9451,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
   child_process@1.0.2: {}
 
   chokidar@4.0.3:
@@ -9489,11 +9491,11 @@ snapshots:
 
   client-only@0.0.1: {}
 
-  cliui@8.0.1:
+  cliui@9.0.1:
     dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
 
   clsx@2.1.1: {}
 
@@ -9522,14 +9524,14 @@ snapshots:
 
   commondir@1.0.1: {}
 
-  concurrently@9.2.1:
+  concurrently@10.0.3:
     dependencies:
-      chalk: 4.1.2
+      chalk: 5.6.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
-      supports-color: 8.1.1
+      shell-quote: 1.8.4
+      supports-color: 10.2.2
       tree-kill: 1.2.2
-      yargs: 17.7.2
+      yargs: 18.0.0
 
   confbox@0.2.4: {}
 
@@ -11731,8 +11733,6 @@ snapshots:
 
   remeda@2.34.1: {}
 
-  require-directory@2.1.1: {}
-
   require-from-string@2.0.2: {}
 
   require-in-the-middle@8.0.1:
@@ -11959,7 +11959,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   si-encryption@https://codeload.github.com/safeinsights/encryption/tar.gz/2e35d3bb56f02bfc0e6d5cd9d83c54637ed0ac20:
     dependencies:
@@ -12178,6 +12178,8 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@babel/core': 7.29.0
+
+  supports-color@10.2.2: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -12667,12 +12669,6 @@ snapshots:
 
   wordwrapjs@5.1.1: {}
 
-  wrap-ansi@7.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
   wrap-ansi@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
@@ -12704,17 +12700,16 @@ snapshots:
 
   yargs-parser@20.2.9: {}
 
-  yargs-parser@21.1.1: {}
+  yargs-parser@22.0.0: {}
 
-  yargs@17.7.2:
+  yargs@18.0.0:
     dependencies:
-      cliui: 8.0.1
+      cliui: 9.0.1
       escalade: 3.2.0
       get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
+      string-width: 7.2.0
       y18n: 5.0.8
-      yargs-parser: 21.1.1
+      yargs-parser: 22.0.0
 
   yjs@13.6.30:
     dependencies:

--- a/src/app/[orgSlug]/study/[studyId]/view/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/page.test.tsx
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest'
 import * as RouterMock from 'next-router-mock'
 import {
     insertTestBaselineJob,
-    insertTestOrg,
     insertTestStudyJobData,
     insertTestStudyOnly,
     mockSessionWithTestData,
@@ -13,7 +12,7 @@ import {
     faker,
 } from '@/tests/unit.helpers'
 import { db } from '@/database'
-import type { StudyJobStatus, StudyStatus } from '@/database/types'
+import type { StudyJobStatus } from '@/database/types'
 import StudyReviewPage from './page'
 import { CodePostDecisionView } from './code-post-decision-view'
 import { CodePostSubmissionView } from './code-post-submission-view'
@@ -187,47 +186,6 @@ describe('StudyViewPage', () => {
             .insertInto('jobStatusChange')
             .values({ status, studyJobId: job.id, createdAt: new Date(base + 1000) })
             .execute()
-    }
-
-    const setupCrossOrgSubmittedCode = async ({
-        studyStatus = 'APPROVED',
-        jobStatus = 'CODE-SUBMITTED',
-    }: {
-        studyStatus?: StudyStatus
-        jobStatus?: StudyJobStatus
-    } = {}) => {
-        const enclave = await insertTestOrg({ slug: faker.string.alpha(10), type: 'enclave' })
-        const { org: lab, user } = await mockSessionWithTestData({ orgSlug: faker.string.alpha(10), orgType: 'lab' })
-        const submittedAt = studyStatus === 'DRAFT' ? null : new Date()
-        const study = await db
-            .insertInto('study')
-            .values({
-                orgId: enclave.id,
-                submittedByOrgId: lab.id,
-                containerLocation: 'test-container',
-                title: 'cross-org code review study',
-                researcherId: user.id,
-                piName: 'test',
-                status: studyStatus,
-                submittedAt,
-                dataSources: ['all'],
-                outputMimeType: 'application/zip',
-                language: 'R',
-            })
-            .returningAll()
-            .executeTakeFirstOrThrow()
-
-        const job = await db
-            .insertInto('studyJob')
-            .values({ studyId: study.id })
-            .returning('id')
-            .executeTakeFirstOrThrow()
-        await db
-            .insertInto('jobStatusChange')
-            .values({ status: jobStatus, studyJobId: job.id, userId: user.id })
-            .execute()
-
-        return { enclave, lab, study, job, user }
     }
 
     describe('post-code-submission', () => {
@@ -523,13 +481,19 @@ describe('StudyViewPage', () => {
             expect(reopen?.props.latestJobStatus).toBe('CODE-CHANGES-REQUESTED')
         })
 
-        it('replays the production lab/enclave split and keeps the RL resubmit CTA after a late scan', async () => {
-            const { lab, study } = await setupCrossOrgSubmittedCode()
+        it('keeps the resubmit CTA on the decision page after a late scan (CODE-CHANGES-REQUESTED)', async () => {
+            const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+            const { study } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'APPROVED',
+                jobStatus: 'CODE-SUBMITTED',
+            })
             await addJobStatus(study.id, 'CODE-CHANGES-REQUESTED')
             await addJobStatus(study.id, 'CODE-SCANNED')
 
             const page = await StudyReviewPage({
-                params: Promise.resolve({ orgSlug: lab.slug, studyId: study.id }),
+                params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
                 searchParams: defaultSearchParams,
             })
 

--- a/src/app/[orgSlug]/study/[studyId]/view/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/page.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import * as RouterMock from 'next-router-mock'
 import {
     insertTestBaselineJob,
+    insertTestOrg,
     insertTestStudyJobData,
     insertTestStudyOnly,
     mockSessionWithTestData,
@@ -12,6 +13,7 @@ import {
     faker,
 } from '@/tests/unit.helpers'
 import { db } from '@/database'
+import type { StudyJobStatus, StudyStatus } from '@/database/types'
 import StudyReviewPage from './page'
 import { CodePostDecisionView } from './code-post-decision-view'
 import { CodePostSubmissionView } from './code-post-submission-view'
@@ -167,22 +169,7 @@ describe('StudyViewPage', () => {
         ).rejects.toThrow()
     })
 
-    const addJobStatus = async (
-        studyId: string,
-        status:
-            | 'CODE-SCANNED'
-            | 'CODE-APPROVED'
-            | 'CODE-CHANGES-REQUESTED'
-            | 'CODE-REJECTED'
-            | 'JOB-PROVISIONING'
-            | 'JOB-PACKAGING'
-            | 'JOB-READY'
-            | 'JOB-RUNNING'
-            | 'RUN-COMPLETE'
-            | 'FILES-APPROVED'
-            | 'FILES-REJECTED'
-            | 'JOB-ERRORED',
-    ) => {
+    const addJobStatus = async (studyId: string, status: StudyJobStatus) => {
         const job = await db
             .selectFrom('studyJob')
             .select('id')
@@ -200,6 +187,47 @@ describe('StudyViewPage', () => {
             .insertInto('jobStatusChange')
             .values({ status, studyJobId: job.id, createdAt: new Date(base + 1000) })
             .execute()
+    }
+
+    const setupCrossOrgSubmittedCode = async ({
+        studyStatus = 'APPROVED',
+        jobStatus = 'CODE-SUBMITTED',
+    }: {
+        studyStatus?: StudyStatus
+        jobStatus?: StudyJobStatus
+    } = {}) => {
+        const enclave = await insertTestOrg({ slug: faker.string.alpha(10), type: 'enclave' })
+        const { org: lab, user } = await mockSessionWithTestData({ orgSlug: faker.string.alpha(10), orgType: 'lab' })
+        const submittedAt = studyStatus === 'DRAFT' ? null : new Date()
+        const study = await db
+            .insertInto('study')
+            .values({
+                orgId: enclave.id,
+                submittedByOrgId: lab.id,
+                containerLocation: 'test-container',
+                title: 'cross-org code review study',
+                researcherId: user.id,
+                piName: 'test',
+                status: studyStatus,
+                submittedAt,
+                dataSources: ['all'],
+                outputMimeType: 'application/zip',
+                language: 'R',
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        const job = await db
+            .insertInto('studyJob')
+            .values({ studyId: study.id })
+            .returning('id')
+            .executeTakeFirstOrThrow()
+        await db
+            .insertInto('jobStatusChange')
+            .values({ status: jobStatus, studyJobId: job.id, userId: user.id })
+            .execute()
+
+        return { enclave, lab, study, job, user }
     }
 
     describe('post-code-submission', () => {
@@ -430,6 +458,107 @@ describe('StudyViewPage', () => {
             expect(page?.type).toBe(CodePostDecisionView)
             expect(page?.props.latestJobStatus).toBe('CODE-APPROVED')
             expect(page?.props.showStudyCode).toBe(false)
+        })
+    })
+
+    describe('late CODE-SCANNED after a code decision (OTTER-556 reopen dead-end)', () => {
+        // The scan result is an async webhook (job-scan-results/route.ts). When a reviewer records a
+        // decision before the scan finishes, CODE-SCANNED is appended *after* the decision with a
+        // later createdAt and becomes the job's latest status. Routing must derive the decision
+        // order-independently (it stays live until a real resubmission); otherwise the researcher
+        // lands on CodePostSubmissionView with no way to resubmit — the dead end QA re-reported in
+        // OTTER-556 comment 43432 ("open once correct, reopen wrong").
+        it.each(['CODE-CHANGES-REQUESTED', 'CODE-REJECTED', 'CODE-APPROVED'] as const)(
+            'keeps CodePostDecisionView for %s when a late CODE-SCANNED lands after the decision',
+            async (decision) => {
+                const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+                // All three code-review decisions leave the study at APPROVED (the proposal was
+                // approved; only the job carries the code decision — OTTER-603). A routing
+                // fall-through here resolves to the wrong post-submission/proposal flow.
+                const { study } = await insertTestStudyJobData({
+                    org,
+                    researcherId: user.id,
+                    studyStatus: 'APPROVED',
+                    jobStatus: 'CODE-SUBMITTED',
+                })
+                await addJobStatus(study.id, decision)
+                await addJobStatus(study.id, 'CODE-SCANNED')
+
+                const page = await StudyReviewPage({
+                    params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+                    searchParams: defaultSearchParams,
+                })
+
+                expect(page?.type).toBe(CodePostDecisionView)
+                expect(page?.props.latestJobStatus).toBe(decision)
+            },
+        )
+
+        it('still shows the decision page on reopen after a late scan (OTTER-556 comment 43432)', async () => {
+            const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+            const { study } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'APPROVED',
+                jobStatus: 'CODE-SUBMITTED',
+            })
+            await addJobStatus(study.id, 'CODE-CHANGES-REQUESTED')
+
+            // First open, before the scan webhook arrives: the decision page renders correctly.
+            const firstOpen = await StudyReviewPage({
+                params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+                searchParams: defaultSearchParams,
+            })
+            expect(firstOpen?.type).toBe(CodePostDecisionView)
+
+            // The async scan completes and appends CODE-SCANNED after the decision.
+            await addJobStatus(study.id, 'CODE-SCANNED')
+
+            // Reopen / refresh: must still land on the decision page, not the under-review page.
+            const reopen = await StudyReviewPage({
+                params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+                searchParams: defaultSearchParams,
+            })
+            expect(reopen?.type).toBe(CodePostDecisionView)
+            expect(reopen?.props.latestJobStatus).toBe('CODE-CHANGES-REQUESTED')
+        })
+
+        it('replays the production lab/enclave split and keeps the RL resubmit CTA after a late scan', async () => {
+            const { lab, study } = await setupCrossOrgSubmittedCode()
+            await addJobStatus(study.id, 'CODE-CHANGES-REQUESTED')
+            await addJobStatus(study.id, 'CODE-SCANNED')
+
+            const page = await StudyReviewPage({
+                params: Promise.resolve({ orgSlug: lab.slug, studyId: study.id }),
+                searchParams: defaultSearchParams,
+            })
+
+            expect(page?.type).toBe(CodePostDecisionView)
+            expect(page?.props.latestJobStatus).toBe('CODE-CHANGES-REQUESTED')
+
+            renderWithProviders(page!)
+            expect(screen.getByTestId('cta-edit-and-resubmit')).toHaveTextContent('Edit and resubmit')
+        })
+
+        it('returns to CodePostSubmissionView when the round is resubmitted after changes requested', async () => {
+            const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+            const { study } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'PENDING-REVIEW',
+                jobStatus: 'CODE-SUBMITTED',
+            })
+            // Legacy same-job resubmission shape: a new CODE-SUBMITTED after the decision reopens
+            // review, so the decision is no longer live and the under-review page is correct.
+            await addJobStatus(study.id, 'CODE-CHANGES-REQUESTED')
+            await addJobStatus(study.id, 'CODE-SUBMITTED')
+
+            const page = await StudyReviewPage({
+                params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+                searchParams: defaultSearchParams,
+            })
+
+            expect(page?.type).toBe(CodePostSubmissionView)
         })
     })
 

--- a/src/app/[orgSlug]/study/[studyId]/view/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/page.test.tsx
@@ -548,8 +548,8 @@ describe('StudyViewPage', () => {
                 studyStatus: 'PENDING-REVIEW',
                 jobStatus: 'CODE-SUBMITTED',
             })
-            // Legacy same-job resubmission shape: a new CODE-SUBMITTED after the decision reopens
-            // review, so the decision is no longer live and the under-review page is correct.
+            // Historical same-job resubmission shape: a new CODE-SUBMITTED after the decision
+            // reopens review, so the decision is no longer live and the under-review page is correct.
             await addJobStatus(study.id, 'CODE-CHANGES-REQUESTED')
             await addJobStatus(study.id, 'CODE-SUBMITTED')
 

--- a/src/app/[orgSlug]/study/[studyId]/view/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/page.tsx
@@ -10,9 +10,9 @@ import { actionResult } from '@/lib/utils'
 import {
     type CodeDecisionStatus,
     hasJobStatus,
-    isCodeDecisionStatus,
     isCodeUnderReviewStatus,
     isStudyResultsStatus,
+    latestSubmittedJobLiveCodeDecisionStatus,
     STUDY_CODE_RUNNING_JOB_STATUSES,
 } from '@/lib/study-job-status'
 import { isSubmittedStudy } from '@/schema/study'
@@ -54,14 +54,13 @@ export default async function StudyReviewPage(props: {
         // Effective code-decision status for the redesigned decision page. The execution window
         // (JOB-PROVISIONING/PACKAGING/READY/RUNNING) and an approved-but-late CODE-SCANNED both
         // resolve to CODE-APPROVED, keeping the researcher on the Code-approved page until results exist.
+        const liveDecisionStatus = latestSubmittedJobLiveCodeDecisionStatus(job.statusChanges)
         const decisionStatus: CodeDecisionStatus | null = hasJobStatus(job.statusChanges, [
             'CODE-APPROVED',
             ...STUDY_CODE_RUNNING_JOB_STATUSES,
         ])
             ? 'CODE-APPROVED'
-            : isCodeDecisionStatus(latestJobStatus)
-              ? latestJobStatus
-              : null
+            : liveDecisionStatus
 
         // RL "Previous" from the results-stage Study Details page returns here with ?from=code-submission.
         // Render the OTTER-537 post-submission page explicitly, with the "code under review" banner hidden

--- a/src/lib/study-job-status.test.ts
+++ b/src/lib/study-job-status.test.ts
@@ -101,8 +101,8 @@ describe('latestSubmittedJobLiveCodeDecisionStatus', () => {
     })
 
     it('returns a decision once a resubmission is itself decided', () => {
-        // Route data is ordered newest-first by jobStatusChange.createdAt/id. With two same-job
-        // legacy rounds, the first decision in that ordered list is the live round's decision.
+        // Route data is ordered newest-first by jobStatusChange.createdAt/id. In a historical
+        // same-job history, the first decision in that ordered list is the live round's decision.
         expect(
             latestSubmittedJobLiveCodeDecisionStatus(
                 changes('CODE-APPROVED', 'CODE-SUBMITTED', 'CODE-CHANGES-REQUESTED', 'CODE-SUBMITTED'),

--- a/src/lib/study-job-status.test.ts
+++ b/src/lib/study-job-status.test.ts
@@ -101,8 +101,12 @@ describe('latestSubmittedJobLiveCodeDecisionStatus', () => {
     })
 
     it('returns a decision once a resubmission is itself decided', () => {
-        // Route data is ordered newest-first by jobStatusChange.createdAt/id. In a historical
-        // same-job history, the first decision in that ordered list is the live round's decision.
+        // The only case that genuinely exercises .find()'s position-dependence: two *different*
+        // decisions in one history. The "regardless of array order" test above has a single
+        // decision, so it cannot prove this path. Route data is ordered newest-first by
+        // jobStatusChange.createdAt/id, so the first decision in that list is the live round's.
+        // In page.tsx this exact combo never reaches here: the hasJobStatus(['CODE-APPROVED', ...])
+        // short-circuit picks CODE-APPROVED before this function is consulted.
         expect(
             latestSubmittedJobLiveCodeDecisionStatus(
                 changes('CODE-APPROVED', 'CODE-SUBMITTED', 'CODE-CHANGES-REQUESTED', 'CODE-SUBMITTED'),

--- a/src/lib/study-job-status.test.ts
+++ b/src/lib/study-job-status.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import type { StudyJobStatus } from '@/database/types'
-import { latestSubmittedJobHasLiveCodeDecision } from './study-job-status'
+import { latestSubmittedJobHasLiveCodeDecision, latestSubmittedJobLiveCodeDecisionStatus } from './study-job-status'
 
 const changes = (...statuses: StudyJobStatus[]) => statuses.map((status) => ({ status }))
 
@@ -50,5 +50,63 @@ describe('latestSubmittedJobHasLiveCodeDecision', () => {
         expect(latestSubmittedJobHasLiveCodeDecision(changes('CODE-SUBMITTED', 'CODE-SCANNED', 'CODE-APPROVED'))).toBe(
             true,
         )
+    })
+})
+
+describe('latestSubmittedJobLiveCodeDecisionStatus', () => {
+    it('returns null before any decision', () => {
+        expect(latestSubmittedJobLiveCodeDecisionStatus(changes('CODE-SUBMITTED'))).toBeNull()
+        expect(latestSubmittedJobLiveCodeDecisionStatus(changes('CODE-SUBMITTED', 'CODE-SCANNED'))).toBeNull()
+        expect(latestSubmittedJobLiveCodeDecisionStatus([])).toBeNull()
+    })
+
+    it.each(['CODE-APPROVED', 'CODE-CHANGES-REQUESTED', 'CODE-REJECTED'] as const)(
+        'returns %s when the decision follows a submission',
+        (decision) => {
+            expect(latestSubmittedJobLiveCodeDecisionStatus(changes('CODE-SUBMITTED', decision))).toBe(decision)
+        },
+    )
+
+    // OTTER-556 dead-end: the scan result is an async webhook (job-scan-results/route.ts) that can
+    // land *after* the decision, appending CODE-SCANNED as the job's latest status. CODE-SCANNED is
+    // scan metadata, not a new submission, so the decision must still be reported.
+    it.each(['CODE-APPROVED', 'CODE-CHANGES-REQUESTED', 'CODE-REJECTED'] as const)(
+        'returns %s when a late CODE-SCANNED lands after the decision',
+        (decision) => {
+            expect(latestSubmittedJobLiveCodeDecisionStatus(changes('CODE-SUBMITTED', decision, 'CODE-SCANNED'))).toBe(
+                decision,
+            )
+        },
+    )
+
+    // Order-independent: a decision written in the same transaction as a sibling status ties on
+    // createdAt, so it can appear anywhere in the array. The reported decision must not depend on
+    // position (mirrors the latestSubmittedJobHasLiveCodeDecision tie tests).
+    it.each(['CODE-APPROVED', 'CODE-CHANGES-REQUESTED', 'CODE-REJECTED'] as const)(
+        'returns %s regardless of array order',
+        (decision) => {
+            expect(latestSubmittedJobLiveCodeDecisionStatus(changes('CODE-SCANNED', decision, 'CODE-SUBMITTED'))).toBe(
+                decision,
+            )
+        },
+    )
+
+    it('returns null once a resubmission adds an un-decided CODE-SUBMITTED', () => {
+        // Round 1 decided (changes requested), round 2 resubmitted and awaiting review: no live decision.
+        expect(
+            latestSubmittedJobLiveCodeDecisionStatus(
+                changes('CODE-SUBMITTED', 'CODE-CHANGES-REQUESTED', 'CODE-SUBMITTED'),
+            ),
+        ).toBeNull()
+    })
+
+    it('returns a decision once a resubmission is itself decided', () => {
+        // Route data is ordered newest-first by jobStatusChange.createdAt/id. With two same-job
+        // legacy rounds, the first decision in that ordered list is the live round's decision.
+        expect(
+            latestSubmittedJobLiveCodeDecisionStatus(
+                changes('CODE-APPROVED', 'CODE-SUBMITTED', 'CODE-CHANGES-REQUESTED', 'CODE-SUBMITTED'),
+            ),
+        ).toBe('CODE-APPROVED')
     })
 })

--- a/src/lib/study-job-status.ts
+++ b/src/lib/study-job-status.ts
@@ -72,3 +72,24 @@ export const latestSubmittedJobHasLiveCodeDecision = (
     const decisionCount = statusChanges.filter((s) => isCodeDecisionStatus(s.status)).length
     return decisionCount > 0 && decisionCount >= submittedCount
 }
+
+// OTTER-556 follow-up: the live code-review decision on the latest submitted job
+// (CODE-APPROVED / CODE-CHANGES-REQUESTED / CODE-REJECTED), or null when none is live.
+// The researcher's /view routing needs the actual decision (not just the boolean from
+// latestSubmittedJobHasLiveCodeDecision) and must not treat CODE-SCANNED as a new
+// submission. A late CODE-SCANNED webhook can append after the decision and become the
+// job's latest status (job-scan-results/route.ts), which would otherwise mask the decision
+// and dead-end the researcher on the under-review page when they reopen the study.
+//
+// When multiple legacy same-job rounds exist, callers pass statusChanges in newest-first DB
+// order so the first decision in the live decided history is the current round's decision.
+export const latestSubmittedJobLiveCodeDecisionStatus = (
+    statusChanges: ReadonlyArray<{ status: StudyJobStatus }>,
+): CodeDecisionStatus | null => {
+    if (!latestSubmittedJobHasLiveCodeDecision(statusChanges)) {
+        return null
+    }
+
+    const decision = statusChanges.find((s): s is { status: CodeDecisionStatus } => isCodeDecisionStatus(s.status))
+    return decision?.status ?? null
+}

--- a/src/lib/study-job-status.ts
+++ b/src/lib/study-job-status.ts
@@ -60,11 +60,11 @@ export const isCodeDecisionStatus = (status: StudyJobStatus | undefined): status
 //
 // Each review round is CODE-SUBMITTED → (decision). Counting is order-independent: when at
 // least as many decisions as submissions exist, the latest submission has been decided and the
-// DO belongs on the post-feedback page. A resubmission adds a CODE-SUBMITTED with no following
-// decision — either on a brand-new job (the current resubmission model, where this job is no
-// longer the latest submitted job) or appended to the same job (legacy) — tipping the count
-// back so the DO returns to active review. CODE-SCANNED is an automated step between submit and
-// decision, not a fresh submission, so it is excluded from the submitted count.
+// DO belongs on the post-feedback page. Current resubmissions open a brand-new job, but the
+// count also handles historical/defensive same-job histories where a new CODE-SUBMITTED with
+// no following decision tips the count back so the DO returns to active review. CODE-SCANNED is
+// an automated step between submit and decision, not a fresh submission, so it is excluded from
+// the submitted count.
 export const latestSubmittedJobHasLiveCodeDecision = (
     statusChanges: ReadonlyArray<{ status: StudyJobStatus }>,
 ): boolean => {
@@ -81,8 +81,8 @@ export const latestSubmittedJobHasLiveCodeDecision = (
 // job's latest status (job-scan-results/route.ts), which would otherwise mask the decision
 // and dead-end the researcher on the under-review page when they reopen the study.
 //
-// When multiple legacy same-job rounds exist, callers pass statusChanges in newest-first DB
-// order so the first decision in the live decided history is the current round's decision.
+// For historical/defensive same-job rounds, callers pass statusChanges in newest-first DB order
+// so the first decision in the live decided history is the current round's decision.
 export const latestSubmittedJobLiveCodeDecisionStatus = (
     statusChanges: ReadonlyArray<{ status: StudyJobStatus }>,
 ): CodeDecisionStatus | null => {

--- a/src/lib/study-job-status.ts
+++ b/src/lib/study-job-status.ts
@@ -81,8 +81,12 @@ export const latestSubmittedJobHasLiveCodeDecision = (
 // job's latest status (job-scan-results/route.ts), which would otherwise mask the decision
 // and dead-end the researcher on the under-review page when they reopen the study.
 //
-// For historical/defensive same-job rounds, callers pass statusChanges in newest-first DB order
-// so the first decision in the live decided history is the current round's decision.
+// Whether a decision is live is order-independent (the count gate above); which decision to
+// return uses .find() (first decision in array order). That is safe: two decisions only tie on
+// createdAt when written in one transaction, and a single review round writes exactly one
+// decision, so a tie never spans two different decisions. A history with two *different*
+// decisions comes from separate rounds (separate transactions), so callers passing statusChanges
+// in newest-first DB order get the current round's decision first.
 export const latestSubmittedJobLiveCodeDecisionStatus = (
     statusChanges: ReadonlyArray<{ status: StudyJobStatus }>,
 ): CodeDecisionStatus | null => {


### PR DESCRIPTION
see [OTTER-556 comments](https://openstax.atlassian.net/browse/OTTER-556?focusedCommentId=43559)

Issue: after a reviewer requested code changes or rejected/approved code, the async scanner could still append a later CODE-SCANNED status. Because the researcher /view page trusted the latest status too directly, reopening the study could send the researcher back to the under-review/submission page instead of the decision page.

This branch fixes that by deriving the live code decision from the full submitted-job status history, so late scan results no longer mask reviewer decisions. It also adds tests for the reopen case, all code decision outcomes, lab routing, and resubmission behavior.

- Keeps researchers on the code decision page when a late scan result arrives after review feedback.
- Preserves the existing approved-and-running flow until study results are available.
- Adds coverage for reopen behavior, all code decision outcomes, and production-like lab routing.
- Adds shared decision-status coverage for late scans, tied status ordering, and resubmission cases.
- Clarifies that same-job resubmission handling is defensive historical compatibility.
- Bumps concurrently to ^10.0.3 to clear a security advisory (includes the corresponding pnpm-lock.yaml update).