### PR TITLE
Trivy: bump nodemailer

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   hono@<4.12.25: '>=4.12.25'
   js-yaml@<=4.1.1: '>=4.1.2'
   nodemailer@<=8.0.8: '>=8.0.9'
+  nodemailer@<9.0.1: '>=9.0.1'
   '@opentelemetry/core@<2.8.0': '>=2.8.0'
   '@babel/core@<=7.29.0': '>=7.29.1'
 
@@ -5402,8 +5403,8 @@ packages:
   node-releases@2.0.44:
     resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
 
-  nodemailer@9.0.0:
-    resolution: {integrity: sha512-tbPTid7d/p9jAA8CRZ3iomvrMaST0o6NYuY7v6JQZHpPRZ61mLFSPKYd7342NtOFuej9/+L48SOIxwfu2uDvtw==}
+  nodemailer@9.0.1:
+    resolution: {integrity: sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==}
     engines: {node: '>=6.0.0'}
 
   normalize-package-data@3.0.3:
@@ -9559,7 +9560,7 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@babel/runtime': 7.29.2
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
@@ -12974,7 +12975,7 @@ snapshots:
       lz-utils: 2.1.1
       monocart-coverage-reports: 2.12.11
       monocart-locator: 1.0.3
-      nodemailer: 9.0.0
+      nodemailer: 9.0.1
 
   ms@2.1.3: {}
 
@@ -13084,7 +13085,7 @@ snapshots:
 
   node-releases@2.0.44: {}
 
-  nodemailer@9.0.0: {}
+  nodemailer@9.0.1: {}
 
   normalize-package-data@3.0.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,5 +22,6 @@ overrides:
     'hono@<4.12.25': '>=4.12.25'
     'js-yaml@<=4.1.1': '>=4.1.2'
     'nodemailer@<=8.0.8': '>=8.0.9'
+    'nodemailer@<9.0.1': '>=9.0.1'
     '@opentelemetry/core@<2.8.0': '>=2.8.0'
     '@babel/core@<=7.29.0': '>=7.29.1'


### PR DESCRIPTION
## Summary

Bump `nodemailer` past [GHSA-p6gq-j5cr-w38f](https://github.com/advisories/GHSA-p6gq-j5cr-w38f) (HIGH, CVSS 7.1) via a pnpm override.

`nodemailer@9.0.0` is pulled in transitively by `monocart-reporter` (Playwright reporter, dev-only). The advisory — message-level `raw` option bypasses `disableFileAccess`/`disableUrlAccess`, enabling arbitrary file read and full-response
SSRF — was published 2026-06-18 and started failing the Trivy `infosec` check on all open PRs.

## Changes

- `pnpm-workspace.yaml`: add `'nodemailer@<9.0.1': '>=9.0.1'` to `overrides`, following the existing pattern (`'nodemailer@<=8.0.8': '>=8.0.9'`, `'hono@<4.12.25': '>=4.12.25'`, etc.)
- `pnpm-lock.yaml`: refreshed — resolves to `nodemailer@9.0.1`