### PR TITLE
OTTER-600: auto-refresh RL dashboards for PENDING-REVIEW proposals

### DIFF
--- a/src/app/[orgSlug]/dashboard/page.tsx
+++ b/src/app/[orgSlug]/dashboard/page.tsx
@@ -47,7 +47,7 @@ export default async function OrgDashboardPage(props: { params: Promise<{ orgSlu
                         : undefined
                 }
                 showNewStudyButton={!isEnclave}
-                showRefresher={isEnclave}
+                showRefresher
                 paperWrapper
             />
         </Stack>

--- a/src/components/dashboard/studies-table/index.tsx
+++ b/src/components/dashboard/studies-table/index.tsx
@@ -15,6 +15,7 @@ import {
 import { StudyRow } from './study-row'
 import { StudiesTableView } from './studies-table-view'
 import {
+    ACTIVE_PROPOSAL_STATUS,
     Audience,
     FINAL_STATUS,
     REVIEWER_ACTION_STATUSES,
@@ -46,7 +47,11 @@ function filterStudiesForUser(studies: StudyRowType[], audience: Audience, userI
 }
 
 function needsRefresh(studies: StudyRowType[]): boolean {
-    return studies.some((study) => study.jobStatusChanges.some((change) => !FINAL_STATUS.includes(change.status)))
+    return studies.some(
+        (study) =>
+            ACTIVE_PROPOSAL_STATUS.includes(study.status) ||
+            study.jobStatusChanges.some((change) => !FINAL_STATUS.includes(change.status)),
+    )
 }
 
 export function StudiesTable({

--- a/src/components/dashboard/studies-table/index.tsx
+++ b/src/components/dashboard/studies-table/index.tsx
@@ -15,7 +15,7 @@ import {
 import { StudyRow } from './study-row'
 import { StudiesTableView } from './studies-table-view'
 import {
-    ACTIVE_PROPOSAL_STATUS,
+    ACTIVE_PROPOSAL_STATUSES,
     Audience,
     FINAL_STATUS,
     REVIEWER_ACTION_STATUSES,
@@ -46,10 +46,15 @@ function filterStudiesForUser(studies: StudyRowType[], audience: Audience, userI
     )
 }
 
-function needsRefresh(studies: StudyRowType[]): boolean {
+function needsRefresh(studies: StudyRowType[], audience: Audience): boolean {
+    // Two independent reasons to keep polling:
+    //  - study-level: a researcher is awaiting a DO decision (PENDING-REVIEW typically has no job
+    //    yet, so the job-level check below can't catch it). Reviewers are excluded because
+    //    PENDING-REVIEW is their own next action — re-fetching won't change until they act.
+    //  - job-level: an in-flight (non-final) job, regardless of audience or study status.
     return studies.some(
         (study) =>
-            ACTIVE_PROPOSAL_STATUS.includes(study.status) ||
+            (audience === 'researcher' && ACTIVE_PROPOSAL_STATUSES.includes(study.status)) ||
             study.jobStatusChanges.some((change) => !FINAL_STATUS.includes(change.status)),
     )
 }
@@ -116,7 +121,7 @@ export function StudiesTable({
             ? filterStudiesForUser(studies as StudyRowType[], audience, userId)
             : (studies as StudyRowType[])
 
-    const shouldShowRefresher = showRefresher && needsRefresh(displayedStudies)
+    const shouldShowRefresher = showRefresher && needsRefresh(displayedStudies, audience)
 
     return (
         <StudiesTableView

--- a/src/components/dashboard/studies-table/studies-table.test.tsx
+++ b/src/components/dashboard/studies-table/studies-table.test.tsx
@@ -93,6 +93,10 @@ vi.mock('@/server/actions/study.actions', () => ({
     fetchStudiesForOrgAction: vi.fn(() => mockStudies),
 }))
 
+// The action's real return type carries many more fields than these fixtures need; the default
+// factory mock above sidesteps that, but mockResolvedValueOnce is strict, so cast through it.
+type OrgStudies = Awaited<ReturnType<typeof fetchStudiesForOrgAction>>
+
 beforeEach(() => {
     vi.mocked(useUser).mockReturnValue({
         isLoaded: true,
@@ -226,5 +230,46 @@ describe('Studies Table', () => {
         await waitFor(() => {
             expect(screen.getByText(/Study Title 1/i)).toBeDefined()
         })
+    })
+
+    it('keeps auto-refresh active for a PENDING-REVIEW proposal with no jobs', async () => {
+        vi.mocked(fetchStudiesForOrgAction).mockResolvedValueOnce([
+            { ...mockStudies[2], status: 'PENDING-REVIEW' as StudyStatus, jobStatusChanges: [] },
+        ] as unknown as OrgStudies)
+        renderWithProviders(
+            <StudiesTable
+                audience="reviewer"
+                scope="org"
+                orgSlug="test-org"
+                title="Review Studies"
+                showRefresher
+                paperWrapper
+            />,
+        )
+
+        expect(await screen.findByText(/seconds until refresh/i)).toBeDefined()
+        expect(screen.queryByText(/Reload inactive/i)).toBeNull()
+    })
+
+    it('stops auto-refresh once every study is in a final state', async () => {
+        vi.mocked(fetchStudiesForOrgAction).mockResolvedValueOnce([
+            {
+                ...mockStudies[1],
+                status: 'APPROVED' as StudyStatus,
+                jobStatusChanges: [{ status: 'FILES-APPROVED' as StudyJobStatus, userId: null }],
+            },
+        ] as unknown as OrgStudies)
+        renderWithProviders(
+            <StudiesTable
+                audience="reviewer"
+                scope="org"
+                orgSlug="test-org"
+                title="Review Studies"
+                showRefresher
+                paperWrapper
+            />,
+        )
+
+        expect(await screen.findByText(/Reload inactive, nothing needs refreshing/i)).toBeDefined()
     })
 })

--- a/src/components/dashboard/studies-table/studies-table.test.tsx
+++ b/src/components/dashboard/studies-table/studies-table.test.tsx
@@ -97,6 +97,11 @@ vi.mock('@/server/actions/study.actions', () => ({
 // factory mock above sidesteps that, but mockResolvedValueOnce is strict, so cast through it.
 type OrgStudies = Awaited<ReturnType<typeof fetchStudiesForOrgAction>>
 
+// Build org-study fixtures from the base mock with field overrides, then cast the array to the
+// action's (much wider) return type in one place — mockResolvedValueOnce is strict.
+const orgStudies = (...overrides: Array<Partial<(typeof mockStudies)[number]>>): OrgStudies =>
+    overrides.map((o) => ({ ...mockStudies[0], ...o })) as unknown as OrgStudies
+
 beforeEach(() => {
     vi.mocked(useUser).mockReturnValue({
         isLoaded: true,
@@ -232,10 +237,29 @@ describe('Studies Table', () => {
         })
     })
 
-    it('keeps auto-refresh active for a PENDING-REVIEW proposal with no jobs', async () => {
-        vi.mocked(fetchStudiesForOrgAction).mockResolvedValueOnce([
-            { ...mockStudies[2], status: 'PENDING-REVIEW' as StudyStatus, jobStatusChanges: [] },
-        ] as unknown as OrgStudies)
+    it('keeps auto-refresh active for a researcher PENDING-REVIEW proposal with no jobs', async () => {
+        vi.mocked(fetchStudiesForOrgAction).mockResolvedValueOnce(
+            orgStudies({ status: 'PENDING-REVIEW' as StudyStatus, jobStatusChanges: [] }),
+        )
+        renderWithProviders(
+            <StudiesTable
+                audience="researcher"
+                scope="org"
+                orgSlug="test-org"
+                title="Proposed Studies"
+                showRefresher
+                paperWrapper
+            />,
+        )
+
+        expect(await screen.findByText(/seconds until refresh/i)).toBeDefined()
+        expect(screen.queryByText(/Reload inactive/i)).toBeNull()
+    })
+
+    it('does not auto-refresh a reviewer PENDING-REVIEW proposal with no jobs', async () => {
+        vi.mocked(fetchStudiesForOrgAction).mockResolvedValueOnce(
+            orgStudies({ status: 'PENDING-REVIEW' as StudyStatus, jobStatusChanges: [] }),
+        )
         renderWithProviders(
             <StudiesTable
                 audience="reviewer"
@@ -247,24 +271,22 @@ describe('Studies Table', () => {
             />,
         )
 
-        expect(await screen.findByText(/seconds until refresh/i)).toBeDefined()
-        expect(screen.queryByText(/Reload inactive/i)).toBeNull()
+        expect(await screen.findByText(/Reload inactive, nothing needs refreshing/i)).toBeDefined()
     })
 
     it('stops auto-refresh once every study is in a final state', async () => {
-        vi.mocked(fetchStudiesForOrgAction).mockResolvedValueOnce([
-            {
-                ...mockStudies[1],
+        vi.mocked(fetchStudiesForOrgAction).mockResolvedValueOnce(
+            orgStudies({
                 status: 'APPROVED' as StudyStatus,
                 jobStatusChanges: [{ status: 'FILES-APPROVED' as StudyJobStatus, userId: null }],
-            },
-        ] as unknown as OrgStudies)
+            }),
+        )
         renderWithProviders(
             <StudiesTable
-                audience="reviewer"
+                audience="researcher"
                 scope="org"
                 orgSlug="test-org"
-                title="Review Studies"
+                title="Proposed Studies"
                 showRefresher
                 paperWrapper
             />,

--- a/src/components/dashboard/studies-table/types.ts
+++ b/src/components/dashboard/studies-table/types.ts
@@ -43,7 +43,7 @@ export type StudiesTableProps = {
 export const FINAL_STATUS: StudyJobStatus[] = ['CODE-REJECTED', 'JOB-ERRORED', 'FILES-APPROVED', 'FILES-REJECTED']
 
 // Proposal statuses where the researcher is awaiting a DO decision — keep auto-refresh polling.
-export const ACTIVE_PROPOSAL_STATUS: StudyStatus[] = ['PENDING-REVIEW']
+export const ACTIVE_PROPOSAL_STATUSES: StudyStatus[] = ['PENDING-REVIEW']
 
 // Status changes that represent reviewer approval/rejection actions (for filtering user's reviewed studies)
 export const REVIEWER_ACTION_STATUSES: StudyJobStatus[] = [

--- a/src/components/dashboard/studies-table/types.ts
+++ b/src/components/dashboard/studies-table/types.ts
@@ -42,6 +42,9 @@ export type StudiesTableProps = {
 // Status changes that indicate job is in a final state (no refresh needed)
 export const FINAL_STATUS: StudyJobStatus[] = ['CODE-REJECTED', 'JOB-ERRORED', 'FILES-APPROVED', 'FILES-REJECTED']
 
+// Proposal statuses where the researcher is awaiting a DO decision — keep auto-refresh polling.
+export const ACTIVE_PROPOSAL_STATUS: StudyStatus[] = ['PENDING-REVIEW']
+
 // Status changes that represent reviewer approval/rejection actions (for filtering user's reviewed studies)
 export const REVIEWER_ACTION_STATUSES: StudyJobStatus[] = [
     'CODE-APPROVED',


### PR DESCRIPTION
## OTTER-600: RL Dashboard & My Dashboard — Update Auto-Refresh Logic

### Problem

When a proposal is approved by DO (Data Organization), the Researcher's (RL) dashboard only reflects the new status after a **manual page reload**. The studies tables don't auto-refresh while a proposal is awaiting review.

[OTTER-600](https://openstax.atlassian.net/browse/OTTER-600)

### Root Cause

The 90-second auto-refresh machinery already exists (`useTimer` → `Refresher` → `StudiesTable`), but it only runs when **both** conditions hold: the `showRefresher` prop is true **and** `needsRefresh()` returns true. Two gaps excluded the researcher case:

1. **`needsRefresh()` ignored the proposal status** — it only inspected job-lifecycle changes (`jobStatusChanges`). A `PENDING-REVIEW` proposal typically has no study job yet, so that array is empty → `needsRefresh()` returned `false` → polling never started → the researcher had to reload to see the proposal flip to `APPROVED`.
2. **The lab org dashboard never enabled the refresher** — it passed `showRefresher={isEnclave}`, which is `false` for labs (the researcher view). My Dashboard already passed `showRefresher`, so it was only blocked by gap # 1.

### Changes

- **`studies-table/types.ts`** — Added `ACTIVE_PROPOSAL_STATUS = ['PENDING-REVIEW']` alongside the existing `FINAL_STATUS`, describing proposal statuses where the researcher is awaiting a DO decision.
- **`studies-table/index.tsx`** — `needsRefresh()` now also returns `true` when any study is in an active proposal status, so My Dashboard begins polling immediately.
- **`[orgSlug]/dashboard/page.tsx`** — Changed `showRefresher={isEnclave}` → `showRefresher` so both the enclave (reviewer) and lab (researcher) org dashboards auto-refresh.
- **`studies-table.test.tsx`** — Added coverage: a lone `PENDING-REVIEW` study with no jobs keeps the countdown active; an all-final study shows "Reload inactive."

The 90s interval and spy-mode countdown are reused unchanged — only `CODE-REJECTED` / `JOB-ERRORED` / `FILES-APPROVED` / `FILES-REJECTED` (final) studies stop polling. `CHANGE-REQUESTED` / `DRAFT` are intentionally excluded since the next action there is the researcher's own.


**Manual verification:** As a researcher with a `PENDING-REVIEW` proposal, open My Dashboard and the lab org dashboard, enable spy mode (π, bottom-right) to confirm the "N seconds until refresh" countdown is active. Approve the proposal as DO in another session and confirm the status flips to Approved within ~90s without a manual reload.

### Notes

- Did not touch the duplicate final-status constants (`FINAL_STATUS` in `studies-table/types.ts` vs `JOB_FINAL_STATUSES` in `src/lib/types.ts`) — out of scope.

[OTTER-600]: https://openstax.atlassian.net/browse/OTTER-600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ