### PR TITLE
rl-study-code-refactor

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.test.tsx
@@ -215,8 +215,8 @@ describe('CodePostDecisionView', () => {
         })
     })
 
-    describe('submitted code table', () => {
-        it('starts collapsed and toggles to "Hide submitted study code", rendering the file table', async () => {
+    describe('submitted code', () => {
+        it('breaks the submitted code out into its own "Submitted code" card, toggled from the step card', async () => {
             const { study, job, latestJobStatus } = await setupDecidedStudy('CODE-APPROVED')
             renderView(study, job, [buildEntry({ decision: 'APPROVE' })], latestJobStatus)
 
@@ -227,9 +227,23 @@ describe('CodePostDecisionView', () => {
             const interact = userEvent.setup()
             await interact.click(toggle)
 
-            await waitFor(() => expect(toggle).toHaveTextContent('Hide submitted study code'))
-            expect(toggle).toHaveAttribute('aria-expanded', 'true')
+            // Expanding removes the in-step opener (returns null) and reveals the breakout card's "Hide" toggle.
+            await waitFor(() => expect(screen.queryByTestId('study-code-toggle')).not.toBeInTheDocument())
+            const collapseToggle = screen.getByTestId('study-code-toggle-collapse')
+            expect(collapseToggle).toHaveTextContent('Hide submitted study code')
+            // The file table lives in its own "Submitted code" card, not inside the step header.
+            expect(screen.getByRole('heading', { name: 'Submitted code' })).toBeInTheDocument()
             expect(screen.getByTestId('submitted-code-table')).toBeInTheDocument()
+        })
+
+        it('shows the "View approved initial request" link to studySubmitted in the broken-out card', async () => {
+            const { study, job, latestJobStatus } = await setupDecidedStudy('CODE-CHANGES-REQUESTED')
+            renderView(study, job, [buildEntry({ decision: 'NEEDS-CLARIFICATION' })], latestJobStatus)
+
+            const link = screen.getByTestId('view-approved-initial-request')
+            expect(link).toHaveTextContent('View approved initial request')
+            expect(link).toHaveAttribute('href', Routes.studySubmitted({ orgSlug: ORG_SLUG, studyId: study.id }))
+            expect(link).toHaveAttribute('target', '_blank')
         })
     })
 

--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.tsx
@@ -2,8 +2,8 @@
 
 import { type FC, type ReactNode } from 'react'
 import type { Route } from 'next'
-import { Box, Collapse, Group, Stack, Text, Title } from '@mantine/core'
-import { CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
+import { Anchor, Box, Collapse, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
+import { ArrowSquareOut, CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
 import { AlertNotFound } from '@/components/errors'
 import { ButtonLink } from '@/components/links'
 import { PageBreadcrumbs } from '@/components/page-breadcrumbs'
@@ -149,34 +149,17 @@ const FeedbackSection: FC<{ feedbackLoadError: boolean; entries: CodeReviewFeedb
     return <FeedbackAndNotesSection entries={entries} alwaysExpandLatest />
 }
 
-const StudyCodeSection: FC<{ isVisible: boolean; jobId: string; codeFiles: CodeFileList }> = ({
-    isVisible,
-    jobId,
-    codeFiles,
-}) => {
-    const { expanded, toggle } = useExpandable()
-    if (!isVisible) return null
-    return (
-        <Stack gap="sm">
-            <StudyCodeToggle expanded={expanded} onClick={toggle} />
-            <Collapse in={expanded}>
-                <SubmittedCodeTable jobId={jobId} files={codeFiles} />
-            </Collapse>
-        </Stack>
-    )
-}
-
 type StepCardProps = {
     study: Submitted<SelectedStudy>
-    job: LatestJobForStudy
     copy: DecisionCopy
     timestampDate: Date | string | null
-    codeFiles: CodeFileList
     banner: ReactNode
-    showStudyCode: boolean
+    showToggle: boolean
+    expanded: boolean
+    onToggle: () => void
 }
 
-function StepCard({ study, job, copy, timestampDate, codeFiles, banner, showStudyCode }: StepCardProps) {
+function StepCard({ study, copy, timestampDate, banner, showToggle, expanded, onToggle }: StepCardProps) {
     return (
         <ProposalStepHeader
             stepLabel="STEP 4"
@@ -186,8 +169,58 @@ function StepCard({ study, job, copy, timestampDate, codeFiles, banner, showStud
             timestampDate={timestampDate}
             banner={banner}
         >
-            <StudyCodeSection isVisible={showStudyCode} jobId={job.id} codeFiles={codeFiles} />
+            <StudyCodeToggle isVisible={showToggle} expanded={expanded} onClick={onToggle} />
         </ProposalStepHeader>
+    )
+}
+
+// Broken out into its own card per design (OTTER-590): collapsed, only the in-step toggle shows; expanded,
+// this card reveals the proposal link, file table, and the matching "Hide" toggle.
+type SubmittedCodePanelProps = {
+    isVisible: boolean
+    expanded: boolean
+    jobId: string
+    codeFiles: CodeFileList
+    proposalHref: Route
+    onCollapse: () => void
+}
+
+const SubmittedCodePanel: FC<SubmittedCodePanelProps> = ({
+    isVisible,
+    expanded,
+    jobId,
+    codeFiles,
+    proposalHref,
+    onCollapse,
+}) => {
+    if (!isVisible) return null
+    return (
+        <Collapse in={expanded}>
+            <Paper p="xxl">
+                <Stack gap="md">
+                    <Group justify="space-between" align="center" wrap="nowrap">
+                        <Title order={5}>Submitted code</Title>
+                        <Anchor
+                            href={proposalHref}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            size="sm"
+                            fw={700}
+                            display="inline-flex"
+                            style={{ alignItems: 'center', gap: 4, whiteSpace: 'nowrap', flexShrink: 0 }}
+                            data-testid="view-approved-initial-request"
+                        >
+                            View approved initial request
+                            <ArrowSquareOut size={14} />
+                        </Anchor>
+                    </Group>
+                    <Divider />
+                    <Text>View the code files that you uploaded to run against the dataset.</Text>
+                    <SubmittedCodeTable jobId={jobId} files={codeFiles} />
+                    <StudyCodeToggle expanded onClick={onCollapse} testId="study-code-toggle-collapse" />
+                </Stack>
+            </Paper>
+        </Collapse>
     )
 }
 
@@ -203,6 +236,7 @@ export function CodePostDecisionView({
     showStudyCode = true,
 }: CodePostDecisionViewProps) {
     const { copy, timestampDate, codeFiles } = deriveCodePostDecision({ job, entries, decision: latestJobStatus })
+    const { expanded, toggle, collapse } = useExpandable()
 
     const proposalHref = Routes.studySubmitted({ orgSlug, studyId: study.id })
     const previousHref = Routes.studyAgreements({ orgSlug, studyId: study.id, from: 'previous' })
@@ -224,12 +258,20 @@ export function CodePostDecisionView({
             <Stack gap="xxl">
                 <StepCard
                     study={study}
-                    job={job}
                     copy={copy}
                     timestampDate={timestampDate}
-                    codeFiles={codeFiles}
                     banner={banner}
-                    showStudyCode={showStudyCode}
+                    showToggle={showStudyCode && !expanded}
+                    expanded={expanded}
+                    onToggle={toggle}
+                />
+                <SubmittedCodePanel
+                    isVisible={showStudyCode}
+                    expanded={expanded}
+                    jobId={job.id}
+                    codeFiles={codeFiles}
+                    proposalHref={proposalHref}
+                    onCollapse={collapse}
                 />
                 <FeedbackSection feedbackLoadError={feedbackLoadError} entries={entries} />
                 <DecisionActions

--- a/src/app/[orgSlug]/study/[studyId]/view/study-code-collapse.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/study-code-collapse.tsx
@@ -16,9 +16,17 @@ interface StudyCodeToggleProps {
     onClick: () => void
     isVisible?: boolean
     mt?: MantineSpacing
+    /** Override the test id so multiple toggles on one page (e.g. an in-card opener and an in-panel closer) stay distinct. */
+    testId?: string
 }
 
-export const StudyCodeToggle: FC<StudyCodeToggleProps> = ({ expanded, onClick, isVisible = true, mt }) => {
+export const StudyCodeToggle: FC<StudyCodeToggleProps> = ({
+    expanded,
+    onClick,
+    isVisible = true,
+    mt,
+    testId = 'study-code-toggle',
+}) => {
     if (!isVisible) return null
     return (
         <Anchor
@@ -32,7 +40,7 @@ export const StudyCodeToggle: FC<StudyCodeToggleProps> = ({ expanded, onClick, i
             w="fit-content"
             style={{ alignItems: 'center', gap: 4 }}
             aria-expanded={expanded}
-            data-testid="study-code-toggle"
+            data-testid={testId}
         >
             {expanded ? 'Hide submitted study code' : 'View submitted study code'}
             <CaretRightIcon size={12} weight="bold" style={{ transform: expanded ? 'rotate(-90deg)' : undefined }} />


### PR DESCRIPTION
## OTTER-590: Fix RL study code "change requested" view to match design

### Summary

The Researcher study proposal view, in the **code change requested** state, didn't match
the design. QA flagged two issues:

> Does not match design; submitted code not broken out, proposal link missing

This PR brings the view in line with the design by breaking the submitted code into its own
card and adding the missing "View approved initial request" link. The change mirrors the
pattern already used in the sibling post-submission view.

[OTTER-590](https://openstax.atlassian.net/browse/OTTER-590)

### What changed

- **Submitted code is now broken out into its own "Submitted code" card** below the Step 4
  card. While collapsed, the Step 4 card shows a `View submitted study code ›` toggle; once
  expanded, that opener is replaced by the separate card containing the file table and a
  `Hide submitted study code` toggle.
- **Added the "View approved initial request" link** (external-link icon, opens the submitted
  proposal in a new tab) in the broken-out card's header.
- Added an optional `testId` prop to `StudyCodeToggle` so the in-card opener and the in-panel
  closer remain distinct — Mantine's `Collapse` keeps its children mounted while collapsed,
  which otherwise made the shared test id ambiguous.
- The execution-window behavior (`showStudyCode=false`) is preserved: neither the toggle nor
  the code card renders.

### Files

| File | Change |
| --- | --- |
| `code-post-decision-view.tsx` | Lifted expand state up; split the toggle/table into a step-card toggle + a broken-out `SubmittedCodePanel` with the proposal link |
| `study-code-collapse.tsx` | Added optional `testId` prop to `StudyCodeToggle` |
| `code-post-decision-view.test.tsx` | Updated the toggle test for the new structure; added a test for the proposal link's href/target |


### Screenshots

| Before | After |
| --- | --- |
| <img width="1047" height="1318" alt="Screenshot 2026-06-24 at 9 15 16 AM" src="https://github.com/user-attachments/assets/e020da03-c84e-4ec5-94f4-6644a5711282" />| <img width="1546" height="1267" alt="Screenshot 2026-06-24 at 8 58 01 AM" src="https://github.com/user-attachments/assets/5c318164-aa1d-4203-a73e-76c7f4a4b42e" />|




[OTTER-590]: https://openstax.atlassian.net/browse/OTTER-590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ