### PR TITLE
fix RL study-code-view

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.test.tsx
@@ -215,31 +215,31 @@ describe('CodePostDecisionView', () => {
         })
     })
 
-    describe('study code viewer', () => {
-        it('starts collapsed and toggles to "Hide submitted study code" with body visible', async () => {
+    describe('submitted code table', () => {
+        it('starts collapsed and toggles to "Hide submitted study code", rendering the file table', async () => {
             const { study, job, latestJobStatus } = await setupDecidedStudy('CODE-APPROVED')
             renderView(study, job, [buildEntry({ decision: 'APPROVE' })], latestJobStatus)
 
-            expect(screen.getByTestId('study-code-viewer')).toBeInTheDocument()
-            expect(screen.queryByTestId('study-code-body')).not.toBeInTheDocument()
-
             const toggle = screen.getByTestId('study-code-toggle')
             expect(toggle).toHaveTextContent('View submitted study code')
+            expect(toggle).toHaveAttribute('aria-expanded', 'false')
 
             const interact = userEvent.setup()
             await interact.click(toggle)
 
-            await waitFor(() => expect(screen.getByTestId('study-code-body')).toBeInTheDocument())
-            expect(toggle).toHaveTextContent('Hide submitted study code')
+            await waitFor(() => expect(toggle).toHaveTextContent('Hide submitted study code'))
+            expect(toggle).toHaveAttribute('aria-expanded', 'true')
+            expect(screen.getByTestId('submitted-code-table')).toBeInTheDocument()
         })
     })
 
     describe('study code visibility', () => {
-        it('hides the study code viewer during the execution window (showStudyCode=false)', async () => {
+        it('hides the submitted code table during the execution window (showStudyCode=false)', async () => {
             const { study, job, latestJobStatus } = await setupDecidedStudy('CODE-APPROVED')
             renderView(study, job, [buildEntry({ decision: 'APPROVE' })], latestJobStatus, { showStudyCode: false })
 
-            expect(screen.queryByTestId('study-code-viewer')).not.toBeInTheDocument()
+            expect(screen.queryByTestId('submitted-code-table')).not.toBeInTheDocument()
+            expect(screen.queryByTestId('study-code-toggle')).not.toBeInTheDocument()
             // The approved/running banner still renders so the page reads as "running / results pending".
             expect(screen.getByTestId('decision-banner-code-approved')).toBeInTheDocument()
         })

--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.tsx
@@ -1,25 +1,24 @@
 'use client'
 
-import type { FC, ReactNode } from 'react'
+import { useCallback, useState, type FC, type ReactNode } from 'react'
 import type { Route } from 'next'
-import { Box, Group, Stack, Text, Title } from '@mantine/core'
-import { CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
+import { Anchor, Box, Collapse, Group, Stack, Text, Title } from '@mantine/core'
+import { CaretLeftIcon, CaretRightIcon } from '@phosphor-icons/react/dist/ssr'
 import { AlertNotFound } from '@/components/errors'
 import { ButtonLink } from '@/components/links'
 import { PageBreadcrumbs } from '@/components/page-breadcrumbs'
 import { FeedbackAndNotesSection } from '@/components/study/feedback-and-notes'
 import { ProposalStepHeader } from '@/components/study/proposal-step-header'
-import {
-    StudyCodeViewer,
-    type StudyCodeToggleLabels,
-} from '@/app/[orgSlug]/study/[studyId]/review/submitted-code-interactive'
-import { filterAndOrderCodeFiles, type CodeFile } from '@/app/[orgSlug]/study/[studyId]/review/study-code-files'
+import { SubmittedCodeTable } from '@/components/study/submitted-code-table'
+import { filterAndOrderCodeFiles } from '@/app/[orgSlug]/study/[studyId]/review/study-code-files'
 import { displayOrgName } from '@/lib/string'
 import { Routes } from '@/lib/routes'
 import { type Submitted } from '@/schema/study'
 import type { CodeReviewFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
 import type { LatestJobForStudy } from '@/server/db/queries'
 import { type CodeDecisionStatus } from '@/lib/study-job-status'
+
+type CodeFileList = LatestJobForStudy['files']
 
 interface CodePostDecisionViewProps {
     orgSlug: string
@@ -43,11 +42,6 @@ type DecisionCopy = {
     bannerBg: string
     bannerTestId: string
     banner: (orgName: string) => string
-}
-
-const STUDY_CODE_TOGGLE_LABELS: StudyCodeToggleLabels = {
-    expand: 'View submitted study code',
-    collapse: 'Hide submitted study code',
 }
 
 const DECISION_COPY: Record<CodeDecisionStatus, DecisionCopy> = {
@@ -154,19 +148,44 @@ const FeedbackSection: FC<{ feedbackLoadError: boolean; entries: CodeReviewFeedb
     return <FeedbackAndNotesSection entries={entries} />
 }
 
-const StudyCodeSection: FC<{ isVisible: boolean; jobId: string; codeFiles: CodeFile[] }> = ({
+function useExpandable(initial = false) {
+    const [expanded, setExpanded] = useState(initial)
+    const toggle = useCallback(() => setExpanded((prev) => !prev), [])
+    return { expanded, toggle }
+}
+
+const StudyCodeToggle: FC<{ expanded: boolean; onClick: () => void }> = ({ expanded, onClick }) => (
+    <Anchor
+        component="button"
+        type="button"
+        size="sm"
+        fw={700}
+        onClick={onClick}
+        display="inline-flex"
+        w="fit-content"
+        style={{ alignItems: 'center', gap: 4 }}
+        aria-expanded={expanded}
+        data-testid="study-code-toggle"
+    >
+        {expanded ? 'Hide submitted study code' : 'View submitted study code'}
+        <CaretRightIcon size={12} weight="bold" style={{ transform: expanded ? 'rotate(90deg)' : undefined }} />
+    </Anchor>
+)
+
+const StudyCodeSection: FC<{ isVisible: boolean; jobId: string; codeFiles: CodeFileList }> = ({
     isVisible,
     jobId,
     codeFiles,
 }) => {
+    const { expanded, toggle } = useExpandable()
     if (!isVisible) return null
     return (
-        <StudyCodeViewer
-            studyJobId={jobId}
-            files={codeFiles}
-            initialExpanded={false}
-            toggleLabels={STUDY_CODE_TOGGLE_LABELS}
-        />
+        <Stack gap="sm">
+            <StudyCodeToggle expanded={expanded} onClick={toggle} />
+            <Collapse in={expanded}>
+                <SubmittedCodeTable jobId={jobId} files={codeFiles} />
+            </Collapse>
+        </Stack>
     )
 }
 
@@ -175,7 +194,7 @@ type StepCardProps = {
     job: LatestJobForStudy
     copy: DecisionCopy
     timestampDate: Date | string | null
-    codeFiles: CodeFile[]
+    codeFiles: CodeFileList
     banner: ReactNode
     showStudyCode: boolean
 }

--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useCallback, useState, type FC, type ReactNode } from 'react'
+import { type FC, type ReactNode } from 'react'
 import type { Route } from 'next'
-import { Anchor, Box, Collapse, Group, Stack, Text, Title } from '@mantine/core'
-import { CaretLeftIcon, CaretRightIcon } from '@phosphor-icons/react/dist/ssr'
+import { Box, Collapse, Group, Stack, Text, Title } from '@mantine/core'
+import { CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
 import { AlertNotFound } from '@/components/errors'
 import { ButtonLink } from '@/components/links'
 import { PageBreadcrumbs } from '@/components/page-breadcrumbs'
@@ -11,6 +11,7 @@ import { FeedbackAndNotesSection } from '@/components/study/feedback-and-notes'
 import { ProposalStepHeader } from '@/components/study/proposal-step-header'
 import { SubmittedCodeTable } from '@/components/study/submitted-code-table'
 import { filterAndOrderCodeFiles } from '@/app/[orgSlug]/study/[studyId]/review/study-code-files'
+import { StudyCodeToggle, useExpandable } from './study-code-collapse'
 import { displayOrgName } from '@/lib/string'
 import { Routes } from '@/lib/routes'
 import { type Submitted } from '@/schema/study'
@@ -147,30 +148,6 @@ const FeedbackSection: FC<{ feedbackLoadError: boolean; entries: CodeReviewFeedb
     }
     return <FeedbackAndNotesSection entries={entries} />
 }
-
-function useExpandable(initial = false) {
-    const [expanded, setExpanded] = useState(initial)
-    const toggle = useCallback(() => setExpanded((prev) => !prev), [])
-    return { expanded, toggle }
-}
-
-const StudyCodeToggle: FC<{ expanded: boolean; onClick: () => void }> = ({ expanded, onClick }) => (
-    <Anchor
-        component="button"
-        type="button"
-        size="sm"
-        fw={700}
-        onClick={onClick}
-        display="inline-flex"
-        w="fit-content"
-        style={{ alignItems: 'center', gap: 4 }}
-        aria-expanded={expanded}
-        data-testid="study-code-toggle"
-    >
-        {expanded ? 'Hide submitted study code' : 'View submitted study code'}
-        <CaretRightIcon size={12} weight="bold" style={{ transform: expanded ? 'rotate(90deg)' : undefined }} />
-    </Anchor>
-)
 
 const StudyCodeSection: FC<{ isVisible: boolean; jobId: string; codeFiles: CodeFileList }> = ({
     isVisible,

--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useState, type FC } from 'react'
+import { type FC } from 'react'
 import { Alert, Anchor, Collapse, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
 import { CaretRightIcon, CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
 import dayjs from 'dayjs'
@@ -14,6 +14,7 @@ import { FeedbackAndNotesSection } from '@/components/study/feedback-and-notes'
 import type { LatestJobForStudy } from '@/server/db/queries'
 import type { CodeReviewFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
 import { filterAndOrderCodeFiles } from '@/app/[orgSlug]/study/[studyId]/review/study-code-files'
+import { StudyCodeToggle, useExpandable } from './study-code-collapse'
 
 type CodeFileList = LatestJobForStudy['files']
 
@@ -28,13 +29,6 @@ interface CodePostSubmissionViewProps {
     /** Reviewer feedback + resubmission notes for v2+. */
     feedbackEntries?: CodeReviewFeedbackEntry[]
     isUnderReview?: boolean
-}
-
-function useExpandable(initial = false) {
-    const [expanded, setExpanded] = useState(initial)
-    const toggle = useCallback(() => setExpanded((prev) => !prev), [])
-    const collapse = useCallback(() => setExpanded(false), [])
-    return { expanded, toggle, collapse }
 }
 
 const getCodeSubmittedDate = (job: LatestJobForStudy): string | null => {
@@ -83,30 +77,6 @@ const ExpandToggle: FC<{ isVisible: boolean; onClick: () => void }> = ({ isVisib
         >
             View full study code
             <CaretRightIcon size={12} />
-        </Anchor>
-    )
-}
-
-const InlineToggle: FC<{ isVisible: boolean; expanded: boolean; onClick: () => void }> = ({
-    isVisible,
-    expanded,
-    onClick,
-}) => {
-    if (!isVisible) return null
-    return (
-        <Anchor
-            component="button"
-            size="sm"
-            fw={700}
-            onClick={onClick}
-            mt="md"
-            display="inline-flex"
-            style={{ alignItems: 'center', gap: 4 }}
-            aria-expanded={expanded}
-            data-testid="study-code-toggle"
-        >
-            {expanded ? 'Hide submitted study code' : 'View submitted study code'}
-            <CaretRightIcon size={12} weight="bold" style={{ transform: expanded ? 'rotate(-90deg)' : undefined }} />
         </Anchor>
     )
 }
@@ -236,7 +206,7 @@ export function CodePostSubmissionView({
                         isResubmission={isResubmission}
                     />
                     <ExpandToggle isVisible={!isResubmission && !expanded} onClick={toggle} />
-                    <InlineToggle isVisible={isResubmission} expanded={expanded} onClick={toggle} />
+                    <StudyCodeToggle isVisible={isResubmission} expanded={expanded} onClick={toggle} mt="md" />
                     <InlineCodePanel isVisible={isResubmission} expanded={expanded} jobId={job.id} files={codeFiles} />
                 </Paper>
 

--- a/src/app/[orgSlug]/study/[studyId]/view/study-code-collapse.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/study-code-collapse.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useCallback, useState, type FC } from 'react'
+import { Anchor, type MantineSpacing } from '@mantine/core'
+import { CaretRightIcon } from '@phosphor-icons/react/dist/ssr'
+
+export function useExpandable(initial = false) {
+    const [expanded, setExpanded] = useState(initial)
+    const toggle = useCallback(() => setExpanded((prev) => !prev), [])
+    const collapse = useCallback(() => setExpanded(false), [])
+    return { expanded, toggle, collapse }
+}
+
+interface StudyCodeToggleProps {
+    expanded: boolean
+    onClick: () => void
+    isVisible?: boolean
+    mt?: MantineSpacing
+}
+
+export const StudyCodeToggle: FC<StudyCodeToggleProps> = ({ expanded, onClick, isVisible = true, mt }) => {
+    if (!isVisible) return null
+    return (
+        <Anchor
+            component="button"
+            type="button"
+            size="sm"
+            fw={700}
+            onClick={onClick}
+            mt={mt}
+            display="inline-flex"
+            w="fit-content"
+            style={{ alignItems: 'center', gap: 4 }}
+            aria-expanded={expanded}
+            data-testid="study-code-toggle"
+        >
+            {expanded ? 'Hide submitted study code' : 'View submitted study code'}
+            <CaretRightIcon size={12} weight="bold" style={{ transform: expanded ? 'rotate(-90deg)' : undefined }} />
+        </Anchor>
+    )
+}


### PR DESCRIPTION
## Summary

**Issue**: [OTTER-590](https://openstax.atlassian.net/browse/OTTER-590)

When a Researcher Lead (RL) views a study whose code is in the `CODE-CHANGES-REQUESTED` state, the post-decision page rendered the code listing using `StudyCodeViewer` — the reviewer's interactive, tabbed code reader — instead of `SubmittedCodeTable`, the file table with preview/download actions used elsewhere in the researcher flow.

Root cause: `CODE-CHANGES-REQUESTED` is correctly treated as a code *decision*, so the page routes to `CodePostDecisionView`. That view hard-coded its code listing to `StudyCodeViewer`. The routing is right (the changes-requested banner, reviewer feedback section, and "Edit and resubmit" button all live in `CodePostDecisionView`) — only the code-listing widget was wrong.

This PR swaps that widget to `SubmittedCodeTable` for **all** researcher-facing decision states (approved, changes-requested, rejected), so the RL consistently sees their code as the familiar preview/download table. `StudyCodeViewer` remains in use only on the reviewer (DO) side.

## Changes

- **`code-post-decision-view.tsx`**
  - Replaced the `StudyCodeViewer` listing in `StudyCodeSection` with a collapsible `SubmittedCodeTable`, reusing the `useExpandable` + Mantine `Collapse` + toggle pattern from `code-post-submission-view.tsx`.
  - Preserved the existing UX: collapsed by default, "View / Hide submitted study code" toggle labels (`data-testid="study-code-toggle"`), and the `showStudyCode` execution-window gating.
  - Corrected the `codeFiles` prop type to the full `LatestJobForStudy['files']` row type (what `SubmittedCodeTable` requires), and removed the now-unused `StudyCodeViewer` / `CodeFile` / toggle-label imports.
- **`code-post-decision-view.test.tsx`**
  - Updated the code-listing assertions to target `submitted-code-table` (via the toggle's `aria-expanded`) instead of `study-code-viewer` / `study-code-body`.
  - The execution-window test now asserts the table and toggle are both absent when `showStudyCode={false}`.

Routing is unchanged — `page.test.tsx` still asserts `CodePostDecisionView` renders for `CODE-CHANGES-REQUESTED`.

## Before / After

| Before | After |
| --- | --- |
| <img width="1539" height="999" alt="Screenshot 2026-06-10 at 7 44 05 AM" src="https://github.com/user-attachments/assets/3811d0f2-9f4e-443f-bc19-a07b0fdc3a0f" />| <img width="1620" height="744" alt="Screenshot 2026-06-10 at 7 44 39 AM" src="https://github.com/user-attachments/assets/cf3854e3-2b05-4e78-bd84-e1410b233878" /> |

### Manual verification

As an RL, open a study whose job is `CODE-CHANGES-REQUESTED` and confirm the page shows:
- the purple "changes requested" banner,
- the reviewer feedback section,
- the "Edit and resubmit" button, and
- the **SubmittedCodeTable** (file rows with preview/download) behind the "View submitted study code" toggle.

[OTTER-590]: https://openstax.atlassian.net/browse/OTTER-590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ