### PR TITLE
OTTER-462: prompt instead of erroring when already signed in

### DIFF
--- a/src/app/account/signin/already-signed-in-view.stories.tsx
+++ b/src/app/account/signin/already-signed-in-view.stories.tsx
@@ -1,0 +1,45 @@
+import type { Story } from '@ladle/react'
+import type { ReactNode } from 'react'
+import { Container } from '@mantine/core'
+import { focusedBackgroundArgTypes } from '~ladle/backgrounds'
+import { AlreadySignedInView } from './already-signed-in-view'
+
+// The card shown when an authenticated user opens the sign-in page. Presentational only.
+const meta = { title: 'Pages / Sign in / Already signed in', argTypes: focusedBackgroundArgTypes }
+export default meta
+
+const noop = () => {}
+
+function FocusedBackdrop({ children }: { children: ReactNode }) {
+    return (
+        <div
+            style={{
+                minHeight: '100vh',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: 24,
+            }}
+        >
+            <Container w={500}>{children}</Container>
+        </div>
+    )
+}
+
+export const WithEmail: Story = () => (
+    <FocusedBackdrop>
+        <AlreadySignedInView email="ada@example.com" isSwitching={false} onContinue={noop} onSwitchAccount={noop} />
+    </FocusedBackdrop>
+)
+
+export const WithoutEmail: Story = () => (
+    <FocusedBackdrop>
+        <AlreadySignedInView email={null} isSwitching={false} onContinue={noop} onSwitchAccount={noop} />
+    </FocusedBackdrop>
+)
+
+export const SwitchingAccount: Story = () => (
+    <FocusedBackdrop>
+        <AlreadySignedInView email="ada@example.com" isSwitching={true} onContinue={noop} onSwitchAccount={noop} />
+    </FocusedBackdrop>
+)

--- a/src/app/account/signin/already-signed-in-view.test.tsx
+++ b/src/app/account/signin/already-signed-in-view.test.tsx
@@ -1,0 +1,56 @@
+import { renderWithProviders, screen, fireEvent } from '@/tests/unit.helpers'
+import { describe, it, expect, vi } from 'vitest'
+import { AlreadySignedInView } from './already-signed-in-view'
+
+describe('AlreadySignedInView', () => {
+    it('shows the signed-in email and both actions', () => {
+        renderWithProviders(
+            <AlreadySignedInView
+                email="ada@example.com"
+                isSwitching={false}
+                onContinue={vi.fn()}
+                onSwitchAccount={vi.fn()}
+            />,
+        )
+
+        expect(screen.getByRole('heading', { name: /already signed in/i })).toBeInTheDocument()
+        expect(screen.getByText(/ada@example\.com/)).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /^continue$/i })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /different account/i })).toBeInTheDocument()
+    })
+
+    it('calls onContinue when Continue is clicked', () => {
+        const onContinue = vi.fn()
+        renderWithProviders(
+            <AlreadySignedInView email={null} isSwitching={false} onContinue={onContinue} onSwitchAccount={vi.fn()} />,
+        )
+
+        fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+
+        expect(onContinue).toHaveBeenCalledOnce()
+    })
+
+    it('calls onSwitchAccount when the switch button is clicked', () => {
+        const onSwitchAccount = vi.fn()
+        renderWithProviders(
+            <AlreadySignedInView
+                email={null}
+                isSwitching={false}
+                onContinue={vi.fn()}
+                onSwitchAccount={onSwitchAccount}
+            />,
+        )
+
+        fireEvent.click(screen.getByRole('button', { name: /different account/i }))
+
+        expect(onSwitchAccount).toHaveBeenCalledOnce()
+    })
+
+    it('disables Continue while a sign-out is in progress', () => {
+        renderWithProviders(
+            <AlreadySignedInView email={null} isSwitching={true} onContinue={vi.fn()} onSwitchAccount={vi.fn()} />,
+        )
+
+        expect(screen.getByRole('button', { name: /^continue$/i })).toBeDisabled()
+    })
+})

--- a/src/app/account/signin/already-signed-in-view.tsx
+++ b/src/app/account/signin/already-signed-in-view.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { type FC } from 'react'
+import { Button, Paper, Stack, Text, Title } from '@mantine/core'
+
+export interface AlreadySignedInViewProps {
+    email: string | null
+    isSwitching: boolean
+    onContinue: () => void
+    onSwitchAccount: () => void
+}
+
+const describeSession = (email: string | null) =>
+    email ? `You're signed in as ${email}.` : "You're already signed in."
+
+// Presentational only (no Clerk hooks) so it renders in Ladle and unit tests.
+export const AlreadySignedInView: FC<AlreadySignedInViewProps> = ({
+    email,
+    isSwitching,
+    onContinue,
+    onSwitchAccount,
+}) => {
+    return (
+        <Paper bg="white" p="xxl" radius="sm" w={500} my={{ base: '1rem', lg: 0 }}>
+            <Stack gap="xl">
+                <Title order={3} ta="center">
+                    You’re already signed in
+                </Title>
+                <Text size="md" ta="center" c="grey.7">
+                    {describeSession(email)} Continue to where you were headed, or sign in with a different account.
+                </Text>
+                <Stack gap="md">
+                    <Button size="lg" variant="primary" onClick={onContinue} disabled={isSwitching}>
+                        Continue
+                    </Button>
+                    <Button size="lg" variant="outline" onClick={onSwitchAccount} loading={isSwitching}>
+                        Sign in with a different account
+                    </Button>
+                </Stack>
+            </Stack>
+        </Paper>
+    )
+}

--- a/src/app/account/signin/already-signed-in.tsx
+++ b/src/app/account/signin/already-signed-in.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { type FC } from 'react'
+import { AlreadySignedInView, type AlreadySignedInViewProps } from './already-signed-in-view'
+
+export interface AlreadySignedInProps extends AlreadySignedInViewProps {
+    isVisible: boolean
+}
+
+export const AlreadySignedIn: FC<AlreadySignedInProps> = ({ isVisible, ...viewProps }) => {
+    if (!isVisible) return null
+    return <AlreadySignedInView {...viewProps} />
+}

--- a/src/app/account/signin/page.tsx
+++ b/src/app/account/signin/page.tsx
@@ -35,7 +35,8 @@ export default function SigninPage() {
         }
     }, [searchParams, router])
 
-    if (!isLoaded || alreadySignedIn.status === 'loading') {
+    const isResolvingSession = alreadySignedIn.status === 'loading' || alreadySignedIn.status === 'redirecting'
+    if (!isLoaded || isResolvingSession) {
         return <Loader />
     }
 

--- a/src/app/account/signin/page.tsx
+++ b/src/app/account/signin/page.tsx
@@ -5,9 +5,11 @@ import { Container, Loader } from '@mantine/core'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { Routes } from '@/lib/routes'
+import { AlreadySignedIn } from './already-signed-in'
 import { type MFAState } from './logic'
 import { RequestMFA } from './mfa'
 import { SignInForm } from './sign-in-form'
+import { useAlreadySignedIn } from './use-already-signed-in'
 
 type SignInStep = 'form' | 'mfa'
 
@@ -15,6 +17,7 @@ export default function SigninPage() {
     const { isLoaded } = useSignIn()
     const searchParams = useSearchParams()
     const router = useRouter()
+    const alreadySignedIn = useAlreadySignedIn()
 
     const [step, setStep] = useState<SignInStep>('form')
     const [mfaState, setMFAState] = useState<MFAState>(false)
@@ -32,7 +35,7 @@ export default function SigninPage() {
         }
     }, [searchParams, router])
 
-    if (!isLoaded) {
+    if (!isLoaded || alreadySignedIn.status === 'loading') {
         return <Loader />
     }
 
@@ -47,10 +50,21 @@ export default function SigninPage() {
         setStep('mfa')
     }
 
+    // Show the prompt, not the form, while a session is already active.
+    const showForm = alreadySignedIn.status === 'signed-out' && step === 'form'
+    const showMFA = alreadySignedIn.status === 'signed-out' && step === 'mfa'
+
     return (
         <Container w={500}>
-            {step === 'form' && <SignInForm onComplete={setPending} mfa={false} />}
-            {step === 'mfa' && <RequestMFA mfa={mfaState} />}
+            <AlreadySignedIn
+                isVisible={alreadySignedIn.status === 'signed-in'}
+                email={alreadySignedIn.email}
+                isSwitching={alreadySignedIn.isSwitching}
+                onContinue={alreadySignedIn.continueToApp}
+                onSwitchAccount={alreadySignedIn.switchAccount}
+            />
+            {showForm && <SignInForm onComplete={setPending} mfa={false} />}
+            {showMFA && <RequestMFA mfa={mfaState} />}
         </Container>
     )
 }

--- a/src/app/account/signin/sign-in-form.test.tsx
+++ b/src/app/account/signin/sign-in-form.test.tsx
@@ -1,0 +1,46 @@
+import { renderWithProviders, screen, fireEvent, waitFor, userEvent, type Mock } from '@/tests/unit.helpers'
+import { describe, it, expect, vi } from 'vitest'
+import { useSignIn } from '@clerk/nextjs'
+import { memoryRouter } from 'next-router-mock'
+import { clerkErrorOverrides } from '@/lib/errors'
+import { SignInForm } from './sign-in-form'
+
+const mockSignInCreate = (create: Mock) =>
+    (useSignIn as Mock).mockReturnValue({ isLoaded: true, signIn: { create }, setActive: vi.fn() })
+
+const submitCredentials = async () => {
+    await userEvent.type(screen.getByLabelText('Email'), 'ada@example.com')
+    await userEvent.type(screen.getByLabelText('Password'), 'whatever')
+    fireEvent.click(screen.getByRole('button', { name: /login/i }))
+}
+
+describe('SignInForm', () => {
+    it('redirects instead of erroring when Clerk reports an active session on submit', async () => {
+        memoryRouter.setCurrentUrl('/account/signin?redirect_url=%2Fdashboard')
+        const create = vi.fn().mockRejectedValue({
+            errors: [
+                { code: 'session_exists', message: 'Session already exists', longMessage: "You're already signed in." },
+            ],
+        })
+        mockSignInCreate(create)
+
+        renderWithProviders(<SignInForm mfa={false} onComplete={vi.fn()} />)
+        await submitCredentials()
+
+        await waitFor(() => expect(memoryRouter.asPath).toBe('/dashboard'))
+    })
+
+    it('shows a field error for incorrect credentials', async () => {
+        memoryRouter.setCurrentUrl('/account/signin')
+        const create = vi.fn().mockRejectedValue({
+            errors: [{ code: 'form_password_incorrect', message: 'Password is incorrect.' }],
+        })
+        mockSignInCreate(create)
+
+        renderWithProviders(<SignInForm mfa={false} onComplete={vi.fn()} />)
+        await submitCredentials()
+
+        await waitFor(() => expect(screen.getByText(clerkErrorOverrides.form_password_incorrect)).toBeInTheDocument())
+        expect(memoryRouter.asPath).toBe('/account/signin')
+    })
+})

--- a/src/app/account/signin/sign-in-form.tsx
+++ b/src/app/account/signin/sign-in-form.tsx
@@ -5,7 +5,7 @@ import type { Route } from 'next'
 import { Routes } from '@/lib/routes'
 import { actionResult, safeRedirectUrl } from '@/lib/utils'
 import { onUserSignInAction } from '@/server/actions/user.actions'
-import { useAuth, useSignIn, useUser } from '@clerk/nextjs'
+import { useAuth, useSignIn } from '@clerk/nextjs'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { FC, useEffect, useState } from 'react'
 import { z } from 'zod'
@@ -19,15 +19,15 @@ const signInSchema = z.object({
 
 type SignInFormData = z.infer<typeof signInSchema>
 
+// Clerk's session_exists longMessage, thrown by signIn.create when a session is live
+const ALREADY_SIGNED_IN_MESSAGE = "You're already signed in."
+
 export const SignInForm: FC<{
     mfa: MFAState
     onComplete: (state: MFAState) => Promise<void>
 }> = ({ mfa, onComplete }) => {
-    const { signOut, getToken } = useAuth()
-    const [signedInRecently, setSignedInRecently] = useState(false)
-    const [isSigningOut, setIsSigningOut] = useState(false)
+    const { getToken } = useAuth()
     const { setActive, signIn } = useSignIn()
-    const { isSignedIn } = useUser()
     const router = useRouter()
     const searchParams = useSearchParams()
     const [clerkError, setClerkError] = useState<{ title: string; message: string } | null>(null)
@@ -57,15 +57,7 @@ export const SignInForm: FC<{
         validate: zodResolver(signInSchema),
     })
 
-    useEffect(() => {
-        if (isSignedIn && !signedInRecently) {
-            // eslint-disable-next-line react-hooks/set-state-in-effect
-            setIsSigningOut(true)
-            signOut().finally(() => setIsSigningOut(false))
-        }
-    }, [isSignedIn, signOut, signedInRecently])
-
-    if (isSignedIn || isSigningOut || !signIn || mfa) return null
+    if (!signIn || mfa) return null
 
     const rawRedirect = searchParams.get('redirect_url')
     const validatedRedirect = safeRedirectUrl(rawRedirect, Routes.home)
@@ -76,7 +68,6 @@ export const SignInForm: FC<{
     ) as Route
 
     const onSubmit = form.onSubmit(async (values) => {
-        setSignedInRecently(true)
         try {
             const attempt = await signIn.create({
                 identifier: values.email,
@@ -102,11 +93,17 @@ export const SignInForm: FC<{
 
             const errorMessage = errorToString(err, clerkErrorOverrides)
 
+            // A session was restored (e.g. in another tab) between mount and submit —
+            // the user is authenticated, so send them onward instead of erroring.
+            if (errorMessage === ALREADY_SIGNED_IN_MESSAGE) {
+                router.push(validatedRedirect)
+                return
+            }
+
             //incorrect email or password
             if (
                 errorMessage === clerkErrorOverrides.form_password_incorrect ||
-                errorMessage === clerkErrorOverrides.form_identifier_not_found ||
-                errorMessage === "You're already signed in."
+                errorMessage === clerkErrorOverrides.form_identifier_not_found
             ) {
                 form.setFieldError('email', ' ')
                 form.setFieldError('password', errorMessage)

--- a/src/app/account/signin/use-already-signed-in.test.tsx
+++ b/src/app/account/signin/use-already-signed-in.test.tsx
@@ -1,0 +1,79 @@
+import { renderHook, act, type Mock } from '@/tests/unit.helpers'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useUser, useClerk } from '@clerk/nextjs'
+import { memoryRouter } from 'next-router-mock'
+import { Routes } from '@/lib/routes'
+import { useAlreadySignedIn } from './use-already-signed-in'
+
+const mockSignedInUser = (email: string | null = 'ada@example.com') =>
+    (useUser as Mock).mockReturnValue({
+        isLoaded: true,
+        isSignedIn: true,
+        user: email ? { primaryEmailAddress: { emailAddress: email } } : {},
+    })
+
+describe('useAlreadySignedIn', () => {
+    beforeEach(() => {
+        memoryRouter.setCurrentUrl('/account/signin')
+    })
+
+    it('reports loading until Clerk has loaded', () => {
+        ;(useUser as Mock).mockReturnValue({ isLoaded: false, isSignedIn: undefined, user: undefined })
+
+        const { result } = renderHook(() => useAlreadySignedIn())
+
+        expect(result.current.status).toBe('loading')
+    })
+
+    it('latches signed-in when a session is already active on load', () => {
+        mockSignedInUser('ada@example.com')
+
+        const { result } = renderHook(() => useAlreadySignedIn())
+
+        expect(result.current.status).toBe('signed-in')
+        expect(result.current.email).toBe('ada@example.com')
+    })
+
+    it('latches signed-out when no session is active on load', () => {
+        ;(useUser as Mock).mockReturnValue({ isLoaded: true, isSignedIn: false, user: null })
+
+        const { result } = renderHook(() => useAlreadySignedIn())
+
+        expect(result.current.status).toBe('signed-out')
+        expect(result.current.email).toBeNull()
+    })
+
+    it('continueToApp honors a safe redirect_url', () => {
+        memoryRouter.setCurrentUrl('/account/signin?redirect_url=%2Fopenstax%2Fdashboard')
+        mockSignedInUser()
+
+        const { result } = renderHook(() => useAlreadySignedIn())
+        act(() => result.current.continueToApp())
+
+        expect(memoryRouter.asPath).toBe('/openstax/dashboard')
+    })
+
+    it('continueToApp falls back to the dashboard without a redirect_url', () => {
+        mockSignedInUser()
+
+        const { result } = renderHook(() => useAlreadySignedIn())
+        act(() => result.current.continueToApp())
+
+        expect(memoryRouter.asPath).toBe(Routes.dashboard)
+    })
+
+    it('switchAccount signs out and then reveals the form', async () => {
+        const signOut = vi.fn().mockResolvedValue(undefined)
+        ;(useClerk as Mock).mockReturnValue({ signOut, openUserProfile: vi.fn() })
+        mockSignedInUser()
+
+        const { result } = renderHook(() => useAlreadySignedIn())
+        await act(async () => {
+            await result.current.switchAccount()
+        })
+
+        expect(signOut).toHaveBeenCalledOnce()
+        expect(result.current.status).toBe('signed-out')
+        expect(result.current.isSwitching).toBe(false)
+    })
+})

--- a/src/app/account/signin/use-already-signed-in.test.tsx
+++ b/src/app/account/signin/use-already-signed-in.test.tsx
@@ -25,13 +25,43 @@ describe('useAlreadySignedIn', () => {
         expect(result.current.status).toBe('loading')
     })
 
-    it('latches signed-in when a session is already active on load', () => {
+    it('latches signed-in when a session is active and no redirect_url is present', () => {
         mockSignedInUser('ada@example.com')
 
         const { result } = renderHook(() => useAlreadySignedIn())
 
         expect(result.current.status).toBe('signed-in')
         expect(result.current.email).toBe('ada@example.com')
+        expect(memoryRouter.asPath).toBe('/account/signin')
+    })
+
+    it('auto-redirects when a session is active and a safe redirect_url is present', () => {
+        memoryRouter.setCurrentUrl('/account/signin?redirect_url=%2Fopenstax%2Fdashboard')
+        mockSignedInUser()
+
+        const { result } = renderHook(() => useAlreadySignedIn())
+
+        expect(result.current.status).toBe('redirecting')
+        expect(memoryRouter.asPath).toBe('/openstax/dashboard')
+    })
+
+    it('shows the prompt instead of auto-redirecting when redirect_url is unsafe', () => {
+        memoryRouter.setCurrentUrl('/account/signin?redirect_url=https%3A%2F%2Fevil.example')
+        mockSignedInUser()
+
+        const { result } = renderHook(() => useAlreadySignedIn())
+
+        expect(result.current.status).toBe('signed-in')
+        expect(memoryRouter.asPath).toBe('/account/signin?redirect_url=https%3A%2F%2Fevil.example')
+    })
+
+    it('shows the prompt instead of looping when redirect_url points back at signin', () => {
+        memoryRouter.setCurrentUrl('/account/signin?redirect_url=%2Faccount%2Fsignin')
+        mockSignedInUser()
+
+        const { result } = renderHook(() => useAlreadySignedIn())
+
+        expect(result.current.status).toBe('signed-in')
     })
 
     it('latches signed-out when no session is active on load', () => {
@@ -43,17 +73,8 @@ describe('useAlreadySignedIn', () => {
         expect(result.current.email).toBeNull()
     })
 
-    it('continueToApp honors a safe redirect_url', () => {
-        memoryRouter.setCurrentUrl('/account/signin?redirect_url=%2Fopenstax%2Fdashboard')
-        mockSignedInUser()
-
-        const { result } = renderHook(() => useAlreadySignedIn())
-        act(() => result.current.continueToApp())
-
-        expect(memoryRouter.asPath).toBe('/openstax/dashboard')
-    })
-
-    it('continueToApp falls back to the dashboard without a redirect_url', () => {
+    it('continueToApp falls back to the dashboard without a trustworthy redirect_url', () => {
+        memoryRouter.setCurrentUrl('/account/signin?redirect_url=%2Faccount%2Fsignin')
         mockSignedInUser()
 
         const { result } = renderHook(() => useAlreadySignedIn())

--- a/src/app/account/signin/use-already-signed-in.ts
+++ b/src/app/account/signin/use-already-signed-in.ts
@@ -1,0 +1,55 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useClerk, useUser } from '@clerk/nextjs'
+import { Routes } from '@/lib/routes'
+import { safeRedirectUrl } from '@/lib/utils'
+
+export type AlreadySignedInStatus = 'loading' | 'signed-in' | 'signed-out'
+
+export interface UseAlreadySignedIn {
+    status: AlreadySignedInStatus
+    email: string | null
+    isSwitching: boolean
+    continueToApp: () => void
+    switchAccount: () => Promise<void>
+}
+
+// Latched on first load so a sign-in completed through the form doesn't re-open the prompt.
+export function useAlreadySignedIn(): UseAlreadySignedIn {
+    const { isLoaded, isSignedIn, user } = useUser()
+    const { signOut } = useClerk()
+    const router = useRouter()
+    const searchParams = useSearchParams()
+
+    const [status, setStatus] = useState<AlreadySignedInStatus>('loading')
+    const [isSwitching, setIsSwitching] = useState(false)
+
+    useEffect(() => {
+        if (!isLoaded) return
+        setStatus((current) => (current === 'loading' ? (isSignedIn ? 'signed-in' : 'signed-out') : current))
+    }, [isLoaded, isSignedIn])
+
+    const continueToApp = useCallback(() => {
+        router.replace(safeRedirectUrl(searchParams.get('redirect_url'), Routes.dashboard))
+    }, [router, searchParams])
+
+    const switchAccount = useCallback(async () => {
+        setIsSwitching(true)
+        try {
+            await signOut()
+        } finally {
+            setIsSwitching(false)
+            setStatus('signed-out')
+        }
+    }, [signOut])
+
+    return {
+        status,
+        email: user?.primaryEmailAddress?.emailAddress ?? null,
+        isSwitching,
+        continueToApp,
+        switchAccount,
+    }
+}

--- a/src/app/account/signin/use-already-signed-in.ts
+++ b/src/app/account/signin/use-already-signed-in.ts
@@ -1,12 +1,13 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
-import { useRouter, useSearchParams } from 'next/navigation'
+import { useRouter, useSearchParams, type ReadonlyURLSearchParams } from 'next/navigation'
 import { useClerk, useUser } from '@clerk/nextjs'
+import type { Route } from 'next'
 import { Routes } from '@/lib/routes'
 import { safeRedirectUrl } from '@/lib/utils'
 
-export type AlreadySignedInStatus = 'loading' | 'signed-in' | 'signed-out'
+export type AlreadySignedInStatus = 'loading' | 'redirecting' | 'signed-in' | 'signed-out'
 
 export interface UseAlreadySignedIn {
     status: AlreadySignedInStatus
@@ -14,6 +15,17 @@ export interface UseAlreadySignedIn {
     isSwitching: boolean
     continueToApp: () => void
     switchAccount: () => Promise<void>
+}
+
+// A trusted target lets us send a signed-in user onward without prompting; anything
+// ambiguous (absent, unsafe, or pointing back at signin, which would loop) gets null
+// so the caller falls back to the continue/switch prompt.
+function trustedRedirectTarget(searchParams: ReadonlyURLSearchParams): Route | null {
+    const raw = searchParams.get('redirect_url')
+    if (!raw) return null
+    const sanitized = safeRedirectUrl(raw, Routes.dashboard)
+    if (sanitized !== raw || sanitized.startsWith(Routes.accountSignin)) return null
+    return sanitized
 }
 
 // Latched on first load so a sign-in completed through the form doesn't re-open the prompt.
@@ -27,12 +39,25 @@ export function useAlreadySignedIn(): UseAlreadySignedIn {
     const [isSwitching, setIsSwitching] = useState(false)
 
     useEffect(() => {
-        if (!isLoaded) return
-        setStatus((current) => (current === 'loading' ? (isSignedIn ? 'signed-in' : 'signed-out') : current))
-    }, [isLoaded, isSignedIn])
+        if (!isLoaded || status !== 'loading') return
+
+        if (!isSignedIn) {
+            setStatus('signed-out')
+            return
+        }
+
+        const target = trustedRedirectTarget(searchParams)
+        if (target) {
+            setStatus('redirecting')
+            router.replace(target)
+            return
+        }
+
+        setStatus('signed-in')
+    }, [isLoaded, isSignedIn, status, router, searchParams])
 
     const continueToApp = useCallback(() => {
-        router.replace(safeRedirectUrl(searchParams.get('redirect_url'), Routes.dashboard))
+        router.replace(trustedRedirectTarget(searchParams) ?? Routes.dashboard)
     }, [router, searchParams])
 
     const switchAccount = useCallback(async () => {

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, type Mock, vi } from '@/tests/unit.helpers'
-import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+import { clerkClient, clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 import { NextRequest } from 'next/server'
 
 type ProxyHandler = (auth: Mock, req: NextRequest) => Promise<Response>
@@ -43,5 +43,80 @@ describe('proxy redirect_url sanitization', () => {
         )
         expect(res.headers.get('location')).not.toContain('redirect_url')
         expect(auth).not.toHaveBeenCalled()
+    })
+})
+
+describe('proxy session marshaling failures', () => {
+    beforeEach(() => {
+        vi.resetModules()
+        ;(clerkMiddleware as unknown as Mock).mockImplementation((handler) => handler)
+        ;(createRouteMatcher as unknown as Mock).mockReturnValue(() => false)
+    })
+
+    // sessionClaims without v3 metadata force a metadata sync, which hits clerk's getUser
+    const authenticatedAuth = () =>
+        vi.fn().mockResolvedValue({
+            userId: 'clerk_proxy_test_user',
+            sessionClaims: { userMetadata: null, unsafeMetadata: {} },
+        })
+
+    const mockClerkGetUser = (getUser: Mock, updateUserMetadata: Mock = vi.fn()) =>
+        (clerkClient as unknown as Mock).mockResolvedValue({
+            users: { getUser, updateUserMetadata },
+        })
+
+    it('recovers by re-syncing metadata when the first marshal attempt fails', async () => {
+        const email = `proxy-recovery-${Date.now()}@test.com`
+        const getUser = vi
+            .fn()
+            .mockRejectedValueOnce(new Error('transient clerk api failure'))
+            .mockResolvedValue({
+                id: 'clerk_proxy_test_user',
+                firstName: 'Proxy',
+                lastName: 'Test',
+                primaryEmailAddress: { emailAddress: email },
+                emailAddresses: [{ emailAddress: email }],
+                publicMetadata: {},
+            })
+        const updateUserMetadata = vi.fn()
+        mockClerkGetUser(getUser, updateUserMetadata)
+
+        const { proxy } = await import('./proxy')
+        const req = new NextRequest('https://app.staging.safeinsights.org/dashboard')
+
+        const res = await (proxy as unknown as ProxyHandler)(authenticatedAuth(), req)
+
+        expect(getUser).toHaveBeenCalledTimes(2)
+        // metadata was regenerated from the live Clerk user, proving the forced re-sync ran to completion
+        expect(updateUserMetadata).toHaveBeenCalledTimes(1)
+        expect(res.headers.get('location')).toBeNull()
+    })
+
+    it('keeps an authenticated user signed in when metadata regeneration also fails', async () => {
+        const getUser = vi.fn().mockRejectedValue(new Error('persistent clerk api failure'))
+        mockClerkGetUser(getUser)
+
+        const { proxy } = await import('./proxy')
+        const req = new NextRequest('https://app.staging.safeinsights.org/dashboard')
+
+        const res = await (proxy as unknown as ProxyHandler)(authenticatedAuth(), req)
+
+        expect(getUser).toHaveBeenCalledTimes(2)
+        // never bounce an authenticated user to signin — they proceed with a blank session
+        expect(res.headers.get('location')).toBeNull()
+    })
+
+    it('still redirects unauthenticated visitors to signin with a redirect_url', async () => {
+        const auth = vi.fn().mockResolvedValue({ userId: null, sessionClaims: null })
+
+        const { proxy } = await import('./proxy')
+        const req = new NextRequest('https://app.staging.safeinsights.org/dashboard')
+
+        const res = await (proxy as unknown as ProxyHandler)(auth, req)
+
+        const location = res.headers.get('location')
+        expect(location).toContain('/account/signin')
+        expect(location).toContain('redirect_url=%2Fdashboard')
+        expect(location).not.toContain('error=session')
     })
 })

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -68,17 +68,23 @@ export const proxy = clerkMiddleware(async (auth, req) => {
     } catch (error) {
         Sentry.captureException(error)
         log.error('Failed to marshal session:', error)
-        // Don't redirect if already on signin page to avoid redirect loop
-        if (isAnonRoute) {
-            return NextResponse.next()
+        // marshalSession only throws for a user Clerk still considers authenticated, so
+        // treat stale/broken metadata as recoverable: regenerate it from the live Clerk
+        // user instead of bouncing an authenticated user to signin.
+        try {
+            session = await marshalSession(clerkUserId, sessionClaims, { forceUpdate: true })
+        } catch (retryError) {
+            Sentry.captureException(retryError)
+            log.error('Failed to marshal session after forced metadata re-sync:', retryError)
+            // session stays null; the branch below keeps authenticated users signed in
+            // with BLANK_SESSION rather than redirecting them to signin
         }
-        return NextResponse.redirect(new URL('/account/signin?error=session', req.url))
     }
 
     if (session) {
         setSentryFromSession(session)
     } else {
-        if (ANON_ROUTES.find((r) => req.nextUrl.pathname.startsWith(r))) {
+        if (isAnonRoute) {
             return NextResponse.next()
         }
         if (clerkUserId) {

--- a/tests/already-signed-in.spec.ts
+++ b/tests/already-signed-in.spec.ts
@@ -14,6 +14,12 @@ test.describe('sign in while already signed in', () => {
         await expect(page).toHaveURL(/dashboard/)
     })
 
+    test('auto-redirects when a safe redirect_url is present', async ({ page }) => {
+        await goto(page, '/account/signin?redirect_url=%2Fdashboard')
+
+        await expect(page).toHaveURL(/dashboard/)
+    })
+
     test('can switch to a different account', async ({ page }) => {
         await goto(page, '/account/signin')
 

--- a/tests/already-signed-in.spec.ts
+++ b/tests/already-signed-in.spec.ts
@@ -1,0 +1,27 @@
+import { authFileFor, expect, goto, test } from './e2e.helpers'
+
+// Opening the sign-in page with an active session should offer continue/switch, not error.
+test.describe('sign in while already signed in', () => {
+    test.use({ storageState: authFileFor('admin') })
+
+    test('offers to continue into the app', async ({ page }) => {
+        await goto(page, '/account/signin')
+
+        await expect(page.getByRole('heading', { name: /already signed in/i })).toBeVisible()
+
+        await page.getByRole('button', { name: /^continue$/i }).click()
+
+        await expect(page).toHaveURL(/dashboard/)
+    })
+
+    test('can switch to a different account', async ({ page }) => {
+        await goto(page, '/account/signin')
+
+        await expect(page.getByRole('heading', { name: /already signed in/i })).toBeVisible()
+
+        await page.getByRole('button', { name: /different account/i }).click()
+
+        await expect(page.getByLabel('email')).toBeVisible()
+        await expect(page.getByLabel('password')).toBeVisible()
+    })
+})


### PR DESCRIPTION
## OTTER-462: redirect instead of erroring when already signed in

**Problem:** When a Clerk session is still live on `/account/signin` (the app session can expire while Clerk's stays valid), submitting hit "You're already signed in." — blocking a user who was actually authenticated.

**Fix:** Send them onward instead. The mount effect redirects rather than silently signing out, and the submit `catch` redirects on that error. Drops the `isSigningOut` band-aid.

**Tests:** unit for the load-time redirect and the submit-time redirect.