### PR TITLE
fix: absorb quotes around %f so env command templates don't double-quote the entry-point filename (OTTER-477)

### DIFF
--- a/src/app/[orgSlug]/admin/settings/code-env-form.tsx
+++ b/src/app/[orgSlug]/admin/settings/code-env-form.tsx
@@ -182,7 +182,8 @@ function CommandLinesSection({
                 Command Lines
             </Title>
             <Text size="xs" c="dimmed" mb="sm">
-                Map file extensions to the command used to execute them. Use %f for the main code file name.
+                Map file extensions to the command used to execute them. Use %f for the main code file name; it’s quoted
+                automatically, so you don’t need to wrap it in quotes.
             </Text>
             <Stack gap="xs">
                 {Object.entries(commandLines).map(([ext, cmd]) => (

--- a/src/lib/string.test.ts
+++ b/src/lib/string.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { strToAscii, slugify, getInitials, shellQuote } from './string'
+import { strToAscii, slugify, getInitials, shellQuote, substituteEntryPointFile } from './string'
 
 describe('getInitials', () => {
     it('returns the uppercased first initial for a single name', () => {
@@ -88,5 +88,47 @@ describe('shellQuote', () => {
 
     it('handles an empty string', () => {
         expect(shellQuote('')).toBe("''")
+    })
+})
+
+describe('substituteEntryPointFile', () => {
+    it('quotes a bare %f token', () => {
+        expect(substituteEntryPointFile('Rscript %f', 'main(1).r')).toBe("Rscript 'main(1).r'")
+    })
+
+    it('replaces every %f occurrence', () => {
+        expect(substituteEntryPointFile('cp %f /tmp/ && Rscript %f', 'main(1).r')).toBe(
+            "cp 'main(1).r' /tmp/ && Rscript 'main(1).r'",
+        )
+    })
+
+    it('absorbs double quotes an admin wrapped around %f instead of double-quoting (OTTER-477 follow-up)', () => {
+        // Without absorbing, "%f" -> "'main_revised (1).R'", which /bin/sh hands to R as the
+        // literal 'main_revised (1).R' (Greg Fitch: cannot open file ''main_revised (1).R'').
+        expect(substituteEntryPointFile('Rscript "%f"', 'main_revised (1).R')).toBe("Rscript 'main_revised (1).R'")
+    })
+
+    it('absorbs single quotes an admin wrapped around %f instead of re-exposing parens', () => {
+        // Without absorbing, '%f' -> ''main(1).r'', whose parens are unquoted -> `(` syntax error.
+        expect(substituteEntryPointFile("Rscript '%f'", 'main(1).r')).toBe("Rscript 'main(1).r'")
+    })
+
+    it('leaves quotes elsewhere in the template untouched', () => {
+        expect(substituteEntryPointFile('Rscript %f --title "My Study"', 'main.R')).toBe(
+            'Rscript \'main.R\' --title "My Study"',
+        )
+    })
+
+    it('does not absorb a non-matching quote pair around %f', () => {
+        // Mismatched quotes are a malformed template; only the inner bare %f is quoted.
+        expect(substituteEntryPointFile(`"%f'`, 'main.R')).toBe(`"'main.R''`)
+    })
+
+    it('escapes embedded single quotes in the filename', () => {
+        expect(substituteEntryPointFile('Rscript "%f"', "it's.r")).toBe("Rscript 'it'\\''s.r'")
+    })
+
+    it('returns the template unchanged when there is no %f token', () => {
+        expect(substituteEntryPointFile('Rscript main.R', 'ignored.r')).toBe('Rscript main.R')
     })
 })

--- a/src/lib/string.ts
+++ b/src/lib/string.ts
@@ -18,6 +18,18 @@ export function shellQuote(value: string): string {
     return `'${escaped}'`
 }
 
+/**
+ * Replace each `%f` token in a command template with a shell-quoted `fileName`.
+ *
+ * A quote pair hugging the token (`"%f"`, `'%f'`) is absorbed so an admin-quoted
+ * template doesn't double-quote on top of our own quoting (OTTER-477).
+ */
+export function substituteEntryPointFile(template: string, fileName: string): string {
+    // \1 matches only quotes hugging the token; the function form keeps `$` in the
+    // filename from being read as a replacement pattern.
+    return template.replace(/(['"]?)%f\1/g, () => shellQuote(fileName))
+}
+
 // https://dense13.com/blog/2009/05/03/converting-string-to-slug-javascript/
 export function slugify(str: string) {
     str = str.replace(/^\s+|\s+$/g, '') // trim

--- a/src/server/aws.test.ts
+++ b/src/server/aws.test.ts
@@ -133,6 +133,36 @@ describe('buildTriggerBuildImageCommandInput', () => {
         const cmdLineVar = input.environmentVariablesOverride.find((v) => v.name === 'DOCKER_CMD_LINE')
         expect(cmdLineVar?.value).toBe("cp 'main(1).r' /tmp/ && Rscript 'main(1).r'")
     })
+
+    it('does not double-quote when the env template already wraps %f in double quotes (OTTER-477 follow-up)', async () => {
+        const input = await buildTriggerBuildImageCommandInput({
+            studyJobId: 'job-123',
+            codeEnvURL: 'docker.io/my-base-image:latest',
+            codeEntryPointFileName: 'main_revised (1).R',
+            containerLocation: 'a-bad-url',
+            cmdLine: 'Rscript "%f"',
+            studyId: 'study-abc',
+            orgSlug: 'org-xyz',
+        })
+
+        const cmdLineVar = input.environmentVariablesOverride.find((v) => v.name === 'DOCKER_CMD_LINE')
+        expect(cmdLineVar?.value).toBe("Rscript 'main_revised (1).R'")
+    })
+
+    it('does not re-expose parens when the env template already wraps %f in single quotes', async () => {
+        const input = await buildTriggerBuildImageCommandInput({
+            studyJobId: 'job-123',
+            codeEnvURL: 'docker.io/my-base-image:latest',
+            codeEntryPointFileName: 'main(1).r',
+            containerLocation: 'a-bad-url',
+            cmdLine: "Rscript '%f'",
+            studyId: 'study-abc',
+            orgSlug: 'org-xyz',
+        })
+
+        const cmdLineVar = input.environmentVariablesOverride.find((v) => v.name === 'DOCKER_CMD_LINE')
+        expect(cmdLineVar?.value).toBe("Rscript 'main(1).r'")
+    })
 })
 
 describe('buildTriggerScanForStudyJobCommandInput', () => {

--- a/src/server/aws.ts
+++ b/src/server/aws.ts
@@ -31,7 +31,7 @@ import {
     pathForStudyJobCode,
 } from '@/lib/paths'
 import type { MinimalCodeEnvInfo } from '@/lib/types'
-import { shellQuote, strToAscii } from '@/lib/string'
+import { substituteEntryPointFile, strToAscii } from '@/lib/string'
 import { parseCsv } from '@/lib/file-content-helpers'
 import logger from '@/lib/logger'
 import { Readable } from 'stream'
@@ -466,12 +466,11 @@ export async function buildTriggerBuildImageCommandInput(
         containerLocation: string
     },
 ) {
-    // Shell-quote the filename so names with parentheses or other shell metacharacters
-    // don't break the `/bin/sh` command the containerizer runs (OTTER-477). The
-    // replacement must be a function — a string replacement would interpret `$`
-    // sequences in the filename as special replacement patterns. replaceAll covers
-    // templates that reference %f more than once.
-    const cmd = info.cmdLine.replaceAll('%f', () => shellQuote(info.codeEntryPointFileName))
+    // Substitute the %f entry-point token, shell-quoting the filename so names with
+    // parentheses or other shell metacharacters don't break the `/bin/sh` command the
+    // containerizer runs (OTTER-477). The helper also absorbs quotes an admin may have
+    // wrapped around %f in the env's command template, so the two don't double-quote.
+    const cmd = substituteEntryPointFile(info.cmdLine, info.codeEntryPointFileName)
     return {
         projectName: process.env.CONTAINERIZER_PROJECT_NAME || `MgmntAppContainerizer-${ENVIRONMENT_ID}`,
         environmentVariablesOverride: await buildCodeBuildEnvVars('/api/services/containerizer', {


### PR DESCRIPTION
Fix
substituteEntryPointFile(template, fileName) makes %f substitution idempotent: it consumes one matching pair of quotes hugging the token, then shell-quotes. Result is singly quoted whether the template is %f, "%f", or '%f'. buildTriggerBuildImageCommandInput now calls it instead of replaceAll('%f', …). Admin help text updated to note %f is quoted automatically.
Testing

Unit tests for the helper: bare / double-quoted / single-quoted token, embedded single quote, multiple %f, quotes elsewhere, no token.
Regression tests in aws.test.ts for double- and single-quoted templates.
Verified through a real /bin/sh: all three forms produce one clean argument (main_revised (1).R).