### PR TITLE
OTTER-638: Fix duplicate ID error blocking resubmission code review

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/view/job-results-status-message.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/job-results-status-message.test.tsx
@@ -31,6 +31,7 @@ describe('JobResultsStatusMessage', () => {
         createdAt: new Date(),
         files: [],
         resubmissionNote: null,
+        resubmissionRound: null,
     })
 
     const createMockFiles = (fileTypes: FileType[]) => fileTypes.map((fileType) => ({ fileType }))

--- a/src/components/study/job-approval-status.test.tsx
+++ b/src/components/study/job-approval-status.test.tsx
@@ -16,6 +16,7 @@ describe('ApprovalStatus', () => {
         statusChanges: [],
         files: [],
         resubmissionNote: null,
+        resubmissionRound: null,
     }
 
     it('shows approved status for CODE-APPROVED', () => {

--- a/src/database/migrations/1780200000000_study_review_comment_round.ts
+++ b/src/database/migrations/1780200000000_study_review_comment_round.ts
@@ -1,0 +1,59 @@
+import { type Kysely, sql } from 'kysely'
+
+// OTTER-638: a CODE-CHANGES-REQUESTED resubmit revises the SAME job in place (OTTER-316), so a
+// second review round lands on the same study_job. The old unique constraint
+// (study_job_id, review_kind) permitted only one CODE decision per job for its lifetime, which
+// wrongly blocked the reviewer's decision on resubmitted code with a duplicate-key error. Scope
+// uniqueness to the review ROUND instead: each round on a job gets its own decision row, while two
+// reviewers racing within the SAME round still collide (preserving the OTTER-471 race-loser guard).
+// `round` is the study-wide submission version (see codeSubmissionVersion) at decision time.
+export async function up(db: Kysely<unknown>): Promise<void> {
+    await db.schema
+        .alterTable('study_review_comment')
+        .addColumn('round', 'integer', (col) => col.notNull().defaultTo(1))
+        .execute()
+
+    // Backfill each CODE row to the study-wide round it belonged to, as-of its own created_at:
+    // 1 + the number of round-opening events recorded before it. PROPOSAL rows keep the default 1.
+    // jsc.status is cast to text so the literals stay text: comparing them as the enum would be an
+    // "unsafe use of new value of enum type" when those values were added earlier in this same
+    // migration transaction (the migrator runs all pending migrations in one transaction).
+    await sql`
+        UPDATE study_review_comment src
+        SET round = 1 + (
+            SELECT count(*)
+            FROM job_status_change jsc
+            JOIN study_job sj ON sj.id = jsc.study_job_id
+            WHERE sj.study_id = src.study_id
+              AND jsc.status::text IN ('CODE-CHANGES-REQUESTED', 'FILES-APPROVED', 'FILES-REJECTED')
+              AND jsc.created_at < src.created_at
+        )
+        WHERE src.review_kind::text = 'CODE'
+    `.execute(db)
+
+    await db.schema
+        .alterTable('study_review_comment')
+        .dropConstraint('study_review_comment_one_code_review_per_job')
+        .execute()
+
+    // study_job_id is NULL for PROPOSAL rows; Postgres treats NULLs as distinct, so those stay
+    // unrestricted. CODE rows always carry a job id (existing CHECK), so this keys per round.
+    await db.schema
+        .alterTable('study_review_comment')
+        .addUniqueConstraint('study_review_comment_one_code_review_per_round', ['study_job_id', 'review_kind', 'round'])
+        .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+    await db.schema
+        .alterTable('study_review_comment')
+        .dropConstraint('study_review_comment_one_code_review_per_round')
+        .execute()
+
+    await db.schema
+        .alterTable('study_review_comment')
+        .addUniqueConstraint('study_review_comment_one_code_review_per_job', ['study_job_id', 'review_kind'])
+        .execute()
+
+    await db.schema.alterTable('study_review_comment').dropColumn('round').execute()
+}

--- a/src/database/migrations/1780200000000_study_review_comment_round.ts
+++ b/src/database/migrations/1780200000000_study_review_comment_round.ts
@@ -6,12 +6,16 @@ import { type Kysely, sql } from 'kysely'
 // wrongly blocked the reviewer's decision on resubmitted code with a duplicate-key error. Scope
 // uniqueness to the review ROUND instead: each round on a job gets its own decision row, while two
 // reviewers racing within the SAME round still collide (preserving the OTTER-471 race-loser guard).
-// `round` is the study-wide submission version (see codeSubmissionVersion) at decision time.
+// `round` is the study-wide submission version (see codeSubmissionVersion) at decision time, and
+// study_job.resubmission_round records the same version for the resubmission note that opened a
+// round, so the feedback panel labels a round's note and decision with the same version.
 export async function up(db: Kysely<unknown>): Promise<void> {
     await db.schema
         .alterTable('study_review_comment')
         .addColumn('round', 'integer', (col) => col.notNull().defaultTo(1))
         .execute()
+
+    await db.schema.alterTable('study_job').addColumn('resubmission_round', 'integer').execute()
 
     // Backfill each CODE row to the study-wide round it belonged to, as-of its own created_at:
     // 1 + the number of round-opening events recorded before it. PROPOSAL rows keep the default 1.
@@ -29,6 +33,24 @@ export async function up(db: Kysely<unknown>): Promise<void> {
               AND jsc.created_at < src.created_at
         )
         WHERE src.review_kind::text = 'CODE'
+    `.execute(db)
+
+    // Backfill the resubmission note's round the same way, as-of the job's latest code submission.
+    await sql`
+        UPDATE study_job j
+        SET resubmission_round = 1 + (
+            SELECT count(*)
+            FROM job_status_change roe
+            JOIN study_job sj ON sj.id = roe.study_job_id
+            WHERE sj.study_id = j.study_id
+              AND roe.status::text IN ('CODE-CHANGES-REQUESTED', 'FILES-APPROVED', 'FILES-REJECTED')
+              AND roe.created_at < (
+                  SELECT max(cs.created_at)
+                  FROM job_status_change cs
+                  WHERE cs.study_job_id = j.id AND cs.status::text = 'CODE-SUBMITTED'
+              )
+        )
+        WHERE j.resubmission_note IS NOT NULL
     `.execute(db)
 
     await db.schema
@@ -50,10 +72,24 @@ export async function down(db: Kysely<unknown>): Promise<void> {
         .dropConstraint('study_review_comment_one_code_review_per_round')
         .execute()
 
+    // Restoring the one-decision-per-job constraint requires collapsing any multi-round history: keep
+    // each (job, kind) group's latest round and drop the earlier ones, otherwise re-adding the unique
+    // constraint would fail on rows this feature legitimately created.
+    await sql`
+        DELETE FROM study_review_comment a
+        USING study_review_comment b
+        WHERE a.study_job_id = b.study_job_id
+          AND a.review_kind = b.review_kind
+          AND a.study_job_id IS NOT NULL
+          AND a.round < b.round
+    `.execute(db)
+
     await db.schema
         .alterTable('study_review_comment')
         .addUniqueConstraint('study_review_comment_one_code_review_per_job', ['study_job_id', 'review_kind'])
         .execute()
+
+    await db.schema.alterTable('study_job').dropColumn('resubmission_round').execute()
 
     await db.schema.alterTable('study_review_comment').dropColumn('round').execute()
 }

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -302,6 +302,7 @@ export interface StudyReviewComment {
     entryType: StudyReviewCommentEntryType
     id: Generated<string>
     reviewKind: StudyReviewCommentKind
+    round: Generated<number>
     studyId: string
     studyJobId: string | null
 }

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -251,6 +251,7 @@ export interface StudyJob {
     createdAt: Generated<Timestamp>
     id: Generated<string>
     resubmissionNote: Json | null
+    resubmissionRound: number | null
     studyId: string
 }
 

--- a/src/server/actions/study-request.test.ts
+++ b/src/server/actions/study-request.test.ts
@@ -904,6 +904,16 @@ describe('Request Study Actions', () => {
             // count-based liveness back to "under review" so the researcher leaves the feedback screen.
             expect(await jobCount(study.id)).toBe(1)
             expect(await submittedStatusCount(study.id)).toBe(2)
+
+            // The note records the round it opened (study-wide submission version) so the reviewer's
+            // feedback panel labels it v2, matching the round-2 decision (OTTER-638).
+            const jobAfter = await db
+                .selectFrom('studyJob')
+                .select(['resubmissionNote', 'resubmissionRound'])
+                .where('id', '=', round1Job.id)
+                .executeTakeFirstOrThrow()
+            expect(jobAfter.resubmissionNote).not.toBeNull()
+            expect(jobAfter.resubmissionRound).toBe(2)
         })
 
         // Regression: in the real flow the researcher uploads files on the resubmit page *before*

--- a/src/server/actions/study-request.ts
+++ b/src/server/actions/study-request.ts
@@ -17,7 +17,12 @@ import {
 } from '@/server/aws'
 import { CODER_DISABLED, getConfigValue, SIMULATE_CODE_BUILD } from '@/server/config'
 import { getOrCreateCurrentRoundJob, nextVersionForStudyComment } from '@/server/db/mutations'
-import { getInfoForStudyId, getOrgIdFromSlug, latestSubmittedJobForStudy } from '@/server/db/queries'
+import {
+    codeSubmissionVersion,
+    getInfoForStudyId,
+    getOrgIdFromSlug,
+    latestSubmittedJobForStudy,
+} from '@/server/db/queries'
 import { db as database } from '@/database'
 import { deferred, onStudyReviewRequested, onStudyCodeSubmitted, onStudyCreated } from '@/server/events'
 import { purgeProposalYjsDocsBeforeAt } from '@/server/db/yjs-cleanup'
@@ -988,9 +993,13 @@ export const resubmitStudyCodeAction = new Action('resubmitStudyCodeAction', { p
 
         await markCodeSubmitted(db, { studyJobId, userId })
 
+        // Record the round this note opened (the study-wide submission version) so the reviewer's
+        // feedback panel labels the note and that round's decision with the same version (OTTER-638).
+        const resubmissionRound = await codeSubmissionVersion(studyId, db)
+
         await db
             .updateTable('studyJob')
-            .set({ resubmissionNote: JSON.parse(lexicalJson(resubmissionNote)) })
+            .set({ resubmissionNote: JSON.parse(lexicalJson(resubmissionNote)), resubmissionRound })
             .where('id', '=', studyJobId)
             .execute()
 

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -2373,6 +2373,40 @@ describe('getCodeReviewFeedbackAction', () => {
         expect(rows.map((row) => row.entryType)).toEqual(['RESUBMISSION-NOTE', 'REVIEWER-FEEDBACK'])
         expect(rows.map((row) => row.version)).toEqual([1, 1])
     })
+
+    it('positions a resubmission note by the latest CODE-SUBMITTED timestamp even with a null userId', async () => {
+        const { user, org } = await mockSessionWithTestData({ orgType: 'enclave' })
+        const { study, job } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'PENDING-REVIEW',
+            jobStatus: 'CODE-SUBMITTED',
+        })
+        const jobCreatedAt = new Date('2026-01-01T00:00:00Z')
+        const submittedAt = new Date('2026-02-15T00:00:00Z')
+
+        await db.updateTable('studyJob').set({ createdAt: jobCreatedAt }).where('id', '=', job.id).execute()
+
+        await db
+            .deleteFrom('jobStatusChange')
+            .where('studyJobId', '=', job.id)
+            .where('status', '=', 'CODE-SUBMITTED')
+            .execute()
+        await db
+            .insertInto('jobStatusChange')
+            .values({ studyJobId: job.id, status: 'CODE-SUBMITTED', createdAt: submittedAt, userId: null })
+            .execute()
+        await db
+            .updateTable('studyJob')
+            .set({ resubmissionNote: { root: { type: 'root', children: [{ text: 'note text' }] } } })
+            .where('id', '=', job.id)
+            .execute()
+
+        const rows = actionResult(await getCodeReviewFeedbackAction({ studyId: study.id }))
+        const note = rows.find((r) => r.entryType === 'RESUBMISSION-NOTE')
+        expect(note).toBeTruthy()
+        expect(new Date(note!.createdAt).toISOString()).toBe(submittedAt.toISOString())
+    })
 })
 
 function validCriteriaFixture() {

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -1776,9 +1776,12 @@ describe('submitCodeReviewDecisionAction', () => {
         })
 
         const entries = actionResult(await getCodeReviewFeedbackAction({ studyId: study.id }))
-        const note = entries.find((e) => e.entryType === 'RESUBMISSION-NOTE')
+        // The job now carries two CODE-SUBMITTED rows (round 1 + the resubmit); the note must still
+        // appear exactly once, not once per submission.
+        const notes = entries.filter((e) => e.entryType === 'RESUBMISSION-NOTE')
+        expect(notes).toHaveLength(1)
         const round2Decision = entries.find((e) => e.entryType === 'REVIEWER-FEEDBACK' && e.decision === 'APPROVE')
-        expect(note?.version).toBe(2)
+        expect(notes[0].version).toBe(2)
         expect(round2Decision?.version).toBe(2)
     })
 

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -1676,6 +1676,44 @@ describe('submitCodeReviewDecisionAction', () => {
         expect(updated.status).toBe('APPROVED')
     })
 
+    it('OTTER-638: numbers three rounds on the same job (changes → changes → approve)', async () => {
+        // Each same-job round bumps the study-wide submission version (count of CODE-CHANGES-REQUESTED
+        // before the decision), so three rounds on one job get rounds 1, 2, 3 with no collision.
+        const { user, org, study, job } = await setApprovedStudyAndCodeSubmitted()
+
+        await submitCodeReviewDecisionAction({
+            studyId: study.id,
+            orgSlug: org.slug,
+            decision: 'needs-clarification',
+            feedback: validFeedback,
+            criteria: validCriteria,
+        })
+        await simulateResubmitOnSameJob(job.id, user.id)
+
+        await submitCodeReviewDecisionAction({
+            studyId: study.id,
+            orgSlug: org.slug,
+            decision: 'needs-clarification',
+            feedback: validFeedback,
+            criteria: validCriteria,
+        })
+        await simulateResubmitOnSameJob(job.id, user.id)
+
+        const third = await submitCodeReviewDecisionAction({
+            studyId: study.id,
+            orgSlug: org.slug,
+            decision: 'approve',
+            feedback: validFeedback,
+            criteria: validCriteria,
+        })
+        expect(third).not.toMatchObject({ error: expect.anything() })
+
+        const rows = await loadCodeReviewRows(study.id)
+        expect(rows.map((r) => r.round)).toEqual([1, 2, 3])
+        expect(rows.map((r) => r.decision)).toEqual(['NEEDS-CLARIFICATION', 'NEEDS-CLARIFICATION', 'APPROVE'])
+        expect(rows.every((r) => r.studyJobId === job.id)).toBe(true)
+    })
+
     it('OTTER-638: accepts a round-2 reject on resubmitted code', async () => {
         const { user, org, study, job } = await setApprovedStudyAndCodeSubmitted()
 

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -1742,6 +1742,46 @@ describe('submitCodeReviewDecisionAction', () => {
         expect(reviewerEntries.map((e) => e.version).sort()).toEqual([1, 2])
     })
 
+    it('OTTER-638: a same-job resubmission note shares its round version with that round decision', async () => {
+        // Regression for the label divergence: the resubmission note that opened round 2 must read as
+        // v2, matching the round-2 decision — not v1 from the job-creation-order fallback.
+        const { user, org, study, job } = await setApprovedStudyAndCodeSubmitted()
+
+        await submitCodeReviewDecisionAction({
+            studyId: study.id,
+            orgSlug: org.slug,
+            decision: 'needs-clarification',
+            feedback: validFeedback,
+            criteria: validCriteria,
+        })
+
+        // The researcher's resubmit revises the same job: append the submission and record the note's
+        // round (study-wide submission version), exactly as resubmitStudyCodeAction does.
+        await simulateResubmitOnSameJob(job.id, user.id)
+        await db
+            .updateTable('studyJob')
+            .set({
+                resubmissionNote: { root: { type: 'root', children: [{ text: 'addressed feedback' }] } },
+                resubmissionRound: 2,
+            })
+            .where('id', '=', job.id)
+            .execute()
+
+        await submitCodeReviewDecisionAction({
+            studyId: study.id,
+            orgSlug: org.slug,
+            decision: 'approve',
+            feedback: validFeedback,
+            criteria: validCriteria,
+        })
+
+        const entries = actionResult(await getCodeReviewFeedbackAction({ studyId: study.id }))
+        const note = entries.find((e) => e.entryType === 'RESUBMISSION-NOTE')
+        const round2Decision = entries.find((e) => e.entryType === 'REVIEWER-FEEDBACK' && e.decision === 'APPROVE')
+        expect(note?.version).toBe(2)
+        expect(round2Decision?.version).toBe(2)
+    })
+
     it('OTTER-638: rejects a second decision when code was not resubmitted (still already decided)', async () => {
         // Guard the eligibility gate: after a change request with no resubmit, the latest code change
         // is a decision, so claimInitialCodeReviewJob blocks before reaching the insert — the fix must

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -1821,6 +1821,14 @@ describe('submitCodeReviewDecisionAction', () => {
         const round2Decision = entries.find((e) => e.entryType === 'REVIEWER-FEEDBACK' && e.decision === 'APPROVE')
         expect(notes[0].version).toBe(2)
         expect(round2Decision?.version).toBe(2)
+
+        // The note opened round 2, so it must sit above round 1's decision in the newest-first
+        // timeline — positioned by its resubmit time, not the (older) job-creation time.
+        const noteIdx = entries.findIndex((e) => e.entryType === 'RESUBMISSION-NOTE')
+        const round1Idx = entries.findIndex(
+            (e) => e.entryType === 'REVIEWER-FEEDBACK' && e.decision === 'NEEDS-CLARIFICATION',
+        )
+        expect(noteIdx).toBeLessThan(round1Idx)
     })
 
     it('OTTER-638: rejects a second decision when code was not resubmitted (still already decided)', async () => {
@@ -2333,6 +2341,14 @@ describe('getCodeReviewFeedbackAction', () => {
                 resubmissionNote: { root: { type: 'root', children: [{ text: 'fixed things' }] } },
             })
             .where('id', '=', job.id)
+            .execute()
+        // The note is positioned by its latest CODE-SUBMITTED timestamp; align it so it ties with the
+        // reviewer decision and the deterministic tie-break (not the timestamp) decides the order.
+        await db
+            .updateTable('jobStatusChange')
+            .set({ createdAt: sharedCreatedAt })
+            .where('studyJobId', '=', job.id)
+            .where('status', '=', 'CODE-SUBMITTED')
             .execute()
 
         const review = await db

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -1378,10 +1378,18 @@ describe('submitCodeReviewDecisionAction', () => {
     const loadCodeReviewRows = (studyId: string) =>
         db
             .selectFrom('studyReviewComment')
-            .select(['authorId', 'decision', 'entryType', 'reviewKind', 'studyJobId', 'criteria'])
+            .select(['authorId', 'decision', 'entryType', 'reviewKind', 'studyJobId', 'criteria', 'round'])
             .where('studyId', '=', studyId)
             .where('reviewKind', '=', 'CODE')
+            .orderBy('round', 'asc')
             .execute()
+
+    // A CODE-CHANGES-REQUESTED resubmit revises the SAME job in place (OTTER-316): it appends a
+    // fresh CODE-SUBMITTED on the existing job, which flips count-based liveness back to "under
+    // review" so the reviewer can decide again. Mirror just that DB effect here so the cycle stays
+    // a single-session unit test (the researcher's resubmit action is covered in study-request.test.ts).
+    const simulateResubmitOnSameJob = (jobId: string, userId: string) =>
+        db.insertInto('jobStatusChange').values({ studyJobId: jobId, status: 'CODE-SUBMITTED', userId }).execute()
 
     it('approve writes a code-review row, advances the job, and approves the study', async () => {
         const { user, org, study, job } = await setApprovedStudyAndCodeSubmitted()
@@ -1629,6 +1637,180 @@ describe('submitCodeReviewDecisionAction', () => {
         expect(await loadCodeReviewRows(study.id)).toHaveLength(1)
     })
 
+    it('OTTER-638: accepts the reviewer decision on resubmitted code (changes requested, then approved)', async () => {
+        // The headline bug: round 1 records a decision on the job; the same-job resubmit reuses that
+        // job; round 2's decision used to collide with round 1 on the (job, kind) unique constraint
+        // and was wrongly rejected as "another reviewer has already submitted a decision".
+        const { user, org, study, job } = await setApprovedStudyAndCodeSubmitted()
+
+        const first = await submitCodeReviewDecisionAction({
+            studyId: study.id,
+            orgSlug: org.slug,
+            decision: 'needs-clarification',
+            feedback: validFeedback,
+            criteria: validCriteria,
+        })
+        expect(first).not.toMatchObject({ error: expect.anything() })
+
+        await simulateResubmitOnSameJob(job.id, user.id)
+
+        const second = await submitCodeReviewDecisionAction({
+            studyId: study.id,
+            orgSlug: org.slug,
+            decision: 'approve',
+            feedback: validFeedback,
+            criteria: validCriteria,
+        })
+        expect(second).not.toMatchObject({ error: expect.anything() })
+
+        const rows = await loadCodeReviewRows(study.id)
+        expect(rows.map((r) => r.round)).toEqual([1, 2])
+        expect(rows.map((r) => r.decision)).toEqual(['NEEDS-CLARIFICATION', 'APPROVE'])
+        expect(rows.every((r) => r.studyJobId === job.id)).toBe(true)
+
+        const updated = await db
+            .selectFrom('study')
+            .select('status')
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+        expect(updated.status).toBe('APPROVED')
+    })
+
+    it('OTTER-638: accepts a round-2 reject on resubmitted code', async () => {
+        const { user, org, study, job } = await setApprovedStudyAndCodeSubmitted()
+
+        await submitCodeReviewDecisionAction({
+            studyId: study.id,
+            orgSlug: org.slug,
+            decision: 'needs-clarification',
+            feedback: validFeedback,
+            criteria: validCriteria,
+        })
+        await simulateResubmitOnSameJob(job.id, user.id)
+
+        const second = await submitCodeReviewDecisionAction({
+            studyId: study.id,
+            orgSlug: org.slug,
+            decision: 'reject',
+            feedback: validFeedback,
+            criteria: validCriteria,
+        })
+        expect(second).not.toMatchObject({ error: expect.anything() })
+
+        const rows = await loadCodeReviewRows(study.id)
+        expect(rows.map((r) => r.round)).toEqual([1, 2])
+        expect(rows.map((r) => r.decision)).toEqual(['NEEDS-CLARIFICATION', 'REJECT'])
+
+        // Rejecting code only fails the job; the proposal stays approved (OTTER-603).
+        const rejected = await db
+            .selectFrom('jobStatusChange')
+            .select('id')
+            .where('studyJobId', '=', job.id)
+            .where('status', '=', 'CODE-REJECTED')
+            .execute()
+        expect(rejected).toHaveLength(1)
+        const updated = await db
+            .selectFrom('study')
+            .select('status')
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+        expect(updated.status).toBe('APPROVED')
+    })
+
+    it('OTTER-638: getCodeReviewFeedbackAction labels each round with a distinct, increasing version', async () => {
+        const { user, org, study, job } = await setApprovedStudyAndCodeSubmitted()
+
+        await submitCodeReviewDecisionAction({
+            studyId: study.id,
+            orgSlug: org.slug,
+            decision: 'needs-clarification',
+            feedback: validFeedback,
+            criteria: validCriteria,
+        })
+        await simulateResubmitOnSameJob(job.id, user.id)
+        await submitCodeReviewDecisionAction({
+            studyId: study.id,
+            orgSlug: org.slug,
+            decision: 'approve',
+            feedback: validFeedback,
+            criteria: validCriteria,
+        })
+
+        const entries = actionResult(await getCodeReviewFeedbackAction({ studyId: study.id }))
+        const reviewerEntries = entries.filter((e) => e.entryType === 'REVIEWER-FEEDBACK')
+        expect(reviewerEntries).toHaveLength(2)
+        expect(reviewerEntries.map((e) => e.version).sort()).toEqual([1, 2])
+    })
+
+    it('OTTER-638: rejects a second decision when code was not resubmitted (still already decided)', async () => {
+        // Guard the eligibility gate: after a change request with no resubmit, the latest code change
+        // is a decision, so claimInitialCodeReviewJob blocks before reaching the insert — the fix must
+        // not turn this into an accepted duplicate.
+        const { org, study } = await setApprovedStudyAndCodeSubmitted()
+
+        await submitCodeReviewDecisionAction({
+            studyId: study.id,
+            orgSlug: org.slug,
+            decision: 'needs-clarification',
+            feedback: validFeedback,
+            criteria: validCriteria,
+        })
+
+        const second = await submitCodeReviewDecisionAction({
+            studyId: study.id,
+            orgSlug: org.slug,
+            decision: 'approve',
+            feedback: validFeedback,
+            criteria: validCriteria,
+        })
+
+        expect(second).toMatchObject({ error: { study: expect.stringContaining('already been decided') } })
+        expect(await loadCodeReviewRows(study.id)).toHaveLength(1)
+    })
+
+    it('OTTER-638: numbers rounds across separate jobs (new job after results approved)', async () => {
+        // Multi-job path: a results decision (FILES-APPROVED) closes the round and the next submission
+        // opens a NEW job. Round = study-wide submission version, so the decision on the second job is
+        // round 2 even though it is that job's first decision.
+        const { user, org, study, job } = await setApprovedStudyAndCodeSubmitted()
+
+        await submitCodeReviewDecisionAction({
+            studyId: study.id,
+            orgSlug: org.slug,
+            decision: 'approve',
+            feedback: validFeedback,
+            criteria: validCriteria,
+        })
+
+        // Results approved closes round 1 and opens a fresh job for round 2.
+        await db
+            .insertInto('jobStatusChange')
+            .values({ studyJobId: job.id, status: 'FILES-APPROVED', userId: user.id })
+            .execute()
+        const job2 = await db
+            .insertInto('studyJob')
+            .values({ studyId: study.id })
+            .returning('id')
+            .executeTakeFirstOrThrow()
+        await db
+            .insertInto('jobStatusChange')
+            .values({ studyJobId: job2.id, status: 'CODE-SUBMITTED', userId: user.id })
+            .execute()
+
+        const second = await submitCodeReviewDecisionAction({
+            studyId: study.id,
+            orgSlug: org.slug,
+            decision: 'approve',
+            feedback: validFeedback,
+            criteria: validCriteria,
+        })
+        expect(second).not.toMatchObject({ error: expect.anything() })
+
+        const rows = await loadCodeReviewRows(study.id)
+        expect(rows.map((r) => r.round)).toEqual([1, 2])
+        expect(rows.map((r) => r.studyJobId)).toEqual([job.id, job2.id])
+    })
+
     it('rejects a duplicate code-review submission for the same job', async () => {
         // First submit approves the code, which advances the job to CODE-APPROVED;
         // a second submit then fails the reviewable-state precondition rather
@@ -1660,8 +1842,9 @@ describe('submitCodeReviewDecisionAction', () => {
         // Simulates the race-loser path: claimInitialCodeReviewJob passes (the
         // study/job are still in reviewable state because the winning reviewer
         // has not yet committed), but the studyReviewComment insert trips the
-        // composite unique constraint on (studyJobId, reviewKind). We seed the
-        // row directly to force that exact failure mode.
+        // composite unique constraint on (studyJobId, reviewKind, round). Both
+        // reviewers are in round 1 (no round-opening event yet), so the action's
+        // computed round (1) collides with the pre-seeded round-1 row.
         const { user, org, study, job } = await setApprovedStudyAndCodeSubmitted()
         await db
             .insertInto('studyReviewComment')
@@ -1673,6 +1856,7 @@ describe('submitCodeReviewDecisionAction', () => {
                 entryType: 'DECISION',
                 decision: 'APPROVE',
                 body: { root: { type: 'root', children: [] } },
+                round: 1,
             })
             .execute()
 
@@ -1733,7 +1917,7 @@ describe('submitCodeReviewDecisionAction', () => {
         expect(codeApproved.length + codeRejected.length).toBe(1)
     })
 
-    it('composite unique constraint blocks two CODE review rows for the same job', async () => {
+    it('composite unique constraint blocks two CODE decisions for the same job in the same round', async () => {
         const { user, org } = await mockSessionWithTestData({ orgType: 'enclave' })
         const { study, job } = await insertTestStudyJobData({
             org,
@@ -1751,6 +1935,7 @@ describe('submitCodeReviewDecisionAction', () => {
                 entryType: 'DECISION',
                 decision: 'APPROVE',
                 body: { root: { type: 'root', children: [] } },
+                round: 1,
             })
             .execute()
 
@@ -1765,9 +1950,54 @@ describe('submitCodeReviewDecisionAction', () => {
                     entryType: 'DECISION',
                     decision: 'REJECT',
                     body: { root: { type: 'root', children: [] } },
+                    round: 1,
                 })
                 .execute(),
         ).rejects.toThrow(/duplicate key|unique/i)
+    })
+
+    it('composite unique constraint allows two CODE decisions for the same job in different rounds', async () => {
+        // OTTER-638: a same-job resubmit opens a new review round, so a second decision on the same
+        // job in round 2 must be permitted (it is the round that distinguishes the rows).
+        const { user, org } = await mockSessionWithTestData({ orgType: 'enclave' })
+        const { study, job } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'PENDING-REVIEW',
+            jobStatus: 'CODE-SUBMITTED',
+        })
+
+        await db
+            .insertInto('studyReviewComment')
+            .values({
+                studyId: study.id,
+                studyJobId: job.id,
+                authorId: user.id,
+                reviewKind: 'CODE',
+                entryType: 'DECISION',
+                decision: 'NEEDS-CLARIFICATION',
+                body: { root: { type: 'root', children: [] } },
+                round: 1,
+            })
+            .execute()
+
+        await expect(
+            db
+                .insertInto('studyReviewComment')
+                .values({
+                    studyId: study.id,
+                    studyJobId: job.id,
+                    authorId: user.id,
+                    reviewKind: 'CODE',
+                    entryType: 'DECISION',
+                    decision: 'APPROVE',
+                    body: { root: { type: 'root', children: [] } },
+                    round: 2,
+                })
+                .execute(),
+        ).resolves.not.toThrow()
+
+        expect(await loadCodeReviewRows(study.id)).toHaveLength(2)
     })
 
     it('CHECK constraint blocks DECISION rows with NULL decision', async () => {

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -773,6 +773,11 @@ export const submitCodeReviewDecisionAction = new Action('submitCodeReviewDecisi
         // keeps the same job, so uniqueness is scoped to (studyJobId, reviewKind, round) and each
         // round gets its own decision row (OTTER-638). The round-1 decision is written before its
         // CODE-CHANGES-REQUESTED status below, so round 1 → 1 and a post-resubmit decision → 2.
+        // Load-bearing: codeSubmissionVersion counts CODE-CHANGES-REQUESTED/FILES-APPROVED/FILES-REJECTED
+        // but NOT CODE-REJECTED, which is safe only because reject is terminal (not in
+        // CODE_RESUBMITTABLE_JOB_STATUSES) so no second decision can follow it. If reject ever becomes
+        // resubmittable, codeSubmissionVersion must count it too, or the round won't advance and the
+        // next decision would collide on the round-scoped unique constraint.
         const round = await codeSubmissionVersion(studyId, db)
 
         try {
@@ -878,17 +883,18 @@ export const getCodeReviewFeedbackAction = new Action('getCodeReviewFeedbackActi
         // label even when a same-job resubmit revises in place (OTTER-316/638) and the job ordinal
         // would not advance. jobVersion (job creation order) is only a fallback for legacy rows whose
         // resubmissionRound was not backfilled. studyJob has no userId column; the author of the
-        // resubmission note is the user recorded on the job's latest CODE-SUBMITTED. A same-job
-        // resubmit appends more than one CODE-SUBMITTED, so joining the rows directly would multiply
-        // the job into duplicate codeJobs rows (and duplicate note entries) — a lateral join to the
-        // single latest submission keeps each job to one row.
+        // resubmission note is the user recorded on the job's latest CODE-SUBMITTED (left-joined so
+        // the timestamp and author are independent: a null/deleted user does not lose the submission
+        // row). A same-job resubmit appends more than one CODE-SUBMITTED, so joining the rows directly
+        // would multiply the job into duplicate codeJobs rows (and duplicate note entries); a lateral
+        // join to the single latest submission keeps each job to one row.
         const codeJobs = await db
             .selectFrom('studyJob')
             .leftJoinLateral(
                 (eb) =>
                     eb
                         .selectFrom('jobStatusChange as cs')
-                        .innerJoin('user as submitter', 'submitter.id', 'cs.userId')
+                        .leftJoin('user as submitter', 'submitter.id', 'cs.userId')
                         .select([
                             'cs.userId as authorId',
                             'submitter.fullName as authorName',

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -13,6 +13,7 @@ import { isCodeUnderReviewStatus, latestCodeChangeIsSubmission } from '@/lib/stu
 import { MAX_SAVE_INTERVAL_MS } from '../../../services/editor/constants'
 import { sleep } from '@/lib/utils'
 import {
+    codeSubmissionVersion,
     currentReviewVersion,
     getProposalFeedbackForStudy,
     getStudyJobFileOfType,
@@ -767,6 +768,12 @@ export const submitCodeReviewDecisionAction = new Action('submitCodeReviewDecisi
 
         const claimedJob = await claimInitialCodeReviewJob({ studyId })
 
+        // Round = study-wide submission version at decision time. A same-job resubmit (OTTER-316)
+        // keeps the same job, so uniqueness is scoped to (studyJobId, reviewKind, round) and each
+        // round gets its own decision row (OTTER-638). The round-1 decision is written before its
+        // CODE-CHANGES-REQUESTED status below, so round 1 → 1 and a post-resubmit decision → 2.
+        const round = await codeSubmissionVersion(studyId, db)
+
         try {
             await db
                 .insertInto('studyReviewComment')
@@ -779,15 +786,16 @@ export const submitCodeReviewDecisionAction = new Action('submitCodeReviewDecisi
                     decision: toReviewDecision(decision),
                     body: JSON.parse(json),
                     criteria,
+                    round,
                 })
                 .executeTakeFirstOrThrow()
         } catch (err) {
             // Postgres unique_violation (SQLSTATE 23505). The composite unique
-            // index on (studyJobId, reviewKind) fires when two reviewers race
-            // through claimInitialCodeReviewJob and both reach this insert
-            // before either commits. The race-loser sees this; the data is
-            // already safe, so surface a clean message instead of the raw
-            // duplicate-key error.
+            // index on (studyJobId, reviewKind, round) fires when two reviewers
+            // race through claimInitialCodeReviewJob within the same round and
+            // both reach this insert before either commits. The race-loser sees
+            // this; the data is already safe, so surface a clean message instead
+            // of the raw duplicate-key error.
             if (isPgUniqueViolation(err)) {
                 throw new ActionFailure({
                     study: 'another reviewer has already submitted a decision for this study code',
@@ -863,11 +871,11 @@ export const getCodeReviewFeedbackAction = new Action('getCodeReviewFeedbackActi
     })
     .requireAbilityTo('view', 'Study')
     .handler(async ({ params: { studyId }, db }) => {
-        // Each code job, in creation order, is its own review round (v1, v2, ...).
-        // Reviewer decisions on a job and the researcher's resubmission note on
-        // that same job share the round number. studyJob has no userId column;
-        // the author of the resubmission note is the user recorded on the
-        // CODE-SUBMITTED status change for that job.
+        // Resubmission-note versions come from job creation order (v1, v2, ...). Reviewer-decision
+        // versions come from the stored `round` (the study-wide submission version at decision
+        // time) so multiple decisions on the same job — a same-job resubmit revises in place
+        // (OTTER-316/638) — get distinct, increasing labels. studyJob has no userId column; the
+        // author of the resubmission note is the user recorded on the CODE-SUBMITTED status change.
         const codeJobs = await db
             .selectFrom('studyJob')
             .leftJoin('jobStatusChange as submission', (join) =>
@@ -899,6 +907,7 @@ export const getCodeReviewFeedbackAction = new Action('getCodeReviewFeedbackActi
                 'studyReviewComment.body',
                 'studyReviewComment.criteria',
                 'studyReviewComment.createdAt',
+                'studyReviewComment.round',
                 'author.fullName as authorName',
             ])
             .where('studyReviewComment.studyId', '=', studyId)
@@ -915,7 +924,7 @@ export const getCodeReviewFeedbackAction = new Action('getCodeReviewFeedbackActi
             criteria: row.criteria,
             createdAt: row.createdAt,
             authorName: row.authorName,
-            version: row.studyJobId ? (jobVersion.get(row.studyJobId) ?? null) : null,
+            version: row.round ?? null,
         }))
 
         const noteEntries = codeJobs

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -879,34 +879,31 @@ export const getCodeReviewFeedbackAction = new Action('getCodeReviewFeedbackActi
         // resubmissionRound was not backfilled. studyJob has no userId column; the author of the
         // resubmission note is the user recorded on the job's latest CODE-SUBMITTED. A same-job
         // resubmit appends more than one CODE-SUBMITTED, so joining the rows directly would multiply
-        // the job into duplicate codeJobs rows (and duplicate note entries) — pick the latest
-        // submission with a scalar subquery so each job yields exactly one row.
+        // the job into duplicate codeJobs rows (and duplicate note entries) — a lateral join to the
+        // single latest submission keeps each job to one row.
         const codeJobs = await db
             .selectFrom('studyJob')
-            .select((eb) => [
+            .leftJoinLateral(
+                (eb) =>
+                    eb
+                        .selectFrom('jobStatusChange as cs')
+                        .innerJoin('user as submitter', 'submitter.id', 'cs.userId')
+                        .select(['cs.userId as authorId', 'submitter.fullName as authorName'])
+                        .whereRef('cs.studyJobId', '=', 'studyJob.id')
+                        .where('cs.status', '=', 'CODE-SUBMITTED')
+                        .orderBy('cs.createdAt', 'desc')
+                        .orderBy('cs.id', 'desc')
+                        .limit(1)
+                        .as('latestSubmission'),
+                (join) => join.onTrue(),
+            )
+            .select([
                 'studyJob.id as studyJobId',
                 'studyJob.resubmissionNote',
                 'studyJob.resubmissionRound',
                 'studyJob.createdAt',
-                eb
-                    .selectFrom('jobStatusChange as cs')
-                    .select('cs.userId')
-                    .whereRef('cs.studyJobId', '=', 'studyJob.id')
-                    .where('cs.status', '=', 'CODE-SUBMITTED')
-                    .orderBy('cs.createdAt', 'desc')
-                    .orderBy('cs.id', 'desc')
-                    .limit(1)
-                    .as('authorId'),
-                eb
-                    .selectFrom('jobStatusChange as cs')
-                    .innerJoin('user as submitter', 'submitter.id', 'cs.userId')
-                    .select('submitter.fullName')
-                    .whereRef('cs.studyJobId', '=', 'studyJob.id')
-                    .where('cs.status', '=', 'CODE-SUBMITTED')
-                    .orderBy('cs.createdAt', 'desc')
-                    .orderBy('cs.id', 'desc')
-                    .limit(1)
-                    .as('authorName'),
+                'latestSubmission.authorId',
+                'latestSubmission.authorName',
             ])
             .where('studyJob.studyId', '=', studyId)
             .orderBy('studyJob.createdAt', 'asc')

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -711,8 +711,8 @@ async function claimInitialCodeReviewJob({ studyId }: { studyId: string }) {
     // approved stays APPROVED while its code is (re)submitted for review, so a latest
     // job whose newest code change is a fresh submission is the only correct gate. A
     // peer submitting a decision advances the round past that (and the unique
-    // (studyJobId, reviewKind) index blocks a true insert race), so this check is also
-    // the race-loser guard (OTTER-471). latestCodeChangeIsSubmission counts submissions
+    // (studyJobId, reviewKind, round) index blocks a true same-round insert race), so this
+    // check is also the race-loser guard (OTTER-471). latestCodeChangeIsSubmission counts submissions
     // vs decisions rather than reading statusChanges[0], so it is immune to the
     // createdAt/v7-id tie ordering this file leans on being non-deterministic elsewhere.
     const job = await latestJobForStudyOrNull(studyId)
@@ -871,11 +871,13 @@ export const getCodeReviewFeedbackAction = new Action('getCodeReviewFeedbackActi
     })
     .requireAbilityTo('view', 'Study')
     .handler(async ({ params: { studyId }, db }) => {
-        // Resubmission-note versions come from job creation order (v1, v2, ...). Reviewer-decision
-        // versions come from the stored `round` (the study-wide submission version at decision
-        // time) so multiple decisions on the same job — a same-job resubmit revises in place
-        // (OTTER-316/638) — get distinct, increasing labels. studyJob has no userId column; the
-        // author of the resubmission note is the user recorded on the CODE-SUBMITTED status change.
+        // Both reviewer decisions and resubmission notes are versioned by the study-wide submission
+        // round (see codeSubmissionVersion): the decision stores it in studyReviewComment.round, the
+        // note in studyJob.resubmissionRound. This keeps a round's note and decision on the same
+        // label even when a same-job resubmit revises in place (OTTER-316/638) and the job ordinal
+        // would not advance. jobVersion (job creation order) is only a fallback for legacy rows whose
+        // resubmissionRound was not backfilled. studyJob has no userId column; the author of the
+        // resubmission note is the user recorded on the CODE-SUBMITTED status change.
         const codeJobs = await db
             .selectFrom('studyJob')
             .leftJoin('jobStatusChange as submission', (join) =>
@@ -885,6 +887,7 @@ export const getCodeReviewFeedbackAction = new Action('getCodeReviewFeedbackActi
             .select([
                 'studyJob.id as studyJobId',
                 'studyJob.resubmissionNote',
+                'studyJob.resubmissionRound',
                 'studyJob.createdAt',
                 'submission.userId as authorId',
                 'author.fullName as authorName',
@@ -901,7 +904,6 @@ export const getCodeReviewFeedbackAction = new Action('getCodeReviewFeedbackActi
             .select([
                 'studyReviewComment.id',
                 'studyReviewComment.authorId',
-                'studyReviewComment.studyJobId',
                 'studyReviewComment.entryType',
                 'studyReviewComment.decision',
                 'studyReviewComment.body',
@@ -938,7 +940,7 @@ export const getCodeReviewFeedbackAction = new Action('getCodeReviewFeedbackActi
                 criteria: null,
                 createdAt: j.createdAt,
                 authorName: j.authorName ?? '',
-                version: jobVersion.get(j.studyJobId) ?? null,
+                version: j.resubmissionRound ?? jobVersion.get(j.studyJobId) ?? null,
             }))
 
         return [...reviewerEntries, ...noteEntries].sort((a, b) => {

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -877,20 +877,36 @@ export const getCodeReviewFeedbackAction = new Action('getCodeReviewFeedbackActi
         // label even when a same-job resubmit revises in place (OTTER-316/638) and the job ordinal
         // would not advance. jobVersion (job creation order) is only a fallback for legacy rows whose
         // resubmissionRound was not backfilled. studyJob has no userId column; the author of the
-        // resubmission note is the user recorded on the CODE-SUBMITTED status change.
+        // resubmission note is the user recorded on the job's latest CODE-SUBMITTED. A same-job
+        // resubmit appends more than one CODE-SUBMITTED, so joining the rows directly would multiply
+        // the job into duplicate codeJobs rows (and duplicate note entries) — pick the latest
+        // submission with a scalar subquery so each job yields exactly one row.
         const codeJobs = await db
             .selectFrom('studyJob')
-            .leftJoin('jobStatusChange as submission', (join) =>
-                join.onRef('submission.studyJobId', '=', 'studyJob.id').on('submission.status', '=', 'CODE-SUBMITTED'),
-            )
-            .leftJoin('user as author', 'author.id', 'submission.userId')
-            .select([
+            .select((eb) => [
                 'studyJob.id as studyJobId',
                 'studyJob.resubmissionNote',
                 'studyJob.resubmissionRound',
                 'studyJob.createdAt',
-                'submission.userId as authorId',
-                'author.fullName as authorName',
+                eb
+                    .selectFrom('jobStatusChange as cs')
+                    .select('cs.userId')
+                    .whereRef('cs.studyJobId', '=', 'studyJob.id')
+                    .where('cs.status', '=', 'CODE-SUBMITTED')
+                    .orderBy('cs.createdAt', 'desc')
+                    .orderBy('cs.id', 'desc')
+                    .limit(1)
+                    .as('authorId'),
+                eb
+                    .selectFrom('jobStatusChange as cs')
+                    .innerJoin('user as submitter', 'submitter.id', 'cs.userId')
+                    .select('submitter.fullName')
+                    .whereRef('cs.studyJobId', '=', 'studyJob.id')
+                    .where('cs.status', '=', 'CODE-SUBMITTED')
+                    .orderBy('cs.createdAt', 'desc')
+                    .orderBy('cs.id', 'desc')
+                    .limit(1)
+                    .as('authorName'),
             ])
             .where('studyJob.studyId', '=', studyId)
             .orderBy('studyJob.createdAt', 'asc')

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -709,10 +709,11 @@ async function claimInitialCodeReviewJob({ studyId }: { studyId: string }) {
     // Code-review eligibility is driven by the JOB status alone, not study.status.
     // PENDING-REVIEW is a proposal-stage status; a study whose proposal was already
     // approved stays APPROVED while its code is (re)submitted for review, so a latest
-    // job whose newest code change is a fresh submission is the only correct gate. A
-    // peer submitting a decision advances the round past that (and the unique
-    // (studyJobId, reviewKind, round) index blocks a true same-round insert race), so this
-    // check is also the race-loser guard (OTTER-471). latestCodeChangeIsSubmission counts submissions
+    // job whose newest code change is a fresh submission is the only correct gate. Once a
+    // peer decides the current submission this gate fails (the newest code change is a
+    // decision, not a submission), and within the same round the unique
+    // (studyJobId, reviewKind, round) index blocks a true insert race — so this check is
+    // also the race-loser guard (OTTER-471). latestCodeChangeIsSubmission counts submissions
     // vs decisions rather than reading statusChanges[0], so it is immune to the
     // createdAt/v7-id tie ordering this file leans on being non-deterministic elsewhere.
     const job = await latestJobForStudyOrNull(studyId)

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -889,7 +889,11 @@ export const getCodeReviewFeedbackAction = new Action('getCodeReviewFeedbackActi
                     eb
                         .selectFrom('jobStatusChange as cs')
                         .innerJoin('user as submitter', 'submitter.id', 'cs.userId')
-                        .select(['cs.userId as authorId', 'submitter.fullName as authorName'])
+                        .select([
+                            'cs.userId as authorId',
+                            'submitter.fullName as authorName',
+                            'cs.createdAt as submittedAt',
+                        ])
                         .whereRef('cs.studyJobId', '=', 'studyJob.id')
                         .where('cs.status', '=', 'CODE-SUBMITTED')
                         .orderBy('cs.createdAt', 'desc')
@@ -905,6 +909,7 @@ export const getCodeReviewFeedbackAction = new Action('getCodeReviewFeedbackActi
                 'studyJob.createdAt',
                 'latestSubmission.authorId',
                 'latestSubmission.authorName',
+                'latestSubmission.submittedAt',
             ])
             .where('studyJob.studyId', '=', studyId)
             .orderBy('studyJob.createdAt', 'asc')
@@ -952,7 +957,11 @@ export const getCodeReviewFeedbackAction = new Action('getCodeReviewFeedbackActi
                 decision: null,
                 body: j.resubmissionNote as NonNullable<typeof j.resubmissionNote>,
                 criteria: null,
-                createdAt: j.createdAt,
+                // The note is written at resubmit time, not job creation: a same-job resubmit revises
+                // an old job in place, so use the latest CODE-SUBMITTED timestamp to position the note
+                // in the round it opened (newest-first sort below). Falls back to job creation only for
+                // a job with no submission (which never carries a note).
+                createdAt: j.submittedAt ?? j.createdAt,
                 authorName: j.authorName ?? '',
                 version: j.resubmissionRound ?? jobVersion.get(j.studyJobId) ?? null,
             }))

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -146,8 +146,8 @@ export const latestSubmittedJobForStudy = async (studyId: string): Promise<Lates
 // on version > 1). OTTER-556/558 require an ever-increasing version with prior feedback/notes kept
 // visible across rounds. Counting these round-opening events (not CODE-SUBMITTED) also keeps the
 // version immune to a duplicate CODE-SUBMITTED from a concurrent submit.
-export const codeSubmissionVersion = async (studyId: string): Promise<number> => {
-    const row = await Action.db
+export const codeSubmissionVersion = async (studyId: string, db: DBExecutor = Action.db): Promise<number> => {
+    const row = await db
         .selectFrom('jobStatusChange')
         .innerJoin('studyJob', 'studyJob.id', 'jobStatusChange.studyJobId')
         .where('studyJob.studyId', '=', studyId)


### PR DESCRIPTION
## Problem

A legitimate reviewer could not submit a decision on **resubmitted** code. The system wrongly rejected it as a duplicate with *"another reviewer has already submitted a decision for this study code"*, even when it was the same reviewer and no race occurred.

**Root cause.** `study_review_comment` had a unique constraint on `(study_job_id, review_kind)`, i.e. one CODE decision per job for the job's lifetime. But a `CODE-CHANGES-REQUESTED` resubmit revises the **same job in place** (OTTER-316), so the round-2 decision collided with the round-1 decision row already on that job. The collision was caught and surfaced as the OTTER-471 race-loser message.

Replication: DP requests changes → researcher resubmits → original reviewer tries to approve → blocked.

## Fix

Scope code-review uniqueness to the review **round** instead of the job, so each round on the same job gets its own decision row while a genuine same-round two-reviewer race still collides (preserving the OTTER-471 guard).

- **Migration** `1780200000000_study_review_comment_round.ts`: add `study_review_comment.round` (`integer NOT NULL DEFAULT 1`), backfill existing CODE rows to their historical study-wide round, drop `study_review_comment_one_code_review_per_job`, add `study_review_comment_one_code_review_per_round` on `(study_job_id, review_kind, round)`. The backfill casts `status::text` to avoid Postgres's "unsafe use of new value of enum type" within the single migration transaction.
- **`codeSubmissionVersion`** gains an optional `db` executor so the round is computed inside the action's transaction (and always matches the number the UI derives).
- **`submitCodeReviewDecisionAction`** computes `round = codeSubmissionVersion(studyId, db)` and stores it on the decision. The unique-violation catch is unchanged; post-fix it fires only on a true same-round race.
- **`getCodeReviewFeedbackAction`** labels reviewer-feedback entries by the stored `round`.

`round` is the study-wide submission version (existing `codeSubmissionVersion` semantics), so it doubles as the display version rather than introducing a third numbering scheme.

## Code-review follow-ups

High-effort reviews surfaced several issues, all now fixed:

- **Resubmission-note version divergence (would hide the resubmission UI).** The reviewer page derives `isResubmission`/heading from the max entry version; with only reviewer decisions on the study-wide `round` and notes still on job-creation order, a same-job round-2 review showed all entries as v1 → rendered as a first submission and hid prior feedback. Fixed by versioning the note on the same study-wide round: new `study_job.resubmission_round` column, set by `resubmitStudyCodeAction` (= `codeSubmissionVersion` at resubmit time) and backfilled; `getCodeReviewFeedbackAction` reads it (falling back to job-ordinal only for legacy rows). No UI component changes were needed.
- **Duplicate resubmission-note entries.** The feedback query joined every `CODE-SUBMITTED` row, so a same-job resubmit (which appends a second `CODE-SUBMITTED`) fanned one job into multiple rows and emitted duplicate note entries (identical id/body/version). Fixed by selecting the note author from the job's single latest `CODE-SUBMITTED` via a `leftJoinLateral`, so each job yields exactly one row.
- **Migration rollback was not dedupe-safe.** `down()` re-added the per-job unique constraint, which fails once a job legitimately has multiple round rows. `down()` now collapses each `(job, kind)` group to its latest round before restoring the old constraint (intentionally lossy, as a rollback to one-decision-per-job must be).

Also addressed: dropped a now-dead `studyJobId` select, and updated a stale race-guard comment that referenced the old constraint shape.

## Tests

`src/server/actions/study.actions.test.ts`:

- New: full cycle (changes-requested → resubmit → approve), full cycle with round-2 reject, distinct/increasing version labels per round, a note sharing its round version with that round's decision (and appearing exactly once despite two `CODE-SUBMITTED` rows), a second decision without a resubmit still rejected as "already decided", and round numbering across separate jobs (post `FILES-APPROVED`).
- Updated: the race-loser and unique-constraint tests are now round-aware (same round blocks; different rounds are allowed).

`src/server/actions/study-request.test.ts`: the same-job resubmit test now asserts `resubmission_round` is recorded as 2.

## Verification

- `pnpm run checks` (typecheck + lint + action validation): pass.
- Full unit suite: 1719 tests across 190 files, all passing.

## Out of scope

Removing the legacy job-creation-order `jobVersion` fallback entirely once all rows carry `resubmission_round`.
