### PR TITLE
OTTER-643: reviewer results "Previous" walks back through the flow

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/_screens/render-screen.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/render-screen.tsx
@@ -5,6 +5,7 @@ import {
     projectStudyState,
     resolveScreen,
     resolveResearcherCodeScreen,
+    resolveReviewerCodeScreen,
     type RawStudyState,
     type ScreenDescriptor,
     type StudyRole,
@@ -50,6 +51,14 @@ export async function renderStudyScreen(
 // when the study hasn't reached the code stage (no forward jumps).
 export async function renderResearcherCodeStep(args: RenderArgs): Promise<React.JSX.Element> {
     const descriptor = resolveResearcherCodeScreen(projectStudyState(args.raw))
+    if (!descriptor) notFound()
+    return renderScreen(descriptor, args)
+}
+
+// /review/code dispatch: the reviewer counterpart, walked back to from the results screen. Same
+// 404-when-not-yet-code contract as the researcher step.
+export async function renderReviewerCodeStep(args: RenderArgs): Promise<React.JSX.Element> {
+    const descriptor = resolveReviewerCodeScreen(projectStudyState(args.raw))
     if (!descriptor) notFound()
     return renderScreen(descriptor, args)
 }

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-agreements-screen.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-agreements-screen.tsx
@@ -5,10 +5,13 @@ import { AgreementsPage } from '../agreements/agreements-page'
 import type { ScreenComponentProps } from './types'
 
 // Reviewer agreements gate, modelled as a screen (not a redirect). Acking proceeds into code review
-// (the bare /review re-resolves to reviewer-code-review once reviewerAgreementsAckedAt is set);
-// Previous returns to the dashboard. No ?from= — the screen authority decides the next view.
-export function ReviewerAgreementsScreen({ study, orgSlug, dashboardHref }: ScreenComponentProps) {
+// (the bare /review re-resolves to reviewer-code-review once reviewerAgreementsAckedAt is set).
+// OTTER-643: Previous walks back to the decided proposal (/review/proposal), the loop-free analog of
+// the researcher agreements → /submitted hop. Pointing it at /review would re-resolve to
+// reviewer-code-review, whose own Previous comes back here — an agreements ⇄ code-review loop.
+export function ReviewerAgreementsScreen({ study, orgSlug }: ScreenComponentProps) {
     const reviewHref = Routes.studyReview({ orgSlug, studyId: study.id })
+    const previousHref = Routes.studyReviewProposal({ orgSlug, studyId: study.id })
     return (
         <Stack p="xl" gap="xl">
             <OrgBreadcrumbs crumbs={{ orgSlug, current: 'Agreements' }} />
@@ -17,7 +20,7 @@ export function ReviewerAgreementsScreen({ study, orgSlug, dashboardHref }: Scre
                 isReviewer
                 studyId={study.id}
                 proceedHref={reviewHref}
-                previousHref={dashboardHref}
+                previousHref={previousHref}
                 previousLabel="Previous"
             />
         </Stack>

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-code-feedback-screen.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-code-feedback-screen.tsx
@@ -2,16 +2,25 @@ import { isSubmittedStudy } from '@/schema/study'
 import { isActionError } from '@/lib/errors'
 import { AlertNotFound } from '@/components/errors'
 import { projectStudyState } from '@/lib/study-screen'
+import { Routes } from '@/lib/routes'
 import { CODE_DECISION_TO_REVIEW_DECISION } from '@/lib/review-decision'
 import { getCodeReviewFeedbackAction } from '@/server/actions/study.actions'
 import { getStudyReviewForJob, jobScanResultForJob, latestSubmittedJobForStudy } from '@/server/db/queries'
 import { PostFeedbackView } from '../review/post-feedback-view'
 import type { ScreenComponentProps } from './types'
 
-export async function ReviewerCodeFeedbackScreen({ study, raw, orgSlug }: ScreenComponentProps) {
+export async function ReviewerCodeFeedbackScreen({ study, raw, orgSlug, descriptor }: ScreenComponentProps) {
     if (!isSubmittedStudy(study)) {
         return <AlertNotFound title="Study was not found" message="No such study exists" />
     }
+
+    // Only the read-only /review/code walk-back (descriptor.readOnlyCodeStep) shows "Previous" → it
+    // continues back through agreements → proposal (OTTER-643). The live code-decision screen leaves it
+    // unset, matching the live DO design that hides Previous.
+    const previousHref = descriptor.readOnlyCodeStep
+        ? Routes.studyReviewerAgreements({ orgSlug, studyId: study.id })
+        : undefined
+
     const job = await latestSubmittedJobForStudy(study.id)
     // The post-decision code page shows the full "Submitted code" section (datasets, AI summary,
     // security scan log, code viewer), the same section as active review, so it needs the review +
@@ -31,6 +40,7 @@ export async function ReviewerCodeFeedbackScreen({ study, raw, orgSlug }: Screen
                 job={job}
                 review={review}
                 scan={scan}
+                previousHref={previousHref}
             />
         )
     }
@@ -56,6 +66,7 @@ export async function ReviewerCodeFeedbackScreen({ study, raw, orgSlug }: Screen
             review={review}
             scan={scan}
             fallback={fallback}
+            previousHref={previousHref}
         />
     )
 }

--- a/src/app/[orgSlug]/study/[studyId]/agreements/reviewer/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/reviewer/page.tsx
@@ -41,8 +41,9 @@ export default async function ReviewerAgreementsRoute(props: {
     }
 
     // Mirror ReviewerAgreementsScreen: Proceed acks and re-resolves bare /review to the code-review
-    // editor; Previous returns to the dashboard. Pointing Previous at /review would re-resolve to
-    // reviewer-code-review, whose own Previous comes back here — an agreements ⇄ code-review loop.
+    // editor. OTTER-643: Previous walks back to the decided proposal (/review/proposal). Pointing it at
+    // /review would re-resolve to reviewer-code-review, whose own Previous comes back here — an
+    // agreements ⇄ code-review loop.
     return (
         <Stack p="xl" gap="xl">
             <OrgBreadcrumbs crumbs={{ orgSlug, current: 'Agreements' }} />
@@ -51,7 +52,7 @@ export default async function ReviewerAgreementsRoute(props: {
                 isReviewer
                 studyId={studyId}
                 proceedHref={Routes.studyReview({ orgSlug, studyId })}
-                previousHref={Routes.orgDashboard({ orgSlug })}
+                previousHref={Routes.studyReviewProposal({ orgSlug, studyId })}
                 previousLabel="Previous"
             />
         </Stack>

--- a/src/app/[orgSlug]/study/[studyId]/review/code/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code/page.test.tsx
@@ -1,0 +1,106 @@
+import type React from 'react'
+import { describe, it, expect } from 'vitest'
+import {
+    db,
+    faker,
+    insertTestOrg,
+    insertTestStudyJobData,
+    insertTestStudyOnly,
+    mockSessionWithTestData,
+    renderWithProviders,
+    screen,
+    setTestStudyStatus,
+} from '@/tests/unit.helpers'
+import type { StudyJobStatus } from '@/database/types'
+import { Routes } from '@/lib/routes'
+import { AccessDeniedAlert, AlertNotFound } from '@/components/errors'
+import { PostFeedbackView } from '../post-feedback-view'
+import StudyReviewCodePage from './page'
+
+// Append a job status strictly after the latest existing one so multi-status histories keep a stable order.
+const addJobStatus = async (studyId: string, status: StudyJobStatus) => {
+    const job = await db.selectFrom('studyJob').select('id').where('studyId', '=', studyId).executeTakeFirstOrThrow()
+    const last = await db
+        .selectFrom('jobStatusChange')
+        .select('createdAt')
+        .where('studyJobId', '=', job.id)
+        .orderBy('createdAt', 'desc')
+        .executeTakeFirst()
+    const base = last?.createdAt ? new Date(last.createdAt).getTime() : Date.now()
+    await db
+        .insertInto('jobStatusChange')
+        .values({ status, studyJobId: job.id, createdAt: new Date(base + 1000) })
+        .execute()
+}
+
+const callPage = async (orgSlug: string, studyId: string) =>
+    (await StudyReviewCodePage({
+        params: Promise.resolve({ orgSlug, studyId }),
+    })) as React.ReactElement<Record<string, unknown>>
+
+// A study with results: the read-only /review/code step is reachable and lands on the code-feedback screen.
+const seedResultsStudy = async (orgSlug: string) => {
+    const { org, user } = await mockSessionWithTestData({ orgSlug, orgType: 'enclave' })
+    const { study } = await insertTestStudyJobData({
+        org,
+        researcherId: user.id,
+        studyStatus: 'APPROVED',
+        jobStatus: 'CODE-SUBMITTED',
+    })
+    await addJobStatus(study.id, 'CODE-APPROVED')
+    await addJobStatus(study.id, 'FILES-APPROVED')
+    return { org, study }
+}
+
+describe('StudyReviewCodePage', () => {
+    it('renders the code-feedback screen with a Previous link to reviewer agreements for a results study', async () => {
+        const { org, study } = await seedResultsStudy('openstax')
+
+        const page = await callPage(org.slug, study.id)
+
+        expect(page?.type).toBe(PostFeedbackView)
+        expect(page?.props.kind).toBe('CODE')
+        expect(page?.props.previousHref).toBe(Routes.studyReviewerAgreements({ orgSlug: org.slug, studyId: study.id }))
+
+        renderWithProviders(page!)
+        expect(screen.getByTestId('post-feedback-previous')).toBeInTheDocument()
+    })
+
+    it('renders code-feedback with the Previous link for a decided-code study without results yet', async () => {
+        // The route is reachable mid-flow (e.g. a reviewer navigating directly), not only after results.
+        // A code decision with no results still resolves to reviewer-code-feedback and shows Previous.
+        const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+        const { study } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'APPROVED',
+            jobStatus: 'CODE-SUBMITTED',
+        })
+        await addJobStatus(study.id, 'CODE-CHANGES-REQUESTED')
+
+        const page = await callPage(org.slug, study.id)
+
+        expect(page?.type).toBe(PostFeedbackView)
+        expect(page?.props.kind).toBe('CODE')
+        expect(page?.props.previousHref).toBe(Routes.studyReviewerAgreements({ orgSlug: org.slug, studyId: study.id }))
+    })
+
+    it('404s when the study has not reached the code stage (no forward jumps)', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+        const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
+        await setTestStudyStatus(study.id, 'PENDING-REVIEW')
+
+        await expect(callPage(org.slug, study.id)).rejects.toThrow()
+    })
+
+    it('denies a non-member, non-SI user (guard runs before the code step)', async () => {
+        await mockSessionWithTestData({ orgType: 'enclave' })
+        const otherOrg = await insertTestOrg({ slug: faker.string.alpha(10), type: 'enclave' })
+        const { study } = await insertTestStudyJobData({ org: otherOrg, studyStatus: 'PENDING-REVIEW' })
+
+        const page = await callPage(otherOrg.slug, study.id)
+
+        expect(page?.type).not.toBe(PostFeedbackView)
+        expect([AccessDeniedAlert, AlertNotFound]).toContain(page?.type)
+    })
+})

--- a/src/app/[orgSlug]/study/[studyId]/review/code/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code/page.tsx
@@ -1,0 +1,28 @@
+'use server'
+
+import { AlertNotFound } from '@/components/errors'
+import { Routes } from '@/lib/routes'
+import { rawStudyStateForStudy } from '@/server/db/study-state-query'
+import { renderReviewerCodeStep } from '../../_screens/render-screen'
+import { reviewerPageGuard } from '../reviewer-page-guard'
+
+// Read-only post-decision code step for the reviewer (DO), reached by walking back from the results
+// screen. renderReviewerCodeStep 404s if the study hasn't reached the code stage. Uses the shared
+// reviewerPageGuard so a non-reviewer is handled exactly as on /review and /review/proposal.
+export default async function StudyReviewCodePage(props: { params: Promise<{ orgSlug: string; studyId: string }> }) {
+    const { orgSlug, studyId } = await props.params
+
+    const guard = await reviewerPageGuard(orgSlug, studyId)
+    if (!guard.ok) return guard.render
+    const { study } = guard
+
+    const raw = await rawStudyStateForStudy(studyId)
+    if (!raw) return <AlertNotFound title="Study was not found" message="No such study exists" />
+
+    return renderReviewerCodeStep({
+        raw,
+        study,
+        orgSlug,
+        dashboardHref: Routes.orgDashboard({ orgSlug }),
+    })
+}

--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.test.tsx
@@ -289,6 +289,30 @@ describe('PostFeedbackView', () => {
             await user.click(screen.getByRole('button', { name: 'Go to dashboard' }))
             expect(memoryRouter.asPath).toBe('/dashboard')
         })
+
+        // OTTER-643: Previous is opt-in via previousHref (set only on the read-only /review/code
+        // walk-back). It must stay hidden for the live code screen and every proposal usage.
+        it('omits the Previous button when previousHref is not provided', () => {
+            renderWithProviders(<PostFeedbackView orgSlug={ORG_SLUG} study={study} entries={[buildEntry()]} />)
+
+            expect(screen.queryByTestId('post-feedback-previous')).not.toBeInTheDocument()
+        })
+
+        it('renders Previous and navigates to previousHref when provided', async () => {
+            const user = userEvent.setup()
+            const previousHref = Routes.studyReviewerAgreements({ orgSlug: ORG_SLUG, studyId: study.id })
+            renderWithProviders(
+                <PostFeedbackView
+                    orgSlug={ORG_SLUG}
+                    study={study}
+                    entries={[buildEntry()]}
+                    previousHref={previousHref}
+                />,
+            )
+
+            await user.click(screen.getByTestId('post-feedback-previous'))
+            expect(memoryRouter.asPath).toBe(previousHref)
+        })
     })
 
     describe('kind="CODE"', () => {

--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
@@ -8,7 +8,9 @@ import { ProposalStepHeader } from '@/components/study/proposal-step-header'
 import { Routes } from '@/lib/routes'
 import { type Submitted } from '@/schema/study'
 import { Box, Button, Group, Stack, Text, Title } from '@mantine/core'
+import { CaretLeftIcon } from '@phosphor-icons/react'
 import { useRouter } from 'next/navigation'
+import type { Route } from 'next'
 import type { ReactNode } from 'react'
 import type { CodeReviewFeedbackEntry, ProposalFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
 import type { JobScanResult, LatestJobForStudy, StudyReviewWithMeta } from '@/server/db/queries'
@@ -34,6 +36,12 @@ type PostFeedbackViewProps = {
         decision: ReviewDecision
         timestamp: Date | string
     }
+    /**
+     * Set only on the read-only /review/code walk-back step (OTTER-643) to render a "Previous" link back
+     * through the flow. Omitted for the live code-decision screen and every proposal usage, which show
+     * only "Go to dashboard" (matching the live DO design, which hides Previous).
+     */
+    previousHref?: Route
 }
 
 type DecisionCopy = {
@@ -136,6 +144,20 @@ function GoToDashboardButton() {
     return (
         <Button onClick={handleClick} data-testid="go-to-dashboard">
             Go to dashboard
+        </Button>
+    )
+}
+
+function PreviousButton({ href }: { href: Route }) {
+    const router = useRouter()
+    return (
+        <Button
+            variant="subtle"
+            leftSection={<CaretLeftIcon />}
+            onClick={() => router.push(href)}
+            data-testid="post-feedback-previous"
+        >
+            Previous
         </Button>
     )
 }
@@ -271,6 +293,7 @@ export function PostFeedbackView({
     review = null,
     scan = null,
     fallback,
+    previousHref,
 }: PostFeedbackViewProps) {
     const latest = entries[0]
     const latestDecision = latest?.decision ?? null
@@ -316,7 +339,8 @@ export function PostFeedbackView({
                     banner={banner}
                 />
                 <FeedbackAndNotesSection entries={entries} alwaysExpandLatest={isCode} />
-                <Group justify="flex-end">
+                <Group justify={previousHref ? 'space-between' : 'flex-end'}>
+                    {previousHref && <PreviousButton href={previousHref} />}
                     <GoToDashboardButton />
                 </Group>
             </Stack>

--- a/src/app/[orgSlug]/study/[studyId]/review/study-details-reviewer.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/study-details-reviewer.test.tsx
@@ -4,9 +4,9 @@ import { useParams } from 'next/navigation'
 import { type Mock, describe, expect, it } from 'vitest'
 import { StudyDetailsReviewer } from './study-details-reviewer'
 
-// OTTER-538: server-side smoke tests for the new DO Study Details page —
-// it drops the Study Code section and points "Previous" at the dashboard (results out-rank every
-// other reviewer screen, so a bare /review href would self-link straight back to this screen).
+// OTTER-538: server-side smoke tests for the new DO Study Details page — it drops the Study Code
+// section. OTTER-643: "Previous" walks back to the read-only code step (/review/code) rather than the
+// dashboard (a bare /review href would self-link straight back to this screen).
 
 describe('StudyDetailsReviewer', () => {
     it('omits the Study Code section', async () => {
@@ -28,13 +28,13 @@ describe('StudyDetailsReviewer', () => {
         expect(screen.getByText('No submission found')).toBeInTheDocument()
     })
 
-    it('routes Previous to the dashboard (avoids the results-screen self-link)', async () => {
+    it('routes Previous to the read-only code step (avoids the results-screen self-link)', async () => {
         const { org, study } = await setupStudyAction({ orgSlug: 'openstax', orgType: 'enclave' })
         ;(useParams as Mock).mockReturnValue({ orgSlug: org.slug, studyId: study.id })
 
         renderWithProviders(await StudyDetailsReviewer({ orgSlug: org.slug, study }))
 
         const previousButton = screen.getByRole('link', { name: /previous/i })
-        expect(previousButton).toHaveAttribute('href', `/${org.slug}/dashboard`)
+        expect(previousButton).toHaveAttribute('href', `/${org.slug}/study/${study.id}/review/code`)
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/review/study-details-reviewer.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/study-details-reviewer.tsx
@@ -6,9 +6,9 @@ import { StudyDetailsReviewerView } from './study-details-reviewer-view'
 import type { SelectedStudy } from '@/server/actions/study.actions'
 
 // OTTER-538: Study Details page (DO) — results-only layout, removes the "Study Code" section.
-// Previous returns to the dashboard: results out-rank every other reviewer screen in
-// REVIEWER_SCREEN_RULES, so a bare /review href would re-resolve straight back to this same screen
-// (a self-link). The dashboard is the only non-looping target while results are present.
+// OTTER-643: Previous walks back to the read-only code step (/review/code). A bare /review href would
+// re-resolve straight back to this screen (results out-rank every other reviewer screen), so the
+// dedicated route is what breaks the self-link — see resolveReviewerCodeScreen.
 
 type StudyDetailsReviewerProps = {
     orgSlug: string
@@ -21,7 +21,7 @@ export async function StudyDetailsReviewer({ orgSlug, study }: StudyDetailsRevie
         return <AlertNotFound title="No submission found" message="This study has no submitted code to review." />
     }
 
-    const previousHref = Routes.orgDashboard({ orgSlug })
+    const previousHref = Routes.studyReviewCode({ orgSlug, studyId: study.id })
 
     return (
         <StudyDetailsReviewerView orgSlug={orgSlug} previousHref={previousHref}>

--- a/src/lib/routes/definitions.ts
+++ b/src/lib/routes/definitions.ts
@@ -127,6 +127,11 @@ export const Routes = {
 
     studyReview: makeRoute(({ orgSlug, studyId }) => `/${orgSlug}/study/${studyId}/review`, StudyParams),
 
+    // Read-only post-decision code view for the reviewer (DO), the counterpart to studyViewCode: lets a
+    // reviewer walk back to the code step from a results study (whose /review resolves to results). No
+    // returnTo — the reviewer flow is always org-scoped via the path. The page 404s if code isn't reached.
+    studyReviewCode: makeRoute(({ orgSlug, studyId }) => `/${orgSlug}/study/${studyId}/review/code`, StudyParams),
+
     studyReviewProposal: makeRoute(
         ({ orgSlug, studyId }) => `/${orgSlug}/study/${studyId}/review/proposal`,
         StudyParams,

--- a/src/lib/study-screen/index.ts
+++ b/src/lib/study-screen/index.ts
@@ -1,5 +1,10 @@
 export * from './state.types'
 export * from './screens'
 export { projectStudyState, isErroredResultHiddenFromResearcher } from './state'
-export { resolveScreen, resolveResearcherCodeScreen, resolveDashboardAction } from './resolve'
+export {
+    resolveScreen,
+    resolveResearcherCodeScreen,
+    resolveReviewerCodeScreen,
+    resolveDashboardAction,
+} from './resolve'
 export { resolvePillStatus, resolveRowHighlight } from './pill'

--- a/src/lib/study-screen/resolve.test.ts
+++ b/src/lib/study-screen/resolve.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { StudyState } from './state.types'
-import { resolveScreen, resolveResearcherCodeScreen } from './resolve'
+import { resolveScreen, resolveResearcherCodeScreen, resolveReviewerCodeScreen } from './resolve'
 
 const state = (overrides: Partial<StudyState>): StudyState => ({
     status: 'DRAFT',
@@ -178,12 +178,76 @@ describe('resolveResearcherCodeScreen (read-only /view/code)', () => {
     })
 })
 
-// Reviewer rules are deferred (spec §13): resolveScreen('reviewer', …) currently falls through to
-// the researcher table rather than erroring. This pins that contract — when reviewer rules land,
-// this test should be updated, not silently start passing for the wrong reason.
-describe('resolveScreen (reviewer fall-through, not yet implemented)', () => {
-    it('returns a defined descriptor for the reviewer role (researcher fallback for now)', () => {
-        const d = resolveScreen('reviewer', state({ status: 'PENDING-REVIEW', isDraft: false }), ctx)
-        expect(d.screen).toBeDefined()
+describe('resolveScreen (reviewer)', () => {
+    it('results present → reviewer-study-results (highest precedence)', () => {
+        expect(resolveScreen('reviewer', state({ hasResults: true, codeDecision: 'CODE-APPROVED' }), ctx).screen).toBe(
+            'reviewer-study-results',
+        )
+    })
+    it('pending review → reviewer-proposal-review', () => {
+        expect(resolveScreen('reviewer', state({ status: 'PENDING-REVIEW', isDraft: false }), ctx).screen).toBe(
+            'reviewer-proposal-review',
+        )
+    })
+})
+
+// OTTER-643: resolveReviewerCodeScreen backs the read-only /review/code route — the DO counterpart to
+// resolveResearcherCodeScreen. It returns the matching code screen (skipping reviewer-study-results so
+// a results study doesn't loop), or undefined when the study hasn't reached the code stage (route 404s).
+describe('resolveReviewerCodeScreen (read-only /review/code)', () => {
+    it('results study → reviewer-code-feedback (results imply an approved code decision)', () => {
+        const resultsStudy = state({
+            status: 'APPROVED',
+            isDraft: false,
+            hasSubmittedCode: true,
+            codeDecision: 'CODE-APPROVED',
+            hasResults: true,
+            resultsApproved: true,
+        })
+        expect(resolveReviewerCodeScreen(resultsStudy)).toEqual({
+            screen: 'reviewer-code-feedback',
+            readOnlyCodeStep: true,
+        })
+    })
+
+    it('changes-requested decision → reviewer-code-feedback', () => {
+        const s = state({
+            status: 'APPROVED',
+            isDraft: false,
+            hasSubmittedCode: true,
+            codeDecision: 'CODE-CHANGES-REQUESTED',
+        })
+        expect(resolveReviewerCodeScreen(s)).toEqual({ screen: 'reviewer-code-feedback', readOnlyCodeStep: true })
+    })
+
+    it('awaiting decision, agreements acked → reviewer-code-review', () => {
+        const s = state({
+            status: 'APPROVED',
+            isDraft: false,
+            hasSubmittedCode: true,
+            codeAwaitingDecision: true,
+            reviewerAgreementsAcked: true,
+        })
+        expect(resolveReviewerCodeScreen(s)).toEqual({ screen: 'reviewer-code-review', readOnlyCodeStep: true })
+    })
+
+    it('awaiting decision, agreements NOT acked → reviewer-agreements', () => {
+        const s = state({
+            status: 'APPROVED',
+            isDraft: false,
+            hasSubmittedCode: true,
+            codeAwaitingDecision: true,
+            reviewerAgreementsAcked: false,
+        })
+        expect(resolveReviewerCodeScreen(s)).toEqual({ screen: 'reviewer-agreements', readOnlyCodeStep: true })
+    })
+
+    it('cannot jump ahead: approved proposal with no code → undefined (route 404s)', () => {
+        const s = state({ status: 'APPROVED', isDraft: false })
+        expect(resolveReviewerCodeScreen(s)).toBeUndefined()
+    })
+    it('cannot jump ahead: pending-review study → undefined (route 404s)', () => {
+        const s = state({ status: 'PENDING-REVIEW', isDraft: false })
+        expect(resolveReviewerCodeScreen(s)).toBeUndefined()
     })
 })

--- a/src/lib/study-screen/resolve.ts
+++ b/src/lib/study-screen/resolve.ts
@@ -27,6 +27,25 @@ export function resolveResearcherCodeScreen(state: StudyState): ScreenDescriptor
     return screen ? { screen, readOnlyCodeStep: true } : undefined
 }
 
+const REVIEWER_CODE_SCREENS: ReadonlyArray<ScreenId> = [
+    'reviewer-code-feedback',
+    'reviewer-agreements',
+    'reviewer-code-review',
+]
+
+// Reviewer counterpart to resolveResearcherCodeScreen, for the read-only /review/code route a DO walks
+// back to from the results screen. Excluding reviewer-study-results from the candidate set is the whole
+// point: a results study keeps codeDecision === 'CODE-APPROVED', so re-running the table's own predicates
+// over just the code-stage screens lands on reviewer-code-feedback instead of looping back to results
+// (which out-ranks everything in REVIEWER_SCREEN_RULES). undefined when the study hasn't reached code yet,
+// so the route 404s rather than jumping forward.
+export function resolveReviewerCodeScreen(state: StudyState): ScreenDescriptor | undefined {
+    const screen = REVIEWER_SCREEN_RULES.find(
+        ([id, rule]) => REVIEWER_CODE_SCREENS.includes(id) && rule.when(state),
+    )?.[0]
+    return screen ? { screen, readOnlyCodeStep: true } : undefined
+}
+
 export function resolveDashboardAction(role: StudyRole, state: DashboardState, ctx: DashboardRuleCtx): DashboardAction {
     // researcher-only for now; reviewer dashboard link is unchanged in this plan.
     const rule = DASHBOARD_RULES.find((r) => r.when(state))!


### PR DESCRIPTION
## What

The reviewer (DO) results page "Previous" button dead-ended at the dashboard. It now walks back **results → code → agreements → proposal**, matching the researcher flow (OTTER-614).

- `resolveReviewerCodeScreen` + new read-only `/review/code` route bypass the `hasResults` self-loop (results out-rank every reviewer screen, so a bare `/review` link would loop back).
- `PostFeedbackView` gains an opt-in `previousHref` — shown only on the read-only code step, hidden on the live screen and all proposal usages.
- Reviewer agreements "Previous" (screen + route) now targets the decided proposal (`/review/proposal`), the loop-free terminal.

[OTTER-643](https://openstax.atlassian.net/browse/OTTER-643)



## Tests

- `resolveReviewerCodeScreen` unit cases (all state branches + 404 guards)
- `/review/code` route: results study, decided-code-without-results, 404 pre-code, access denial
- `PostFeedbackView` Previous show/hide/navigate
- Flipped the reviewer-results assertion to expect `/review/code`

[OTTER-643]: https://openstax.atlassian.net/browse/OTTER-643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ