### PR TITLE
OTTER-641: fix stuck "code change requested" status after resubmitted code is approved

### DIFF
--- a/src/lib/study-screen/pill.test.ts
+++ b/src/lib/study-screen/pill.test.ts
@@ -77,6 +77,30 @@ describe('resolvePillStatus', () => {
         )
         expect(label.label).toBe('Rejected')
     })
+    // OTTER-641: resubmit approved. The stale CODE-CHANGES-REQUESTED must not win over the live approval.
+    it('resubmit then approved reads Approved, not the stale Change requested', () => {
+        const label = resolvePillStatus(
+            'researcher',
+            state({
+                latestJobStatuses: ['CODE-SUBMITTED', 'CODE-CHANGES-REQUESTED', 'CODE-SUBMITTED', 'CODE-APPROVED'],
+                codeDecision: 'CODE-APPROVED',
+            }),
+        )
+        expect(label.label).toBe('Approved')
+    })
+    // Researcher has no execution-status labels, so the pill falls through JOB-READY to the live code
+    // decision; that must be the approval, not the superseded change-request from the earlier round.
+    it('approved then executing still reads Approved for the researcher (falls through to live decision)', () => {
+        const label = resolvePillStatus(
+            'researcher',
+            state({
+                latestJobStatuses: ['CODE-CHANGES-REQUESTED', 'CODE-SUBMITTED', 'CODE-APPROVED', 'JOB-READY'],
+                codeDecision: 'CODE-APPROVED',
+                isExecuting: true,
+            }),
+        )
+        expect(label.label).toBe('Approved')
+    })
 })
 
 describe('resolveRowHighlight', () => {

--- a/src/lib/study-screen/pill.test.ts
+++ b/src/lib/study-screen/pill.test.ts
@@ -88,6 +88,19 @@ describe('resolvePillStatus', () => {
         )
         expect(label.label).toBe('Approved')
     })
+    // Reviewers DO have a label for CODE-CHANGES-REQUESTED, so before the fix the stale round-1 status
+    // could win by DISPLAY_STATUS_PRIORITY. isStaleCodeDecision now runs for every role, so a reviewer
+    // viewing an approved-after-resubmit job also reads the live decision.
+    it('reviewer: resubmit then approved reads Approved, not the stale Change requested', () => {
+        const label = resolvePillStatus(
+            'reviewer',
+            state({
+                latestJobStatuses: ['CODE-SUBMITTED', 'CODE-CHANGES-REQUESTED', 'CODE-SUBMITTED', 'CODE-APPROVED'],
+                codeDecision: 'CODE-APPROVED',
+            }),
+        )
+        expect(label.label).toBe('Approved')
+    })
     // Researcher has no execution-status labels, so the pill falls through JOB-READY to the live code
     // decision; that must be the approval, not the superseded change-request from the earlier round.
     it('approved then executing still reads Approved for the researcher (falls through to live decision)', () => {

--- a/src/lib/study-screen/pill.ts
+++ b/src/lib/study-screen/pill.ts
@@ -1,8 +1,7 @@
 import type { StudyJobStatus } from '@/database/types'
 import { RESEARCHER_STATUS_LABELS, REVIEWER_STATUS_LABELS, type StatusLabel } from '@/lib/status-labels'
-import { CODE_DECISION_JOB_STATUSES, type CodeDecisionStatus } from '@/lib/study-job-status'
 import type { StudyRole, StudyState } from './state.types'
-import { DISPLAY_STATUS_PRIORITY, isErroredResultHiddenFromResearcher } from './state'
+import { DISPLAY_STATUS_PRIORITY, isErroredResultHiddenFromResearcher, isStaleCodeDecision } from './state'
 
 const LABELS: Record<StudyRole, Partial<Record<StudyJobStatus | string, StatusLabel>>> = {
     researcher: RESEARCHER_STATUS_LABELS,
@@ -16,25 +15,25 @@ const LABELS: Record<StudyRole, Partial<Record<StudyJobStatus | string, StatusLa
 const FALLBACK_LABEL: StatusLabel = { stage: 'Proposal', label: 'Draft', colors: { bg: 'grey.10', c: 'gray.9' } }
 
 // Port of useStudyStatus's pill selection. Walk the latest job's status SET by fixed priority,
-// returning the first status THE ROLE HAS A LABEL FOR — so researchers (who have no execution
-// sub-status labels) fall through JOB-PACKAGING/READY/RUNNING to CODE-APPROVED, exactly as today,
-// while reviewers show the granular execution label. One deliberate change from legacy: a job
-// carrying both CODE-CHANGES-REQUESTED and a terminal CODE-REJECTED now reads "Rejected" (see
-// DISPLAY_STATUS_PRIORITY). Role-specific rules layered on top:
+// returning the first status THE ROLE HAS A LABEL FOR, so researchers (who have no execution
+// sub-status labels) fall through JOB-PACKAGING/READY/RUNNING to CODE-APPROVED, while reviewers show
+// the granular execution label. Role-specific rules layered on top:
 //  - researcher hides JOB-ERRORED until a reviewer records a FILES-* decision;
-//  - on a resubmission (codeAwaitingDecision), stale code-decision statuses are dropped so the
-//    fresh CODE-SUBMITTED drives the pill, not the prior round's decision.
+//  - a code-decision status is eligible only when it is the live one (isStaleCodeDecision reuses
+//    state.codeDecision). This drops stale prior-round decisions AND, when no decision is live
+//    (mid-resubmission, codeDecision null), every decision, so the fresh CODE-SUBMITTED drives the pill.
+//    A job carrying an early CODE-CHANGES-REQUESTED plus a later CODE-APPROVED / CODE-REJECTED therefore
+//    reads Approved / Rejected, not the stale earlier round.
 export function resolvePillStatus(role: StudyRole, state: StudyState): StatusLabel {
     const labels = LABELS[role]
     const present = new Set<StudyJobStatus>(state.latestJobStatuses)
 
     const hideErrored = role === 'researcher' && isErroredResultHiddenFromResearcher(state)
-    const dropStaleDecisions = state.codeAwaitingDecision
 
     const candidate = DISPLAY_STATUS_PRIORITY.find((st) => {
         if (!present.has(st)) return false
         if (hideErrored && st === 'JOB-ERRORED') return false
-        if (dropStaleDecisions && CODE_DECISION_JOB_STATUSES.includes(st as CodeDecisionStatus)) return false
+        if (isStaleCodeDecision(st, state.codeDecision)) return false
         return labels[st] !== undefined // only statuses THIS ROLE can label
     })
 

--- a/src/lib/study-screen/state.test.ts
+++ b/src/lib/study-screen/state.test.ts
@@ -82,6 +82,18 @@ describe('projectStudyState', () => {
         expect(s.displayStatus).toBe('CODE-APPROVED')
     })
 
+    // OTTER-641 symmetry: the same stale-decision drop applies when the resubmit is rejected. The job
+    // carries a round-1 CODE-CHANGES-REQUESTED alongside the live terminal CODE-REJECTED, and
+    // displayStatus must follow the live rejection (codeDecision ranks CODE-REJECTED above the stale
+    // change request), matching the pill's "reads Rejected" case.
+    it('same-job resubmit then rejected → displayStatus is CODE-REJECTED, not the stale changes-requested', () => {
+        const rejected = job(ID1, ['CODE-SUBMITTED', 'CODE-CHANGES-REQUESTED', 'CODE-SUBMITTED', 'CODE-REJECTED'])
+        const s = projectStudyState(raw({ status: 'APPROVED', jobs: [rejected] }))
+        expect(s.codeDecision).toBe('CODE-REJECTED')
+        expect(s.codeAwaitingDecision).toBe(false)
+        expect(s.displayStatus).toBe('CODE-REJECTED')
+    })
+
     it('approved job then execution starts → displayStatus follows execution, not the code decision', () => {
         const running = job(ID1, [
             'CODE-SUBMITTED',

--- a/src/lib/study-screen/state.test.ts
+++ b/src/lib/study-screen/state.test.ts
@@ -71,6 +71,29 @@ describe('projectStudyState', () => {
         expect(s.codeAwaitingDecision).toBe(true)
     })
 
+    // OTTER-641: after the resubmit is approved the same job carries a stale CODE-CHANGES-REQUESTED
+    // alongside the live CODE-APPROVED. displayStatus must follow the live decision, not the stale
+    // earlier round (which used to win by DISPLAY_STATUS_PRIORITY order).
+    it('same-job resubmit then approved → displayStatus is CODE-APPROVED, not the stale changes-requested', () => {
+        const approved = job(ID1, ['CODE-SUBMITTED', 'CODE-CHANGES-REQUESTED', 'CODE-SUBMITTED', 'CODE-APPROVED'])
+        const s = projectStudyState(raw({ status: 'APPROVED', jobs: [approved] }))
+        expect(s.codeDecision).toBe('CODE-APPROVED')
+        expect(s.codeAwaitingDecision).toBe(false)
+        expect(s.displayStatus).toBe('CODE-APPROVED')
+    })
+
+    it('approved job then execution starts → displayStatus follows execution, not the code decision', () => {
+        const running = job(ID1, [
+            'CODE-SUBMITTED',
+            'CODE-CHANGES-REQUESTED',
+            'CODE-SUBMITTED',
+            'CODE-APPROVED',
+            'JOB-READY',
+        ])
+        const s = projectStudyState(raw({ status: 'APPROVED', jobs: [running] }))
+        expect(s.displayStatus).toBe('JOB-READY')
+    })
+
     it('agreements acked booleans map from the two columns', () => {
         const s = projectStudyState(raw({ researcherAgreementsAckedAt: new Date(), reviewerAgreementsAckedAt: null }))
         expect(s.researcherAgreementsAcked).toBe(true)

--- a/src/lib/study-screen/state.ts
+++ b/src/lib/study-screen/state.ts
@@ -3,7 +3,7 @@ import type { AllStatus } from '@/lib/types'
 import type { CodeDecisionStatus } from '@/lib/study-job-status'
 import {
     CODE_DECISION_JOB_STATUSES,
-    isCodeDecisionStatus,
+    latestSubmittedJobHasLiveCodeDecision,
     STUDY_CODE_RUNNING_JOB_STATUSES,
     STUDY_RESULTS_JOB_STATUSES,
 } from '@/lib/study-job-status'
@@ -26,10 +26,12 @@ const CODE_DECISION_PRIORITY: CodeDecisionStatus[] = ['CODE-APPROVED', 'CODE-REJ
 
 // Pill display-status priority (highest-priority PRESENT status on the latest job wins).
 // Mirrors useStudyStatus's intent; finer-grained than the screen booleans (keeps exec sub-statuses).
-// Deliberate divergence from legacy: CODE-REJECTED outranks CODE-CHANGES-REQUESTED here (legacy's
-// reversed-label-order ranked them the other way). When a single job carries both (round-1 changes
-// requested, then a terminal round-2 rejection), the truthful terminal state is "rejected" — and it
-// agrees with the code-rejected screen routing — so Rejected wins, not the stale earlier round.
+// Which of several coexisting code decisions wins is NOT decided by their order here: callers keep only
+// the live codeDecision (see projectStudyState / resolvePillStatus), resolved by CODE_DECISION_PRIORITY.
+// So a job carrying an early CODE-CHANGES-REQUESTED plus a later terminal CODE-APPROVED / CODE-REJECTED
+// reads Approved / Rejected (the truthful terminal state), not the stale earlier round. The relative
+// order of the three decision statuses below is therefore immaterial; only their position relative to
+// the JOB-*/CODE-SUBMITTED entries matters.
 export const DISPLAY_STATUS_PRIORITY: StudyJobStatus[] = [
     'JOB-ERRORED',
     'FILES-REJECTED',
@@ -58,18 +60,23 @@ function latestJob(jobs: ReadonlyArray<RawJob>): RawJob | undefined {
     return pool.reduce((a, b) => (b.id > a.id ? b : a))
 }
 
+// A code-decision status is "stale" once it is no longer the live decision: an earlier round's
+// CODE-CHANGES-REQUESTED superseded by a later approval/rejection on the same job, or any decision while
+// none is live (mid-resubmission, liveDecision null). Dropping stale decisions makes the pill and
+// displayStatus follow the live codeDecision, never a prior round's. Shared by projectStudyState and
+// resolvePillStatus so the two can't drift (OTTER-641).
+export const isStaleCodeDecision = (status: StudyJobStatus, liveDecision: CodeDecisionStatus | null): boolean =>
+    CODE_DECISION_JOB_STATUSES.includes(status as CodeDecisionStatus) && status !== liveDecision
+
 export function projectStudyState(raw: RawStudyState): StudyState {
     const job = latestJob(raw.jobs)
     const jobStatuses = new Set<StudyJobStatus>(job?.statusChanges.map((c) => c.status) ?? [])
 
-    // Count-based liveness: a decision is live only when decisions >= submissions. CODE-SUBMITTED is
-    // append-only per round (markCodeSubmitted), so a same-job resubmit after CODE-CHANGES-REQUESTED
-    // appends a fresh CODE-SUBMITTED (shape: CODE-SUBMITTED → CODE-CHANGES-REQUESTED → CODE-SUBMITTED),
-    // tipping submitted-count past decision-count so the prior decision is no longer live and the
-    // researcher is back under review. Mirrors latestSubmittedJobHasLiveCodeDecision in study-job-status.ts.
-    const submittedCount = job?.statusChanges.filter((c) => c.status === 'CODE-SUBMITTED').length ?? 0
-    const decisionCount = job?.statusChanges.filter((c) => isCodeDecisionStatus(c.status)).length ?? 0
-    const hasLiveDecision = decisionCount > 0 && decisionCount >= submittedCount
+    // A decision is live only when decisions >= submissions on the latest job. Reuse the single
+    // source of truth (latestSubmittedJobHasLiveCodeDecision) shared with reviewer routing and dashboard
+    // highlighting so a same-job resubmit after CODE-CHANGES-REQUESTED (which appends a fresh
+    // CODE-SUBMITTED, tipping submitted-count past decision-count) can't drift between those surfaces.
+    const hasLiveDecision = latestSubmittedJobHasLiveCodeDecision(job?.statusChanges ?? [])
     const codeDecision = hasLiveDecision ? (CODE_DECISION_PRIORITY.find((d) => jobStatuses.has(d)) ?? null) : null
     // Intentionally CODE-SUBMITTED only (legacy gated on ['CODE-SUBMITTED','CODE-SCANNED']): the scan
     // is an automated step, never present without a preceding CODE-SUBMITTED on the same job, so
@@ -94,11 +101,11 @@ export function projectStudyState(raw: RawStudyState): StudyState {
     })
     const isExecuting = has(job, STUDY_CODE_RUNNING_JOB_STATUSES) && (!hasResults || erroredResultHidden)
 
-    // displayStatus: drop stale code decisions on a resubmission (latest job submitted, no live decision),
-    // then pick the highest-priority present status; fall back to study status when the job has none.
-    const dropStale = hasSubmittedCode && codeDecision === null
+    // displayStatus: pick the highest-priority present status, but let a code decision through only when
+    // it is the live one (see isStaleCodeDecision), so DISPLAY_STATUS_PRIORITY's ordering never picks
+    // among coexisting decisions. Fall back to study status when the job carries none.
     const visible = DISPLAY_STATUS_PRIORITY.filter(
-        (st) => jobStatuses.has(st) && !(dropStale && CODE_DECISION_JOB_STATUSES.includes(st as CodeDecisionStatus)),
+        (st) => jobStatuses.has(st) && !isStaleCodeDecision(st, codeDecision),
     )
     const displayStatus: AllStatus = visible[0] ?? raw.status
 


### PR DESCRIPTION
see [OTTER-641](https://openstax.atlassian.net/browse/OTTER-641)

## Problem

On the researcher's "Proposed Studies" dashboard, the status stayed on "Change requested" even after the researcher resubmitted updated code and the Data Provider approved it. The researcher was effectively stuck in that status until the outputs were approved and released.

## Root cause

Resubmitting after a change request reuses the *same* study job (status rows are append-only), so an approved job accumulates the full round history on one job:

```
CODE-SUBMITTED → CODE-CHANGES-REQUESTED → CODE-SUBMITTED (resubmit) → CODE-APPROVED
```

The state layer already resolved the correct live winner as `codeDecision = 'CODE-APPROVED'` (via `CODE_DECISION_PRIORITY` plus count-based liveness). But the pill and `displayStatus` re-derived which decision to show by walking `DISPLAY_STATUS_PRIORITY`, where `CODE-CHANGES-REQUESTED` was ranked above `CODE-APPROVED`, so the stale earlier round won. Since researchers have no execution-status labels, the pill kept falling through to that stale `CODE-CHANGES-REQUESTED` all the way until `FILES-APPROVED` finally outranked it, which is exactly the "stuck until outputs approved" symptom.

## Fix

Make the status projection defer to the already-resolved live decision instead of letting array ordering pick among coexisting decisions:

- `projectStudyState` and `resolvePillStatus` now keep a code-decision status only when it equals the live `codeDecision`; all other (stale) coexisting decisions are dropped. This unifies the previous mid-resubmission handling with the approved-after-resubmit case.
- The relative ordering of the three code-decision statuses in `DISPLAY_STATUS_PRIORITY` is therefore no longer authoritative (only their position relative to the `JOB-*`/`CODE-SUBMITTED` entries matters).

To keep a single source of truth and avoid drift:

- `projectStudyState` now reuses the existing `latestSubmittedJobHasLiveCodeDecision` helper (shared with reviewer routing and dashboard highlighting) rather than reimplementing the count-based liveness rule.
- The stale-decision rule is factored into one exported helper, `isStaleCodeDecision(status, liveDecision)`, used by both `projectStudyState` and `resolvePillStatus`, so the two can't diverge.

The existing "a job carrying both `CODE-CHANGES-REQUESTED` and a terminal `CODE-REJECTED` reads Rejected" behavior is preserved, because `codeDecision` already ranks `CODE-REJECTED` above `CODE-CHANGES-REQUESTED`.

## Tests

- `state.test.ts`: resubmit then approved yields `displayStatus === 'CODE-APPROVED'`; an approved job that then starts executing follows the execution status (`JOB-READY`).
- `pill.test.ts`: researcher pill reads "Approved" after a resubmit is approved, including once execution has started (falls through to the live decision, not the superseded change request).

## Verification

- `pnpm run checks` passes (type check, lint, action validation).
- Unit tests cover the Jira reproduction path and the execution fall-through case.


[OTTER-641]: https://openstax.atlassian.net/browse/OTTER-641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ