### PR TITLE
fix tests: fix flaky resubmit tests by draining deferred code scan/copy

### DIFF
--- a/src/server/actions/study-request.test.ts
+++ b/src/server/actions/study-request.test.ts
@@ -31,6 +31,7 @@ import {
 import { purgeProposalYjsDocsBeforeAt } from '@/server/db/yjs-cleanup'
 import { ensureRoundJobForLaunch, ensureRoundJobForUpload } from '@/server/db/mutations'
 import { lexicalJson } from '@/lib/lexical'
+import { flushDeferred } from '@/tests/vitest.setup'
 
 vi.mock('@/server/aws', async () => {
     const actual = await vi.importActual('@/server/aws')
@@ -860,6 +861,10 @@ describe('Request Study Actions', () => {
 
             await ensureRoundJobForLaunch(db, study.id)
             await submitCode(study.id, root, { 'main.R': 'round1' }, 'main.R')
+            // The submit fires a deferred CODE-SCANNED insert; drain it before recording the reviewer's
+            // CODE-CHANGES-REQUESTED so the time-ordered v7 ids reflect that real-world order (scan, then
+            // decision). Otherwise the scan can race in afterwards and become the "latest" status.
+            await flushDeferred()
             const round1Job = await db
                 .selectFrom('studyJob')
                 .select('id')
@@ -895,6 +900,10 @@ describe('Request Study Actions', () => {
 
             await ensureRoundJobForLaunch(db, study.id)
             await submitCode(study.id, root, { 'main.R': 'round1' }, 'main.R')
+            // The submit fires a deferred CODE-SCANNED insert; drain it before recording the reviewer's
+            // CODE-CHANGES-REQUESTED so the time-ordered v7 ids reflect that real-world order (scan, then
+            // decision). Otherwise the scan can race in afterwards and become the "latest" status.
+            await flushDeferred()
             const round1Job = await db
                 .selectFrom('studyJob')
                 .select('id')

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -51,6 +51,18 @@ mockState.setRunWithLocalStorage((cb) => {
     localStorageContext.run({ db: undefined as never }, cb)
 })
 
+// Drain the deferred callbacks scheduled so far (the `after()` work the harness collects), so a test
+// can force fire-and-forget side effects to land before continuing. Single-level by design: snapshot
+// then clear before awaiting, so callbacks scheduled *during* the drain stay queued for afterEach
+// rather than being dropped. Use when a later step depends on a deferred side effect having committed
+// (e.g. a deferred CODE-SCANNED insert must land before the test records the next status change, or
+// the time-ordered v7 ids invert and queries reading the "latest" status see the wrong row).
+export async function flushDeferred() {
+    const toRun = mockState.pendingDeferredCallbacks.slice()
+    mockState.pendingDeferredCallbacks.length = 0
+    await Promise.allSettled(toRun)
+}
+
 // vi.mock calls must live at the module top level. Vitest hoists them above imports,
 // so any values referenced by a factory must come from vi.hoisted instead of ordinary
 // module-scope declarations.

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -57,6 +57,11 @@ mockState.setRunWithLocalStorage((cb) => {
 // rather than being dropped. Use when a later step depends on a deferred side effect having committed
 // (e.g. a deferred CODE-SCANNED insert must land before the test records the next status change, or
 // the time-ordered v7 ids invert and queries reading the "latest" status see the wrong row).
+//
+// Relies on an invariant: the `after()` mock (`runDeferredTestCallback`) invokes the callback
+// synchronously and pushes the in-flight promise onto `pendingDeferredCallbacks` before `await
+// submitCode(...)` returns. If that collection ever became async (e.g. queued on a microtask before
+// pushing), `flushDeferred()` could snapshot an empty array and silently no-op, reintroducing the race.
 export async function flushDeferred() {
     const toRun = mockState.pendingDeferredCallbacks.slice()
     mockState.pendingDeferredCallbacks.length = 0


### PR DESCRIPTION
## Description

Two resubmit tests have been failing intermittently on my local machine, especially on a clean run, while passing on CI and on reruns. This fixes the timing race behind that flakiness.

- Fixes two study resubmission tests that failed intermittently due to a background timing race.
- The tests now wait for a study's background code scan to finish before recording the reviewer's decision, matching the real-world order of events.
- Adds a small reusable test helper that lets a test force pending background work to complete before continuing.

Notes:
- It is a test-only race, no product code changed. The background scan could sometimes record its status after the reviewer decision, making the app see the wrong "latest" status and the resubmit guard wrongly block.
- The fix also hardens a second sibling test that had the same latent race but happened to pass.