### PR TITLE
fix(study-view): show study code on read-only /view/code during enclave run (OTTER-640)

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/_screens/code-decision-screen.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/code-decision-screen.tsx
@@ -11,7 +11,14 @@ import type { ScreenComponentProps } from './types'
 // code-approved AND code-feedback both render the post-decision view. The effective decision is
 // APPROVED while the code is approved or executing (OTTER-598: hide the code listing while
 // executing); otherwise it's the live CHANGES-REQUESTED/REJECTED decision.
-export async function CodeDecisionScreen({ study, raw, orgSlug, dashboardHref, returnTo }: ScreenComponentProps) {
+export async function CodeDecisionScreen({
+    study,
+    raw,
+    orgSlug,
+    dashboardHref,
+    returnTo,
+    descriptor,
+}: ScreenComponentProps) {
     const state = projectStudyState(raw)
     const decisionStatus =
         state.codeDecision === 'CODE-APPROVED' || state.isExecuting ? 'CODE-APPROVED' : state.codeDecision
@@ -22,8 +29,10 @@ export async function CodeDecisionScreen({ study, raw, orgSlug, dashboardHref, r
     // so a packaging error doesn't re-expose it (OTTER-598 follow-up).
     // Reviewers route to reviewer-study-results for any hasResults (reviewer rule 1), so this screen
     // is researcher-only and calling the role-named helper with no role guard is safe.
+    // The read-only /view/code route always shows the submitted code (OTTER-640): the execution-window /
+    // hidden-errored hide is for the live /view flow, where the page reads as "running / results pending".
     const hiddenErroredResult = isErroredResultHiddenFromResearcher(state)
-    const hideStudyCode = state.isExecuting || hiddenErroredResult
+    const hideStudyCode = !descriptor.readOnlyCodeStep && (state.isExecuting || hiddenErroredResult)
 
     const job = await latestSubmittedJobForStudy(study.id)
     if (!job) notFound()

--- a/src/app/[orgSlug]/study/[studyId]/_screens/render-screen.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/render-screen.tsx
@@ -6,7 +6,7 @@ import {
     resolveScreen,
     resolveResearcherCodeScreen,
     type RawStudyState,
-    type ScreenId,
+    type ScreenDescriptor,
     type StudyRole,
 } from '@/lib/study-screen'
 import type { SelectedStudy } from '@/server/actions/study.actions'
@@ -20,10 +20,10 @@ type RenderArgs = {
     returnTo?: 'org'
 }
 
-async function renderScreen(screen: ScreenId, args: RenderArgs): Promise<React.JSX.Element> {
-    const Screen = SCREEN_COMPONENTS[screen]
+async function renderScreen(descriptor: ScreenDescriptor, args: RenderArgs): Promise<React.JSX.Element> {
+    const Screen = SCREEN_COMPONENTS[descriptor.screen]
     return (await Screen({
-        descriptor: { screen },
+        descriptor,
         study: args.study,
         raw: args.raw,
         orgSlug: args.orgSlug,
@@ -38,18 +38,18 @@ async function renderScreen(screen: ScreenId, args: RenderArgs): Promise<React.J
 export async function renderStudyScreen(
     args: RenderArgs & { role: StudyRole; studyId: string },
 ): Promise<React.JSX.Element> {
-    const { screen } = resolveScreen(args.role, projectStudyState(args.raw), {
+    const descriptor = resolveScreen(args.role, projectStudyState(args.raw), {
         orgSlug: args.orgSlug,
         studyId: args.studyId,
         returnTo: args.returnTo,
     })
-    return renderScreen(screen, args)
+    return renderScreen(descriptor, args)
 }
 
 // /view/code dispatch: the read-only code screen, even after the study advanced to results. 404s
 // when the study hasn't reached the code stage (no forward jumps).
 export async function renderResearcherCodeStep(args: RenderArgs): Promise<React.JSX.Element> {
-    const screen = resolveResearcherCodeScreen(projectStudyState(args.raw))
-    if (!screen) notFound()
-    return renderScreen(screen, args)
+    const descriptor = resolveResearcherCodeScreen(projectStudyState(args.raw))
+    if (!descriptor) notFound()
+    return renderScreen(descriptor, args)
 }

--- a/src/lib/study-screen/resolve.test.ts
+++ b/src/lib/study-screen/resolve.test.ts
@@ -137,7 +137,7 @@ describe('resolveResearcherCodeScreen (read-only /view/code)', () => {
             hasResults: true,
             resultsApproved: true,
         })
-        expect(resolveResearcherCodeScreen(resultsStudy)).toBe('code-approved')
+        expect(resolveResearcherCodeScreen(resultsStudy)).toEqual({ screen: 'code-approved', readOnlyCodeStep: true })
     })
 
     it('picks the code screen by state: changes-requested → code-feedback', () => {
@@ -147,12 +147,25 @@ describe('resolveResearcherCodeScreen (read-only /view/code)', () => {
             hasSubmittedCode: true,
             codeDecision: 'CODE-CHANGES-REQUESTED',
         })
-        expect(resolveResearcherCodeScreen(s)).toBe('code-feedback')
+        expect(resolveResearcherCodeScreen(s)).toEqual({ screen: 'code-feedback', readOnlyCodeStep: true })
     })
 
     it('awaiting decision → code-under-review', () => {
         const s = state({ status: 'APPROVED', isDraft: false, hasSubmittedCode: true, codeAwaitingDecision: true })
-        expect(resolveResearcherCodeScreen(s)).toBe('code-under-review')
+        expect(resolveResearcherCodeScreen(s)).toEqual({ screen: 'code-under-review', readOnlyCodeStep: true })
+    })
+
+    // OTTER-640: the read-only step marks readOnlyCodeStep so the code screen keeps the submitted code
+    // visible while the job runs in the enclave — unlike the live /view flow, which hides it.
+    it('marks readOnlyCodeStep for an executing study (code stays visible)', () => {
+        const s = state({
+            status: 'APPROVED',
+            isDraft: false,
+            hasSubmittedCode: true,
+            codeDecision: 'CODE-APPROVED',
+            isExecuting: true,
+        })
+        expect(resolveResearcherCodeScreen(s)).toEqual({ screen: 'code-approved', readOnlyCodeStep: true })
     })
 
     it('cannot jump ahead: approved proposal with no code → undefined (route 404s)', () => {

--- a/src/lib/study-screen/resolve.ts
+++ b/src/lib/study-screen/resolve.ts
@@ -17,9 +17,14 @@ const RESEARCHER_CODE_SCREENS: ReadonlyArray<ScreenId> = ['code-approved', 'code
 
 // The code screen for the read-only /view/code route, reusing the table's own predicates. undefined
 // when the study hasn't reached the code stage (route 404s), so a researcher can walk back to the
-// code step but never jump ahead.
-export function resolveResearcherCodeScreen(state: StudyState): ScreenId | undefined {
-    return RESEARCHER_SCREEN_RULES.find(([id, rule]) => RESEARCHER_CODE_SCREENS.includes(id) && rule.when(state))?.[0]
+// code step but never jump ahead. Marks the descriptor readOnlyCodeStep so the code screen keeps the
+// submitted code visible during enclave execution (OTTER-640) — a distinction this route owns, not the
+// live /view resolver.
+export function resolveResearcherCodeScreen(state: StudyState): ScreenDescriptor | undefined {
+    const screen = RESEARCHER_SCREEN_RULES.find(
+        ([id, rule]) => RESEARCHER_CODE_SCREENS.includes(id) && rule.when(state),
+    )?.[0]
+    return screen ? { screen, readOnlyCodeStep: true } : undefined
 }
 
 export function resolveDashboardAction(role: StudyRole, state: DashboardState, ctx: DashboardRuleCtx): DashboardAction {

--- a/src/lib/study-screen/screens.ts
+++ b/src/lib/study-screen/screens.ts
@@ -21,6 +21,11 @@ export type ScreenId =
 // centralizing). The screen is derived purely from state — no URL params feed into it.
 export type ScreenDescriptor = {
     screen: ScreenId
+    // True only for the read-only /view/code step (resolveResearcherCodeScreen). The code screen reads
+    // this to keep the submitted code visible even while the job runs in the enclave (OTTER-640): the
+    // execution-window hide is the live /view flow's behavior, not the read-only step the researcher
+    // walks back to. The live resolver never sets it, so the live flow is unchanged.
+    readOnlyCodeStep?: boolean
 }
 
 export type DashboardAction = {

--- a/src/lib/study-screen/state.test.ts
+++ b/src/lib/study-screen/state.test.ts
@@ -93,6 +93,83 @@ describe('projectStudyState', () => {
         expect(s.latestJobStatuses).toContain('FILES-APPROVED')
     })
 
+    // isExecuting is the LIVE execution window only. Status changes are append-only, so a JOB-RUNNING
+    // row survives forever — gating on results keeps "ever ran" from reading as "executing", which had
+    // kept the approved/will-run banner showing after the run. A bare JOB-ERRORED stays hidden from the
+    // researcher (reviewer triages it), so it must NOT end the window; only a researcher-visible result
+    // (RUN-COMPLETE / FILES-APPROVED / FILES-REJECTED) does.
+    describe('isExecuting (live execution window)', () => {
+        it('running, no results yet → executing', () => {
+            const s = projectStudyState(
+                raw({ status: 'APPROVED', jobs: [job(ID1, ['CODE-SUBMITTED', 'CODE-APPROVED', 'JOB-RUNNING'])] }),
+            )
+            expect(s.isExecuting).toBe(true)
+        })
+
+        it('ran then completed (RUN-COMPLETE) → no longer executing', () => {
+            const s = projectStudyState(
+                raw({
+                    status: 'APPROVED',
+                    jobs: [job(ID1, ['CODE-SUBMITTED', 'CODE-APPROVED', 'JOB-RUNNING', 'RUN-COMPLETE'])],
+                }),
+            )
+            expect(s.isExecuting).toBe(false)
+        })
+
+        it('ran then files-approved → no longer executing', () => {
+            const s = projectStudyState(
+                raw({
+                    status: 'APPROVED',
+                    jobs: [job(ID1, ['CODE-SUBMITTED', 'CODE-APPROVED', 'JOB-RUNNING', 'FILES-APPROVED'])],
+                }),
+            )
+            expect(s.isExecuting).toBe(false)
+        })
+
+        // A bare JOB-ERRORED is hidden from the researcher until a reviewer files a decision, so the
+        // window stays live for them — they hold on the code-approved page, not the results screen.
+        it('ran then errored, no reviewer decision → still executing (errored result hidden)', () => {
+            const s = projectStudyState(
+                raw({
+                    status: 'APPROVED',
+                    jobs: [job(ID1, ['CODE-SUBMITTED', 'CODE-APPROVED', 'JOB-RUNNING', 'JOB-ERRORED'])],
+                }),
+            )
+            expect(s.isExecuting).toBe(true)
+        })
+
+        it('errored then reviewer files-rejected → no longer executing (result now visible)', () => {
+            const s = projectStudyState(
+                raw({
+                    status: 'APPROVED',
+                    jobs: [
+                        job(ID1, ['CODE-SUBMITTED', 'CODE-APPROVED', 'JOB-RUNNING', 'JOB-ERRORED', 'FILES-REJECTED']),
+                    ],
+                }),
+            )
+            expect(s.isExecuting).toBe(false)
+        })
+
+        it('errored then reviewer files-approved → no longer executing (result released to researcher)', () => {
+            const s = projectStudyState(
+                raw({
+                    status: 'APPROVED',
+                    jobs: [
+                        job(ID1, ['CODE-SUBMITTED', 'CODE-APPROVED', 'JOB-RUNNING', 'JOB-ERRORED', 'FILES-APPROVED']),
+                    ],
+                }),
+            )
+            expect(s.isExecuting).toBe(false)
+        })
+
+        it('packaging error (JOB-ERRORED, never ran) → not executing (no running status present)', () => {
+            const s = projectStudyState(
+                raw({ status: 'APPROVED', jobs: [job(ID1, ['CODE-SUBMITTED', 'CODE-APPROVED', 'JOB-ERRORED'])] }),
+            )
+            expect(s.isExecuting).toBe(false)
+        })
+    })
+
     // OTTER-572: hasStep2Progress is true when any Step 2 field is written, false otherwise.
     it('hasStep2Progress: false for a fresh draft, true once any Step 2 field is set', () => {
         expect(projectStudyState(raw({ status: 'DRAFT' })).hasStep2Progress).toBe(false)

--- a/src/lib/study-screen/state.ts
+++ b/src/lib/study-screen/state.ts
@@ -77,7 +77,22 @@ export function projectStudyState(raw: RawStudyState): StudyState {
     const hasSubmittedCode = jobStatuses.has('CODE-SUBMITTED')
     const codeAwaitingDecision = hasSubmittedCode && codeDecision === null
     const hasResults = has(job, STUDY_RESULTS_JOB_STATUSES)
+    const resultsApproved = jobStatuses.has('FILES-APPROVED')
+    const resultsRejected = jobStatuses.has('FILES-REJECTED')
+    const resultsErrored = jobStatuses.has('JOB-ERRORED')
     const resultsDisplayStatus = RESULTS_PRIORITY.find((r) => r && jobStatuses.has(r)) ?? null
+
+    // The execution window is LIVE-only: status changes are append-only, so a job that ran then
+    // completed/errored keeps its JOB-RUNNING row forever — gating on results stops isExecuting from
+    // meaning "ever ran" (which kept showing the approved/will-run banner after the run). A bare
+    // JOB-ERRORED stays hidden from the researcher (the reviewer triages it), so it must NOT end the
+    // window: only a researcher-visible result (RUN-COMPLETE / FILES-APPROVED / FILES-REJECTED) does.
+    const erroredResultHidden = isErroredResultHiddenFromResearcher({
+        resultsErrored,
+        resultsApproved,
+        resultsRejected,
+    })
+    const isExecuting = has(job, STUDY_CODE_RUNNING_JOB_STATUSES) && (!hasResults || erroredResultHidden)
 
     // displayStatus: drop stale code decisions on a resubmission (latest job submitted, no live decision),
     // then pick the highest-priority present status; fall back to study status when the job has none.
@@ -103,11 +118,11 @@ export function projectStudyState(raw: RawStudyState): StudyState {
         hasSubmittedCode,
         codeDecision,
         codeAwaitingDecision,
-        isExecuting: has(job, STUDY_CODE_RUNNING_JOB_STATUSES),
+        isExecuting,
         hasResults,
-        resultsApproved: jobStatuses.has('FILES-APPROVED'),
-        resultsRejected: jobStatuses.has('FILES-REJECTED'),
-        resultsErrored: jobStatuses.has('JOB-ERRORED'),
+        resultsApproved,
+        resultsRejected,
+        resultsErrored,
         resultsDisplayStatus,
         submissionRound,
         hasSavedEdits: !!raw.proposalResubmissionNoteDraft,


### PR DESCRIPTION
## OTTER-640

Study code was missing on the read-only `/view/code` page for studies that had run in the enclave.

### Cause
`/view/code` shares `CodeDecisionScreen` with the live `/view` flow, which hides the code listing while the job executes (OTTER-598). `isExecuting` is sticky — it's true if the job *ever* carried an enclave-run status — so the code stayed hidden on the read-only step for any study that had run.

### Fix
Carry a `readOnlyCodeStep` flag on the `ScreenDescriptor` returned by `resolveResearcherCodeScreen` (the route-specific resolver that already owns the `/view/code` distinction). The code screen reads it to keep the submitted code visible on that route. The live resolver never sets it, so the live `/view` flow is unchanged.

Added a resolver test covering an executing study on the read-only step.