### PR TITLE
Sign full starter-code S3 key in getStarterCodeInfoAction (OTTER-369)

### DIFF
--- a/src/server/actions/workspaces.actions.test.ts
+++ b/src/server/actions/workspaces.actions.test.ts
@@ -3,11 +3,22 @@ import {
     actionResult,
     insertTestBaselineJob,
     insertTestStudyJobData,
+    insertTestCodeEnv,
     db,
 } from '@/tests/unit.helpers'
 import { describe, expect, test, afterEach, beforeEach, vi } from 'vitest'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
+import { pathForStarterCode } from '@/lib/paths'
+
+// Echo the key back so a test can assert which S3 key gets signed.
+vi.mock('@/server/aws', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@/server/aws')>()
+    return {
+        ...actual,
+        signedUrlForFile: vi.fn(async (key: string) => `https://signed.example/${key}`),
+    }
+})
 
 // Mock dependencies moved to doMock in beforeEach
 
@@ -95,6 +106,39 @@ describe('Workspace Actions', () => {
         expect(result.files).toHaveLength(3) // main.py, README.md, data.csv
         expect(result.files[0]).toHaveProperty('size')
         expect(result.files[0]).toHaveProperty('mtime')
+    })
+
+    describe('getStarterCodeInfoAction', () => {
+        test('signs the full starter-code key, not the bare file name', async () => {
+            const { org, user } = await mockSessionWithTestData()
+            const { study } = await insertTestStudyJobData({ org, researcherId: user.id, language: 'R' })
+            const codeEnv = await insertTestCodeEnv({
+                orgId: org.id,
+                language: 'R',
+                starterCodeFileNames: ['main.R'],
+            })
+
+            const { getStarterCodeInfoAction } = await import('./workspaces.actions')
+            const result = actionResult(await getStarterCodeInfoAction({ studyId: study.id }))
+
+            const expectedKey = pathForStarterCode({ orgSlug: org.slug, codeEnvId: codeEnv.id, fileName: 'main.R' })
+            expect(result.starterFiles).toHaveLength(1)
+            expect(result.starterFiles[0].name).toBe('main.R')
+            expect(result.starterFiles[0].url).toContain(expectedKey)
+            // the original bug signed the bare name as the key, which resolves to the bucket root
+            expect(result.starterFiles[0].url).not.toBe('https://signed.example/main.R')
+        })
+
+        test('returns no starter files when the code env has none', async () => {
+            const { org, user } = await mockSessionWithTestData()
+            const { study } = await insertTestStudyJobData({ org, researcherId: user.id, language: 'R' })
+            await insertTestCodeEnv({ orgId: org.id, language: 'R', starterCodeFileNames: [] })
+
+            const { getStarterCodeInfoAction } = await import('./workspaces.actions')
+            const result = actionResult(await getStarterCodeInfoAction({ studyId: study.id }))
+
+            expect(result.starterFiles).toEqual([])
+        })
     })
 
     // OTTER-601: the submit-enable baseline must be the last *submission* time, not the round job's

--- a/src/server/actions/workspaces.actions.ts
+++ b/src/server/actions/workspaces.actions.ts
@@ -124,11 +124,15 @@ export const getStarterCodeInfoAction = new Action('getStarterCodeInfoAction', {
         if (fileNames.length === 0) return { starterFiles: [] }
 
         const { signedUrlForFile } = await import('@/server/aws')
-        const { basename } = await import('@/lib/paths')
+        const { pathForStarterCode } = await import('@/lib/paths')
+        // starterCodeFileNames holds bare names, not S3 keys — sign the key the upload actually wrote to.
         const starterFiles = await Promise.all(
-            fileNames.map(async (filePath: string) => ({
-                name: basename(filePath),
-                url: await signedUrlForFile(filePath),
+            fileNames.map(async (fileName: string) => ({
+                name: fileName,
+                url: await signedUrlForFile(
+                    pathForStarterCode({ orgSlug: codeEnv.slug, codeEnvId: codeEnv.id, fileName }),
+                    { ResponseContentDisposition: 'inline' },
+                ),
             })),
         )
         return { starterFiles }


### PR DESCRIPTION
**Bug:** Researcher "Starter code" link 404'd with S3 `NoSuchKey`.

**Cause:** `getStarterCodeInfoAction` passed the bare filename from `starterCodeFileNames` straight to `signedUrlForFile`, signing `main.R` at the bucket root. Since the `multi_starter_code` migration that column holds bare names, not full keys — the files actually live at `code-env/<org>/<envId>/starter-code/<file>`. Re-uploading never helped because the read path was requesting the wrong key.

**Fix:** Wrap the filename in `pathForStarterCode({ orgSlug, codeEnvId, fileName })` before signing, so it resolves to the same key the upload wrote to (the sibling `getStarterCodeUrlAction` already does this). Also pass `ResponseContentDisposition: 'inline'` so the file opens in-tab instead of downloading.

**Tests:** Added coverage for `getStarterCodeInfoAction` — full-key signing + the empty-starter case. Needs local Postgres: `pnpm test:unit src/server/actions/workspaces.actions.test.ts`.