### PR TITLE
Update term Sample data term to Example Data

### DIFF
--- a/src/app/[orgSlug]/admin/settings/code-env-form.tsx
+++ b/src/app/[orgSlug]/admin/settings/code-env-form.tsx
@@ -331,7 +331,7 @@ export function CodeEnvForm({ image, onCompleteAction }: CodeEnvFormProps) {
                 <Divider />
                 <Box>
                     <Title order={5} mb={4}>
-                        Sample Data
+                        Example Data
                     </Title>
                     <Text size="xs" c="dimmed" mb="sm">
                         Files available to researchers when they develop in Coder
@@ -344,11 +344,11 @@ export function CodeEnvForm({ image, onCompleteAction }: CodeEnvFormProps) {
                             {...form.getInputProps('sampleDataPath')}
                         />
                         <FileInput
-                            label="Sample Data Files"
+                            label="Example Data Files"
                             description={
                                 isEditMode
-                                    ? 'Upload new files to replace the existing sample data (optional)'
-                                    : 'Upload sample data files for researchers (optional)'
+                                    ? 'Upload new files to replace the existing example data (optional)'
+                                    : 'Upload example data files for researchers (optional)'
                             }
                             placeholder="Select files"
                             multiple

--- a/src/app/[orgSlug]/admin/settings/code-envs.tsx
+++ b/src/app/[orgSlug]/admin/settings/code-envs.tsx
@@ -144,7 +144,7 @@ const CodeEnvDetailPanel: React.FC<{
                         {starterCodeFileNames.length === 0 && '-'}
                     </Stack>
                 </DetailRow>
-                <DetailRow label="Sample Data Path">{image.sampleDataPath || '-'}</DetailRow>
+                <DetailRow label="Example Data Path">{image.sampleDataPath || '-'}</DetailRow>
                 <DetailRow label="Data Source Type">
                     {DATA_SOURCE_TYPES[image.dataSourceType as DataSourceType] || '-'}
                 </DetailRow>

--- a/src/components/study/study-code-empty-view.tsx
+++ b/src/components/study/study-code-empty-view.tsx
@@ -47,7 +47,7 @@ export function StudyCodeEmptyView({
                     <Stack gap="sm">
                         <Text fw={700}>Write and test your code in IDE (recommended)</Text>
                         <Text size="sm" c="dimmed">
-                            IDE is pre-configured to help you write your code and test it against sample data. It will
+                            IDE is pre-configured to help you write your code and test it against example data. It will
                             open in a new tab and you can write your code there. All files created in the IDE will
                             populate here.
                         </Text>


### PR DESCRIPTION
Issue: [OTTER-609](https://openstax.atlassian.net/browse/OTTER-609)

### Summary
Renames user-facing "Sample Data" terminology to "Example Data" in the code environment settings form to align with updated product terminology.

### Changes
- Updated the section title from **Sample Data** → **Example Data**
- Updated the file input label from **Sample Data Files** → **Example Data Files**
- Updated the file input description text in both create and edit modes:
  - Edit: "Upload new files to replace the existing example data (optional)"
  - Create: "Upload example data files for researchers (optional)"

### Files Changed
- [code-env-form.tsx](src/app/[orgSlug]/admin/settings/code-env-form.tsx)

### Notes
This is a copy/terminology-only change — no functional, schema, or behavioral changes. The underlying form field (`sampleDataPath`) is unchanged.

### Testing
- [ ] Verified the updated labels render correctly in the code environment settings form (both create and edit modes)

[OTTER-609]: https://openstax.atlassian.net/browse/OTTER-609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ