### PR TITLE
OTTER-611: replace "Data Organization" nomenclature with "Data Partner"

### DIFF
--- a/src/app/[orgSlug]/dashboard/page.tsx
+++ b/src/app/[orgSlug]/dashboard/page.tsx
@@ -23,7 +23,7 @@ export default async function OrgDashboardPage(props: { params: Promise<{ orgSlu
     const orgName = displayOrgName(org.name)
 
     const description = isEnclave
-        ? `Welcome to the ${orgName} Data Organization dashboard. Here you can review submitted study proposals, check study statuses and know when tasks are due.`
+        ? `Welcome to the ${orgName} Data Partner dashboard. Here you can review submitted study proposals, check study statuses and know when tasks are due.`
         : `Welcome to the ${orgName} Research Lab dashboard. Here you can submit new proposals, view study statuses, and access the details of each study.`
 
     return (
@@ -31,10 +31,10 @@ export default async function OrgDashboardPage(props: { params: Promise<{ orgSlu
             <PageBreadcrumbs
                 crumbs={[
                     ['My Dashboard', isEnclave ? '/dashboard?audience=reviewer' : '/dashboard?audience=researcher'],
-                    [orgInitialsOnly + (isEnclave ? ' Data Organization' : ' Research Lab')],
+                    [orgInitialsOnly + (isEnclave ? ' Data Partner' : ' Research Lab')],
                 ]}
             />
-            <Title order={1}>{orgName + (isEnclave ? ' Data Organization' : ' Research Lab')} dashboard</Title>
+            <Title order={1}>{orgName + (isEnclave ? ' Data Partner' : ' Research Lab')} dashboard</Title>
             <Text mt="-md">{description}</Text>
             <StudiesTable
                 audience={isEnclave ? 'reviewer' : 'researcher'}

--- a/src/app/[orgSlug]/study/[studyId]/agreements/agreements-page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/agreements/agreements-page.tsx
@@ -23,7 +23,7 @@ interface SectionProps {
 }
 
 const SECTION_DESCRIPTIONS = {
-    dua: 'A set of tailored Data Use Agreements will be made available here. These documents will clearly define the constraints and responsibilities for both the researcher and the Data Organization, as well as the specific parameters governing your study and the use of the requested datasets. Once both parties agree to the terms in these agreements, they can proceed to the next steps.',
+    dua: 'A set of tailored Data Use Agreements will be made available here. These documents will clearly define the constraints and responsibilities for both the researcher and the Data Partner, as well as the specific parameters governing your study and the use of the requested datasets. Once both parties agree to the terms in these agreements, they can proceed to the next steps.',
     irb: 'An Umbrella Institutional Review Board (IRB) Protocol, with Rice as the IRB of record, will be available to cover all standard base enclave research projects. If your home institution requires separate IRB approval, you will be able to upload your institutionally approved protocol here.',
     sow: "This section will provide a detailed Statement of Work (SOW) and an estimated cost for your study, which will require your agreement to proceed. Depending on our evolving business model, elements of the SOW and payment information may become accessible at different stages of your study's execution.",
 }

--- a/src/app/[orgSlug]/study/[studyId]/proposal/field-config.ts
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/field-config.ts
@@ -45,7 +45,7 @@ export const editableTextFields: EditableTextField[] = [
         id: 'additionalNotes',
         maxWords: WORD_LIMITS.additionalNotes,
         description:
-            'Add any other information, constraints, or questions for the Data Organization. This might include timing, special requirements, references, or related work.',
+            'Add any other information, constraints, or questions for the Data Partner. This might include timing, special requirements, references, or related work.',
         placeholder:
             'Ex. This project is based on grants, so we are operating under specific timelines, reporting requirements, and budget constraints.',
         required: false,

--- a/src/app/[orgSlug]/study/[studyId]/proposal/form.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/form.tsx
@@ -133,7 +133,7 @@ export const ProposalForm: FC<ProposalFormProps> = ({
                             <FormFieldLabel label="Dataset(s) of interest" required inputId="datasets" />
                             <Text size="xs" mb="xs" c="charcoal.7">
                                 Select the dataset(s) you’d like to use for your research. You’ll find options based on
-                                the selected Data Organization in Step 1 and its data availability.
+                                the selected Data Partner in Step 1 and its data availability.
                             </Text>
                             <Group align="center" gap="xxl">
                                 <Box w="50%">

--- a/src/app/[orgSlug]/study/[studyId]/resubmit/edit-study-code-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/resubmit/edit-study-code-view.tsx
@@ -26,7 +26,7 @@ const MAIN_FILE_TOOLTIP =
     "If you're creating or uploading multiple files, please select your main file (i.e., the script that runs first)."
 
 const IDE_BUTTON_TOOLTIP =
-    'After creating or editing files in the IDE, please return here to submit your code to the data organization.'
+    'After creating or editing files in the IDE, please return here to submit your code to the Data Partner.'
 
 const MainFileColumnHeader: FC = () => (
     <Group gap={4} wrap="nowrap" align="center">

--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.test.tsx
@@ -17,7 +17,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ProposalSubmitted } from './proposal-submitted'
 
 const ORG_SLUG = 'test-org'
-const ORG_NAME = 'Test Data Organization'
+const ORG_NAME = 'Test Data Partner'
 
 const buildEntry = (overrides: Partial<ProposalFeedbackEntry> = {}): ProposalFeedbackEntry =>
     ({

--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.test.tsx
@@ -149,7 +149,7 @@ describe('CodePostSubmissionView', () => {
     })
 
     describe('banner', () => {
-        it('renders the yellow status banner with the data org name and the Figma copy', async () => {
+        it('renders the yellow status banner with the data partner name and the Figma copy', async () => {
             const { study, job } = await setupSubmittedStudy()
             renderView(study, job, { reviewingOrgName: REVIEWING_ORG_NAME })
 

--- a/src/app/[orgSlug]/study/[studyId]/view/job-results-status-message-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/job-results-status-message-view.tsx
@@ -53,7 +53,7 @@ function resolveStatusBody(flags: StatusFlags, files: { fileType: FileType }[], 
         }
         return {
             message:
-                'The results of your study have been approved by the data partner and are now available to you. If you are not satisfied with them, you can resubmit your code to generate a new outcome.',
+                'The results of your study have been approved by the Data Partner and are now available to you. If you are not satisfied with them, you can resubmit your code to generate a new outcome.',
             additionalContent: null,
             hideResults: false,
         }
@@ -61,8 +61,8 @@ function resolveStatusBody(flags: StatusFlags, files: { fileType: FileType }[], 
 
     if (isRejected) {
         const message = isFilesRejected
-            ? 'The results of your study have not been released by the data partner, possibly due to the presence of personally identifiable information (PII). Consider resubmitting an updated study code.'
-            : 'This study code has not been approved by the data partner. Consider resubmitting an updated study code.'
+            ? 'The results of your study have not been released by the Data Partner, possibly due to the presence of personally identifiable information (PII). Consider resubmitting an updated study code.'
+            : 'This study code has not been approved by the Data Partner. Consider resubmitting an updated study code.'
         return { message, additionalContent: null, hideResults: true }
     }
 
@@ -91,7 +91,7 @@ export const JobResultsStatusMessageView: FC<JobResultsStatusMessageViewProps> =
     const body = resolveStatusBody(flags, files, jobId)
 
     if (!body) {
-        return <Text>Study results will become available once the data partner reviews and approves them.</Text>
+        return <Text>Study results will become available once the Data Partner reviews and approves them.</Text>
     }
 
     return (

--- a/src/app/[orgSlug]/study/[studyId]/view/job-results-status-message-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/job-results-status-message-view.tsx
@@ -53,7 +53,7 @@ function resolveStatusBody(flags: StatusFlags, files: { fileType: FileType }[], 
         }
         return {
             message:
-                'The results of your study have been approved by the data organization and are now available to you. If you are not satisfied with them, you can resubmit your code to generate a new outcome.',
+                'The results of your study have been approved by the data partner and are now available to you. If you are not satisfied with them, you can resubmit your code to generate a new outcome.',
             additionalContent: null,
             hideResults: false,
         }
@@ -61,8 +61,8 @@ function resolveStatusBody(flags: StatusFlags, files: { fileType: FileType }[], 
 
     if (isRejected) {
         const message = isFilesRejected
-            ? 'The results of your study have not been released by the data organization, possibly due to the presence of personally identifiable information (PII). Consider resubmitting an updated study code.'
-            : 'This study code has not been approved by the data organization. Consider resubmitting an updated study code.'
+            ? 'The results of your study have not been released by the data partner, possibly due to the presence of personally identifiable information (PII). Consider resubmitting an updated study code.'
+            : 'This study code has not been approved by the data partner. Consider resubmitting an updated study code.'
         return { message, additionalContent: null, hideResults: true }
     }
 
@@ -91,7 +91,7 @@ export const JobResultsStatusMessageView: FC<JobResultsStatusMessageViewProps> =
     const body = resolveStatusBody(flags, files, jobId)
 
     if (!body) {
-        return <Text>Study results will become available once the data organization reviews and approves them.</Text>
+        return <Text>Study results will become available once the data partner reviews and approves them.</Text>
     }
 
     return (

--- a/src/app/[orgSlug]/study/[studyId]/view/job-results-status-message.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/job-results-status-message.test.tsx
@@ -93,7 +93,7 @@ describe('JobResultsStatusMessage', () => {
 
             expect(
                 screen.getByText(
-                    'The results of your study have been approved by the data partner and are now available to you. If you are not satisfied with them, you can resubmit your code to generate a new outcome.',
+                    'The results of your study have been approved by the Data Partner and are now available to you. If you are not satisfied with them, you can resubmit your code to generate a new outcome.',
                 ),
             ).toBeDefined()
             expect(screen.getByTestId('job-results')).toBeDefined()
@@ -111,7 +111,7 @@ describe('JobResultsStatusMessage', () => {
 
             expect(
                 screen.getByText(
-                    'The results of your study have not been released by the data partner, possibly due to the presence of personally identifiable information (PII). Consider resubmitting an updated study code.',
+                    'The results of your study have not been released by the Data Partner, possibly due to the presence of personally identifiable information (PII). Consider resubmitting an updated study code.',
                 ),
             ).toBeDefined()
             expect(screen.queryByTestId('job-results')).toBeNull()
@@ -126,7 +126,7 @@ describe('JobResultsStatusMessage', () => {
 
             expect(
                 screen.getByText(
-                    'This study code has not been approved by the data partner. Consider resubmitting an updated study code.',
+                    'This study code has not been approved by the Data Partner. Consider resubmitting an updated study code.',
                 ),
             ).toBeDefined()
             expect(screen.queryByTestId('job-results')).toBeNull()
@@ -152,7 +152,7 @@ describe('JobResultsStatusMessage', () => {
 
             expect(
                 screen.getByText(
-                    'Study results will become available once the data partner reviews and approves them.',
+                    'Study results will become available once the Data Partner reviews and approves them.',
                 ),
             ).toBeDefined()
             expect(screen.queryByTestId('job-results')).toBeNull()
@@ -167,7 +167,7 @@ describe('JobResultsStatusMessage', () => {
 
             expect(
                 screen.getByText(
-                    'Study results will become available once the data partner reviews and approves them.',
+                    'Study results will become available once the Data Partner reviews and approves them.',
                 ),
             ).toBeDefined()
         })
@@ -182,7 +182,7 @@ describe('JobResultsStatusMessage', () => {
 
             expect(
                 screen.getByText(
-                    'Study results will become available once the data partner reviews and approves them.',
+                    'Study results will become available once the Data Partner reviews and approves them.',
                 ),
             ).toBeDefined()
         })
@@ -233,7 +233,7 @@ describe('JobResultsStatusMessage', () => {
             // Should show files rejected message as it's checked first in the component logic
             expect(
                 screen.getByText(
-                    'The results of your study have not been released by the data partner, possibly due to the presence of personally identifiable information (PII). Consider resubmitting an updated study code.',
+                    'The results of your study have not been released by the Data Partner, possibly due to the presence of personally identifiable information (PII). Consider resubmitting an updated study code.',
                 ),
             ).toBeDefined()
         })

--- a/src/app/[orgSlug]/study/[studyId]/view/job-results-status-message.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/job-results-status-message.test.tsx
@@ -93,7 +93,7 @@ describe('JobResultsStatusMessage', () => {
 
             expect(
                 screen.getByText(
-                    'The results of your study have been approved by the data organization and are now available to you. If you are not satisfied with them, you can resubmit your code to generate a new outcome.',
+                    'The results of your study have been approved by the data partner and are now available to you. If you are not satisfied with them, you can resubmit your code to generate a new outcome.',
                 ),
             ).toBeDefined()
             expect(screen.getByTestId('job-results')).toBeDefined()
@@ -111,7 +111,7 @@ describe('JobResultsStatusMessage', () => {
 
             expect(
                 screen.getByText(
-                    'The results of your study have not been released by the data organization, possibly due to the presence of personally identifiable information (PII). Consider resubmitting an updated study code.',
+                    'The results of your study have not been released by the data partner, possibly due to the presence of personally identifiable information (PII). Consider resubmitting an updated study code.',
                 ),
             ).toBeDefined()
             expect(screen.queryByTestId('job-results')).toBeNull()
@@ -126,7 +126,7 @@ describe('JobResultsStatusMessage', () => {
 
             expect(
                 screen.getByText(
-                    'This study code has not been approved by the data organization. Consider resubmitting an updated study code.',
+                    'This study code has not been approved by the data partner. Consider resubmitting an updated study code.',
                 ),
             ).toBeDefined()
             expect(screen.queryByTestId('job-results')).toBeNull()
@@ -152,7 +152,7 @@ describe('JobResultsStatusMessage', () => {
 
             expect(
                 screen.getByText(
-                    'Study results will become available once the data organization reviews and approves them.',
+                    'Study results will become available once the data partner reviews and approves them.',
                 ),
             ).toBeDefined()
             expect(screen.queryByTestId('job-results')).toBeNull()
@@ -167,7 +167,7 @@ describe('JobResultsStatusMessage', () => {
 
             expect(
                 screen.getByText(
-                    'Study results will become available once the data organization reviews and approves them.',
+                    'Study results will become available once the data partner reviews and approves them.',
                 ),
             ).toBeDefined()
         })
@@ -182,7 +182,7 @@ describe('JobResultsStatusMessage', () => {
 
             expect(
                 screen.getByText(
-                    'Study results will become available once the data organization reviews and approves them.',
+                    'Study results will become available once the data partner reviews and approves them.',
                 ),
             ).toBeDefined()
         })
@@ -233,7 +233,7 @@ describe('JobResultsStatusMessage', () => {
             // Should show files rejected message as it's checked first in the component logic
             expect(
                 screen.getByText(
-                    'The results of your study have not been released by the data organization, possibly due to the presence of personally identifiable information (PII). Consider resubmitting an updated study code.',
+                    'The results of your study have not been released by the data partner, possibly due to the presence of personally identifiable information (PII). Consider resubmitting an updated study code.',
                 ),
             ).toBeDefined()
         })

--- a/src/app/[orgSlug]/study/request/form-schemas.ts
+++ b/src/app/[orgSlug]/study/request/form-schemas.ts
@@ -29,7 +29,7 @@ const validateDocumentFile = (label: string) => {
 
 export const studyProposalFormSchema = z
     .object({
-        orgSlug: z.string().min(1, { message: 'Data organization is required' }),
+        orgSlug: z.string().min(1, { message: 'Data Partner is required' }),
         language: z
             .enum(['R', 'PYTHON'])
             .nullable()

--- a/src/app/admin/safeinsights/edit-org-form.test.tsx
+++ b/src/app/admin/safeinsights/edit-org-form.test.tsx
@@ -42,7 +42,7 @@ describe('EditOrgForm', () => {
         const publicKeyTextarea = screen.getByPlaceholderText('Enter your public key') as HTMLTextAreaElement
 
         // Type is a select that shows display text
-        const typeSelect = screen.getByDisplayValue('Enclave (Data Organization)')
+        const typeSelect = screen.getByDisplayValue('Enclave (Data Partner)')
 
         expect(nameInput.value).toBe(mockOrg.name)
         expect(emailInput.value).toBe(mockOrg.email)

--- a/src/app/admin/safeinsights/edit-org-form.tsx
+++ b/src/app/admin/safeinsights/edit-org-form.tsx
@@ -105,7 +105,7 @@ export const EditOrgForm: FC<{
                 name="type"
                 key={form.key('type')}
                 data={[
-                    { value: 'enclave', label: 'Enclave (Data Organization)' },
+                    { value: 'enclave', label: 'Enclave (Data Partner)' },
                     { value: 'lab', label: 'Lab (Research Organization)' },
                 ]}
                 {...form.getInputProps('type')}

--- a/src/components/dashboard/studies-table/studies-table-view.stories.tsx
+++ b/src/components/dashboard/studies-table/studies-table-view.stories.tsx
@@ -34,7 +34,7 @@ const study = (o: Partial<StudyRowType> = {}): StudyRowType => ({
     additionalNotes: null,
     orgName: 'Mars University',
     orgSlug: 'mars-university',
-    reviewingEnclaveName: 'Mars University Data Org',
+    reviewingEnclaveName: 'Mars University Data Partner',
     ...o,
 })
 

--- a/src/components/dashboard/studies-table/study-row.stories.tsx
+++ b/src/components/dashboard/studies-table/study-row.stories.tsx
@@ -33,7 +33,7 @@ const study = (o: Partial<StudyRowType> = {}): StudyRowType => ({
     additionalNotes: null,
     orgName: 'Mars University',
     orgSlug: 'mars-university',
-    reviewingEnclaveName: 'Mars University Data Org',
+    reviewingEnclaveName: 'Mars University Data Partner',
     ...o,
 })
 

--- a/src/components/researcher-profile/researcher-profile-view.tsx
+++ b/src/components/researcher-profile/researcher-profile-view.tsx
@@ -50,7 +50,7 @@ export function ResearcherProfileLayout({ children }: { children: ReactNode }) {
                 <Title order={1}>Researcher Profile</Title>
                 <Text c="dimmed">
                     Create and manage your researcher profile. Adding professional details helps establish your
-                    credibility and allows Data Organizations to view your published work, credentials, and professional
+                    credibility and allows Data Partners to view your published work, credentials, and professional
                     background. Those pursuing a graduate degree will be able to share their background and interests.
                 </Text>
                 {children}

--- a/src/components/study/resubmission-note-section.test.tsx
+++ b/src/components/study/resubmission-note-section.test.tsx
@@ -30,7 +30,7 @@ const renderSection = (props: Partial<React.ComponentProps<typeof Harness>> = {}
     renderWithProviders(<Harness {...props} />)
 
 describe('ResubmissionNoteSection', () => {
-    it('renders the section title and the data org name in the secondary text', () => {
+    it('renders the section title and the data partner name in the secondary text', () => {
         renderSection()
         expect(screen.getByRole('heading', { name: 'Resubmission Note' })).toBeInTheDocument()
         expect(screen.getByText(/Rice University/)).toBeInTheDocument()

--- a/src/components/study/study-code-empty-view.tsx
+++ b/src/components/study/study-code-empty-view.tsx
@@ -39,7 +39,7 @@ export function StudyCodeEmptyView({
             <Text size="sm">
                 To prepare your code, upload existing files
                 {showLaunchIde ? ' or write new code in our Integrated Development Environment (IDE)' : ''}. Once ready,
-                submit your files to the Data Organization to run against their dataset.
+                submit your files to the Data Partner to run against their dataset.
             </Text>
 
             {showLaunchIde && (
@@ -64,7 +64,7 @@ export function StudyCodeEmptyView({
                                 Note:{' '}
                             </Text>
                             After creating or editing files in the IDE, please return here to submit your code to the
-                            Data Organization.
+                            Data Partner.
                         </Text>
                     </Stack>
                 </Paper>
@@ -78,8 +78,8 @@ export function StudyCodeEmptyView({
                         <Text fw={700}>Upload your files</Text>
                         <Text size="sm" c="dimmed">
                             Make sure that your main file contains the <StarterCodeLink file={starterLink} /> provided
-                            by the Data Organization for accessing their datasets. You may also continue to edit your
-                            uploaded files in the IDE before submitting them to the Data Organization.
+                            by the Data Partner for accessing their datasets. You may also continue to edit your
+                            uploaded files in the IDE before submitting them to the Data Partner.
                         </Text>
                         <Box mt="sm">
                             <Stack gap="xs" align="flex-start">

--- a/src/components/study/study-org-selector.test.tsx
+++ b/src/components/study/study-org-selector.test.tsx
@@ -45,11 +45,11 @@ describe('StudyOrgSelector', () => {
         })
     })
 
-    it('renders title as "Data Organization"', async () => {
+    it('renders title as "Data Partner"', async () => {
         render(<FormWrapper />)
 
         await waitFor(() => {
-            expect(screen.getByRole('heading', { name: 'Data Organization', level: 4 })).toBeInTheDocument()
+            expect(screen.getByRole('heading', { name: 'Data Partner', level: 4 })).toBeInTheDocument()
         })
     })
 })

--- a/src/components/study/study-org-selector.tsx
+++ b/src/components/study/study-org-selector.tsx
@@ -32,20 +32,20 @@ export const StudyOrgSelector: React.FC<Props> = ({ form }) => {
                 STEP 1A
             </Text>
             <Title fz={20} order={4} c="charcoal.9">
-                Data Organization
+                Data Partner
             </Title>
             <Divider my="md" />
             <Stack gap="xl">
                 <Text>
                     <Text span fw={600}>
-                        Select the Data Organization your study is intended for.
+                        Select the Data Partner your study is intended for.
                     </Text>{' '}
                     This crucial initial step ensures your proposal is routed correctly for review. You can save a draft
                     or cancel at any time during the process.
                 </Text>
                 <Grid align="center">
                     <Grid.Col span={titleSpan}>
-                        <FormFieldLabel label="Data Organization" inputId="studyOrg" />
+                        <FormFieldLabel label="Data Partner" inputId="studyOrg" />
                     </Grid.Col>
                     <Grid.Col span={inputSpan}>
                         <Select
@@ -54,7 +54,7 @@ export const StudyOrgSelector: React.FC<Props> = ({ form }) => {
                             key={form.key('orgSlug')}
                             allowDeselect={false}
                             data={orgs.map((o) => ({ value: o.slug, label: o.name }))}
-                            placeholder="Select a Data Organization"
+                            placeholder="Select a Data Partner"
                             disabled={isExistingDraft || isLoading}
                             {...form.getInputProps('orgSlug')}
                         />

--- a/src/contexts/edit-code-resubmit/context.tsx
+++ b/src/contexts/edit-code-resubmit/context.tsx
@@ -125,7 +125,7 @@ export function EditCodeResubmitProvider({ children, studyId, initialNote }: Edi
             lastSavedValueRef.current = pendingValueRef.current
             notifications.show({
                 title: 'Study Code Resubmitted',
-                message: 'Your updated code has been submitted to the reviewing organization.',
+                message: 'Your updated code has been submitted to the Data Partner.',
                 color: 'green',
             })
             router.push(Routes.studyView({ orgSlug, studyId }))

--- a/src/contexts/study-request/hooks/use-save-draft.ts
+++ b/src/contexts/study-request/hooks/use-save-draft.ts
@@ -43,7 +43,7 @@ export function useSaveDraft({ studyId, submittingOrgSlug, onStudyCreated }: Use
                 )
             } else {
                 if (!formValues.orgSlug) {
-                    throw new Error('Data organization is required to create a study')
+                    throw new Error('Data Partner is required to create a study')
                 }
                 result = actionResult(
                     await onSaveDraftStudyAction({

--- a/src/hooks/use-ide-files.ts
+++ b/src/hooks/use-ide-files.ts
@@ -196,7 +196,7 @@ export function useIDEFiles({ studyId, onSubmitSuccess }: UseIDEFilesOptions) {
             notifications.show({
                 title: 'Study Code Submitted',
                 message:
-                    'Your code has been successfully submitted to the reviewing organization. Check your dashboard for status updates.',
+                    'Your code has been successfully submitted to the Data Partner. Check your dashboard for status updates.',
                 color: 'green',
             })
 

--- a/src/lib/string.test.ts
+++ b/src/lib/string.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from 'vitest'
-import { strToAscii, slugify, getInitials, shellQuote, substituteEntryPointFile } from './string'
+import { strToAscii, slugify, getInitials, shellQuote, substituteEntryPointFile, orgInitialsTitle } from './string'
+
+describe('orgInitialsTitle', () => {
+    it('uses a space separator for the Data Partner suffix', () => {
+        expect(orgInitialsTitle('OpenStax Education', 'enclave')).toBe('OPE Data Partner')
+    })
+
+    it('keeps the existing hyphen separator for the Research Lab suffix', () => {
+        expect(orgInitialsTitle('OpenStax Education', 'lab')).toBe('OPE-Research Lab')
+    })
+})
 
 describe('getInitials', () => {
     it('returns the uppercased first initial for a single name', () => {

--- a/src/lib/string.ts
+++ b/src/lib/string.ts
@@ -90,7 +90,7 @@ const ORG_SUFFIX_SHORT: Record<string, string> = {
 }
 
 const ORG_SUFFIX_LONG: Record<string, string> = {
-    enclave: '-Data Partner',
+    enclave: ' Data Partner',
     lab: '-Research Lab',
 }
 

--- a/src/lib/string.ts
+++ b/src/lib/string.ts
@@ -90,7 +90,7 @@ const ORG_SUFFIX_SHORT: Record<string, string> = {
 }
 
 const ORG_SUFFIX_LONG: Record<string, string> = {
-    enclave: '-Data Org',
+    enclave: '-Data Partner',
     lab: '-Research Lab',
 }
 

--- a/src/lib/studies.ts
+++ b/src/lib/studies.ts
@@ -15,7 +15,7 @@ export function deriveStudyVersion(entries: { version: number }[]): number {
     return Math.max(...entries.map((e) => e.version))
 }
 
-// Step 1 (data org + language + docs) saves `orgSlug`, `language`, `title`,
+// Step 1 (data partner + language + docs) saves `orgSlug`, `language`, `title`,
 // `piName`, and document paths. Step 2 is the first time any of the columns
 // below are written, so any one being non-empty means the researcher has
 // reached Step 2. Used to route a "resume draft" entry to the step where

--- a/src/lib/study-screen/dashboard-rules.ts
+++ b/src/lib/study-screen/dashboard-rules.ts
@@ -19,7 +19,7 @@ const POST_SUBMISSION_STATUSES: ReadonlyArray<DashboardState['status']> = [
 
 export const DASHBOARD_RULES: DashboardRule[] = [
     // DRAFT that already reached Step 2 → resume on Step 2 (the proposal editor) instead of the
-    // Step 1 data-org picker (OTTER-572). Must precede the plain-DRAFT rule below.
+    // Step 1 data-partner picker (OTTER-572). Must precede the plain-DRAFT rule below.
     {
         when: (s) => s.isDraft && s.hasStep2Progress,
         action: (ctx) => ({ label: 'Edit', href: Routes.studyProposal(ctx), secondaryAction: 'delete-draft' }),

--- a/src/lib/study-screen/state.types.ts
+++ b/src/lib/study-screen/state.types.ts
@@ -12,7 +12,7 @@ export type RawJob = {
 }
 
 // Step 2 of the proposal wizard is the first time any of these columns is written (Step 1 saves only
-// data org + language + title + piName + doc paths). Any one being non-empty means the draft reached
+// data partner + language + title + piName + doc paths). Any one being non-empty means the draft reached
 // Step 2 — see draftHasStep2Progress / projectStudyState's hasStep2Progress.
 export type DraftStep2Fields = {
     piUserId: string | null

--- a/src/server/agents/review-agent/prompts.ts
+++ b/src/server/agents/review-agent/prompts.ts
@@ -4,7 +4,7 @@
  */
 export const DEFAULT_SYSTEM_INSTRUCTION = `You are a strict and meticulous Code & Compliance Auditor for an education research Data Partner.
 Your primary function is to analyze a researcher's submission, which includes a research proposal and associated code, focusing on education data.
-You must compare this submission against the Data Partner's established requirements and documentation for handling student and school data.
+You must compare this submission against the Data Partner's compliance requirements and documentation for handling student and school data.
 Your analysis must be thorough, objective, and precise, with a focus on ethical data handling in an educational context.
 
 You will be provided with several sets of documents:

--- a/src/server/agents/review-agent/prompts.ts
+++ b/src/server/agents/review-agent/prompts.ts
@@ -2,14 +2,14 @@
  * Default system instruction. Sourced from CRATE DO Review Agent.
  * Override via `ReviewAgentConfig.systemPrompt` (e.g. SI Admin org-level config).
  */
-export const DEFAULT_SYSTEM_INSTRUCTION = `You are a strict and meticulous Code & Compliance Auditor for an education research data organization.
+export const DEFAULT_SYSTEM_INSTRUCTION = `You are a strict and meticulous Code & Compliance Auditor for an education research Data Partner.
 Your primary function is to analyze a researcher's submission, which includes a research proposal and associated code, focusing on education data.
-You must compare this submission against the organization's established requirements and documentation for handling student and school data.
+You must compare this submission against the Data Partner's established requirements and documentation for handling student and school data.
 Your analysis must be thorough, objective, and precise, with a focus on ethical data handling in an educational context.
 
 You will be provided with several sets of documents:
 1.  **Requirements:** Organizational requirements and compliance rules. This is the source of truth for all compliance checks.
-2.  **BRC Documents:** Base Research Container documentation — the technical environment created by the data organization that supports the researcher's analysis code.
+2.  **BRC Documents:** Base Research Container documentation — the technical environment created by the Data Partner that supports the researcher's analysis code.
 3.  **Data Documents:** Data schemas, dictionaries, and related documentation.
 4.  **Other Documents:** Any additional reference documentation (API docs, etc.).
 5.  **Researcher Submission:** The researcher's proposal and code.

--- a/src/server/agents/review-agent/types.ts
+++ b/src/server/agents/review-agent/types.ts
@@ -2,7 +2,7 @@ import type Anthropic from '@anthropic-ai/sdk'
 import { z } from 'zod'
 
 /**
- * Reference documents provided by the reviewing organization.
+ * Reference documents provided by the Data Partner.
  * Define the compliance rules and data context for the review.
  */
 export interface ReferenceDocs {


### PR DESCRIPTION
see [OTTER-611](https://openstax.atlassian.net/browse/OTTER-611)

This replaces the "Data Organization(s)" terminology with "Data Partner(s)" across the Management App, respecting singular/plural.

## What was modified

User-facing copy (all "Data Organization(s)" / "Data Org" instances):

- **Org dashboard** (`dashboard/page.tsx`): title, breadcrumb, and welcome secondary text.
- **Study proposal Step 1A** (`study-org-selector.tsx`): section title, secondary text, field label, and dropdown placeholder.
- **Study proposal Step 2** (`proposal/form.tsx`): "Dataset(s) of Interest" helper text.
- **Additional notes field** (`proposal/field-config.ts`): helper text.
- **Agreements page** (`agreements-page.tsx`): Data Use Agreement secondary text.
- **Study code page 1** (`study-code-empty-view.tsx`): submit copy, IDE note, and starter-code copy.
- **Study code panel** (`study-code-panel.tsx`): the IDE reminder tooltip. On `main` this tooltip was relocated here from `resubmit/edit-study-code-view.tsx` and independently reworded to "data partners"; it is now "Data Partner" to match the singular, capitalized usage everywhere else.
- **Researcher profile** (`researcher-profile-view.tsx`): secondary text (plural, "Data Partners").
- **Job results status messages** (`job-results-status-message-view.tsx`): four messages, capitalized "Data Partner" to match how the term is used elsewhere.
- **SI Admin org form** (`edit-org-form.tsx`): the org-type option "Enclave (Data Organization)" is now "Enclave (Data Partner)".
- **Sidebar org title suffix** (`lib/string.ts`): the enclave suffix `-Data Org` is now `-Data Partner`.
- **Validation messages** (`request/form-schemas.ts`, `study-request/hooks/use-save-draft.ts`): "Data Partner is required".
- **Code submission toasts** (`use-ide-files.ts`, `edit-code-resubmit/context.tsx`): these said "reviewing organization" but refer to the enclave that runs and reviews the code, i.e. the Data Partner, so they now say "Data Partner".

Non-user-facing updates for internal consistency:

- **AI review-agent prompt and type doc** (`review-agent/prompts.ts`, `review-agent/types.ts`): references to "data organization" / "reviewing organization" now say "Data Partner". These are internal prompt/comment strings, not shipped copy.
- **Code comments** describing the Step 1 picker (`studies.ts`, `study-screen/state.types.ts`, `study-screen/dashboard-rules.ts`, `study-screen/dashboard.test.ts`).
- **Storybook mocks and test fixtures/descriptions** freshened to "Data Partner".

Affected unit tests were updated to match. `pnpm run checks` (typecheck + lint + action validation) passes and the full unit suite is green (192 files / 1755 tests).

## Merge with `main`

`origin/main` was merged into this branch. The only content conflict was `resubmit/edit-study-code-view.tsx`, where `main`'s "relocate code action buttons to match figma" refactor removed the IDE tooltip block (moved into `study-code-panel.tsx`). Resolved by taking `main`'s structure and re-applying the Data Partner rename in the tooltip's new home (see the study-code-panel bullet above).

## What was intentionally left out

- **Transactional emails (Mailgun):** owned separately by Iris, who confirmed on the card she is updating the term as part of her transactional-email work.
- **SafeInsights marketing webpage:** out of the Otter team's purview per the card.
- **"Members" term:** in this app "members" refers to the users inside an org, not the Marketing "Members" concept (which meant the partner organizations). There is no user-facing "Members" nomenclature to swap, so nothing was changed here to avoid semantically incorrect edits.
- **Enclave dashboard table copy "your organization":** left as-is. It addresses the reviewer about their own org, so "your Data Partner" would read as if the partner were external to them. It is also not the banned exact term.
- **Sidebar suffix separator:** rendered as `OPE-Data Partner` (hyphen), consistent with its sibling `-Research Lab`. The card's example shows `OPE Data Partner` (space). Kept the existing hyphen convention; easy to flip if QA wants the literal spacing.

## Possibly needs a follow-up card

- **Resource Center link** (`lib/routes/definitions.ts`): the external docs URL still ends in `/data-organizations/` (`https://dev-docs.sandbox.safeinsights.org/data-organizations/`). This is an external documentation site, not app copy, and the term only appears in the URL path (the visible label is "Resource Center"). It was left unchanged to avoid a broken link if the docs team has not published a `/data-partners/` page yet. Once the correct docs URL is confirmed, this should be updated (and the `sandbox`/`dev-docs` host reviewed).

[OTTER-611]: https://openstax.atlassian.net/browse/OTTER-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ