### PR TITLE
OTTER-517 follow-up: remove reviewer intro sentence from my dashboard studies table

### DIFF
--- a/src/app/dashboard/user-studies.test.tsx
+++ b/src/app/dashboard/user-studies.test.tsx
@@ -78,6 +78,7 @@ describe('UserStudiesDashboard', () => {
         await userEvent.click(screen.getByRole('radio', { name: 'Reviewer' }))
 
         expect(await screen.findByText('Reviewer Study')).toBeDefined()
+        expect(screen.queryByText(/Review all the studies submitted to your organizations/i)).toBeNull()
         expect(screen.getByRole('radio', { name: 'Reviewer' })).toBeDefined()
         expect(screen.getByRole('radio', { name: 'Researcher' })).toBeDefined()
     })
@@ -100,6 +101,7 @@ describe('UserStudiesDashboard', () => {
         await userEvent.click(screen.getByRole('radio', { name: 'Reviewer' }))
 
         expect(await screen.findByText("You haven't yet participated in reviewing a study")).toBeDefined()
+        expect(screen.queryByText(/Review all the studies submitted to your organizations/i)).toBeNull()
         expect(screen.getByRole('radio', { name: 'Reviewer' })).toBeDefined()
         expect(screen.getByRole('radio', { name: 'Researcher' })).toBeDefined()
     })

--- a/src/app/dashboard/user-studies.tsx
+++ b/src/app/dashboard/user-studies.tsx
@@ -49,7 +49,6 @@ export default function UserStudiesDashboard() {
     }
 
     const audience = showTabs ? activeTab : defaultTab
-    const isResearcher = audience === 'researcher'
 
     return (
         <Stack p="xxl" gap="xxl">
@@ -62,11 +61,6 @@ export default function UserStudiesDashboard() {
                     scope="user"
                     orgSlug=""
                     title="My studies"
-                    description={
-                        !isResearcher
-                            ? "Review all the studies submitted to your organizations. Studies that need your attention will be labeled 'Needs review'."
-                            : undefined
-                    }
                     showRefresher
                     headerActions={
                         showTabs ? (


### PR DESCRIPTION
small fix, see [OTTER-517](https://openstax.atlassian.net/browse/OTTER-517) last comments:

- Removed the introductory description text from the reviewer view of the personal "My dashboard" so it no longer appears above the studies list.
- The reviewer now sees only the studies table when studies exist, and only the role-specific empty message when there are none.
- Added tests confirming the intro text no longer appears in either the empty or populated reviewer states.

[OTTER-517]: https://openstax.atlassian.net/browse/OTTER-517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ