### PR TITLE
OTTER-597: clarify breached-password error copy on signup

### DIFF
--- a/src/app/account/invitation/[inviteId]/signup/page.tsx
+++ b/src/app/account/invitation/[inviteId]/signup/page.tsx
@@ -6,7 +6,7 @@ import {
     usePasswordRequirements,
 } from '@/app/account/reset-password/password-requirements'
 import { useMutation, useQuery, z, zodResolver } from '@/common'
-import { CLERK_ERROR_TITLES } from '@/components/clerk-errors'
+import { CLERK_ERROR_COPY } from '@/components/clerk-errors'
 import { handleMutationErrorsWithForm, InputError, reportError } from '@/components/errors'
 import { LoadingMessage } from '@/components/loading'
 import { useAuth, useSignIn } from '@clerk/nextjs'
@@ -113,6 +113,10 @@ const SetupAccountForm: FC<InviteData> = ({ inviteId, email, orgName }) => {
         },
     })
 
+    const clerkErrorCopy = CLERK_ERROR_COPY[String(form.errors.code)]
+    const formErrorTitle = clerkErrorCopy?.title || 'Could not create account'
+    const formErrorBody = clerkErrorCopy?.message || form.errors.form
+
     return (
         <Paper bg="white" p="xxl" radius="sm" w={600} my={{ base: '1rem', lg: 0 }}>
             <form onSubmit={form.onSubmit((values) => createAccount(values))}>
@@ -182,11 +186,11 @@ const SetupAccountForm: FC<InviteData> = ({ inviteId, email, orgName }) => {
                     {form.errors.form && (
                         <Alert
                             color="red"
-                            title={CLERK_ERROR_TITLES[String(form.errors.code)]?.title || 'Could not create account'}
+                            title={formErrorTitle}
                             withCloseButton
                             onClose={() => form.clearFieldError('form')}
                         >
-                            {form.errors.form}
+                            {formErrorBody}
                         </Alert>
                     )}
 

--- a/src/components/clerk-errors.test.tsx
+++ b/src/components/clerk-errors.test.tsx
@@ -1,0 +1,39 @@
+import { renderWithProviders, screen } from '@/tests/unit.helpers'
+import { describe, expect, it } from 'vitest'
+import { ClerkErrorAlert } from './clerk-errors'
+
+describe('ClerkErrorAlert', () => {
+    it('replaces the pwned-password message with the breach copy from OTTER-597', () => {
+        const error = {
+            errors: [
+                {
+                    code: 'form_password_pwned',
+                    message: 'Password has been found in an online data breach.',
+                    longMessage:
+                        'Password has been found in an online data breach. For account safety, please use a different password.',
+                },
+            ],
+        }
+
+        renderWithProviders(<ClerkErrorAlert error={error} />)
+
+        expect(screen.getByText('Compromised Password')).toBeInTheDocument()
+        expect(
+            screen.getByText(
+                'This password was found in a database of known breached passwords and cannot be used. ' +
+                    'Please choose a different password.',
+            ),
+        ).toBeInTheDocument()
+    })
+
+    it('falls back to the Clerk message for codes without custom copy', () => {
+        const error = {
+            errors: [{ code: 'form_password_length_too_short', message: 'Passwords must be 8 characters or more.' }],
+        }
+
+        renderWithProviders(<ClerkErrorAlert error={error} />)
+
+        expect(screen.getByText('An Error Occurred')).toBeInTheDocument()
+        expect(screen.getByText('Passwords must be 8 characters or more.')).toBeInTheDocument()
+    })
+})

--- a/src/components/clerk-errors.tsx
+++ b/src/components/clerk-errors.tsx
@@ -3,10 +3,14 @@ import { Alert } from '@mantine/core'
 import { WarningIcon } from '@phosphor-icons/react'
 import { FC } from 'react'
 
-// Custom error titles for Clerk error alerts
-export const CLERK_ERROR_TITLES: Record<string, { title: string }> = {
+// Custom copy for Clerk error alerts; `message` replaces Clerk's wording when it is
+// too vague for end users (OTTER-597)
+export const CLERK_ERROR_COPY: Record<string, { title: string; message?: string }> = {
     form_password_pwned: {
         title: 'Compromised Password',
+        message:
+            'This password was found in a database of known breached passwords and cannot be used. ' +
+            'Please choose a different password.',
     },
     verification_failed: {
         title: 'Too Many Attempts',
@@ -26,8 +30,9 @@ export const ClerkErrorAlert: FC<ClerkErrorAlertProps> = ({ error, onClose }) =>
 
     if (isClerkApiError(error)) {
         const clerkErr = error.errors[0]
-        title = CLERK_ERROR_TITLES[clerkErr.code]?.title || title
-        body = clerkErr.longMessage || clerkErr.message
+        const copy = CLERK_ERROR_COPY[clerkErr.code]
+        title = copy?.title || title
+        body = copy?.message || clerkErr.longMessage || clerkErr.message
     }
 
     return (


### PR DESCRIPTION
## Summary

Signing up with a breached password showed Clerk's raw error, which doesn't
explain the problem or the fix. It now reads: "This password was found in a
database of known breached passwords and cannot be used. Please choose a
different password."

## Changes

- Renamed `CLERK_ERROR_TITLES` → `CLERK_ERROR_COPY` (`clerk-errors.tsx`); entries can now carry a `message` that replaces Clerk's wording for that error code
- Added the OTTER-597 copy for `form_password_pwned`
- Signup alert (`signup/page.tsx`) and `ClerkErrorAlert` now use the message override; codes without one keep Clerk's wording
- Server action unchanged — raw Clerk message still passes through as the fallback body

## Tests

- New `clerk-errors.test.tsx`: pwned code renders the new copy + "Compromised Password" title; unknown codes fall back to Clerk's message
- `create-account.action.test.ts` unchanged (still asserts raw passthrough)
