### PR TITLE
OTTER-602: don't reset submit-enable when launching IDE after manual upload

### DIFF
--- a/src/server/actions/workspaces.actions.test.ts
+++ b/src/server/actions/workspaces.actions.test.ts
@@ -233,4 +233,67 @@ describe('Workspace Actions', () => {
             expect(result?.fileNames).toEqual(['main.r'])
         })
     })
+
+    // OTTER-602: launching the IDE must not reset submit-enable when files were already uploaded
+    // manually. The re-anchor that fixed OTTER-601 (advance createdAt so post-launch edits enable
+    // Submit) is correct only on an empty round — with files present it marks them all stale.
+    describe('createUserAndWorkspaceAction submit-enable baseline (OTTER-602)', () => {
+        const mockCoder = () =>
+            vi.doMock('@/server/coder', () => ({
+                createUserAndWorkspace: vi.fn(async () => ({ success: true, workspace: { id: 'ws-test' } })),
+                getCoderWorkspaceUrl: vi.fn(async () => 'https://coder.example/ws-test'),
+            }))
+
+        const jobCreatedAt = async (jobId: string) =>
+            (await db.selectFrom('studyJob').select('createdAt').where('id', '=', jobId).executeTakeFirstOrThrow())
+                .createdAt
+
+        test('does not advance the round job createdAt when files were already uploaded', async () => {
+            process.env.CODER_FILES = TEST_CODER_FILES
+            mockCoder()
+
+            const { org, user } = await mockSessionWithTestData()
+            const { study, job } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'APPROVED',
+                jobStatus: 'INITIATED',
+            })
+
+            // Backdate the round so a wrongful re-anchor would be unmistakable.
+            const backdated = new Date(Date.now() - 60_000)
+            await db.updateTable('studyJob').set({ createdAt: backdated }).where('id', '=', job.id).execute()
+
+            // Simulate a manual upload: a real file on disk in the study workspace.
+            const studyDir = path.join(TEST_CODER_FILES, study.id)
+            await fs.mkdir(studyDir, { recursive: true })
+            await fs.writeFile(path.join(studyDir, 'main.py'), 'print("hi")')
+
+            const { createUserAndWorkspaceAction } = await import('./workspaces.actions')
+            actionResult(await createUserAndWorkspaceAction({ studyId: study.id }))
+
+            expect((await jobCreatedAt(job.id)).getTime()).toBe(backdated.getTime())
+        })
+
+        test('still re-anchors createdAt when the round has no files yet', async () => {
+            process.env.CODER_FILES = TEST_CODER_FILES
+            mockCoder()
+
+            const { org, user } = await mockSessionWithTestData()
+            const { study, job } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'APPROVED',
+                jobStatus: 'INITIATED',
+            })
+
+            const backdated = new Date(Date.now() - 60_000)
+            await db.updateTable('studyJob').set({ createdAt: backdated }).where('id', '=', job.id).execute()
+
+            const { createUserAndWorkspaceAction } = await import('./workspaces.actions')
+            actionResult(await createUserAndWorkspaceAction({ studyId: study.id }))
+
+            expect((await jobCreatedAt(job.id)).getTime()).toBeGreaterThan(backdated.getTime())
+        })
+    })
 })

--- a/src/server/actions/workspaces.actions.ts
+++ b/src/server/actions/workspaces.actions.ts
@@ -14,6 +14,36 @@ const isMainFile = (filename: string): boolean => {
     return basename.toLowerCase() === 'main'
 }
 
+// Whether the study's workspace currently holds any researcher-visible file. Mirrors the filtering in
+// listWorkspaceFilesAction (skip dotfiles, symlinks, non-files, empty files) so "has files" matches
+// exactly what the review table shows — and what submit-enable is computed from.
+async function studyHasWorkspaceFiles(studyId: string): Promise<boolean> {
+    let coderFilesPath = await getConfigValue('CODER_FILES')
+    if (!CODER_DISABLED) {
+        coderFilesPath += `/${studyId}`
+    }
+
+    let entries: string[]
+    try {
+        entries = await fs.readdir(coderFilesPath)
+    } catch (e) {
+        if (e instanceof Error && 'code' in e && e.code === 'ENOENT') return false
+        throw e
+    }
+
+    for (const entry of entries) {
+        if (entry.startsWith('.')) continue
+        try {
+            const stats = await fs.lstat(path.join(coderFilesPath, entry))
+            if (stats.isSymbolicLink() || !stats.isFile() || stats.size === 0) continue
+            return true
+        } catch {
+            continue
+        }
+    }
+    return false
+}
+
 export const listWorkspaceFilesAction = new Action('listWorkspaceFilesAction', {})
     .params(z.object({ studyId: z.string() }))
     .middleware(async ({ params: { studyId } }) => await getInfoForStudyId(studyId))
@@ -81,7 +111,8 @@ export const createUserAndWorkspaceAction = new Action('createUserAndWorkspaceAc
     .requireAbilityTo('load', 'IDE')
     .handler(async ({ db, params: { studyId }, session }) => {
         if (!session) throw new Error('Unauthorized')
-        await ensureRoundJobForLaunch(db, studyId)
+        const hasWorkspaceFiles = await studyHasWorkspaceFiles(studyId)
+        await ensureRoundJobForLaunch(db, studyId, { hasWorkspaceFiles })
         if (CODER_DISABLED) {
             return {
                 success: true,

--- a/src/server/db/mutations.test.ts
+++ b/src/server/db/mutations.test.ts
@@ -238,6 +238,36 @@ describe('ensureRoundJobForLaunch (OTTER-601)', () => {
 
         expect(await jobsForStudy(study.id)).toHaveLength(2)
     })
+
+    it('does NOT refresh createdAt when the round already has files (OTTER-602)', async () => {
+        const org = await insertTestOrg()
+        const { study, job } = await insertTestStudyJobData({ org, studyStatus: 'APPROVED', jobStatus: 'INITIATED' })
+        const backdated = new Date(Date.now() - 60_000)
+        await db.updateTable('studyJob').set({ createdAt: backdated }).where('id', '=', job.id).execute()
+
+        const result = await ensureRoundJobForLaunch(db, study.id, { hasWorkspaceFiles: true })
+
+        const after = await jobsForStudy(study.id)
+        expect(after).toHaveLength(1)
+        expect(after[0].id).toBe(job.id)
+        // A manual upload before launch must keep counting toward submit-enable.
+        expect(after[0].createdAt.getTime()).toBe(backdated.getTime())
+        expect(result.createdAt.getTime()).toBe(backdated.getTime())
+    })
+
+    it('still refreshes createdAt when the round has no files yet', async () => {
+        const org = await insertTestOrg()
+        const { study, job } = await insertTestStudyJobData({ org, studyStatus: 'APPROVED', jobStatus: 'INITIATED' })
+        const backdated = new Date(Date.now() - 60_000)
+        await db.updateTable('studyJob').set({ createdAt: backdated }).where('id', '=', job.id).execute()
+
+        await ensureRoundJobForLaunch(db, study.id, { hasWorkspaceFiles: false })
+
+        const after = await jobsForStudy(study.id)
+        expect(after).toHaveLength(1)
+        expect(after[0].id).toBe(job.id)
+        expect(after[0].createdAt.getTime()).toBeGreaterThan(backdated.getTime())
+    })
 })
 
 describe('ensureRoundJobForUpload (OTTER-601)', () => {

--- a/src/server/db/mutations.ts
+++ b/src/server/db/mutations.ts
@@ -121,15 +121,29 @@ export async function getOrCreateCurrentRoundJob(
 
 // Submit is enabled when any workspace file's mtime > the current round job's createdAt.
 
+interface EnsureRoundJobForLaunchOptions {
+    /**
+     * Whether the workspace already holds researcher-visible files. When true, the re-anchor below is
+     * skipped: those files (e.g. a manual upload made before opening the IDE) already define
+     * submit-enable, and pushing createdAt past their mtimes would mark them all stale — flipping
+     * "Last updated" to Never and disabling Submit (OTTER-602).
+     */
+    hasWorkspaceFiles?: boolean
+}
+
 /**
  * IDE launch: ensure the current round has a job. When the round is still open work (no submission
- * yet — only INITIATED), re-anchor its createdAt to now so edits made after this launch enable Submit.
- * A round whose job already carries a submission is left untouched. Reuses the round's job rather than
- * stacking a new one (OTTER-601).
+ * yet — only INITIATED) and has no files yet, re-anchor its createdAt to now so edits made after this
+ * launch enable Submit. A round whose job already carries a submission — or that already has uploaded
+ * files — is left untouched. Reuses the round's job rather than stacking a new one (OTTER-601, OTTER-602).
  */
-export async function ensureRoundJobForLaunch(db: Kysely<DB>, studyId: string): Promise<RoundJob> {
+export async function ensureRoundJobForLaunch(
+    db: Kysely<DB>,
+    studyId: string,
+    { hasWorkspaceFiles = false }: EnsureRoundJobForLaunchOptions = {},
+): Promise<RoundJob> {
     const job = await getOrCreateCurrentRoundJob(db, studyId)
-    if (job.created || job.hasSubmission) return job
+    if (job.created || job.hasSubmission || hasWorkspaceFiles) return job
     const reanchored = await db
         .updateTable('studyJob')
         .set({ createdAt: new Date() })


### PR DESCRIPTION
## OTTER-602: Don't reset submit-enable when launching IDE after a manual upload

### Problem
On the initial proposal code submission page, a researcher who uploads files manually and then clicks the IDE option sees every file's **Last updated** flip to "Never" and the **Submit** button go disabled — staying disabled until they edit a file in the IDE. The manual upload's work is effectively discarded from the UI's point of view.

### Fix
`ensureRoundJobForLaunch` now skips the re-anchor when the workspace already holds files. `createUserAndWorkspaceAction` checks the workspace on disk (new `studyHasWorkspaceFiles` helper, mirroring `listWorkspaceFilesAction`'s filters) and passes `hasWorkspaceFiles` in. The option defaults to `false`, so the OTTER-601 behavior — re-anchoring on a genuinely empty round so IDE edits enable Submit — is unchanged.

### Tests
- `mutations.test.ts`: `ensureRoundJobForLaunch` does not re-anchor when files exist; still re-anchors on an empty round.
- `workspaces.actions.test.ts`: `createUserAndWorkspaceAction` leaves the baseline untouched when a file is present on disk, and re-anchors when none is.
