### PR TITLE
Prune redundant pnpm overrides, keep only the ones still needed

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,15 +7,8 @@ settings:
 overrides:
   '@types/react': 19.2.14
   minimatch: ^10.2.1
-  fast-xml-parser: ^5.7.0
-  serialize-javascript: ^7.0.3
-  express-rate-limit: ^8.2.2
-  flatted: ^3.4.0
-  nodemailer: ^8.0.4
   picomatch: ^4.0.4
   postcss: ^8.5.10
-  uuid: ^14.0.0
-  shell-quote: ^1.8.4
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,12 +11,5 @@ minimumReleaseAge: 2880
 overrides:
     '@types/react': 19.2.14
     minimatch: ^10.2.1
-    fast-xml-parser: ^5.7.0
-    serialize-javascript: ^7.0.3
-    express-rate-limit: ^8.2.2
-    flatted: ^3.4.0
-    nodemailer: ^8.0.4
     picomatch: ^4.0.4
     postcss: ^8.5.10
-    uuid: ^14.0.0
-    shell-quote: ^1.8.4


### PR DESCRIPTION
## What

Audited every entry in the `pnpm-workspace.yaml` `overrides` block to validate which pins are still doing work. Removed the 7 that are no longer needed, kept the 4 that still are. `pnpm audit` stays clean (0 vulnerabilities) before and after.

## Method

`pnpm audit` is clean **with** the overrides applied, which hides whether each override is still necessary. To test each one, I regenerated the lockfile from scratch with the `overrides` block removed (respecting `minimumReleaseAge`, never lowered) and re-audited. An override is "still necessary" only if removing it reintroduces an advisory or drops a package below a safe floor.

With all overrides removed, only **one** advisory reappears (`postcss`), and two packages (`minimatch`, `picomatch`) revert legacy sub-trees to lower majors. Everything else resolves safely on its own.

## Per-override verdict

| Override | Floor | Resolve without override | Verdict |
|---|---|---|---|
| `postcss` | `^8.5.10` | `8.4.31` (pinned by `next@16.2.6`) -> **GHSA-qx2v-qp2m-jg93 XSS** | keep (security) |
| `minimatch` | `^10.2.1` | reverts `glob@7.1.6` + some eslint internals to `3.1.5` | keep (avoid legacy-major split) |
| `picomatch` | `^4.0.4` | reverts `micromatch@4.0.8` to `2.3.2` | keep (avoid legacy-major split) |
| `@types/react` | `19.2.14` (exact) | `19.2.14` | keep (React type-dedup pin, not security) |
| `shell-quote` | `^1.8.4` | `1.8.4` (`concurrently@10.0.3` now requires it) | removed (redundant) |
| `fast-xml-parser` | `^5.7.0` | `5.7.3` | removed (redundant) |
| `express-rate-limit` | `^8.2.2` | `8.5.2` | removed (redundant) |
| `flatted` | `^3.4.0` | `3.4.2` | removed (redundant) |
| `nodemailer` | `^8.0.4` | `8.0.7` | removed (redundant) |
| `uuid` | `^14.0.0` | `14.0.0` (single instance, direct dep) | removed (redundant) |
| `serialize-javascript` | `^7.0.3` | **absent from the tree entirely** | removed (dead override, nothing to pin) |

Notably `serialize-javascript` is no longer pulled in by anything, so its override was pinning a package that isn't even installed.

## Result

- `pnpm audit`: **0 vulnerabilities** (info/low/moderate/high/critical all 0), unchanged from before.
- `pnpm-workspace.yaml`: overrides block trimmed from 11 entries to 4 (`@types/react`, `minimatch`, `picomatch`, `postcss`).
- `pnpm-lock.yaml`: embedded override block trimmed to match. With `minimatch`/`picomatch` kept, **no package versions move** and there is **zero transitive churn**, the lockfile diff is exactly the 7 removed override lines.

## Scope / caveats

- Verdicts are judged strictly against the current `pnpm audit` advisory DB, as requested. A removed pin could in principle regress if a dependent later widens its range to include a vulnerable version, that is the trade-off of dropping a defensive pin; none are vulnerable today.
- `@types/react` is a type-stability pin, not a security fix; kept as-is.
- GitHub Dependabot uses a separate advisory DB and reports pre-existing alerts on `main` that are out of scope for this PR; this change does not affect the `pnpm audit`-clean status.
