### PR TITLE
show AI Summary snippet

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-interactive.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-interactive.tsx
@@ -36,10 +36,17 @@ function useAiSummaryToggle() {
     return { isExpanded, toggle: () => setIsExpanded((v) => !v) }
 }
 
-function AiSummaryBody({ isVisible, summary }: { isVisible: boolean; summary: string }) {
-    if (!isVisible) return null
+// Collapsed, the body shows a 3-line preview of the summary; expanded shows it in full.
+const AI_SUMMARY_COLLAPSED_LINE_CLAMP = 3
+
+function AiSummaryBody({ isExpanded, summary }: { isExpanded: boolean; summary: string }) {
     return (
-        <Text size="sm" data-testid="ai-summary-body" style={{ whiteSpace: 'pre-wrap' }}>
+        <Text
+            size="sm"
+            data-testid="ai-summary-body"
+            lineClamp={isExpanded ? undefined : AI_SUMMARY_COLLAPSED_LINE_CLAMP}
+            style={{ whiteSpace: 'pre-wrap' }}
+        >
             {summary}
         </Text>
     )
@@ -123,7 +130,7 @@ type AiSummaryContentProps = { summary: string; isExpanded: boolean; onToggle: (
 function AiSummaryContent({ summary, isExpanded, onToggle }: AiSummaryContentProps) {
     return (
         <>
-            <AiSummaryBody isVisible={isExpanded} summary={summary} />
+            <AiSummaryBody isExpanded={isExpanded} summary={summary} />
             <AiSummaryToggle isExpanded={isExpanded} onToggle={onToggle} />
         </>
     )

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
@@ -188,29 +188,33 @@ describe('SubmittedCodeSection — AI summary', () => {
         expect(screen.getByText('Overview')).toBeInTheDocument()
     })
 
-    it('renders the toggle with "View full AI summary" by default and the body is collapsed', async () => {
+    it('renders the toggle with "View full AI summary" by default and shows a clamped snippet', async () => {
         await renderSection(fixture)
         expect(screen.getByTestId('ai-summary-toggle')).toHaveTextContent('View full AI summary')
-        expect(screen.queryByTestId('ai-summary-body')).not.toBeInTheDocument()
+        const body = screen.getByTestId('ai-summary-body')
+        expect(body).toHaveTextContent(SUMMARY_TEXT)
+        expect(body.style.getPropertyValue('--text-line-clamp')).toBe('3')
     })
 
-    it('expands the body and flips the toggle label when clicked', async () => {
+    it('expands the body to full text and flips the toggle label when clicked', async () => {
         await renderSection(fixture)
         const user = userEvent.setup()
         await user.click(screen.getByTestId('ai-summary-toggle'))
 
-        expect(screen.getByTestId('ai-summary-body')).toHaveTextContent(SUMMARY_TEXT)
+        const body = screen.getByTestId('ai-summary-body')
+        expect(body).toHaveTextContent(SUMMARY_TEXT)
+        expect(body.style.getPropertyValue('--text-line-clamp')).toBe('')
         expect(screen.getByTestId('ai-summary-toggle')).toHaveTextContent('Hide full AI summary')
     })
 
-    it('collapses the body again when the toggle is clicked twice', async () => {
+    it('collapses back to the clamped snippet when the toggle is clicked twice', async () => {
         await renderSection(fixture)
         const user = userEvent.setup()
         const toggle = screen.getByTestId('ai-summary-toggle')
         await user.click(toggle)
         await user.click(toggle)
 
-        expect(screen.queryByTestId('ai-summary-body')).not.toBeInTheDocument()
+        expect(screen.getByTestId('ai-summary-body').style.getPropertyValue('--text-line-clamp')).toBe('3')
         expect(toggle).toHaveTextContent('View full AI summary')
     })
 


### PR DESCRIPTION
## Summary

Issue: [OTTER-604](https://openstax.atlassian.net/browse/OTTER-604)

On the DO (Data Organization) study proposal / code review page, the **AI Summary** container hid its body entirely when collapsed — below the "Overview" subtitle reviewers saw only the "View full AI summary" toggle, with no preview of the content.

This change keeps a **3-line snippet** of the summary visible under "Overview" when collapsed, so reviewers get a preview at a glance without having to expand.

### Changes

- **`submitted-code-interactive.tsx`** — `AiSummaryBody` no longer returns `null` when collapsed. It always renders the summary text and clamps it to 3 lines while collapsed via Mantine's `lineClamp` prop (`lineClamp={isExpanded ? undefined : 3}`), following the existing pattern in `feedback-and-notes.tsx`. Expanding shows the full text; collapsing returns to the 3-line snippet. The toggle and its labels are unchanged.
- **`submitted-code-section.test.tsx`** — Updated the two collapsed-state tests that previously asserted the body was absent. They now assert the body is present and clamped, checking the inline CSS variable Mantine emits (`--text-line-clamp` = `3` when collapsed, empty when expanded).

### Behavior

| State | Before | After |
|-------|--------|-------|
| Collapsed | Nothing below "Overview" | 3-line clamped snippet + "View full AI summary" |
| Expanded | Full summary | Full summary (unchanged) |

[OTTER-604]: https://openstax.atlassian.net/browse/OTTER-604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ