### PR TITLE
OTTER-629: address code review UX inconsistencies

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-interactive.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-interactive.tsx
@@ -193,7 +193,12 @@ type AiSummaryContentProps = { summary: string; isExpanded: boolean; onToggle: (
 function AiSummaryContent({ summary, isExpanded, onToggle }: AiSummaryContentProps) {
     return (
         <>
-            <AiSummaryBody isExpanded={isExpanded} summary={summary} />
+            <Stack gap="xs">
+                <Text fw={600} size="sm">
+                    Overview
+                </Text>
+                <AiSummaryBody isExpanded={isExpanded} summary={summary} />
+            </Stack>
             <AiSummaryToggle isExpanded={isExpanded} onToggle={onToggle} />
         </>
     )
@@ -254,11 +259,8 @@ export function AiSummaryCollapsible({
     }
 
     return (
-        <Stack gap="xs" data-testid="ai-summary">
+        <Stack gap="lg" data-testid="ai-summary">
             <Text fw={700}>AI Summary: Analysis of all files</Text>
-            <Text fw={600} size="sm">
-                Overview
-            </Text>
             {renderBody()}
         </Stack>
     )
@@ -294,7 +296,7 @@ function FileTab({
             wrap="nowrap"
             align="center"
             style={{
-                backgroundColor: isActive ? 'var(--mantine-color-blue-6)' : 'transparent',
+                backgroundColor: isActive ? 'var(--mantine-color-blue-7)' : 'transparent',
                 borderRadius: 0,
                 whiteSpace: 'nowrap',
                 paddingRight: 6,
@@ -310,7 +312,7 @@ function FileTab({
                 py="xs"
                 style={{ whiteSpace: 'nowrap' }}
             >
-                <Text size="sm" component="span" c={isActive ? 'white' : 'charcoal.7'} fw={isActive ? 700 : 400}>
+                <Text size="sm" component="span" c={isActive ? 'white' : 'charcoal.7'} fw={400}>
                     {display}
                 </Text>
             </UnstyledButton>
@@ -473,7 +475,7 @@ function StudyCodeBody({
     }
     return (
         <div data-testid="study-code-body">
-            <CodeViewer code={data.contents} language={highlightLanguageForFile(activeFile.name)} />
+            <CodeViewer code={data.contents} language={highlightLanguageForFile(activeFile.name)} withBorder />
         </div>
     )
 }
@@ -535,16 +537,18 @@ export function StudyCodeViewer({
     const hasFiles = files.length > 0
 
     return (
-        <Stack gap="sm" data-testid="study-code-viewer">
-            <FileTabsRow
-                isVisible={isExpanded}
-                visible={visible}
-                activeFileName={activeFile?.name ?? null}
-                onSelect={selectFile}
-                hidden={hidden}
-                studyJobId={studyJobId}
-            />
-            <StudyCodeBody isVisible={isExpanded} activeFile={activeFile} studyJobId={studyJobId} />
+        <Stack gap="lg" data-testid="study-code-viewer">
+            <Stack gap="sm">
+                <FileTabsRow
+                    isVisible={isExpanded}
+                    visible={visible}
+                    activeFileName={activeFile?.name ?? null}
+                    onSelect={selectFile}
+                    hidden={hidden}
+                    studyJobId={studyJobId}
+                />
+                <StudyCodeBody isVisible={isExpanded} activeFile={activeFile} studyJobId={studyJobId} />
+            </Stack>
             <StudyCodeToggle
                 isVisible={hasFiles}
                 isExpanded={isExpanded}

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
@@ -242,6 +242,8 @@ describe('SubmittedCodeSection — AI summary', () => {
         expect(screen.queryByTestId('ai-summary-toggle')).not.toBeInTheDocument()
         expect(screen.queryByTestId('ai-summary-empty')).not.toBeInTheDocument()
         expect(screen.queryByTestId('ai-summary-error')).not.toBeInTheDocument()
+        // "Overview" only accompanies a rendered summary, never the spinner.
+        expect(screen.queryByText('Overview')).not.toBeInTheDocument()
     })
 
     it('surfaces the error + retry state immediately when a failed review row exists', async () => {
@@ -261,6 +263,8 @@ describe('SubmittedCodeSection — AI summary', () => {
         expect(screen.getByTestId('ai-summary-retry')).toBeInTheDocument()
         // A persisted failure is terminal — no spinner, even though it landed fast.
         expect(screen.queryByTestId('ai-summary-pending')).not.toBeInTheDocument()
+        // "Overview" belongs to the summary body, not the error alert.
+        expect(screen.queryByText('Overview')).not.toBeInTheDocument()
     })
 
     it('retrying a failed summary clears the failure row and drops back to pending', async () => {
@@ -346,6 +350,8 @@ describe('SubmittedCodeSection — AI summary', () => {
         await new Promise((resolve) => setTimeout(resolve, 60))
         expect(screen.getByTestId('ai-summary-empty')).toHaveTextContent('No AI summary available yet.')
         expect(screen.queryByTestId('ai-summary-error')).not.toBeInTheDocument()
+        // "Overview" only accompanies a rendered summary, never the empty-state.
+        expect(screen.queryByText('Overview')).not.toBeInTheDocument()
     })
 
     it('falls back to an empty-state when a review row exists but the summary is blank', async () => {

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.tsx
@@ -41,7 +41,9 @@ function DatasetPills({ names }: { names: string[] }) {
     )
     return (
         <Stack gap="xs" data-testid="submitted-code-datasets">
-            <Text size="sm">Dataset(s) associated with the study</Text>
+            <Text size="sm" fw={700}>
+                Dataset(s) associated with the study
+            </Text>
             <Group gap="xs">{names.length === 0 ? empty : pills}</Group>
         </Stack>
     )
@@ -132,16 +134,22 @@ export function SubmittedCodeSection({
                 <Divider />
                 <DatasetPills names={datasetNames} />
                 <Divider />
-                <Group align="stretch" grow gap="xl" wrap="nowrap">
-                    <Paper withBorder p="lg" radius={0}>
-                        <AiSummaryCollapsible studyJobId={job.id} initialReview={review} submittedAt={job.createdAt} />
-                    </Paper>
-                    <Paper withBorder p="lg" radius={0}>
-                        <SecurityScanLog scan={scan} />
-                    </Paper>
-                </Group>
-                <Divider />
-                <StudyCodeViewer studyJobId={job.id} files={codeFiles} initialExpanded={codeInitiallyExpanded} />
+                <Stack gap="xxl">
+                    <Group align="stretch" grow gap="xl" wrap="nowrap">
+                        <Paper withBorder p="lg" radius={0}>
+                            <AiSummaryCollapsible
+                                studyJobId={job.id}
+                                initialReview={review}
+                                submittedAt={job.createdAt}
+                            />
+                        </Paper>
+                        <Paper withBorder p="lg" radius={0}>
+                            <SecurityScanLog scan={scan} />
+                        </Paper>
+                    </Group>
+                    <Divider />
+                    <StudyCodeViewer studyJobId={job.id} files={codeFiles} initialExpanded={codeInitiallyExpanded} />
+                </Stack>
             </Stack>
         </Paper>
     )

--- a/src/components/editable-text/collaborative-editor.tsx
+++ b/src/components/editable-text/collaborative-editor.tsx
@@ -385,7 +385,7 @@ export function CollaborativeEditor({
                     <LinkPlugin validateUrl={isValidUrl} />
                     <Toolbar />
                 </Paper>
-                <Stack gap={4} mt="xs">
+                <Stack gap={4} mt={4}>
                     <Group align="center" wrap="nowrap">
                         <SaveStatus provider={activeProvider} />
                         {footerRight && <Box ml="auto">{footerRight}</Box>}

--- a/src/components/editable-text/single-user-editor.tsx
+++ b/src/components/editable-text/single-user-editor.tsx
@@ -121,7 +121,7 @@ export function SingleUserEditor({
                 <Toolbar />
             </Paper>
             {footerRight && (
-                <Stack gap={4} mt="xs">
+                <Stack gap={4} mt={4}>
                     <Group align="center" wrap="nowrap">
                         <Box ml="auto">{footerRight}</Box>
                     </Group>

--- a/src/components/file-viewers/code-viewer.tsx
+++ b/src/components/file-viewers/code-viewer.tsx
@@ -71,9 +71,17 @@ interface CodeViewerProps {
     code: string
     language: HighlightLanguage
     fileName?: string
+    // Wraps the code display in an outline, matching the reviewer's submitted-code design.
+    withBorder?: boolean
 }
 
-export function CodeViewer({ code, language, fileName }: CodeViewerProps) {
+const OUTLINE_STYLE = {
+    border: '1px solid var(--mantine-color-charcoal-1)',
+    borderRadius: '4px',
+    overflow: 'hidden',
+} as const
+
+export function CodeViewer({ code, language, fileName, withBorder = false }: CodeViewerProps) {
     const highlightedCode = useMemo(() => {
         try {
             return hljs.highlight(code, { language }).value
@@ -83,6 +91,27 @@ export function CodeViewer({ code, language, fileName }: CodeViewerProps) {
         }
     }, [code, language])
 
+    const scroller = (
+        <ScrollArea h={500} type="auto">
+            <pre
+                style={{
+                    margin: 0,
+                    padding: '1rem',
+                    background: '#f6f8fa',
+                    borderRadius: '4px',
+                    color: '#24292f',
+                    fontSize: '14px',
+                }}
+            >
+                <code
+                    className={`language-${language}`}
+                    style={{ color: 'inherit' }}
+                    dangerouslySetInnerHTML={{ __html: highlightedCode }}
+                />
+            </pre>
+        </ScrollArea>
+    )
+
     return (
         <Box>
             {fileName && (
@@ -90,23 +119,7 @@ export function CodeViewer({ code, language, fileName }: CodeViewerProps) {
                     {fileName}
                 </Text>
             )}
-            <ScrollArea h={500} type="auto">
-                <pre
-                    style={{
-                        margin: 0,
-                        padding: '1rem',
-                        background: '#f6f8fa',
-                        borderRadius: '4px',
-                        color: '#24292f',
-                    }}
-                >
-                    <code
-                        className={`language-${language}`}
-                        style={{ color: 'inherit' }}
-                        dangerouslySetInnerHTML={{ __html: highlightedCode }}
-                    />
-                </pre>
-            </ScrollArea>
+            {withBorder ? <Box style={OUTLINE_STYLE}>{scroller}</Box> : scroller}
         </Box>
     )
 }

--- a/src/components/file-viewers/code-viewer.tsx
+++ b/src/components/file-viewers/code-viewer.tsx
@@ -100,7 +100,7 @@ export function CodeViewer({ code, language, fileName, withBorder = false }: Cod
                     background: '#f6f8fa',
                     borderRadius: '4px',
                     color: '#24292f',
-                    fontSize: '14px',
+                    fontSize: 'var(--mantine-font-size-sm)',
                 }}
             >
                 <code


### PR DESCRIPTION
see [OTTER-629](https://openstax.atlassian.net/browse/OTTER-629)

Resolves the mismatches between the "Code Needs Review" screen in staging and the intended Figma design for Data Partners.

## Changes

- **Dataset heading**: "Dataset(s) associated with the study" is now bold (`fw={700}`).
- **AI Summary spacing**: added spacing between the "AI Summary: Analysis of all files" title and "Overview", between the summary and the show/hide toggle, and between the summary and the divider. "Overview" now sits directly above the summary body inside its own stack.
- **Selected file tab**: background color for the active file uses `blue-7` (#0058BD) instead of `blue-6` (#006DEB).
- **File tab font weight**: the file title no longer shifts to bold when selected; it stays regular (`fw={400}`) in all states.
- **Code display font size**: lines of code render at 14px instead of 16px.
- **Code display outline**: `CodeViewer` gains an optional `withBorder` prop and the submitted-code view wraps the display in an outline.
- **Code display spacing**: added spacing between the code display and the "Hide full study code" button, and between the divider and the code display.
- **Editor footer spacing**: reduced the gap between the code review input field and the "changes saved" / character counter row underneath it.


[OTTER-629]: https://openstax.atlassian.net/browse/OTTER-629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ