### PR TITLE
Scan failure should set CODE-SCANNED, not JOB-ERRORED

### DIFF
--- a/src/server/aws.test.ts
+++ b/src/server/aws.test.ts
@@ -134,8 +134,10 @@ describe('buildTriggerScanForStudyJobCommandInput', () => {
                 value: JSON.stringify({ jobId: info.studyJobId, status: 'CODE-SCANNED' }),
             },
             {
+                // A failed source scan posts CODE-SCANNED, not JOB-ERRORED: the scan is advisory and
+                // a human reviewer decides. See buildTriggerScanForStudyJobCommandInput.
                 name: 'ON_FAILURE_PAYLOAD',
-                value: JSON.stringify({ jobId: info.studyJobId, status: 'JOB-ERRORED' }),
+                value: JSON.stringify({ jobId: info.studyJobId, status: 'CODE-SCANNED' }),
             },
             { name: 'SCAN_MODE', value: 'source' },
             { name: 'STUDY_JOB_ID', value: info.studyJobId },

--- a/src/server/aws.ts
+++ b/src/server/aws.ts
@@ -504,8 +504,14 @@ export async function buildTriggerScanForStudyJobCommandInput(info: MinimalJobIn
             // and if the scan's start hook lands after a reviewer has already decided the round
             // (e.g. requested changes) the spurious CODE-SUBMITTED reopens active review. The real
             // submission is recorded at upload time; the scanner only needs to report completion.
+            //
+            // A failed scan posts CODE-SCANNED too, not JOB-ERRORED. The source scan is advisory:
+            // finding issues means the code reaches the reviewer with the scan log attached so a
+            // human makes the call. JOB-ERRORED is a terminal results-stage status (it routes the
+            // job to the post-run results UI), so erroring the job on a scan finding both ends the
+            // review round prematurely and lands it on a page that assumes a run already happened.
             ON_SUCCESS_PAYLOAD: { jobId: info.studyJobId, status: 'CODE-SCANNED' },
-            ON_FAILURE_PAYLOAD: { jobId: info.studyJobId, status: 'JOB-ERRORED' },
+            ON_FAILURE_PAYLOAD: { jobId: info.studyJobId, status: 'CODE-SCANNED' },
             SCAN_MODE: 'source',
             STUDY_JOB_ID: info.studyJobId,
             S3_PATH: pathForStudyJobCode(info),


### PR DESCRIPTION
## Problem

When the source security scan fails (finds issues), CodeBuild's `ON_FAILURE` webhook posts `JOB-ERRORED`. But `JOB-ERRORED` is a terminal results-stage status — it's in `STUDY_RESULTS_JOB_STATUSES`, so it routes the job into the post-run results UI. A scan finding therefore ends the code-review round prematurely and lands the user on a page that assumes a run already happened.

The source scan is advisory: a failed scan should still reach a human reviewer (with the scan log attached) so they make the call.

## Fix

`ON_FAILURE_PAYLOAD` now posts `CODE-SCANNED` (same as success) instead of `JOB-ERRORED`. This writes the correct status at the source — the same approach as #789 — so the scan only ever reports completion and the reviewer decides.

The scan log is still stored: posting `CODE-SCANNED` records it as a `SECURITY-SCAN-LOG` (which is what a scan-failure log is), rather than the `PACKAGING-ERROR-LOG` it was mislabeled as under `JOB-ERRORED`.

## Tests

- `aws.test.ts`: updated the `ON_FAILURE_PAYLOAD` expectation to `CODE-SCANNED`.
- `aws.test.ts` and `route.test.ts` pass; typecheck + lint clean.