### PR TITLE
OTTER-558 follow up: fix review copy

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/resubmit/edit-study-code-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/resubmit/edit-study-code-view.tsx
@@ -70,7 +70,7 @@ export const EditStudyCodeView: FC<EditStudyCodeViewProps> = ({
                 footer={null}
             />
 
-            <FeedbackAndNotesSection entries={feedbackEntries} />
+            <FeedbackAndNotesSection entries={feedbackEntries} alwaysExpandLatest />
 
             <ResubmissionNoteSection noteForm={noteForm} orgName={orgName} autosaveStatus={{ isSaving, lastSavedAt }} />
 

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review.tsx
@@ -136,7 +136,7 @@ export async function CodeReview({ orgSlug, study, entries }: CodeReviewProps) {
                     scan={scan}
                     codeInitiallyExpanded={!isResubmission}
                 />
-                {isResubmission && <FeedbackAndNotesSection entries={entries} />}
+                {isResubmission && <FeedbackAndNotesSection entries={entries} alwaysExpandLatest />}
                 <CodeReviewClient
                     orgSlug={orgSlug}
                     study={study}

--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
@@ -265,7 +265,7 @@ export function PostFeedbackView({
                     timestampLabel={timestampLabel}
                     banner={banner}
                 />
-                <FeedbackAndNotesSection entries={entries} />
+                <FeedbackAndNotesSection entries={entries} alwaysExpandLatest={isCode} />
                 <Group justify="flex-end">
                     <GoToDashboardButton />
                 </Group>

--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.tsx
@@ -151,7 +151,7 @@ const FeedbackSection: FC<{ feedbackLoadError: boolean; entries: CodeReviewFeedb
     if (feedbackLoadError) {
         return <AlertNotFound title="Feedback could not be loaded" message="Please refresh and try again" />
     }
-    return <FeedbackAndNotesSection entries={entries} />
+    return <FeedbackAndNotesSection entries={entries} alwaysExpandLatest />
 }
 
 const StudyCodeSection: FC<{ isVisible: boolean; jobId: string; codeFiles: CodeFile[] }> = ({

--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.tsx
@@ -178,7 +178,7 @@ const ExpandedCodePanel: FC<ExpandedCodePanelProps> = ({
 
 const FeedbackSection: FC<{ isVisible: boolean; entries: CodeReviewFeedbackEntry[] }> = ({ isVisible, entries }) => {
     if (!isVisible) return null
-    return <FeedbackAndNotesSection entries={entries} />
+    return <FeedbackAndNotesSection entries={entries} alwaysExpandLatest />
 }
 
 export function CodePostSubmissionView({

--- a/src/components/study/feedback-and-notes.test.tsx
+++ b/src/components/study/feedback-and-notes.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it, renderWithProviders, screen, userEvent, vi } from '@/tests/unit.helpers'
+import { lexicalJson } from '@/lib/lexical'
+import { FeedbackAndNotesSection } from './feedback-and-notes'
+
+const reviewerEntry = {
+    id: 'reviewer-v1',
+    entryType: 'REVIEWER-FEEDBACK',
+    authorName: 'Dr. Reviewer',
+    createdAt: new Date('2026-04-18T10:00:00Z'),
+    version: 1,
+    body: JSON.parse(lexicalJson('Reviewer feedback for the first round.')),
+}
+
+const noteEntry = {
+    id: 'note-v2',
+    entryType: 'RESUBMISSION-NOTE',
+    authorName: 'Dr. Researcher',
+    createdAt: new Date('2026-04-20T10:00:00Z'),
+    version: 2,
+    body: JSON.parse(lexicalJson('Addressed all the requested changes.')),
+}
+
+// Entries arrive newest-first from getCodeReviewFeedbackAction.
+// happy-dom has no layout, so force overflow to make the View more/less toggle render.
+const forceOverflow = () => vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(1000)
+
+describe('FeedbackAndNotesSection', () => {
+    it('expands the latest reviewer-feedback entry by default', () => {
+        const spy = forceOverflow()
+        try {
+            renderWithProviders(<FeedbackAndNotesSection entries={[reviewerEntry, noteEntry]} />)
+
+            expect(screen.getByTestId('feedback-toggle-reviewer-v1')).toHaveAttribute('aria-expanded', 'true')
+            expect(screen.getByTestId('feedback-toggle-note-v2')).toHaveAttribute('aria-expanded', 'false')
+        } finally {
+            spy.mockRestore()
+        }
+    })
+
+    it('leaves a latest resubmission note collapsed by default (proposal surfaces)', () => {
+        const spy = forceOverflow()
+        try {
+            renderWithProviders(<FeedbackAndNotesSection entries={[noteEntry, reviewerEntry]} />)
+
+            expect(screen.getByTestId('feedback-toggle-note-v2')).toHaveAttribute('aria-expanded', 'false')
+        } finally {
+            spy.mockRestore()
+        }
+    })
+
+    it('expands a latest resubmission note when alwaysExpandLatest is set (code surfaces, OTTER-558)', () => {
+        const spy = forceOverflow()
+        try {
+            renderWithProviders(<FeedbackAndNotesSection entries={[noteEntry, reviewerEntry]} alwaysExpandLatest />)
+
+            expect(screen.getByTestId('feedback-toggle-note-v2')).toHaveAttribute('aria-expanded', 'true')
+            expect(screen.getByTestId('feedback-toggle-reviewer-v1')).toHaveAttribute('aria-expanded', 'false')
+        } finally {
+            spy.mockRestore()
+        }
+    })
+
+    it('toggles a collapsed prior entry open on click', async () => {
+        const spy = forceOverflow()
+        try {
+            const user = userEvent.setup()
+            renderWithProviders(<FeedbackAndNotesSection entries={[noteEntry, reviewerEntry]} alwaysExpandLatest />)
+
+            const priorToggle = screen.getByTestId('feedback-toggle-reviewer-v1')
+            expect(priorToggle).toHaveAttribute('aria-expanded', 'false')
+            await user.click(priorToggle)
+            expect(priorToggle).toHaveAttribute('aria-expanded', 'true')
+        } finally {
+            spy.mockRestore()
+        }
+    })
+
+    it('renders nothing when there are no entries', () => {
+        const { container } = renderWithProviders(<FeedbackAndNotesSection entries={[]} />)
+        expect(container.querySelector('[data-testid="feedback-and-notes-section"]')).toBeNull()
+    })
+})

--- a/src/components/study/feedback-and-notes.tsx
+++ b/src/components/study/feedback-and-notes.tsx
@@ -123,12 +123,14 @@ function FeedbackEntry({ entry, isExpanded, onToggle }: FeedbackEntryProps) {
     )
 }
 
-function useExpandedEntries(entries: FeedbackEntryShape[]) {
+function useExpandedEntries(entries: FeedbackEntryShape[], alwaysExpandLatest: boolean) {
     const [expandedIds, setExpandedIds] = useState<Set<string>>(() => {
-        // Resubmission notes must be collapsed by default per spec,
-        // so only auto-expand the latest entry when it's reviewer feedback.
+        // The newest entry is expanded by default, the rest collapsed. On proposal surfaces a
+        // newest resubmission note stays collapsed (the researcher just wrote it); code surfaces
+        // opt in via alwaysExpandLatest to expand the newest entry regardless of type (OTTER-558).
         const latest = entries[0]
-        if (!latest || latest.entryType === 'RESUBMISSION-NOTE') return new Set()
+        if (!latest) return new Set()
+        if (!alwaysExpandLatest && latest.entryType === 'RESUBMISSION-NOTE') return new Set()
         return new Set([latest.id])
     })
 
@@ -149,8 +151,14 @@ function useExpandedEntries(entries: FeedbackEntryShape[]) {
     return { isExpanded, toggle }
 }
 
-export function FeedbackAndNotesSection({ entries }: { entries: FeedbackEntryShape[] }) {
-    const { isExpanded, toggle } = useExpandedEntries(entries)
+export function FeedbackAndNotesSection({
+    entries,
+    alwaysExpandLatest = false,
+}: {
+    entries: FeedbackEntryShape[]
+    alwaysExpandLatest?: boolean
+}) {
+    const { isExpanded, toggle } = useExpandedEntries(entries, alwaysExpandLatest)
 
     if (entries.length === 0) return null
 

--- a/src/components/study/resubmission-note-section.test.tsx
+++ b/src/components/study/resubmission-note-section.test.tsx
@@ -36,6 +36,14 @@ describe('ResubmissionNoteSection', () => {
         expect(screen.getByText(/Rice University/)).toBeInTheDocument()
     })
 
+    it('renders the placeholder guidance copy on the textarea', () => {
+        renderSection()
+        expect(screen.getByRole('textbox', { name: 'Resubmission Note' })).toHaveAttribute(
+            'placeholder',
+            'Ex. Summarize the modifications made to your submitted code, including specific sections revised, issues identified by the reviewer that have been addressed, and the rationale behind your resubmission.',
+        )
+    })
+
     it('renders a 0/300 word counter when empty', () => {
         renderSection()
         expect(screen.getByText('0/300')).toBeInTheDocument()

--- a/src/components/study/resubmission-note-section.tsx
+++ b/src/components/study/resubmission-note-section.tsx
@@ -58,7 +58,7 @@ export const ResubmissionNoteSection: FC<ResubmissionNoteSectionProps> = ({ note
                     <Textarea
                         id="resubmissionNote"
                         aria-label="Resubmission Note"
-                        placeholder="Ex. Revised sections, added details, and answered reviewer feedback"
+                        placeholder="Ex. Summarize the modifications made to your submitted code, including specific sections revised, issues identified by the reviewer that have been addressed, and the rationale behind your resubmission."
                         autosize
                         minRows={5}
                         styles={{ input: { resize: 'vertical' } }}

--- a/src/components/study/study-code-review-view.test.tsx
+++ b/src/components/study/study-code-review-view.test.tsx
@@ -27,7 +27,8 @@ describe('StudyCodeReviewView', () => {
         expect(screen.getByRole('button', { name: /edit files in ide/i })).toBeInTheDocument()
         expect(screen.getByRole('button', { name: /upload files/i })).toBeInTheDocument()
         expect(screen.getByText(/review files/i)).toBeInTheDocument()
-        expect(screen.getByText(/select your main file/i)).toBeInTheDocument()
+        expect(screen.getByText(/review and manage submitted code files/i)).toBeInTheDocument()
+        expect(screen.queryByText(/select your main file/i)).not.toBeInTheDocument()
     })
 
     it('renders each file row', () => {

--- a/src/components/study/study-code-review-view.tsx
+++ b/src/components/study/study-code-review-view.tsx
@@ -72,8 +72,7 @@ export function StudyCodeReviewView({
             <Stack gap={4}>
                 <Text fw={600}>Review files</Text>
                 <Text size="sm" c="dimmed">
-                    If you’re creating or uploading multiple files, please select your main file (i.e., the script that
-                    runs first).
+                    Review and manage submitted code files. You can update files, delete them, or upload new ones.
                 </Text>
             </Stack>
 


### PR DESCRIPTION
see [OTTER-558 all comments](https://openstax.atlassian.net/browse/OTTER-558?focusedCommentId=43191)

- Fixed the "Review files" section so it shows the correct descriptive text instead of the main-file tooltip text.
- Corrected the placeholder guidance shown in the resubmission note field.
- Made the most recent feedback or note expand automatically on the code review and resubmit screens.
- Kept earlier feedback and notes collapsed unless they overflow, matching the agreed design.
- Added tests covering the expand behavior and the corrected copy.