### PR TITLE
Fix resubmit page 404 when CODE-SCANNED sorts ahead of decision

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/resubmit/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/resubmit/page.test.tsx
@@ -1,0 +1,58 @@
+// OTTER-556 follow-up: the resubmit page's eligibility gate must read the job's
+// resubmittable status order-independently. jobStatusChange.createdAt defaults to now()
+// (constant within a transaction) and v7 ids are not reliably monotonic within a
+// millisecond, so a late CODE-SCANNED webhook can append *after* the decision and become
+// statusChanges[0]. Reading the topmost row alone would fail canResubmitStudyCode and
+// 404 the page even though the "Edit and resubmit" button (which uses the order-independent
+// decision helper) correctly rendered.
+import { describe, it, expect } from 'vitest'
+import { db } from '@/database'
+import type { StudyJobStatus } from '@/database/types'
+import { insertTestStudyJobData, mockSessionWithTestData } from '@/tests/unit.helpers'
+import ResubmitStudyCodePage from './page'
+
+const insertStatus = (studyJobId: string, status: StudyJobStatus) =>
+    db.insertInto('jobStatusChange').values({ studyJobId, status }).execute()
+
+describe('ResubmitStudyCodePage', () => {
+    it('renders when CODE-CHANGES-REQUESTED is present even if a later CODE-SCANNED row sorts first', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+        const { study, job } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'CHANGE-REQUESTED',
+            // First status row on the job. Subsequent rows below get higher ids and sort
+            // ahead of it in statusChanges (ordered by id desc).
+            jobStatus: 'CODE-SUBMITTED',
+        })
+
+        // The decision, then a late CODE-SCANNED webhook appended afterward (highest id =>
+        // statusChanges[0]). CODE-SCANNED is not in CODE_RESUBMITTABLE_JOB_STATUSES.
+        await insertStatus(job.id, 'CODE-CHANGES-REQUESTED')
+        await insertStatus(job.id, 'CODE-SCANNED')
+
+        const page = await ResubmitStudyCodePage({
+            params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+        })
+
+        // notFound() is a no-op mock in the test env, so a gated-out page resolves to
+        // undefined. A rendered page is defined.
+        expect(page).toBeDefined()
+    })
+
+    it('returns notFound when no resubmittable status exists in the job history', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+        const { study, job } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            jobStatus: 'CODE-SUBMITTED',
+        })
+        await insertStatus(job.id, 'CODE-SCANNED')
+
+        const page = await ResubmitStudyCodePage({
+            params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+        })
+
+        expect(page).toBeUndefined()
+    })
+})

--- a/src/app/[orgSlug]/study/[studyId]/resubmit/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/resubmit/page.tsx
@@ -21,10 +21,16 @@ export default async function ResubmitStudyCodePage(props: { params: Promise<{ s
     // Gate on the latest *submitted* job: opening this page begins a new round, and a file upload
     // here creates a fresh INITIATED round job that would otherwise mask the prior submission and
     // make canResubmitStudyCode fail (OTTER-601). The prior submission's status is what gates resubmit.
+    //
+    // OTTER-556 follow-up: test the whole status history, not statusChanges[0]. jobStatusChange
+    // .createdAt defaults to now() (constant within a transaction) and v7 ids are not reliably
+    // monotonic within a millisecond, so a late CODE-SCANNED webhook can append after the decision
+    // and become the topmost row. The "Edit and resubmit" button uses the order-independent decision
+    // helper, so reading only the top row here would 404 a page the button correctly linked to.
     const latestJob = await latestSubmittedJobForStudy(studyId)
-    const latestJobStatus = latestJob?.statusChanges.at(0)?.status ?? null
+    const canResubmit = latestJob?.statusChanges.some((s) => canResubmitStudyCode(s.status)) ?? false
 
-    if (!canResubmitStudyCode(latestJobStatus)) return notFound()
+    if (!canResubmit) return notFound()
 
     const feedbackResult = await getCodeReviewFeedbackAction({ studyId })
     if ('error' in feedbackResult) return notFound()


### PR DESCRIPTION
## Summary

Clicking **Edit and resubmit** on a `CODE-CHANGES-REQUESTED` study could 404. The `/resubmit` route exists; the 404 came from a `notFound()` thrown by the page's own eligibility gate.

The button and the gate read job status two different ways:
- **Button** (`view/page.tsx`) uses the order-independent `latestSubmittedJobLiveCodeDecisionStatus()`, so it correctly shows for `CODE-CHANGES-REQUESTED`.
- **Gate** (`resubmit/page.tsx`) used `statusChanges.at(0)?.status` — the topmost row. A late `CODE-SCANNED` webhook (or any sibling status tying on `createdAt`) sorts ahead of the decision, fails `canResubmitStudyCode`, and 404s. This is the exact ordering hazard documented in OTTER-552/556.

## Fix

Gate on whether *any* status in the job history is resubmittable, instead of only the top row:

```ts
const canResubmit = latestJob?.statusChanges.some((s) => canResubmitStudyCode(s.status)) ?? false
if (!canResubmit) return notFound()
```

This preserves the full resubmittable status set, so the results-stage `ResubmitButton` (`FILES-APPROVED`/`FILES-REJECTED`/`JOB-ERRORED`/`RUN-COMPLETE`) entry point keeps working.

## Tests

Added `resubmit/page.test.tsx`:
- Reproduces the bug: `CODE-CHANGES-REQUESTED` present but `CODE-SCANNED` sorts first → page renders (failed before the fix).
- Negative control: no resubmittable status → `notFound()`.