### PR TITLE
Fix code review reopening after scan completes on a decided round

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   picomatch: ^4.0.4
   postcss: ^8.5.10
   uuid: ^14.0.0
+  shell-quote: ^1.8.4
 
 importers:
 
@@ -5465,8 +5466,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   si-encryption@https://codeload.github.com/safeinsights/encryption/tar.gz/2e35d3bb56f02bfc0e6d5cd9d83c54637ed0ac20:
@@ -9526,7 +9527,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -11959,7 +11960,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   si-encryption@https://codeload.github.com/safeinsights/encryption/tar.gz/2e35d3bb56f02bfc0e6d5cd9d83c54637ed0ac20:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,3 +19,4 @@ overrides:
     picomatch: ^4.0.4
     postcss: ^8.5.10
     uuid: ^14.0.0
+    shell-quote: ^1.8.4

--- a/src/app/api/services/job-scan-results/route.test.ts
+++ b/src/app/api/services/job-scan-results/route.test.ts
@@ -146,6 +146,28 @@ test.skipIf(!s3Available)('stores encrypted and plaintext logs on CODE-SCANNED',
     expect(files.some((f) => f.fileType === 'SECURITY-SCAN-LOG')).toBe(true)
 })
 
+// The scanner's start webhook can echo CODE-SUBMITTED after a reviewer has already decided the
+// round. That late echo must not append a second CODE-SUBMITTED, which would reopen active review.
+test('drops a late CODE-SUBMITTED once the round has been decided', async () => {
+    const { org, user } = await mockSessionWithTestData()
+    const { jobIds } = await insertTestStudyData({ org, researcherId: user.id })
+    const jobId = jobIds[0]
+
+    await db
+        .insertInto('jobStatusChange')
+        .values([
+            { studyJobId: jobId, status: 'CODE-SUBMITTED', userId: user.id },
+            { studyJobId: jobId, status: 'CODE-CHANGES-REQUESTED', userId: user.id },
+        ])
+        .execute()
+
+    const resp = await apiHandler.POST(authedRequest({ jobId, status: 'CODE-SUBMITTED' }))
+    expect(resp.ok).toBe(true)
+
+    const rows = await getJobStatusRows(jobId)
+    expect(rows.filter((r) => r.status === 'CODE-SUBMITTED').length).toBe(1)
+})
+
 test('idempotency: duplicate same-status calls do not create duplicate rows', async () => {
     const { org, user } = await mockSessionWithTestData()
     const { jobIds } = await insertTestStudyData({ org, researcherId: user.id })

--- a/src/app/api/services/job-scan-results/route.ts
+++ b/src/app/api/services/job-scan-results/route.ts
@@ -54,6 +54,22 @@ export const POST = createWebhookHandler({
             )
         }
 
+        // A job has exactly one real CODE-SUBMITTED, recorded at upload time before the scan is
+        // triggered. The scanner may still echo a CODE-SUBMITTED on start; if that echo lands after
+        // a reviewer has already decided the round it would tip latestSubmittedJobHasLiveCodeDecision
+        // back to "no live decision" and reopen active review. Drop any duplicate CODE-SUBMITTED so
+        // the invariant holds regardless of webhook timing or scanner version.
+        if (body.status === 'CODE-SUBMITTED') {
+            const existing = await db
+                .selectFrom('jobStatusChange')
+                .select('id')
+                .where('studyJobId', '=', job.jobId)
+                .where('status', '=', 'CODE-SUBMITTED')
+                .limit(1)
+                .executeTakeFirst()
+            if (existing) return
+        }
+
         const last = await db
             .selectFrom('jobStatusChange')
             .select(['status'])

--- a/src/server/aws.test.ts
+++ b/src/server/aws.test.ts
@@ -130,10 +130,6 @@ describe('buildTriggerScanForStudyJobCommandInput', () => {
             { name: 'WEBHOOK_SECRET', value: 'mock-webhook-secret' },
             { name: 'WEBHOOK_ENDPOINT', value: '/api/services/job-scan-results' },
             {
-                name: 'ON_START_PAYLOAD',
-                value: JSON.stringify({ jobId: info.studyJobId, status: 'CODE-SUBMITTED' }),
-            },
-            {
                 name: 'ON_SUCCESS_PAYLOAD',
                 value: JSON.stringify({ jobId: info.studyJobId, status: 'CODE-SCANNED' }),
             },
@@ -149,6 +145,10 @@ describe('buildTriggerScanForStudyJobCommandInput', () => {
 
         expect(input.environmentVariablesOverride).toEqual(expect.arrayContaining(expectedEnvVars))
         expect(input.environmentVariablesOverride.length).toBe(expectedEnvVars.length)
+
+        // The scan must NOT post a status on start: a CODE-SUBMITTED echo here would reopen a
+        // round that a reviewer may have already decided. See buildTriggerScanForStudyJobCommandInput.
+        expect(input.environmentVariablesOverride.some((v) => v.name === 'ON_START_PAYLOAD')).toBe(false)
     })
 })
 

--- a/src/server/aws.ts
+++ b/src/server/aws.ts
@@ -500,7 +500,10 @@ export async function buildTriggerScanForStudyJobCommandInput(info: MinimalJobIn
     return {
         projectName: process.env.SCANNER_PROJECT_NAME || `MgmntAppScanner-${ENVIRONMENT_ID}`,
         environmentVariablesOverride: await buildCodeBuildEnvVars('/api/services/job-scan-results', {
-            ON_START_PAYLOAD: { jobId: info.studyJobId, status: 'CODE-SUBMITTED' },
+            // No ON_START_PAYLOAD: a scan-start webhook would re-post CODE-SUBMITTED onto the job,
+            // and if the scan's start hook lands after a reviewer has already decided the round
+            // (e.g. requested changes) the spurious CODE-SUBMITTED reopens active review. The real
+            // submission is recorded at upload time; the scanner only needs to report completion.
             ON_SUCCESS_PAYLOAD: { jobId: info.studyJobId, status: 'CODE-SCANNED' },
             ON_FAILURE_PAYLOAD: { jobId: info.studyJobId, status: 'JOB-ERRORED' },
             SCAN_MODE: 'source',


### PR DESCRIPTION
## Problem

A reviewer requests changes on a study's code *before* the security scan finishes. They correctly land on the post-feedback page ("You have requested changes…"). Later, once the scan completes, clicking **View** flips them to the active resubmission page ("Review study code v2.0 / has resubmitted") even though the researcher never resubmitted.

## Root cause

The source-scan CodeBuild job posts a `CODE-SUBMITTED` webhook on start (`ON_START`). When that start webhook lands *after* a reviewer has already decided the round, the spurious `CODE-SUBMITTED` gets appended to the job. That tips `latestSubmittedJobHasLiveCodeDecision` (submittedCount=2 vs decisionCount=1) back to "no live decision", so the `/review` page falls through from `PostFeedbackView` to the active `CodeReview` resubmission view.

Confirmed in the DB for the affected study: a phantom `CODE-SUBMITTED` written ~32s before `CODE-SCANNED`, after the `CODE-CHANGES-REQUESTED` row.

## Fix

Guard the `job-scan-results` webhook route so a second `CODE-SUBMITTED` is never appended when the job already has one. A job has exactly one real `CODE-SUBMITTED`, recorded at upload time before the scan is triggered — so any later echo is a duplicate and is dropped.

This fixes the bug at the layer where the bad data is written, so it holds regardless of webhook timing or scanner version, and **does not depend on an IaC deploy landing first** (per @therealmarv's review). It also hardens the "one real submission per job" invariant that `latestSubmittedJobHasLiveCodeDecision` relies on.

As defense-in-depth (not load-bearing), the scan trigger no longer emits `ON_START_PAYLOAD` (`aws.ts`). The matching IaC change to make `ON_START_PAYLOAD` optional in the scanner can now land on its own schedule rather than being a hard merge gate.

## Note

This prevents new occurrences. Studies already carrying the phantom `CODE-SUBMITTED` row are not retroactively fixed by this change.

## Tests

- `route.test.ts`: new case asserting a late `CODE-SUBMITTED` is dropped once the round has been decided.
- Updated `aws.test.ts` to drop the `ON_START_PAYLOAD` expectation.
- `aws.test.ts` and `route.test.ts` pass; typecheck + lint clean.
