### PR TITLE
Study fails if the code file name has parenthesis

### DIFF
--- a/src/lib/string.test.ts
+++ b/src/lib/string.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { strToAscii, slugify } from './string'
+import { strToAscii, slugify, shellQuote } from './string'
 
 describe('strToAscii', () => {
     it('removes non-alphanumeric characters', () => {
@@ -42,5 +42,27 @@ describe('slugify', () => {
 
         expect(output).toBe('this-is-a-very-long-string-that-should-be-truncate')
         expect(output).toHaveLength(50)
+    })
+})
+
+describe('shellQuote', () => {
+    it('wraps a simple value in single quotes', () => {
+        expect(shellQuote('main.R')).toBe("'main.R'")
+    })
+
+    it('keeps parentheses literal so they do not break /bin/sh (OTTER-477)', () => {
+        expect(shellQuote('main(1).r')).toBe("'main(1).r'")
+    })
+
+    it('quotes spaces and other shell metacharacters', () => {
+        expect(shellQuote('my file;rm -rf $HOME.r')).toBe("'my file;rm -rf $HOME.r'")
+    })
+
+    it('escapes embedded single quotes', () => {
+        expect(shellQuote("it's.r")).toBe("'it'\\''s.r'")
+    })
+
+    it('handles an empty string', () => {
+        expect(shellQuote('')).toBe("''")
     })
 })

--- a/src/lib/string.ts
+++ b/src/lib/string.ts
@@ -4,6 +4,20 @@ export function strToAscii(str: string) {
     return str.replace(/[^a-zA-Z0-9]/g, '')
 }
 
+/**
+ * Quote a value for safe use as a single token in a POSIX `/bin/sh` command line.
+ *
+ * Wraps the value in single quotes and escapes any embedded single quotes, so shell
+ * metacharacters (parentheses, spaces, `$`, `;`, etc.) are treated as literal text
+ * instead of being interpreted by the shell. Used when interpolating a user-supplied
+ * filename into a command the containerizer runs via `/bin/sh`.
+ */
+export function shellQuote(value: string): string {
+    // Close the quote, emit an escaped single quote, reopen: ' -> '\''
+    const escaped = value.split("'").join("'\\''")
+    return `'${escaped}'`
+}
+
 // https://dense13.com/blog/2009/05/03/converting-string-to-slug-javascript/
 export function slugify(str: string) {
     str = str.replace(/^\s+|\s+$/g, '') // trim

--- a/src/server/aws.test.ts
+++ b/src/server/aws.test.ts
@@ -118,6 +118,21 @@ describe('buildTriggerBuildImageCommandInput', () => {
         const cmdLineVar = input.environmentVariablesOverride.find((v) => v.name === 'DOCKER_CMD_LINE')
         expect(cmdLineVar?.value).toBe("Rscript 'main(1).r' --arg1 value1")
     })
+
+    it('substitutes and quotes every %f occurrence in the template', async () => {
+        const input = await buildTriggerBuildImageCommandInput({
+            studyJobId: 'job-123',
+            codeEnvURL: 'docker.io/my-base-image:latest',
+            codeEntryPointFileName: 'main(1).r',
+            containerLocation: 'a-bad-url',
+            cmdLine: 'cp %f /tmp/ && Rscript %f',
+            studyId: 'study-abc',
+            orgSlug: 'org-xyz',
+        })
+
+        const cmdLineVar = input.environmentVariablesOverride.find((v) => v.name === 'DOCKER_CMD_LINE')
+        expect(cmdLineVar?.value).toBe("cp 'main(1).r' /tmp/ && Rscript 'main(1).r'")
+    })
 })
 
 describe('buildTriggerScanForStudyJobCommandInput', () => {

--- a/src/server/aws.test.ts
+++ b/src/server/aws.test.ts
@@ -94,12 +94,29 @@ describe('buildTriggerBuildImageCommandInput', () => {
             { name: 'STUDY_JOB_ID', value: info.studyJobId },
             { name: 'S3_PATH', value: 'studies/org-xyz/study-abc/jobs/job-123/code' },
             { name: 'DOCKER_BASE_IMAGE_LOCATION', value: info.codeEnvURL },
-            { name: 'DOCKER_CMD_LINE', value: 'Rscript main.R --arg1 value1' },
+            { name: 'DOCKER_CMD_LINE', value: "Rscript 'main.R' --arg1 value1" },
             { name: 'DOCKER_CODE_LOCATION', value: 'a-bad-url:job-123' },
         ]
 
         expect(input.environmentVariablesOverride).toEqual(expect.arrayContaining(expectedEnvVars))
         expect(input.environmentVariablesOverride.length).toBe(expectedEnvVars.length)
+    })
+
+    it('shell-quotes the entry-point filename so parentheses do not break the command (OTTER-477)', async () => {
+        const info = {
+            studyJobId: 'job-123',
+            codeEnvURL: 'docker.io/my-base-image:latest',
+            codeEntryPointFileName: 'main(1).r',
+            containerLocation: 'a-bad-url',
+            cmdLine: 'Rscript %f --arg1 value1',
+            studyId: 'study-abc',
+            orgSlug: 'org-xyz',
+        }
+
+        const input = await buildTriggerBuildImageCommandInput(info)
+
+        const cmdLineVar = input.environmentVariablesOverride.find((v) => v.name === 'DOCKER_CMD_LINE')
+        expect(cmdLineVar?.value).toBe("Rscript 'main(1).r' --arg1 value1")
     })
 })
 

--- a/src/server/aws.ts
+++ b/src/server/aws.ts
@@ -31,7 +31,7 @@ import {
     pathForStudyJobCode,
 } from '@/lib/paths'
 import type { MinimalCodeEnvInfo } from '@/lib/types'
-import { strToAscii } from '@/lib/string'
+import { shellQuote, strToAscii } from '@/lib/string'
 import { parseCsv } from '@/lib/file-content-helpers'
 import logger from '@/lib/logger'
 import { Readable } from 'stream'
@@ -466,7 +466,11 @@ export async function buildTriggerBuildImageCommandInput(
         containerLocation: string
     },
 ) {
-    const cmd = info.cmdLine.replace('%f', info.codeEntryPointFileName)
+    // Shell-quote the filename so names with parentheses or other shell metacharacters
+    // don't break the `/bin/sh` command the containerizer runs (OTTER-477). The
+    // replacement must be a function — a string replacement would interpret `$`
+    // sequences in the filename as special replacement patterns.
+    const cmd = info.cmdLine.replace('%f', () => shellQuote(info.codeEntryPointFileName))
     return {
         projectName: process.env.CONTAINERIZER_PROJECT_NAME || `MgmntAppContainerizer-${ENVIRONMENT_ID}`,
         environmentVariablesOverride: await buildCodeBuildEnvVars('/api/services/containerizer', {

--- a/src/server/aws.ts
+++ b/src/server/aws.ts
@@ -469,8 +469,9 @@ export async function buildTriggerBuildImageCommandInput(
     // Shell-quote the filename so names with parentheses or other shell metacharacters
     // don't break the `/bin/sh` command the containerizer runs (OTTER-477). The
     // replacement must be a function — a string replacement would interpret `$`
-    // sequences in the filename as special replacement patterns.
-    const cmd = info.cmdLine.replace('%f', () => shellQuote(info.codeEntryPointFileName))
+    // sequences in the filename as special replacement patterns. replaceAll covers
+    // templates that reference %f more than once.
+    const cmd = info.cmdLine.replaceAll('%f', () => shellQuote(info.codeEntryPointFileName))
     return {
         projectName: process.env.CONTAINERIZER_PROJECT_NAME || `MgmntAppContainerizer-${ENVIRONMENT_ID}`,
         environmentVariablesOverride: await buildCodeBuildEnvVars('/api/services/containerizer', {


### PR DESCRIPTION
## Summary
Uploading a study's main code file with parentheses in the name (e.g. `main(1).r`) makes
the study fail at the build/packaging step — the job goes to `JOB-ERRORED` and never runs,
surfacing as `/bin/sh: 1: Syntax error: "(" unexpected` in the containerizer logs. The
file name is user-chosen at upload, so any study can hit it (any shell metacharacter does),
and the only current workaround is renaming the file first. Reproduced on Staging
(job `019d07de-9f91-7442-a239-6a75a2b798ed`).