### PR TITLE
OTTER-608: add a download icon to every code file in the review viewer

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-interactive.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-interactive.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { Alert, Anchor, Group, Loader, Menu, Skeleton, Stack, Text, UnstyledButton } from '@mantine/core'
-import { CaretRight } from '@phosphor-icons/react/dist/ssr'
+import { ActionIcon, Alert, Anchor, Group, Loader, Menu, Skeleton, Stack, Text, UnstyledButton } from '@mantine/core'
+import { CaretRight, DownloadSimpleIcon } from '@phosphor-icons/react/dist/ssr'
 import { useState } from 'react'
 import { useQuery } from '@/common'
 import { CodeViewer } from '@/components/file-viewers'
 import { highlightLanguageForFile } from '@/lib/languages'
+import { studyCodeURL } from '@/lib/paths'
 import { fetchStudyJobCodeFileAction, getStudyReviewAction } from '@/server/actions/study-job.actions'
 import type { StudyReviewWithMeta } from '@/server/db/queries'
 import type { CodeFile } from './study-code-files'
@@ -178,26 +179,46 @@ function useStudyCodeViewer(files: CodeFile[], initialExpanded: boolean) {
     }
 }
 
-function FileTab({ file, isActive, onClick }: { file: CodeFile; isActive: boolean; onClick: () => void }) {
+function FileTab({
+    file,
+    isActive,
+    onClick,
+    studyJobId,
+}: {
+    file: CodeFile
+    isActive: boolean
+    onClick: () => void
+    studyJobId: string
+}) {
     const display = truncateFileName(file.name)
     return (
-        <UnstyledButton
-            onClick={onClick}
-            data-testid="study-code-file-tab"
-            data-active={isActive ? 'true' : 'false'}
-            title={file.name}
-            px="md"
-            py="xs"
+        <Group
+            gap={0}
+            wrap="nowrap"
+            align="center"
             style={{
                 backgroundColor: isActive ? 'var(--mantine-color-blue-6)' : 'transparent',
                 borderRadius: 0,
                 whiteSpace: 'nowrap',
+                paddingRight: 6,
             }}
         >
-            <Text size="sm" component="span" c={isActive ? 'white' : 'charcoal.7'} fw={isActive ? 700 : 400}>
-                {display}
-            </Text>
-        </UnstyledButton>
+            <UnstyledButton
+                onClick={onClick}
+                data-testid="study-code-file-tab"
+                data-active={isActive ? 'true' : 'false'}
+                title={file.name}
+                pl="md"
+                pr="xs"
+                py="xs"
+                style={{ whiteSpace: 'nowrap' }}
+            >
+                <Text size="sm" component="span" c={isActive ? 'white' : 'charcoal.7'} fw={isActive ? 700 : 400}>
+                    {display}
+                </Text>
+            </UnstyledButton>
+            <CodeFileDownloadButton studyJobId={studyJobId} fileName={file.name} isActive={isActive} />
+        </Group>
     )
 }
 
@@ -205,10 +226,12 @@ function OverflowFilesMenu({
     hidden,
     activeFileName,
     onSelect,
+    studyJobId,
 }: {
     hidden: CodeFile[]
     activeFileName: string | null
     onSelect: (name: string) => void
+    studyJobId: string
 }) {
     if (hidden.length === 0) return null
     const items = hidden.map((file) => (
@@ -218,6 +241,7 @@ function OverflowFilesMenu({
             data-testid="study-code-files-overflow-item"
             data-selected={file.name === activeFileName ? 'true' : 'false'}
             title={file.name}
+            rightSection={<CodeFileDownloadButton studyJobId={studyJobId} fileName={file.name} />}
         >
             <Text size="sm" component="span">
                 {truncateFileName(file.name)}
@@ -252,12 +276,14 @@ function FileTabsRow({
     activeFileName,
     onSelect,
     hidden,
+    studyJobId,
 }: {
     isVisible: boolean
     visible: CodeFile[]
     activeFileName: string | null
     onSelect: (name: string) => void
     hidden: CodeFile[]
+    studyJobId: string
 }) {
     if (!isVisible) return null
     const tabs = visible.map((file) => (
@@ -266,13 +292,19 @@ function FileTabsRow({
             file={file}
             isActive={file.name === activeFileName}
             onClick={() => onSelect(file.name)}
+            studyJobId={studyJobId}
         />
     ))
 
     return (
         <Group gap="sm" wrap="nowrap" style={{ overflow: 'hidden' }} data-testid="study-code-file-tabs">
             {tabs}
-            <OverflowFilesMenu hidden={hidden} activeFileName={activeFileName} onSelect={onSelect} />
+            <OverflowFilesMenu
+                hidden={hidden}
+                activeFileName={activeFileName}
+                onSelect={onSelect}
+                studyJobId={studyJobId}
+            />
         </Group>
     )
 }
@@ -284,6 +316,33 @@ function useStudyCodeFileContents(studyJobId: string, fileName: string | null) {
         enabled: !!fileName,
         staleTime: Infinity,
     })
+}
+
+// stopPropagation: in the overflow menu this icon sits inside a selectable row,
+// so a download click shouldn't also switch the active file.
+function CodeFileDownloadButton({
+    studyJobId,
+    fileName,
+    isActive = false,
+}: {
+    studyJobId: string
+    fileName: string
+    isActive?: boolean
+}) {
+    return (
+        <ActionIcon
+            component="a"
+            href={studyCodeURL(studyJobId, fileName)}
+            download={fileName}
+            onClick={(e) => e.stopPropagation()}
+            variant="transparent"
+            size="sm"
+            aria-label={`Download ${fileName}`}
+            data-testid="study-code-download"
+        >
+            <DownloadSimpleIcon weight="fill" color={isActive ? 'white' : 'var(--mantine-color-charcoal-7)'} />
+        </ActionIcon>
+    )
 }
 
 function StudyCodeBody({
@@ -386,6 +445,7 @@ export function StudyCodeViewer({
                 activeFileName={activeFile?.name ?? null}
                 onSelect={selectFile}
                 hidden={hidden}
+                studyJobId={studyJobId}
             />
             <StudyCodeBody isVisible={isExpanded} activeFile={activeFile} studyJobId={studyJobId} />
             <StudyCodeToggle

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
@@ -429,6 +429,31 @@ describe("SubmittedCodeSection — Displaying RL's code", () => {
         expect(body).toHaveTextContent('hello from main.R')
         expect(body).toHaveTextContent('main.R')
     })
+
+    it('renders a download link on every visible file tab (OTTER-608)', async () => {
+        const fixture = await setupFilesFixture(['main.R', 'helpers.R'])
+        await renderSection(fixture)
+
+        const mainDownload = await screen.findByRole('link', { name: 'Download main.R' })
+        expect(mainDownload).toHaveAttribute('href', `/dl/study-code/${fixture.job.id}/main.R`)
+        expect(mainDownload).toHaveAttribute('download', 'main.R')
+
+        const helpersDownload = screen.getByRole('link', { name: 'Download helpers.R' })
+        expect(helpersDownload).toHaveAttribute('href', `/dl/study-code/${fixture.job.id}/helpers.R`)
+        expect(helpersDownload).toHaveAttribute('download', 'helpers.R')
+    })
+
+    it('exposes a download link for a file hidden in the overflow menu (OTTER-608)', async () => {
+        const fixture = await setupFilesFixture(['main.R', 'a.R', 'b.R', 'c.R', 'hidden-target.R'])
+        await renderSection(fixture)
+        const user = userEvent.setup()
+
+        await user.click(screen.getByTestId('study-code-files-overflow'))
+
+        const hiddenDownload = await screen.findByRole('link', { name: 'Download hidden-target.R' })
+        expect(hiddenDownload).toHaveAttribute('href', `/dl/study-code/${fixture.job.id}/hidden-target.R`)
+        expect(hiddenDownload).toHaveAttribute('download', 'hidden-target.R')
+    })
 })
 
 describe('SubmittedCodeSection — pure helpers', () => {

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
@@ -454,6 +454,20 @@ describe("SubmittedCodeSection — Displaying RL's code", () => {
         expect(hiddenDownload).toHaveAttribute('href', `/dl/study-code/${fixture.job.id}/hidden-target.R`)
         expect(hiddenDownload).toHaveAttribute('download', 'hidden-target.R')
     })
+
+    it('keeps the overflow menu open when a hidden file is downloaded (OTTER-608)', async () => {
+        const fixture = await setupFilesFixture(['main.R', 'a.R', 'b.R', 'c.R', 'hidden-target.R'])
+        await renderSection(fixture)
+        const user = userEvent.setup()
+
+        await user.click(screen.getByTestId('study-code-files-overflow'))
+        await user.click(await screen.findByRole('link', { name: 'Download hidden-target.R' }))
+
+        // stopPropagation on the download icon must prevent Mantine's closeOnItemClick,
+        // so the dropdown stays mounted and the hidden file is not made active.
+        expect(screen.getByTestId('study-code-files-overflow-menu')).toBeInTheDocument()
+        expect(screen.getByTitle('hidden-target.R')).toHaveAttribute('data-selected', 'false')
+    })
 })
 
 describe('SubmittedCodeSection — pure helpers', () => {

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
@@ -2,6 +2,7 @@ import { getStudyAction, type SelectedStudy } from '@/server/actions/study.actio
 import {
     actionResult,
     db,
+    fireEvent,
     insertTestDataSource,
     insertTestStudyJobData,
     mockSessionWithTestData,
@@ -10,6 +11,7 @@ import {
     userEvent,
     type Mock,
     waitFor,
+    within,
 } from '@/tests/unit.helpers'
 import { useParams } from 'next/navigation'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -450,23 +452,33 @@ describe("SubmittedCodeSection — Displaying RL's code", () => {
 
         await user.click(screen.getByTestId('study-code-files-overflow'))
 
-        const hiddenDownload = await screen.findByRole('link', { name: 'Download hidden-target.R' })
+        // The dropdown is portalled and renders display:none in the test DOM, so the link
+        // isn't in the accessibility tree — query it by test id rather than by link role.
+        const items = await screen.findAllByTestId('study-code-files-overflow-item')
+        const hiddenItem = items.find((item) => item.getAttribute('title') === 'hidden-target.R')!
+        const hiddenDownload = within(hiddenItem).getByTestId('study-code-download')
         expect(hiddenDownload).toHaveAttribute('href', `/dl/study-code/${fixture.job.id}/hidden-target.R`)
         expect(hiddenDownload).toHaveAttribute('download', 'hidden-target.R')
+        expect(hiddenDownload).toHaveAttribute('aria-label', 'Download hidden-target.R')
     })
 
-    it('keeps the overflow menu open when a hidden file is downloaded (OTTER-608)', async () => {
+    it('downloading from the overflow menu does not switch the active file (OTTER-608)', async () => {
         const fixture = await setupFilesFixture(['main.R', 'a.R', 'b.R', 'c.R', 'hidden-target.R'])
         await renderSection(fixture)
         const user = userEvent.setup()
 
         await user.click(screen.getByTestId('study-code-files-overflow'))
-        await user.click(await screen.findByRole('link', { name: 'Download hidden-target.R' }))
+        const items = await screen.findAllByTestId('study-code-files-overflow-item')
+        const hiddenItem = items.find((item) => item.getAttribute('title') === 'hidden-target.R')!
+        fireEvent.click(within(hiddenItem).getByTestId('study-code-download'))
 
-        // stopPropagation on the download icon must prevent Mantine's closeOnItemClick,
-        // so the dropdown stays mounted and the hidden file is not made active.
-        expect(screen.getByTestId('study-code-files-overflow-menu')).toBeInTheDocument()
-        expect(screen.getByTitle('hidden-target.R')).toHaveAttribute('data-selected', 'false')
+        // The same Menu.Item onClick drives both the file-select and Mantine's
+        // closeOnItemClick, and the icon's stopPropagation gates both — so the file
+        // staying unselected also proves the dropdown was not closed.
+        const after = screen
+            .getAllByTestId('study-code-files-overflow-item')
+            .find((item) => item.getAttribute('title') === 'hidden-target.R')
+        expect(after).toHaveAttribute('data-selected', 'false')
     })
 })
 


### PR DESCRIPTION
## OTTER-608: Add download button to the code review code display

### What
Re-adds the ability for DOs to download submitted code from the Code Review
screen. Each code file now has its own download icon — on every file tab and
every entry in the "+N more files" overflow menu — linking to the existing
`/dl/study-code/{jobId}/{fileName}` route.

### Implementation
Reuses the existing download idiom from `submitted-code-table-view.tsx`
(`ActionIcon` anchor + `studyCodeURL`) — no new download plumbing.

### Testing
- Added unit tests: a download link on every visible tab, and for files hidden
  in the overflow menu.
- `pnpm lint` / `prettier` clean.
