### PR TITLE
Show form error summary on code env form

### DIFF
--- a/src/app/[orgSlug]/admin/settings/code-env-form.tsx
+++ b/src/app/[orgSlug]/admin/settings/code-env-form.tsx
@@ -16,11 +16,13 @@ import {
     Group,
     ActionIcon,
     Box,
+    Alert,
+    List,
 } from '@mantine/core'
 import { Dropzone } from '@mantine/dropzone'
 import { ActionSuccessType, DATA_SOURCE_TYPES } from '@/lib/types'
 import { EnvVar } from '@/database/types'
-import { TrashIcon, PlusCircleIcon, FileArrowUpIcon, UploadIcon } from '@phosphor-icons/react/dist/ssr'
+import { TrashIcon, PlusCircleIcon, FileArrowUpIcon, UploadIcon, WarningIcon } from '@phosphor-icons/react/dist/ssr'
 import { fetchOrgCodeEnvsAction } from './code-envs.actions'
 import { useCodeEnvForm } from './use-code-env-form'
 import { useOrgDataSources } from '@/hooks/use-org-data-sources'
@@ -206,6 +208,20 @@ function CommandLinesSection({
     )
 }
 
+function FormErrorSummary({ isVisible, errors }: { isVisible: boolean; errors: string[] }) {
+    if (!isVisible) return null
+
+    return (
+        <Alert color="red" icon={<WarningIcon size={16} />} title="Please fix the following before saving">
+            <List size="sm">
+                {errors.map((error) => (
+                    <List.Item key={error}>{error}</List.Item>
+                ))}
+            </List>
+        </Alert>
+    )
+}
+
 interface CodeEnvFormProps {
     image?: CodeEnv
     onCompleteAction: () => void
@@ -214,6 +230,7 @@ interface CodeEnvFormProps {
 export function CodeEnvForm({ image, onCompleteAction }: CodeEnvFormProps) {
     const {
         form,
+        formErrors,
         isEditMode,
         isPending,
         onSubmit,
@@ -322,7 +339,13 @@ export function CodeEnvForm({ image, onCompleteAction }: CodeEnvFormProps) {
                                 style={{ flex: 1 }}
                             />
                             <TextInput {...form.getInputProps('newEnvValue')} placeholder="Value" style={{ flex: 1 }} />
-                            <ActionIcon color="blue" variant="subtle" onClick={addEnvVar} mt={4}>
+                            <ActionIcon
+                                color="blue"
+                                variant="subtle"
+                                onClick={addEnvVar}
+                                mt={4}
+                                aria-label="Add environment variable"
+                            >
                                 <PlusCircleIcon size={16} />
                             </ActionIcon>
                         </Group>
@@ -364,6 +387,7 @@ export function CodeEnvForm({ image, onCompleteAction }: CodeEnvFormProps) {
                         </Radio.Group>
                     </Stack>
                 </Box>
+                <FormErrorSummary isVisible={formErrors.length > 0} errors={formErrors} />
                 <Button type="submit" loading={isPending} mt="md">
                     {isEditMode ? 'Update Code Environment' : 'Save Code Environment'}
                 </Button>

--- a/src/app/[orgSlug]/admin/settings/code-envs.test.tsx
+++ b/src/app/[orgSlug]/admin/settings/code-envs.test.tsx
@@ -95,6 +95,28 @@ describe('CodeEnvs', async () => {
         })
     })
 
+    it('surfaces malformed env var errors in the summary above submit', { timeout: 15000 }, async () => {
+        renderWithProviders(<CodeEnvs />)
+
+        fireEvent.click(screen.getByRole('button', { name: /Add Code Environment/i }))
+
+        await waitFor(() => {
+            expect(screen.getByRole('heading', { name: /Add Code Environment/i })).toBeInTheDocument()
+        })
+
+        // Add an env var whose name is invalid (starts with a digit) into the list
+        await userEvent.type(screen.getByPlaceholderText(/Variable name/i), '1BAD')
+        await userEvent.type(screen.getByPlaceholderText(/^Value$/i), 'something')
+        await userEvent.click(screen.getByRole('button', { name: /Add environment variable/i }))
+
+        await userEvent.click(screen.getByRole('button', { name: /Save Code Environment/i }))
+
+        await waitFor(() => {
+            expect(screen.getByText(/Please fix the following before saving/i)).toBeInTheDocument()
+            expect(screen.getByText(/Invalid variable name/i)).toBeInTheDocument()
+        })
+    })
+
     it('hides delete when there is only one code environment', async () => {
         await insertTestCodeEnv({
             orgId: org.id,

--- a/src/app/[orgSlug]/admin/settings/use-code-env-form.ts
+++ b/src/app/[orgSlug]/admin/settings/use-code-env-form.ts
@@ -201,6 +201,11 @@ export function useCodeEnvForm(image: CodeEnv | undefined, onCompleteAction: () 
         },
     })
 
+    const formErrors = Object.values(form.errors)
+        .filter((message): message is string => typeof message === 'string' && message.length > 0)
+        // de-dupe: several nested env var paths can share the same message
+        .filter((message, index, all) => all.indexOf(message) === index)
+
     const onSubmit = form.onSubmit(
         ({ newEnvKey, newEnvValue, newCmdExt, newCmdValue, existingStarterCodeFileNames: _, ...values }) => {
             if (newEnvKey && newEnvValue) {
@@ -218,6 +223,7 @@ export function useCodeEnvForm(image: CodeEnv | undefined, onCompleteAction: () 
 
     return {
         form,
+        formErrors,
         isEditMode,
         isPending,
         onSubmit,


### PR DESCRIPTION
Fixes the silent save failure on the Code Environment form (Org Settings) when an env var is malformed — e.g. a stray space in the variable name. Those errors are keyed at nested zod paths that had no UI rendering, so the form just refused to submit with no feedback.

Adds an error summary above the submit button listing all current form errors as strings (env var name/value, duplicate names, missing command lines, invalid Docker URL, etc.). Includes a unit test.

Jira: [OTTER-625](https://openstax.atlassian.net/browse/OTTER-625)

[OTTER-625]: https://openstax.atlassian.net/browse/OTTER-625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ