### PR TITLE
OTTER-610: standardize button alignment in modals

### DIFF
--- a/src/components/dashboard/studies-table/delete-draft-button.tsx
+++ b/src/components/dashboard/studies-table/delete-draft-button.tsx
@@ -74,7 +74,7 @@ export function DeleteDraftButton({ study }: { study: StudyRow }) {
                         Please confirm that you are wanting to delete this proposal draft. Once this draft is deleted
                         you will not be able to recover it. This action cannot be undone.
                     </Text>
-                    <Group justify="flex-end">
+                    <Group>
                         <Button variant="outline" onClick={close} disabled={isPending}>
                             Cancel
                         </Button>

--- a/src/components/modals/review-confirmation-modal.tsx
+++ b/src/components/modals/review-confirmation-modal.tsx
@@ -36,7 +36,7 @@ export const ReviewConfirmationModal: FC<ReviewConfirmationModalProps> = ({
         >
             <Stack>
                 {children}
-                <Group justify="flex-end">
+                <Group>
                     <Button variant="outline" onClick={onClose} disabled={isPending}>
                         Cancel
                     </Button>

--- a/src/components/modals/submit-confirmation-modal.tsx
+++ b/src/components/modals/submit-confirmation-modal.tsx
@@ -24,7 +24,7 @@ export const SubmitConfirmationModal: FC<SubmitConfirmationModalProps> = ({
     <AppModal isOpen={isOpen} onClose={onClose} title={title} closeButtonProps={{ 'aria-label': 'Close' }}>
         <Stack gap="xl">
             <Text size="md">{body}</Text>
-            <Group justify="flex-start">
+            <Group>
                 <Button variant="outline" onClick={onClose} disabled={isSubmitting}>
                     Cancel
                 </Button>


### PR DESCRIPTION
Removes explicit `justify` properties from button `Group` components in confirmation modals - default behavior is left-aligned. 

This change ensures a consistent default alignment for action buttons across these dialogs, improving overall UI uniformity. 