### PR TITLE
Self-heal editor DB credentials on rotation (OTTER-626)

### DIFF
--- a/services/editor/auth.ts
+++ b/services/editor/auth.ts
@@ -268,6 +268,14 @@ export async function studyIdForDocument(parsed: ParsedDocumentName, db: Pick<Db
 // `onAuthenticationFailed.reason`. The wire format is `CODE: message` so the
 // client can split on the first colon and dispatch on `code` rather than
 // pattern-matching the message text.
+//
+// These are *terminal* auth rejections only. INFRA_UNAVAILABLE is intentionally
+// NOT a member: it travels the same `CODE: message` wire but is a recoverable
+// infra failure carried by InfraUnavailableError (below), and the client treats
+// it as non-terminal (retry, not "editor unavailable"). Do not fold it in here —
+// making it an AuthFailureError code would latch the terminal banner (OTTER-626).
+// The client's AuthFailureCode union (src/lib/realtime/auth-failure.ts) is the
+// superset that lists both; keep the two in sync by hand.
 export type AuthFailureCode =
     | 'MISSING_TOKEN'
     | 'INVALID_TOKEN'

--- a/services/editor/auth.ts
+++ b/services/editor/auth.ts
@@ -293,6 +293,23 @@ export class AuthFailureError extends Error {
     }
 }
 
+// Reason code for an infrastructure failure (e.g. the DB is unreachable or
+// rejected our credentials) encountered while authenticating. Distinct from
+// AuthFailureError so the client can show a recoverable "reconnecting" state
+// instead of a terminal "editor unavailable" banner — a transient DB problem
+// must not masquerade as a permanent auth denial (OTTER-626).
+export const INFRA_UNAVAILABLE_CODE = 'INFRA_UNAVAILABLE'
+
+export class InfraUnavailableError extends Error {
+    readonly reason: string
+    constructor(message: string) {
+        const wire = `${INFRA_UNAVAILABLE_CODE}: ${message}`
+        super(wire)
+        this.name = 'InfraUnavailableError'
+        this.reason = wire
+    }
+}
+
 export async function authenticate(
     args: { token: string | null | undefined; documentName: string },
     deps: AuthenticateDeps,

--- a/services/editor/db-credentials.test.ts
+++ b/services/editor/db-credentials.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+    DbCredentials,
+    INVALID_PASSWORD_CODE,
+    isInvalidPasswordError,
+    poolSettingsFromSecret,
+    resolveDbSource,
+    type ResolvedDbSecret,
+    type SecretFetcher,
+} from './db-credentials'
+
+const SECRET: ResolvedDbSecret = {
+    username: 'mgmntAppDBUser',
+    password: 'old-pw',
+    host: 'db.example.internal',
+    dbname: 'management',
+}
+
+// A SecretFetcher whose returned SecretString can change between calls.
+function fetcherFor(secrets: ResolvedDbSecret[]): { fetcher: SecretFetcher; calls: () => number } {
+    let i = 0
+    const send = vi.fn(async () => {
+        const secret = secrets[Math.min(i, secrets.length - 1)]
+        i += 1
+        return { SecretString: JSON.stringify(secret) }
+    })
+    return { fetcher: { send } as unknown as SecretFetcher, calls: () => send.mock.calls.length }
+}
+
+describe('poolSettingsFromSecret', () => {
+    it('assembles an SSL-enabled connection string with url-encoded credentials', () => {
+        const settings = poolSettingsFromSecret({ ...SECRET, password: 'p@ss/word' })
+        expect(settings.connectionString).toBe('postgres://mgmntAppDBUser:p%40ss%2Fword@db.example.internal/management')
+        expect(settings.ssl).toEqual({ rejectUnauthorized: false })
+    })
+})
+
+describe('isInvalidPasswordError', () => {
+    it('matches the Postgres 28P01 SQLSTATE', () => {
+        expect(isInvalidPasswordError({ code: INVALID_PASSWORD_CODE })).toBe(true)
+    })
+
+    it('ignores other errors', () => {
+        expect(isInvalidPasswordError(new Error('boom'))).toBe(false)
+        expect(isInvalidPasswordError({ code: '08006' })).toBe(false)
+        expect(isInvalidPasswordError(null)).toBe(false)
+        expect(isInvalidPasswordError('28P01')).toBe(false)
+    })
+})
+
+describe('DbCredentials.refresh', () => {
+    it('returns true and updates the cache when the password changed', async () => {
+        const { fetcher } = fetcherFor([SECRET, { ...SECRET, password: 'new-pw' }])
+        const creds = await DbCredentials.resolve('arn:secret', fetcher)
+        expect(creds.current().password).toBe('old-pw')
+
+        await expect(creds.refresh()).resolves.toBe(true)
+        expect(creds.current().password).toBe('new-pw')
+        expect(creds.poolSettings().connectionString).toContain('new-pw')
+    })
+
+    it('returns false and keeps the cache when the password is unchanged', async () => {
+        const { fetcher } = fetcherFor([SECRET, SECRET])
+        const creds = await DbCredentials.resolve('arn:secret', fetcher)
+
+        await expect(creds.refresh()).resolves.toBe(false)
+        expect(creds.current().password).toBe('old-pw')
+    })
+})
+
+describe('resolveDbSource', () => {
+    it('uses DATABASE_URL directly without touching Secrets Manager', async () => {
+        const { fetcher, calls } = fetcherFor([SECRET])
+        const source = await resolveDbSource({ DATABASE_URL: 'postgres://local/dev' }, fetcher)
+        expect(source.kind).toBe('connectionString')
+        if (source.kind === 'connectionString') {
+            expect(source.settings.connectionString).toBe('postgres://local/dev')
+        }
+        expect(calls()).toBe(0)
+    })
+
+    it('resolves the secret when only DB_SECRET_ARN is set', async () => {
+        const { fetcher } = fetcherFor([SECRET])
+        const source = await resolveDbSource({ DB_SECRET_ARN: 'arn:secret' }, fetcher)
+        expect(source.kind).toBe('secret')
+        if (source.kind === 'secret') {
+            expect(source.credentials.poolSettings().connectionString).toContain('old-pw')
+        }
+    })
+
+    it('throws when neither DATABASE_URL nor DB_SECRET_ARN is set', async () => {
+        const { fetcher } = fetcherFor([SECRET])
+        await expect(resolveDbSource({}, fetcher)).rejects.toThrow(/DATABASE_URL or DB_SECRET_ARN/)
+    })
+})

--- a/services/editor/db-credentials.ts
+++ b/services/editor/db-credentials.ts
@@ -1,0 +1,122 @@
+// Resilient DB credential resolution for the long-running editor service.
+//
+// The service authenticates to Postgres with a password fetched from Secrets
+// Manager. A `ManagementAppStack` deploy can reset that password while the
+// editor task keeps running, after which every pooled connection authenticates
+// with the now-stale password and fails with `28P01`. Restarting the task was
+// the only recovery (see OTTER-626).
+//
+// This module caches the resolved secret but, on a connection-time auth
+// failure, re-fetches the secret and reports whether the password actually
+// changed. The caller can then rebuild its pool against the fresh credentials
+// and retry — self-healing without a restart, and without hammering Secrets
+// Manager on every healthy connection.
+
+import { GetSecretValueCommand, SecretsManagerClient } from '@aws-sdk/client-secrets-manager'
+
+export type ResolvedDbSecret = {
+    username: string
+    password: string
+    host: string
+    dbname: string
+}
+
+export type DbPoolSettings = {
+    connectionString: string
+    // Aurora Postgres has rds.force_ssl=1; matches src/database/dialect.ts.
+    ssl?: { rejectUnauthorized: boolean }
+}
+
+// Minimal surface of SecretsManagerClient we depend on, so tests can pass a stub.
+export type SecretFetcher = {
+    send(command: GetSecretValueCommand): Promise<{ SecretString?: string }>
+}
+
+function buildConnectionString(secret: ResolvedDbSecret): string {
+    return `postgres://${encodeURIComponent(secret.username)}:${encodeURIComponent(secret.password)}@${secret.host}/${secret.dbname}`
+}
+
+export function poolSettingsFromSecret(secret: ResolvedDbSecret): DbPoolSettings {
+    return {
+        connectionString: buildConnectionString(secret),
+        ssl: { rejectUnauthorized: false },
+    }
+}
+
+async function fetchSecret(arn: string, client: SecretFetcher): Promise<ResolvedDbSecret> {
+    const data = await client.send(new GetSecretValueCommand({ SecretId: arn }))
+    if (!data.SecretString) throw new Error(`failed to fetch db secret from ${arn}`)
+    return JSON.parse(data.SecretString) as ResolvedDbSecret
+}
+
+// Postgres SQLSTATE for "password authentication failed". A connection that
+// fails with this code is the signal that the cached password may be stale.
+export const INVALID_PASSWORD_CODE = '28P01'
+
+export function isInvalidPasswordError(err: unknown): boolean {
+    return typeof err === 'object' && err !== null && (err as { code?: unknown }).code === INVALID_PASSWORD_CODE
+}
+
+// Holds the most-recently-resolved DB secret and knows how to refresh it from
+// Secrets Manager when a connection rejects the cached password.
+export class DbCredentials {
+    private secret: ResolvedDbSecret
+
+    private constructor(
+        secret: ResolvedDbSecret,
+        private readonly arn: string,
+        private readonly client: SecretFetcher,
+    ) {
+        this.secret = secret
+    }
+
+    static async resolve(arn: string, client: SecretFetcher): Promise<DbCredentials> {
+        const secret = await fetchSecret(arn, client)
+        return new DbCredentials(secret, arn, client)
+    }
+
+    poolSettings(): DbPoolSettings {
+        return poolSettingsFromSecret(this.secret)
+    }
+
+    current(): ResolvedDbSecret {
+        return this.secret
+    }
+
+    // Re-fetch the secret. Returns true when the password differs from the
+    // cached one (i.e. a retry against fresh credentials is worthwhile) and
+    // updates the cache; returns false when the password is unchanged, so the
+    // caller does not loop re-fetching an identical secret on a non-credential
+    // failure.
+    async refresh(): Promise<boolean> {
+        const next = await fetchSecret(this.arn, this.client)
+        if (next.password === this.secret.password) return false
+        this.secret = next
+        return true
+    }
+}
+
+// Resolve the pool source. Mirrors src/server/config.ts:databaseURL() — accept
+// DATABASE_URL directly for local/dev, otherwise resolve the RDS-managed
+// secret. Returns a `DATABASE_URL` source (static, no refresh) or a `secret`
+// source backed by DbCredentials (refreshable).
+export type DbSource =
+    | { kind: 'connectionString'; settings: DbPoolSettings }
+    | { kind: 'secret'; credentials: DbCredentials }
+
+export async function resolveDbSource(
+    env: { DATABASE_URL?: string; DB_SECRET_ARN?: string },
+    client: SecretFetcher,
+): Promise<DbSource> {
+    if (env.DATABASE_URL) {
+        return { kind: 'connectionString', settings: { connectionString: env.DATABASE_URL } }
+    }
+    const arn = env.DB_SECRET_ARN
+    if (!arn) throw new Error('DATABASE_URL or DB_SECRET_ARN is required')
+    const credentials = await DbCredentials.resolve(arn, client)
+    return { kind: 'secret', credentials }
+}
+
+export function createSecretsClient(): SecretFetcher {
+    return new SecretsManagerClient({}) as unknown as SecretFetcher
+}

--- a/services/editor/db-pool.test.ts
+++ b/services/editor/db-pool.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { DbCredentials, INVALID_PASSWORD_CODE, type DbSource, type SecretFetcher } from './db-credentials'
+import { ResilientDbPool, type PoolFactory } from './db-pool'
+
+const SECRET = { username: 'u', password: 'old-pw', host: 'h', dbname: 'd' }
+
+function invalidPasswordError(): Error & { code: string } {
+    return Object.assign(new Error('password authentication failed for user "u"'), { code: INVALID_PASSWORD_CODE })
+}
+
+// Builds a fake pg.Pool whose query() reads from a queued list of behaviors:
+// either resolve with rows or throw. Records how many pools were built so we can
+// assert a rebuild happened (or didn't).
+function fakePoolFactory(behaviorsByPool: Array<Array<() => unknown>>) {
+    const built: Array<{ ended: boolean; queries: number }> = []
+    const factory: PoolFactory = () => {
+        const idx = built.length
+        const state = { ended: false, queries: 0 }
+        built.push(state)
+        const behaviors = behaviorsByPool[idx] ?? []
+        return {
+            on: () => {},
+            end: async () => {
+                state.ended = true
+            },
+            query: async () => {
+                const behavior = behaviors[state.queries] ?? (() => ({ rows: [], rowCount: 0 }))
+                state.queries += 1
+                const result = behavior()
+                if (result instanceof Error) throw result
+                return result
+            },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any
+    }
+    return { factory, built }
+}
+
+async function secretSource(secrets: Array<typeof SECRET>): Promise<DbSource> {
+    let i = 0
+    const send = vi.fn(async () => {
+        const secret = secrets[Math.min(i, secrets.length - 1)]
+        i += 1
+        return { SecretString: JSON.stringify(secret) }
+    })
+    const credentials = await DbCredentials.resolve('arn', { send } as unknown as SecretFetcher)
+    return { kind: 'secret', credentials }
+}
+
+const noopLog = () => {}
+
+describe('ResilientDbPool', () => {
+    it('passes through successful queries without rebuilding', async () => {
+        const source = await secretSource([SECRET])
+        const { factory, built } = fakePoolFactory([[() => ({ rows: [{ now: 1 }], rowCount: 1 })]])
+        const pool = new ResilientDbPool(source, noopLog, factory)
+
+        const result = await pool.query('SELECT now()')
+        expect(result.rows).toEqual([{ now: 1 }])
+        expect(built).toHaveLength(1)
+    })
+
+    it('rethrows non-password errors without recovery', async () => {
+        const source = await secretSource([SECRET])
+        const { factory, built } = fakePoolFactory([[() => new Error('syntax error')]])
+        const pool = new ResilientDbPool(source, noopLog, factory)
+
+        await expect(pool.query('SELECT bad')).rejects.toThrow('syntax error')
+        expect(built).toHaveLength(1)
+    })
+
+    it('refreshes the secret and retries on a rotated password', async () => {
+        const source = await secretSource([SECRET, { ...SECRET, password: 'new-pw' }])
+        const { factory, built } = fakePoolFactory([
+            [() => invalidPasswordError()], // first pool: stale password
+            [() => ({ rows: [{ ok: true }], rowCount: 1 })], // rebuilt pool: succeeds
+        ])
+        const pool = new ResilientDbPool(source, noopLog, factory)
+
+        const result = await pool.query('SELECT 1')
+        expect(result.rows).toEqual([{ ok: true }])
+        expect(built).toHaveLength(2)
+        expect(built[0].ended).toBe(true) // stale pool was torn down
+    })
+
+    it('does not retry when the password is unchanged (genuine credential failure)', async () => {
+        const source = await secretSource([SECRET, SECRET])
+        const { factory, built } = fakePoolFactory([[() => invalidPasswordError()]])
+        const pool = new ResilientDbPool(source, noopLog, factory)
+
+        await expect(pool.query('SELECT 1')).rejects.toMatchObject({ code: INVALID_PASSWORD_CODE })
+        expect(built).toHaveLength(1) // no rebuild
+    })
+
+    it('does not refresh for a static DATABASE_URL source', async () => {
+        const source: DbSource = { kind: 'connectionString', settings: { connectionString: 'postgres://local/dev' } }
+        const { factory, built } = fakePoolFactory([[() => invalidPasswordError()]])
+        const pool = new ResilientDbPool(source, noopLog, factory)
+
+        await expect(pool.query('SELECT 1')).rejects.toMatchObject({ code: INVALID_PASSWORD_CODE })
+        expect(built).toHaveLength(1)
+    })
+})

--- a/services/editor/db-pool.ts
+++ b/services/editor/db-pool.ts
@@ -1,0 +1,81 @@
+// A self-healing Postgres pool for the editor service.
+//
+// Wraps pg.Pool so that a query failing with `28P01 password authentication
+// failed` triggers a one-shot recovery: re-fetch the DB secret, and if the
+// password actually changed, rebuild the pool against the fresh credentials and
+// retry the query once. This recovers from a deploy-driven password change
+// without restarting the long-running editor task (OTTER-626).
+//
+// When the source is a static DATABASE_URL (local/dev) there is nothing to
+// refresh, so the wrapper degrades to a plain pass-through.
+
+import pg from 'pg'
+import { type DbSource, isInvalidPasswordError } from './db-credentials.ts'
+
+export type QueryResult<T> = { rows: T[]; rowCount: number | null }
+
+type Logger = (event: string, fields?: Record<string, unknown>) => void
+
+// Factory seam so tests can substitute a fake pool without a real Postgres.
+export type PoolFactory = (settings: { connectionString: string; ssl?: { rejectUnauthorized: boolean } }) => pg.Pool
+
+const defaultPoolFactory: PoolFactory = (settings) => new pg.Pool(settings)
+
+export class ResilientDbPool {
+    private pool: pg.Pool
+
+    constructor(
+        private readonly source: DbSource,
+        private readonly log: Logger,
+        private readonly makePool: PoolFactory = defaultPoolFactory,
+    ) {
+        this.pool = this.build()
+    }
+
+    private settings(): { connectionString: string; ssl?: { rejectUnauthorized: boolean } } {
+        return this.source.kind === 'connectionString' ? this.source.settings : this.source.credentials.poolSettings()
+    }
+
+    private build(): pg.Pool {
+        const pool = this.makePool(this.settings())
+        pool.on('error', (err) => this.log('db.pool.error', { message: err.message }))
+        return pool
+    }
+
+    // Re-fetch credentials and, if the password changed, swap in a fresh pool.
+    // Returns true when the pool was rebuilt (retry worthwhile). The old pool is
+    // ended in the background; its in-flight queries reject independently.
+    private async recover(): Promise<boolean> {
+        if (this.source.kind !== 'secret') return false
+        const changed = await this.source.credentials.refresh()
+        if (!changed) {
+            this.log('db.credentials.unchanged')
+            return false
+        }
+        this.log('db.credentials.rotated')
+        const old = this.pool
+        this.pool = this.build()
+        old.end().catch((err) =>
+            this.log('db.pool.end.error', { message: err instanceof Error ? err.message : String(err) }),
+        )
+        return true
+    }
+
+    // pg.Pool-compatible query, with one-shot recovery on a stale password.
+    async query<T = Record<string, unknown>>(text: string, values?: unknown[]): Promise<QueryResult<T>> {
+        try {
+            return (await this.pool.query(text, values)) as unknown as QueryResult<T>
+        } catch (err) {
+            if (!isInvalidPasswordError(err)) throw err
+            this.log('db.auth.stale', { message: err instanceof Error ? err.message : String(err) })
+            const recovered = await this.recover()
+            if (!recovered) throw err
+            return (await this.pool.query(text, values)) as unknown as QueryResult<T>
+        }
+    }
+
+    async ping(): Promise<Date | undefined> {
+        const result = await this.query<{ now: Date }>('SELECT now() AS now')
+        return result.rows[0]?.now
+    }
+}

--- a/services/editor/server.ts
+++ b/services/editor/server.ts
@@ -1,14 +1,13 @@
 import { Server } from '@hocuspocus/server'
 import { Database } from '@hocuspocus/extension-database'
 import { verifyToken } from '@clerk/backend'
-import { GetSecretValueCommand, SecretsManagerClient } from '@aws-sdk/client-secrets-manager'
-import pg from 'pg'
 import type { IncomingMessage, ServerResponse } from 'http'
 import { TYPING_DEBOUNCE_MS, MAX_SAVE_INTERVAL_MS } from './constants.ts'
 import {
     type AuthenticatedContext,
     type StudyStatus,
     AuthFailureError,
+    InfraUnavailableError,
     assertStatelessEventConsistent,
     authenticate,
     parseDocumentName,
@@ -16,6 +15,8 @@ import {
     shouldPersistDocument,
     studyIdForDocument,
 } from './auth.ts'
+import { createSecretsClient, resolveDbSource } from './db-credentials.ts'
+import { ResilientDbPool } from './db-pool.ts'
 import { SLUG_TO_STUDY_COLUMN, seedYDocFromLexical } from './lexical-seed.ts'
 
 // Decode (without verifying) the JWT's `sub` claim, purely for diagnostic
@@ -58,36 +59,19 @@ log('startup.config', {
 
 const SI_ADMIN_ORG_SLUG = 'safe-insights'
 
-// Mirrors src/server/config.ts:databaseURL() — accept DATABASE_URL directly for local/dev,
-// otherwise fetch the RDS-managed secret JSON (host/username/password/dbname) and assemble.
-async function resolvePoolConfig(): Promise<pg.PoolConfig> {
-    if (process.env.DATABASE_URL) {
-        log('db.config.source', { source: 'DATABASE_URL' })
-        return { connectionString: process.env.DATABASE_URL }
-    }
-
-    const arn = process.env.DB_SECRET_ARN
-    if (!arn) throw new Error('DATABASE_URL or DB_SECRET_ARN is required')
-
-    log('db.config.source', { source: 'secretsManager', arn })
-    const client = new SecretsManagerClient({})
-    const data = await client.send(new GetSecretValueCommand({ SecretId: arn }))
-    if (!data.SecretString) throw new Error(`failed to fetch db secret from ${arn}`)
-    const db = JSON.parse(data.SecretString) as { username: string; password: string; host: string; dbname: string }
-    log('db.config.resolved', { host: db.host, dbname: db.dbname, user: db.username })
-    return {
-        connectionString: `postgres://${encodeURIComponent(db.username)}:${encodeURIComponent(db.password)}@${db.host}/${db.dbname}`,
-        // Aurora Postgres has rds.force_ssl=1; matches src/database/dialect.ts.
-        ssl: { rejectUnauthorized: false },
-    }
-}
-
-const pool = new pg.Pool(await resolvePoolConfig())
-pool.on('error', (err) => log('db.pool.error', { message: err.message }))
+// Resolve the DB source once at boot, then wrap it in a self-healing pool. The
+// pool re-reads the secret and rebuilds itself if a deploy rotates the DB
+// password, so the long-running editor task recovers without a restart
+// (OTTER-626). DATABASE_URL (local/dev) is static and has nothing to refresh.
+const source = await resolveDbSource(process.env, createSecretsClient())
+log('db.config.source', {
+    source: source.kind === 'connectionString' ? 'DATABASE_URL' : 'secretsManager',
+})
+const pool = new ResilientDbPool(source, log)
 
 try {
-    const ping = await pool.query<{ now: Date }>('SELECT now() AS now')
-    log('db.ping.ok', { now: ping.rows[0]?.now })
+    const now = await pool.ping()
+    log('db.ping.ok', { now })
 } catch (err) {
     log('db.ping.fail', { message: err instanceof Error ? err.message : String(err) })
     throw err
@@ -157,13 +141,23 @@ const server = new Server({
             log('auth.ok', { documentName, internalUserId: ctx.user.id, clerkUserId: ctx.user.clerkId })
             return ctx
         } catch (err) {
-            log('auth.fail', {
-                documentName,
-                code: err instanceof AuthFailureError ? err.code : null,
-                message: err instanceof Error ? err.message : String(err),
-                clerkUserId: unsafeJwtSubject(token),
-            })
-            throw err
+            // A genuine auth rejection carries an AuthFailureError with a stable
+            // CODE. Anything else (DB unreachable, password rejected even after
+            // the pool's self-heal attempt) is an infra failure: re-wrap it so
+            // the client shows a recoverable "reconnecting" state and retries,
+            // rather than the terminal "editor unavailable" banner (OTTER-626).
+            if (err instanceof AuthFailureError) {
+                log('auth.fail', {
+                    documentName,
+                    code: err.code,
+                    message: err.message,
+                    clerkUserId: unsafeJwtSubject(token),
+                })
+                throw err
+            }
+            const message = err instanceof Error ? err.message : String(err)
+            log('auth.infra', { documentName, message, clerkUserId: unsafeJwtSubject(token) })
+            throw new InfraUnavailableError(message)
         }
     },
     async onLoadDocument({ documentName, document }) {

--- a/src/components/editable-text/collaborative-editor.tsx
+++ b/src/components/editable-text/collaborative-editor.tsx
@@ -366,6 +366,8 @@ function ReconnectingBanner() {
 // in this set means the editor genuinely cannot show — wrong user, missing token,
 // wrong document name. STUDY_NOT_EDITABLE intentionally falls through to the
 // kick-out flow handled by useSubmissionRedirectListener / useStudyStatusOnReconnect.
+// INFRA_UNAVAILABLE is deliberately absent: it is recoverable and drives a retry,
+// not a terminal banner (OTTER-626).
 const TERMINAL_AUTH_CODES = new Set<AuthFailureCode>([
     'MISSING_TOKEN',
     'INVALID_TOKEN',
@@ -375,6 +377,10 @@ const TERMINAL_AUTH_CODES = new Set<AuthFailureCode>([
     'NO_MEMBERSHIP',
     'UNKNOWN',
 ])
+
+// How long to wait before re-attempting a connection that failed with
+// INFRA_UNAVAILABLE, giving the editor service time to self-heal its DB pool.
+const INFRA_RETRY_DELAY_MS = 5000
 
 export function CollaborativeEditor({
     id,
@@ -396,6 +402,7 @@ export function CollaborativeEditor({
     // the provider value.
     const [activeProvider, setActiveProvider] = useState<HocuspocusProvider | null>(null)
     const [authFailureCode, setAuthFailureCode] = useState<AuthFailureCode | null>(null)
+    const infraRetryTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
     const phase = useConnectionPhase()
     const triggerKickOut = useTriggerStudyKickOut()
     const userId = user?.id
@@ -412,6 +419,18 @@ export function CollaborativeEditor({
             // websocket dropping (server forcibly closes one handshake), so the page-level
             // reconnect listener wouldn't run. Drive the kick-out check from here too.
             if (code === 'STUDY_NOT_EDITABLE') triggerKickOut()
+            // INFRA_UNAVAILABLE means the server's DB was momentarily unreachable, not
+            // that we're unauthorized. The handshake closed this one provider while the
+            // shared transport stayed up, so nothing else will retry it — re-attempt the
+            // connection after a backoff. Clearing the code drops the banner once the
+            // retry's handshake succeeds.
+            if (code === 'INFRA_UNAVAILABLE') {
+                if (infraRetryTimer.current) clearTimeout(infraRetryTimer.current)
+                infraRetryTimer.current = setTimeout(() => {
+                    setAuthFailureCode(null)
+                    providerRef.current?.connect()
+                }, INFRA_RETRY_DELAY_MS)
+            }
         },
         [id, triggerKickOut],
     )
@@ -453,6 +472,14 @@ export function CollaborativeEditor({
         }
     }, [activeProvider])
 
+    // Cancel any pending INFRA_UNAVAILABLE retry on unmount.
+    useEffect(
+        () => () => {
+            if (infraRetryTimer.current) clearTimeout(infraRetryTimer.current)
+        },
+        [],
+    )
+
     // STUDY_NOT_EDITABLE: a peer submitted while we were disconnected. The kick-out
     // flow (toast + redirect) is wired up at the page level; render nothing here so
     // we don't flash a red error before the navigation completes.
@@ -469,7 +496,7 @@ export function CollaborativeEditor({
     return (
         <LexicalComposer initialConfig={initialConfig}>
             <LexicalCollaboration>
-                {phase === 'reconnecting' && <ReconnectingBanner />}
+                {(phase === 'reconnecting' || authFailureCode === 'INFRA_UNAVAILABLE') && <ReconnectingBanner />}
                 <Paper
                     p={0}
                     className="collaborative-editor-container"

--- a/src/database/dialect.ts
+++ b/src/database/dialect.ts
@@ -1,13 +1,10 @@
 import { PostgresDialect } from 'kysely'
-import PG from 'pg'
-import { databaseURL, DEPLOYED_ENV } from '../server/config'
+import { databaseURL } from '../server/config'
+import { ResilientPool } from './resilient-pool'
 
 export const dialect = new PostgresDialect({
-    pool: async () => {
-        const config = await databaseURL()
-        return new PG.Pool({
-            connectionString: config,
-            ...(DEPLOYED_ENV && { ssl: { rejectUnauthorized: false } }),
-        })
-    },
+    // ResilientPool re-reads the DB secret and rebuilds itself if a deploy
+    // rotates the password, so a warm process recovers without a restart
+    // (OTTER-626).
+    pool: async () => new ResilientPool(await databaseURL()),
 })

--- a/src/database/resilient-pool.test.ts
+++ b/src/database/resilient-pool.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ResilientPool, type PoolLike, type PoolFactory } from './resilient-pool'
+
+function invalidPasswordError() {
+    return Object.assign(new Error('password authentication failed for user "u"'), { code: '28P01' })
+}
+
+// Records every pool the factory builds so tests can stage per-pool behavior
+// and assert which connection string each was built with.
+function trackingFactory() {
+    const pools: Array<{
+        connectionString: string
+        client: object
+        connect: ReturnType<typeof vi.fn>
+        end: ReturnType<typeof vi.fn>
+        on: ReturnType<typeof vi.fn>
+    }> = []
+    const factory: PoolFactory = (connectionString) => {
+        const client = {}
+        const pool: PoolLike = {
+            connect: vi.fn(async () => client as never),
+            end: vi.fn(async () => {}),
+            on: vi.fn(),
+        }
+        pools.push({
+            connectionString,
+            client,
+            connect: pool.connect as never,
+            end: pool.end as never,
+            on: pool.on as never,
+        })
+        return pool
+    }
+    return { factory, pools }
+}
+
+describe('ResilientPool', () => {
+    it('returns the client from the delegate on success', async () => {
+        const { factory, pools } = trackingFactory()
+        const resolve = vi.fn()
+        const pool = new ResilientPool('postgres://u:old@h/d', factory, resolve)
+
+        await expect(pool.connect()).resolves.toBe(pools[0].client)
+        expect(pools).toHaveLength(1)
+        expect(resolve).not.toHaveBeenCalled()
+    })
+
+    it('rebuilds with fresh credentials and retries when the password rotated', async () => {
+        const { factory, pools } = trackingFactory()
+        const resolve = vi.fn(async () => 'postgres://u:new@h/d')
+        const pool = new ResilientPool('postgres://u:old@h/d', factory, resolve)
+        pools[0].connect.mockRejectedValue(invalidPasswordError())
+
+        const client = await pool.connect()
+
+        expect(pools).toHaveLength(2)
+        expect(client).toBe(pools[1].client) // came from the rebuilt pool
+        expect(pools[1].connectionString).toBe('postgres://u:new@h/d')
+        expect(pools[0].end).toHaveBeenCalled() // stale pool torn down
+    })
+
+    it('rethrows and does not rebuild when the password is unchanged', async () => {
+        const { factory, pools } = trackingFactory()
+        const resolve = vi.fn(async () => 'postgres://u:old@h/d')
+        const pool = new ResilientPool('postgres://u:old@h/d', factory, resolve)
+        pools[0].connect.mockRejectedValue(invalidPasswordError())
+
+        await expect(pool.connect()).rejects.toMatchObject({ code: '28P01' })
+        expect(pools).toHaveLength(1)
+    })
+
+    it('re-registers error listeners on the rebuilt pool after rotation', async () => {
+        const { factory, pools } = trackingFactory()
+        const resolve = vi.fn(async () => 'postgres://u:new@h/d')
+        const pool = new ResilientPool('postgres://u:old@h/d', factory, resolve)
+        const listener = vi.fn()
+        pool.on('error', listener)
+        pools[0].connect.mockRejectedValue(invalidPasswordError())
+
+        await pool.connect()
+
+        expect(pools[0].on).toHaveBeenCalledWith('error', listener)
+        expect(pools[1].on).toHaveBeenCalledWith('error', listener) // carried over
+    })
+
+    it('rethrows non-password errors without re-reading the secret', async () => {
+        const { factory, pools } = trackingFactory()
+        const resolve = vi.fn()
+        const pool = new ResilientPool('postgres://u:old@h/d', factory, resolve)
+        pools[0].connect.mockRejectedValue(new Error('connection refused'))
+
+        await expect(pool.connect()).rejects.toThrow('connection refused')
+        expect(resolve).not.toHaveBeenCalled()
+        expect(pools).toHaveLength(1)
+    })
+})

--- a/src/database/resilient-pool.ts
+++ b/src/database/resilient-pool.ts
@@ -1,0 +1,93 @@
+import PG from 'pg'
+import { databaseURL, DEPLOYED_ENV } from '@/server/config'
+
+// Postgres SQLSTATE for "password authentication failed". A connection that
+// fails with this code is the signal that the cached DB password may be stale.
+const INVALID_PASSWORD_CODE = '28P01'
+
+function isInvalidPasswordError(err: unknown): boolean {
+    return typeof err === 'object' && err !== null && (err as { code?: unknown }).code === INVALID_PASSWORD_CODE
+}
+
+// The subset of pg.Pool that Kysely's PostgresDriver actually uses: connect()
+// per query and end() on teardown (PostgresPool in kysely). Implementing the
+// interface rather than extending pg.Pool keeps this unit-testable without
+// mocking pg.
+export interface PoolLike {
+    connect(): Promise<PG.PoolClient>
+    end(): Promise<void>
+    on(event: 'error', listener: (err: Error, client: PG.PoolClient) => void): unknown
+}
+
+export type PoolFactory = (connectionString: string) => PoolLike
+
+// Resolver for the (possibly rotated) connection string. Defaults to the real
+// secret/env lookup; injectable so tests stay hermetic.
+export type ConnectionStringResolver = () => Promise<string>
+
+const defaultPoolFactory: PoolFactory = (connectionString) =>
+    new PG.Pool({
+        connectionString,
+        ...(DEPLOYED_ENV && { ssl: { rejectUnauthorized: false } }),
+    })
+
+// A DB pool that re-reads DATABASE_URL (or the DB_SECRET_ARN secret) and
+// rebuilds itself when a connection is rejected with 28P01. A deploy can rotate
+// the DB password while a warm Lambda/server process keeps a pool wired to the
+// old connection string; without this, every new connection fails until the
+// process is recycled (OTTER-626). On a password change new connections
+// immediately use the fresh credentials; an unchanged password means a genuine
+// auth problem and the original error propagates.
+//
+// Kysely obtains a client via connect() per query, so 28P01 surfaces there;
+// recovering in connect() lets every Kysely query benefit.
+export class ResilientPool implements PoolLike {
+    private connectionString: string
+    private delegate: PoolLike
+    private errorListeners: Array<(err: Error, client: PG.PoolClient) => void> = []
+
+    constructor(
+        connectionString: string,
+        private readonly makePool: PoolFactory = defaultPoolFactory,
+        private readonly resolveConnectionString: ConnectionStringResolver = databaseURL,
+    ) {
+        this.connectionString = connectionString
+        this.delegate = this.makePool(connectionString)
+    }
+
+    // Re-fetch the connection string; if the password changed, swap in a fresh
+    // delegate pool and return true (retry worthwhile). Unchanged → false.
+    private async refresh(): Promise<boolean> {
+        const next = await this.resolveConnectionString()
+        if (next === this.connectionString) return false
+        this.connectionString = next
+        const old = this.delegate
+        this.delegate = this.makePool(next)
+        // Carry registered error listeners onto the replacement pool.
+        for (const listener of this.errorListeners) this.delegate.on('error', listener)
+        old.end().catch(() => {})
+        return true
+    }
+
+    async connect(): Promise<PG.PoolClient> {
+        try {
+            return await this.delegate.connect()
+        } catch (err) {
+            if (!isInvalidPasswordError(err) || !(await this.refresh())) throw err
+            return await this.delegate.connect()
+        }
+    }
+
+    end(): Promise<void> {
+        return this.delegate.end()
+    }
+
+    on(event: 'error', listener: (err: Error, client: PG.PoolClient) => void): this {
+        // Track and forward to the live delegate so idle-client errors still
+        // reach callers, and survive a refresh() rebuild. (Kysely doesn't
+        // subscribe, but the pg.Pool contract emits these.)
+        this.errorListeners.push(listener)
+        this.delegate.on(event, listener)
+        return this
+    }
+}

--- a/src/lib/realtime/auth-failure.test.ts
+++ b/src/lib/realtime/auth-failure.test.ts
@@ -26,6 +26,13 @@ describe('parseAuthFailureReason', () => {
         expect(parseAuthFailureReason(undefined)).toEqual({ code: 'UNKNOWN', message: 'unknown' })
     })
 
+    it('parses INFRA_UNAVAILABLE as a recoverable (non-terminal) code', () => {
+        expect(parseAuthFailureReason('INFRA_UNAVAILABLE: password authentication failed')).toEqual({
+            code: 'INFRA_UNAVAILABLE',
+            message: 'password authentication failed',
+        })
+    })
+
     it('round-trips every known code', () => {
         const codes = [
             'MISSING_TOKEN',
@@ -35,6 +42,7 @@ describe('parseAuthFailureReason', () => {
             'STUDY_NOT_FOUND',
             'NO_MEMBERSHIP',
             'STUDY_NOT_EDITABLE',
+            'INFRA_UNAVAILABLE',
         ] as const
         for (const code of codes) {
             expect(parseAuthFailureReason(`${code}: any message`)).toEqual({ code, message: 'any message' })

--- a/src/lib/realtime/auth-failure.ts
+++ b/src/lib/realtime/auth-failure.ts
@@ -12,6 +12,10 @@ export type AuthFailureCode =
     | 'STUDY_NOT_FOUND'
     | 'NO_MEMBERSHIP'
     | 'STUDY_NOT_EDITABLE'
+    // Not an auth rejection: the server hit an infra failure (DB unreachable or
+    // rejected its credentials) while authenticating. Recoverable, not terminal
+    // — the client retries instead of showing "editor unavailable" (OTTER-626).
+    | 'INFRA_UNAVAILABLE'
     | 'UNKNOWN'
 
 const KNOWN_CODES: Record<string, AuthFailureCode> = {
@@ -22,6 +26,7 @@ const KNOWN_CODES: Record<string, AuthFailureCode> = {
     STUDY_NOT_FOUND: 'STUDY_NOT_FOUND',
     NO_MEMBERSHIP: 'NO_MEMBERSHIP',
     STUDY_NOT_EDITABLE: 'STUDY_NOT_EDITABLE',
+    INFRA_UNAVAILABLE: 'INFRA_UNAVAILABLE',
 }
 
 export type ParsedAuthFailure = {

--- a/src/lib/realtime/auth-failure.ts
+++ b/src/lib/realtime/auth-failure.ts
@@ -3,6 +3,11 @@
  * Codes mirror the server-side `AuthFailureCode` union; an unknown prefix is
  * treated as a generic auth failure so the client never crashes on a future
  * code the server adds.
+ *
+ * This union is a superset of the server's: the server splits terminal
+ * rejections (AuthFailureError) from the recoverable INFRA_UNAVAILABLE
+ * (InfraUnavailableError), but both reach the client over the same wire, so the
+ * client lists both. Keep the two in sync by hand (OTTER-626).
  */
 export type AuthFailureCode =
     | 'MISSING_TOKEN'


### PR DESCRIPTION
## Problem

Two long-running processes resolve their DB password once and cache it for the life of the process, so a deploy that rotates `MgmntApp-DB-<env>` leaves them authenticating with the stale password (`28P01`) until restarted ([OTTER-626](https://openstax.atlassian.net/browse/OTTER-626)):

- **Editor service** (Hocuspocus) — every collaborative field rendered the terminal red "Editor unavailable" banner.
- **Management app** — Kysely's pool factory built one `pg.Pool` per warm container/Lambda with the password baked into the connection string.

## Fix

**Editor — resilient credentials.** `ResilientDbPool` wraps `pg.Pool`; on a `28P01` failure it re-fetches the secret and rebuilds the pool **only when the password actually changed**, then retries the query once. Unchanged-password and non-`28P01` failures rethrow normally. `DATABASE_URL` (local/dev) degrades to plain pass-through.

**Editor — error classification.** `onAuthenticate` re-wraps non-auth errors as a new `INFRA_UNAVAILABLE` reason. The client treats it as recoverable (not in `TERMINAL_AUTH_CODES`): shows the yellow "reconnecting" banner and retries the connection after a backoff, instead of latching the terminal banner.

**Management app — self-healing Kysely pool.** `ResilientPool` (`src/database/resilient-pool.ts`) applies the same `28P01`-retry/rebuild to the app's `pg.Pool` via the Kysely dialect, so a warm process recovers without a restart.

## Tests

- `services/editor/db-credentials.test.ts` / `db-pool.test.ts` — refresh-on-rotation, no-retry-on-unchanged-password, non-`28P01` passthrough, static `DATABASE_URL`.
- `src/database/resilient-pool.test.ts` — same behaviors plus error-listener carryover across rebuild.
- `src/lib/realtime/auth-failure.test.ts` — the new `INFRA_UNAVAILABLE` code.

## Companion PR (IaC repo)

Deploy coupling — force a new editor ECS deployment after the app stack deploys, so the editor re-reads a rotated secret at deploy time: [safeinsights/iac#170](https://github.com/safeinsights/iac/pull/170).

[OTTER-626]: https://openstax.atlassian.net/browse/OTTER-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ