### PR TITLE
OTTER-624: save research interests typed without pressing Enter

### DIFF
--- a/src/components/researcher-profile/research-details-section.test.tsx
+++ b/src/components/researcher-profile/research-details-section.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
 import {
     renderWithProviders,
     userEvent,
@@ -233,9 +233,12 @@ describe('ResearchDetailsSection', () => {
             // Try to add duplicate with different case
             await userEvents.type(input, 'machine learning{Enter}')
 
-            // Should still only have one pill
+            // Should still only have one pill (ignore the aria-live status region, which mirrors
+            // the interest text for screen readers and would otherwise double the match count).
             await waitFor(() => {
-                const pills = screen.getAllByText(/machine learning/i)
+                const pills = screen
+                    .getAllByText(/machine learning/i)
+                    .filter((el) => !el.closest('[role="status"]'))
                 expect(pills.length).toBe(1)
             })
         })
@@ -362,5 +365,76 @@ describe('ResearchDetailsSection', () => {
             expect(screen.getByText(/must start with http:\/\/ or https:\/\//i)).toBeDefined()
         })
         expect(refetch).not.toHaveBeenCalled()
+    })
+
+    // OTTER-624 follow-up: commit-on-blur must not create accidental pills. When focus leaves
+    // the page entirely (switching tabs/windows) relatedTarget is null, so the draft is kept in
+    // the field rather than turned into a committed interest.
+    it('should not commit a typed interest when focus leaves the page (relatedTarget null)', async () => {
+        const userEvents = userEvent.setup()
+        const { user } = await mockSessionWithTestData({ orgType: 'lab' })
+
+        await insertTestResearcherProfile({ userId: user.id })
+
+        const data = await getTestResearcherProfileData(user.id)
+        const refetch = vi.fn(async () => getTestResearcherProfileData(user.id))
+
+        renderWithProviders(<ResearchDetailsSection data={data} refetch={refetch} />)
+
+        const interestInput = screen.getByPlaceholderText('Type a research interest and press enter')
+        await userEvents.type(interestInput, 'Ephemeral Idea')
+
+        // A tab/window switch blurs the field with no next focused element.
+        fireEvent.blur(interestInput, { relatedTarget: null })
+
+        expect(screen.queryByText('Ephemeral Idea')).toBeNull()
+        expect((interestInput as HTMLInputElement).value).toBe('Ephemeral Idea')
+    })
+
+    // OTTER-624 follow-up: moving focus to a control inside the widget (e.g. clicking a pill's
+    // remove button) must not commit the pending draft as a new pill.
+    it('should not commit a typed interest when focus moves to a control inside the widget', async () => {
+        const userEvents = userEvent.setup()
+        const { user } = await mockSessionWithTestData({ orgType: 'lab' })
+
+        await insertTestResearcherProfile({ userId: user.id })
+
+        const data = await getTestResearcherProfileData(user.id)
+        const refetch = vi.fn(async () => getTestResearcherProfileData(user.id))
+
+        renderWithProviders(<ResearchDetailsSection data={data} refetch={refetch} />)
+
+        const interestInput = screen.getByPlaceholderText('Type a research interest and press enter')
+        await userEvents.type(interestInput, 'Uncommitted Draft')
+
+        // relatedTarget resolves to an element inside the PillsInput widget (the same place a
+        // pill's remove button lives), so the blur must be treated as intra-widget, not a commit.
+        const inWidgetControl = interestInput.parentElement as HTMLElement
+        fireEvent.blur(interestInput, { relatedTarget: inWidgetControl })
+
+        expect(screen.queryByText('Uncommitted Draft')).toBeNull()
+        expect((interestInput as HTMLInputElement).value).toBe('Uncommitted Draft')
+    })
+
+    // OTTER-624 follow-up: pill additions are announced in an aria-live region so screen-reader
+    // users get feedback even when a pill is created by moving focus rather than pressing Enter.
+    it('should announce added research interests in an aria-live region', async () => {
+        const userEvents = userEvent.setup()
+        const { user } = await mockSessionWithTestData({ orgType: 'lab' })
+
+        await insertTestResearcherProfile({ userId: user.id })
+
+        const data = await getTestResearcherProfileData(user.id)
+        const refetch = vi.fn(async () => getTestResearcherProfileData(user.id))
+
+        renderWithProviders(<ResearchDetailsSection data={data} refetch={refetch} />)
+
+        const interestInput = screen.getByPlaceholderText('Type a research interest and press enter')
+        await userEvents.type(interestInput, 'Genomics{Enter}')
+
+        await waitFor(() => {
+            const regions = screen.getAllByRole('status')
+            expect(regions.some((region) => region.textContent?.includes('Genomics'))).toBe(true)
+        })
     })
 })

--- a/src/components/researcher-profile/research-details-section.test.tsx
+++ b/src/components/researcher-profile/research-details-section.test.tsx
@@ -277,4 +277,90 @@ describe('ResearchDetailsSection', () => {
         expect(updated.researchInterests).toEqual(['AI Research'])
         expect(updated.detailedPublicationsUrl).toBe('https://scholar.google.com/citations?user=abc123')
     })
+
+    // OTTER-624: a research interest typed but never committed with Enter must still be
+    // saved on a single Save click, instead of leaving the button permanently disabled.
+    it('should save a research interest that was typed without pressing Enter', async () => {
+        const userEvents = userEvent.setup()
+        const { user } = await mockSessionWithTestData({ orgType: 'lab' })
+
+        await insertTestResearcherProfile({ userId: user.id })
+
+        const data = await getTestResearcherProfileData(user.id)
+        const refetch = vi.fn(async () => getTestResearcherProfileData(user.id))
+
+        renderWithProviders(<ResearchDetailsSection data={data} refetch={refetch} />)
+
+        // Fill the URL first, then type the interest LAST and click Save without ever
+        // pressing Enter, so the draft is still uncommitted at submit time.
+        const urlInput = screen.getByPlaceholderText('https://scholar.google.com/user...')
+        await userEvents.type(urlInput, 'https://scholar.google.com/citations?user=abc123')
+
+        const interestInput = screen.getByPlaceholderText('Type a research interest and press enter')
+        await userEvents.type(interestInput, 'Quantum Computing')
+
+        const saveButton = screen.getByRole('button', { name: /save changes/i })
+        await userEvents.click(saveButton)
+
+        await waitFor(() => {
+            expect(refetch).toHaveBeenCalled()
+        })
+
+        const updated = await db
+            .selectFrom('researcherProfile')
+            .select(['researchInterests', 'detailedPublicationsUrl'])
+            .where('userId', '=', user.id)
+            .executeTakeFirstOrThrow()
+
+        expect(updated.researchInterests).toEqual(['Quantum Computing'])
+        expect(updated.detailedPublicationsUrl).toBe('https://scholar.google.com/citations?user=abc123')
+    })
+
+    it('should commit a typed interest to a pill when the field loses focus', async () => {
+        const userEvents = userEvent.setup()
+        const { user } = await mockSessionWithTestData({ orgType: 'lab' })
+
+        await insertTestResearcherProfile({ userId: user.id })
+
+        const data = await getTestResearcherProfileData(user.id)
+        const refetch = vi.fn(async () => getTestResearcherProfileData(user.id))
+
+        renderWithProviders(<ResearchDetailsSection data={data} refetch={refetch} />)
+
+        const interestInput = screen.getByPlaceholderText('Type a research interest and press enter')
+        await userEvents.type(interestInput, 'Bioinformatics')
+
+        // Move focus away without pressing Enter; the draft should become a pill.
+        await userEvents.tab()
+
+        await waitFor(() => {
+            expect(screen.getByText('Bioinformatics')).toBeDefined()
+        })
+    })
+
+    it('should surface a validation message for an invalid URL instead of silently disabling save', async () => {
+        const userEvents = userEvent.setup()
+        const { user } = await mockSessionWithTestData({ orgType: 'lab' })
+
+        await insertTestResearcherProfile({ userId: user.id })
+
+        const data = await getTestResearcherProfileData(user.id)
+        const refetch = vi.fn(async () => getTestResearcherProfileData(user.id))
+
+        renderWithProviders(<ResearchDetailsSection data={data} refetch={refetch} />)
+
+        const interestInput = screen.getByPlaceholderText('Type a research interest and press enter')
+        await userEvents.type(interestInput, 'AI Research{Enter}')
+
+        const urlInput = screen.getByPlaceholderText('https://scholar.google.com/user...')
+        await userEvents.type(urlInput, 'not-a-valid-url')
+
+        const saveButton = screen.getByRole('button', { name: /save changes/i })
+        await userEvents.click(saveButton)
+
+        await waitFor(() => {
+            expect(screen.getByText(/must start with http:\/\/ or https:\/\//i)).toBeDefined()
+        })
+        expect(refetch).not.toHaveBeenCalled()
+    })
 })

--- a/src/components/researcher-profile/research-details-section.test.tsx
+++ b/src/components/researcher-profile/research-details-section.test.tsx
@@ -236,9 +236,7 @@ describe('ResearchDetailsSection', () => {
             // Should still only have one pill (ignore the aria-live status region, which mirrors
             // the interest text for screen readers and would otherwise double the match count).
             await waitFor(() => {
-                const pills = screen
-                    .getAllByText(/machine learning/i)
-                    .filter((el) => !el.closest('[role="status"]'))
+                const pills = screen.getAllByText(/machine learning/i).filter((el) => !el.closest('[role="status"]'))
                 expect(pills.length).toBe(1)
             })
         })

--- a/src/components/researcher-profile/research-details-section.tsx
+++ b/src/components/researcher-profile/research-details-section.tsx
@@ -21,7 +21,7 @@ export function ResearchDetailsSection({ data, refetch, readOnly = false }: Rese
         setInterestDraft,
         addInterest,
         removeInterest,
-        handleSubmit,
+        submitWithDraft,
     } = useResearchDetailsSection(data, refetch)
 
     const hasData = Boolean(defaults.researchInterests?.length) || Boolean(defaults.detailedPublicationsUrl)
@@ -40,7 +40,7 @@ export function ResearchDetailsSection({ data, refetch, readOnly = false }: Rese
             onInterestDraftChange={setInterestDraft}
             onAddInterest={addInterest}
             onRemoveInterest={removeInterest}
-            onSubmit={handleSubmit}
+            onSubmit={submitWithDraft}
         />
     )
 }

--- a/src/components/researcher-profile/research-interests-input.tsx
+++ b/src/components/researcher-profile/research-interests-input.tsx
@@ -54,6 +54,7 @@ export function ResearchInterestsInput({
                         value={draftValue}
                         onChange={handleChange}
                         onKeyDown={handleKeyDown}
+                        onBlur={onAdd}
                     />
                 </Pill.Group>
             </PillsInput>

--- a/src/components/researcher-profile/research-interests-input.tsx
+++ b/src/components/researcher-profile/research-interests-input.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import React from 'react'
-import { Pill, PillsInput, Text } from '@mantine/core'
+import React, { useRef } from 'react'
+import { Pill, PillsInput, Text, VisuallyHidden } from '@mantine/core'
 import type { UseFormReturnType } from '@mantine/form'
 import type { ResearchDetailsValues } from '@/schema/researcher-profile'
 
@@ -20,6 +20,9 @@ export function ResearchInterestsInput({
     onAdd,
     onRemove,
 }: ResearchInterestsInputProps) {
+    // PillsInput forwards ref to its root element; Mantine types that ref as HTMLInputElement
+    // even though the root renders as a div. We only need Node.contains, so the type is harmless.
+    const rootRef = useRef<HTMLInputElement>(null)
     const interests = form.values.researchInterests || []
     const maxItems = 5
     const isAtLimit = interests.length >= maxItems
@@ -38,15 +41,29 @@ export function ResearchInterestsInput({
         }
     }
 
+    // Commit the draft only when focus moves to another element outside this input. Skip when
+    // focus leaves the page entirely (switching tabs/windows makes relatedTarget null) or moves
+    // to a control inside the widget (e.g. a pill's remove button, which lives inside rootRef),
+    // so the user does not get an accidental pill they never meant to add.
+    const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+        const next = e.relatedTarget as Node | null
+        if (!next || rootRef.current?.contains(next)) return
+        onAdd()
+    }
+
     const interestPills = interests.map((item, idx) => (
         <Pill key={form.key(`researchInterests.${idx}`)} withRemoveButton onRemove={() => onRemove(idx)}>
             {item}
         </Pill>
     ))
 
+    const announcement = interests.length
+        ? `Research interests: ${interests.join(', ')}`
+        : 'No research interests selected'
+
     return (
         <>
-            <PillsInput id="researchInterests" error={form.errors.researchInterests as unknown as string}>
+            <PillsInput ref={rootRef} id="researchInterests" error={form.errors.researchInterests as unknown as string}>
                 <Pill.Group>
                     {interestPills}
                     <PillsInput.Field
@@ -54,10 +71,11 @@ export function ResearchInterestsInput({
                         value={draftValue}
                         onChange={handleChange}
                         onKeyDown={handleKeyDown}
-                        onBlur={onAdd}
+                        onBlur={handleBlur}
                     />
                 </Pill.Group>
             </PillsInput>
+            <VisuallyHidden role="status">{announcement}</VisuallyHidden>
             <InterestsHelperText isVisible={!isAtLimit} />
         </>
     )

--- a/src/components/researcher-profile/researcher-profile-view.tsx
+++ b/src/components/researcher-profile/researcher-profile-view.tsx
@@ -385,7 +385,7 @@ interface ResearchDetailsSectionViewProps {
     onInterestDraftChange: (value: string) => void
     onAddInterest: () => void
     onRemoveInterest: (index: number) => void
-    onSubmit: (values: ResearchDetailsValues) => void
+    onSubmit: () => void
 }
 
 type ResearchDetailsEditFormProps = Pick<
@@ -403,7 +403,12 @@ function ResearchDetailsEditForm({
     onSubmit,
 }: ResearchDetailsEditFormProps) {
     return (
-        <form onSubmit={form.onSubmit(onSubmit)}>
+        <form
+            onSubmit={(e) => {
+                e.preventDefault()
+                onSubmit()
+            }}
+        >
             <Stack gap="md">
                 <div>
                     <FormFieldLabel label="Research interests" required inputId="researchInterests" />
@@ -451,7 +456,7 @@ function ResearchDetailsEditForm({
                 </div>
 
                 <Group justify="flex-end" mt="xl">
-                    <Button type="submit" disabled={!form.isValid() || isPending} loading={isPending}>
+                    <Button type="submit" disabled={isPending} loading={isPending}>
                         Save changes
                     </Button>
                 </Group>

--- a/src/hooks/use-research-details-section.ts
+++ b/src/hooks/use-research-details-section.ts
@@ -87,6 +87,18 @@ export function useResearchDetailsSection(data: ResearcherProfileData | null, re
         })
     }
 
+    // Folds any interest the user typed but never committed with Enter into the form
+    // value before validating, so a visible-but-uncommitted interest is not silently
+    // dropped and does not leave the user with a permanently disabled Save button.
+    // insertListItem updates the ref synchronously, so form.validate/getValues below
+    // see the just-added interest even in controlled mode.
+    const submitWithDraft = () => {
+        addInterest()
+        const { hasErrors } = form.validate()
+        if (hasErrors) return
+        handleSubmit(form.getValues())
+    }
+
     return {
         form,
         isEditing,
@@ -98,5 +110,6 @@ export function useResearchDetailsSection(data: ResearcherProfileData | null, re
         addInterest,
         removeInterest,
         handleSubmit,
+        submitWithDraft,
     }
 }


### PR DESCRIPTION
see [OTTER-624](https://openstax.atlassian.net/browse/OTTER-624)

## Problem

On the Researcher Profile page (`/researcher/profile`), the Research details section could not be saved. The "Save changes" button stayed disabled even when every field looked filled in, and reloading discarded the typed values. QA and usability testing both reproduced this.

Root cause: "Research interests" is a custom Mantine `PillsInput`. The text a user types lives in a separate draft state and only becomes part of the form value when Enter is pressed. Without a committed pill, `researchInterests` stays empty, the zod `.min(1)` check fails, and `form.isValid()` keeps the button disabled. Nothing told the user to press Enter, and the typed text would have been dropped on submit anyway.

## Fix

- `research-interests-input.tsx`: commit the pending draft to a pill on blur, so moving focus off the field (for example into the URL input) registers the interest.
- `use-research-details-section.ts`: add `submitWithDraft`, which folds any pending draft into `researchInterests`, then validates and saves. `insertListItem` updates the form ref synchronously, so `form.validate()` / `form.getValues()` see the just-added interest and a single Save click works even if the user never pressed Enter.
- `researcher-profile-view.tsx`: route the form submit through `submitWithDraft` and change the Save button to disable only while a save is pending (dropping `!form.isValid()`), so invalid input shows inline validation messages instead of a silently disabled button.
- `research-details-section.tsx`: pass `submitWithDraft` as the view's `onSubmit`.

Mantine `useForm` behavior confirmed against the v8 docs (via context7) and the installed source: `form.isValid()` does not set errors, while `form.validate()` does; `form.getValues()` returns the latest values from the ref synchronously in controlled mode.

No schema, migration, permission, route, or server-action changes. The server action still validates through `researchDetailsSchema` as defense in depth.

## Tests

Added regression coverage in `research-details-section.test.tsx`:
- saves a research interest typed without pressing Enter (single click)
- commits a typed interest to a pill on blur
- surfaces a validation message for an invalid URL instead of silently disabling save

Full unit suite passes (1799 tests).

## Verification

- `pnpm run checks` (typecheck, lint, prettier, action validation)
- `./bin/docker-test -- --run 'research-details-section'`
- Manual: `/researcher/profile` &rarr; Research details &rarr; type an interest without pressing Enter &rarr; fill a valid URL &rarr; Save once &rarr; values persist after reload. An invalid URL shows an inline error.

## Follow-up: commit-on-blur edge cases + accessibility

Commit-on-blur fixed the reported bug but had a few sharp edges. These follow-up commits refine the blur behavior and add screen-reader feedback, without changing the primary flow (moving focus into the URL field still registers the interest).

- `research-interests-input.tsx`: the blur handler now commits the draft **only when focus moves to a real element outside the widget**. It skips committing when:
  - focus leaves the page entirely, e.g. switching browser tabs or windows (`relatedTarget` is `null`, standard DOM behavior, no Mantine dependency), so a half-typed draft is not turned into an accidental pill; and
  - focus moves to a control inside the widget, e.g. clicking a pill's remove (x) button (`rootRef.current.contains(relatedTarget)`), so removing a pill while a draft is present no longer also commits that draft.
- `research-interests-input.tsx`: added a visually hidden `role="status"` (`aria-live`) region that mirrors the committed interests, so screen-reader users get feedback when a pill is added by moving focus rather than only on Enter.

Verified the Mantine mechanics against the installed source (`@mantine/core` 8.3.18): `PillsInput.Field` forwards `onBlur` to the native input with a real `FocusEvent`, and `PillsInput` forwards `ref` to its root element (Mantine's stable public ref API), so `contains()` reliably detects intra-widget focus. `relatedTarget` semantics (null on tab/window switch) cross-checked via context7 and MDN.

Added regression tests in `research-details-section.test.tsx`:
- does not commit a typed interest when focus leaves the page (`relatedTarget` null)
- does not commit a typed interest when focus moves to a control inside the widget
- announces added research interests in the `aria-live` region

The pre-existing case-insensitive-duplicate test now scopes its pill count to exclude the `aria-live` mirror. Full unit suite passes (1802 tests). Also browser-verified: the primary blur-commit into the URL field still works, clicking a pill's remove button no longer commits the pending draft, and the live region updates on add/remove.

[OTTER-624]: https://openstax.atlassian.net/browse/OTTER-624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
