### PR TITLE
OTTER-594 follow-up: green saved indicator, per-field gating, title spacing

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/proposal/form.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/form.tsx
@@ -10,11 +10,11 @@ import { FormFieldLabel } from '@/components/form-field-label'
 import { InputError } from '@/components/errors'
 import { WordCounter } from '@/components/word-counter'
 import { DatasetMultiSelect } from '@/components/dataset-multi-select'
-import { SaveStatusIndicator } from '@/components/save-status'
+import { SaveStatusIndicator, type SaveStatusValue } from '@/components/save-status'
 import { useProviderSaveStatus } from '@/lib/realtime/use-provider-save-status'
 import { countWords } from '@/lib/lexical'
 import { Routes, ExternalLinks } from '@/lib/routes'
-import { WORD_LIMITS, type ProposalFormValues } from './schema'
+import { WORD_LIMITS, type CollabFieldKey, type ProposalFormValues } from './schema'
 import { useProposal } from '@/contexts/proposal'
 import { ProposalFooter } from './footer'
 import { editableTextFields, type EditableTextField } from './field-config'
@@ -73,6 +73,15 @@ export const ProposalForm: FC<ProposalFormProps> = ({
     const titleInputProps = form.getInputProps('title')
     const fieldsSaveStatus = useProviderSaveStatus(yjsForm.provider)
 
+    // The Yjs provider saves the whole fields doc, so its status is form-wide;
+    // each field only surfaces it after the user has actually edited that field
+    // (OTTER-594 QA: pristine fields must not claim "All changes saved").
+    const saveStatusFor = (key: CollabFieldKey): SaveStatusValue =>
+        yjsForm.editedKeys.has(key) ? fieldsSaveStatus : 'idle'
+    const titleSaveStatus = saveStatusFor('title')
+    const datasetsSaveStatus = saveStatusFor('datasets')
+    const piSaveStatus = saveStatusFor('piName')
+
     useSubmissionRedirectListener({
         provider: yjsForm.provider,
         orgSlug,
@@ -122,11 +131,13 @@ export const ProposalForm: FC<ProposalFormProps> = ({
                                 value={form.values.title ?? ''}
                                 error={!!form.errors.title}
                             />
-                            <Group justify={form.errors.title ? 'space-between' : 'flex-end'} mt={4}>
-                                {form.errors.title && <InputError error={form.errors.title} />}
+                            <Group justify="space-between" align="flex-start" mt={4}>
+                                <Stack gap={4}>
+                                    <InputError error={form.errors.title} />
+                                    <SaveStatusIndicator status={titleSaveStatus} />
+                                </Stack>
                                 <WordCounter wordCount={titleWordCount} maxWords={WORD_LIMITS.title} />
                             </Group>
-                            <SaveStatusIndicator status={fieldsSaveStatus} />
                         </Box>
 
                         <Box>
@@ -162,7 +173,7 @@ export const ProposalForm: FC<ProposalFormProps> = ({
                                 </Anchor>
                             </Group>
                             <InputError error={form.errors.datasets} />
-                            <SaveStatusIndicator status={fieldsSaveStatus} />
+                            <SaveStatusIndicator status={datasetsSaveStatus} />
                         </Box>
                     </Stack>
                 </Paper>
@@ -202,7 +213,7 @@ export const ProposalForm: FC<ProposalFormProps> = ({
                                     error={!!form.errors.piName}
                                 />
                             </Box>
-                            <SaveStatusIndicator status={fieldsSaveStatus} />
+                            <SaveStatusIndicator status={piSaveStatus} />
                         </Box>
 
                         <Box>

--- a/src/components/save-status.test.tsx
+++ b/src/components/save-status.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { renderWithProviders, screen } from '@/tests/unit.helpers'
+import { theme } from '@/theme'
 import { SaveStatusIndicator } from './save-status'
 
 describe('SaveStatusIndicator', () => {
@@ -8,9 +9,11 @@ describe('SaveStatusIndicator', () => {
         expect(screen.queryByTestId('autosave-status')).not.toBeInTheDocument()
     })
 
-    it('renders the saving label', () => {
+    it('renders the saving label without a checkmark', () => {
         renderWithProviders(<SaveStatusIndicator status="saving" />)
-        expect(screen.getByTestId('autosave-status')).toHaveTextContent('Saving…')
+        const status = screen.getByTestId('autosave-status')
+        expect(status).toHaveTextContent('Saving…')
+        expect(status.querySelector('svg')).not.toBeInTheDocument()
     })
 
     it('renders the saved label without a timestamp', () => {
@@ -18,5 +21,12 @@ describe('SaveStatusIndicator', () => {
         const status = screen.getByTestId('autosave-status')
         expect(status).toHaveTextContent('All changes saved')
         expect(status).not.toHaveTextContent(/\d/)
+    })
+
+    it('renders the saved label with a green checkmark', () => {
+        renderWithProviders(<SaveStatusIndicator status="saved" />)
+        const checkmark = screen.getByTestId('autosave-status').querySelector('svg')
+        expect(checkmark).toBeInTheDocument()
+        expect(checkmark).toHaveAttribute('fill', theme.colors!.green![9])
     })
 })

--- a/src/components/save-status.tsx
+++ b/src/components/save-status.tsx
@@ -16,7 +16,7 @@ const SavedLabel: FC = () => {
     const theme = useMantineTheme()
 
     return (
-        <Group gap={4} wrap="nowrap" data-testid="autosave-status">
+        <Group gap={8} wrap="nowrap" data-testid="autosave-status">
             <CheckCircleIcon size={16} color={theme.colors.green[9]} weight="fill" />
             <Text size="xs" c="green.9" fw={600}>
                 All changes saved

--- a/src/components/save-status.tsx
+++ b/src/components/save-status.tsx
@@ -1,11 +1,28 @@
+'use client'
+
 import { FC } from 'react'
-import { Text } from '@mantine/core'
+import { Group, Text, useMantineTheme } from '@mantine/core'
+import { CheckCircleIcon } from '@phosphor-icons/react/dist/ssr'
 
 export type SaveStatusValue = 'idle' | 'saving' | 'saved'
 
-const SAVE_STATUS_LABELS: Record<Exclude<SaveStatusValue, 'idle'>, string> = {
-    saving: 'Saving…',
-    saved: 'All changes saved',
+const SavingLabel: FC = () => (
+    <Text size="xs" c="dimmed" data-testid="autosave-status">
+        Saving…
+    </Text>
+)
+
+const SavedLabel: FC = () => {
+    const theme = useMantineTheme()
+
+    return (
+        <Group gap={4} wrap="nowrap" data-testid="autosave-status">
+            <CheckCircleIcon size={16} color={theme.colors.green[9]} weight="fill" />
+            <Text size="xs" c="green.9" fw={600}>
+                All changes saved
+            </Text>
+        </Group>
+    )
 }
 
 interface SaveStatusIndicatorProps {
@@ -16,11 +33,7 @@ interface SaveStatusIndicatorProps {
 // proposal fields, resubmission note). Renders nothing until there is something
 // to report so it can be dropped under any field unconditionally.
 export const SaveStatusIndicator: FC<SaveStatusIndicatorProps> = ({ status }) => {
-    if (status === 'idle') return null
-
-    return (
-        <Text size="xs" c="dimmed" data-testid="autosave-status">
-            {SAVE_STATUS_LABELS[status]}
-        </Text>
-    )
+    if (status === 'saving') return <SavingLabel />
+    if (status === 'saved') return <SavedLabel />
+    return null
 }

--- a/src/contexts/edit-resubmit/hooks/use-resubmit-proposal.test.ts
+++ b/src/contexts/edit-resubmit/hooks/use-resubmit-proposal.test.ts
@@ -55,6 +55,7 @@ const buildStubYjsForm = (): { yjsForm: StubYjsForm; sendStateless: Mock } => {
         provider: { sendStateless } as unknown as HocuspocusProvider,
         fieldsMap: null,
         isSynced: true,
+        editedKeys: new Set(),
         pushField: vi.fn(),
         pushPI: vi.fn(),
     }

--- a/src/contexts/proposal/hooks/use-submit-proposal.test.ts
+++ b/src/contexts/proposal/hooks/use-submit-proposal.test.ts
@@ -49,6 +49,7 @@ const buildStubYjsForm = (): { yjsForm: StubYjsForm; sendStateless: Mock } => {
         provider: { sendStateless } as unknown as HocuspocusProvider,
         fieldsMap: null,
         isSynced: true,
+        editedKeys: new Set(),
         pushField: vi.fn(),
         pushPI: vi.fn(),
     }

--- a/src/hooks/use-yjs-form-map.test.ts
+++ b/src/hooks/use-yjs-form-map.test.ts
@@ -237,6 +237,83 @@ describe('useYjsFormMap', () => {
         fieldsMap.unobserve(observer)
     })
 
+    it('does not mark fields edited when seeding initial values on first sync', async () => {
+        const { studyId } = await createDraftStudy('seed-not-edit')
+
+        const { hookResult } = setupCollabHook({
+            studyId,
+            formInitial: { title: 'Original', datasets: ['ds-1'], piName: 'PI', piUserId: faker.string.uuid() },
+        })
+
+        constructed[0].triggerSync()
+        await waitFor(() => expect(hookResult.result.current.isSynced).toBe(true))
+
+        expect(hookResult.result.current.fieldsMap!.get('title')).toBe('Original')
+        expect(hookResult.result.current.editedKeys.size).toBe(0)
+    })
+
+    it('marks only the pushed field as edited, and only on an actual write', async () => {
+        const { studyId } = await createDraftStudy('edit-keys')
+
+        const { hookResult } = setupCollabHook({
+            studyId,
+            formInitial: { title: 'Original', datasets: ['ds-1'], piName: 'PI', piUserId: faker.string.uuid() },
+        })
+
+        constructed[0].triggerSync()
+        await waitFor(() => expect(hookResult.result.current.isSynced).toBe(true))
+
+        // A no-op push (value already in the map) must not flag the field. The real
+        // push after it bounds the assertion: once 'title' is marked, a lingering
+        // mark from the no-op would show up in the size check below.
+        hookResult.result.current.pushField('title', 'Original')
+        hookResult.result.current.pushField('datasets', ['ds-1', 'ds-2'])
+
+        await waitFor(() => expect(hookResult.result.current.editedKeys.has('datasets')).toBe(true))
+        expect(hookResult.result.current.editedKeys.has('title')).toBe(false)
+        expect(hookResult.result.current.editedKeys.size).toBe(1)
+    })
+
+    it('marks both PI keys as edited on pushPI', async () => {
+        const { studyId } = await createDraftStudy('edit-pi')
+
+        const { hookResult } = setupCollabHook({
+            studyId,
+            formInitial: { title: 'Original', datasets: ['ds-1'], piName: 'PI', piUserId: faker.string.uuid() },
+        })
+
+        constructed[0].triggerSync()
+        await waitFor(() => expect(hookResult.result.current.isSynced).toBe(true))
+
+        hookResult.result.current.pushPI(faker.string.uuid(), 'Dr. New')
+
+        await waitFor(() => expect(hookResult.result.current.editedKeys.has('piName')).toBe(true))
+        expect(hookResult.result.current.editedKeys.has('piUserId')).toBe(true)
+        expect(hookResult.result.current.editedKeys.has('title')).toBe(false)
+    })
+
+    it('remote updates do not mark fields as edited', async () => {
+        const { studyId } = await createDraftStudy('remote-not-edit')
+
+        const { form, hookResult } = setupCollabHook({
+            studyId,
+            formInitial: { title: 'Original', datasets: ['ds-1'], piName: 'PI', piUserId: faker.string.uuid() },
+        })
+
+        const handle = constructed[0]
+        handle.triggerSync()
+        await waitFor(() => expect(hookResult.result.current.isSynced).toBe(true))
+
+        const remoteOrigin = Symbol('remote')
+        const document = handle.document!
+        document.transact(() => {
+            document.getMap('fields').set('title', 'Remote')
+        }, remoteOrigin)
+
+        await waitFor(() => expect(form.getValues().title).toBe('Remote'))
+        expect(hookResult.result.current.editedKeys.size).toBe(0)
+    })
+
     it('hook is inert without a websocket provider', () => {
         const studyId = faker.string.uuid()
         const { hookResult } = setupCollabHook({

--- a/src/hooks/use-yjs-form-map.ts
+++ b/src/hooks/use-yjs-form-map.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useAuth } from '@clerk/nextjs'
 import { type UseFormReturnType } from '@mantine/form'
 import { HocuspocusProvider, HocuspocusProviderWebsocket } from '@hocuspocus/provider'
@@ -29,6 +29,7 @@ type Return = {
     provider: HocuspocusProvider | null
     fieldsMap: Y.Map<unknown> | null
     isSynced: boolean
+    editedKeys: ReadonlySet<CollabFieldKey>
     pushField: <K extends CollabFieldKey>(key: K, value: ProposalFormValues[K]) => void
     pushPI: (piUserId: string, piName: string) => void
 }
@@ -46,7 +47,23 @@ export function useYjsFormMap({ studyId, form, websocketProvider }: Args): Retur
     const [provider, setProvider] = useState<HocuspocusProvider | null>(null)
     const [fieldsMap, setFieldsMap] = useState<Y.Map<unknown> | null>(null)
     const [isSynced, setIsSynced] = useState(false)
+    // Tracks which fields the user has locally edited via pushField/pushPI.
+    // The initial-value seeding on first sync writes through the map directly,
+    // not through push*, so it never counts as an edit — this is what keeps the
+    // autosave indicator hidden under fields the user hasn't touched.
+    const [editedKeys, setEditedKeys] = useState<ReadonlySet<CollabFieldKey>>(new Set())
     const isApplyingRemoteRef = useRef(false)
+
+    const markEdited = useCallback(
+        (...keys: CollabFieldKey[]) =>
+            setEditedKeys((prev) => {
+                if (keys.every((key) => prev.has(key))) return prev
+                const next = new Set(prev)
+                keys.forEach((key) => next.add(key))
+                return next
+            }),
+        [],
+    )
 
     useEffect(() => {
         if (!websocketProvider) return undefined
@@ -107,6 +124,10 @@ export function useYjsFormMap({ studyId, form, websocketProvider }: Args): Retur
             setProvider(null)
             setFieldsMap(null)
             setIsSynced(false)
+            // Edits are scoped to a provider session; a reconnect swaps in a fresh
+            // provider whose status starts idle, so stale edited flags would only
+            // resurface the indicator without a new local edit.
+            setEditedKeys(new Set())
         }
         // form intentionally excluded — it's recreated each render but stable via Mantine ref semantics.
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -129,12 +150,14 @@ export function useYjsFormMap({ studyId, form, websocketProvider }: Args): Retur
             provider,
             fieldsMap,
             isSynced,
+            editedKeys,
             pushField(key, value) {
                 if (!fieldsMap) return
                 if (isApplyingRemoteRef.current) return
                 const current = fieldsMap.get(key)
                 if (valuesEqual(current, value)) return
                 fieldsMap.doc?.transact(() => fieldsMap.set(key, value), LOCAL_ORIGIN)
+                markEdited(key)
             },
             pushPI(piUserId, piName) {
                 if (!fieldsMap) return
@@ -143,9 +166,10 @@ export function useYjsFormMap({ studyId, form, websocketProvider }: Args): Retur
                     fieldsMap.set('piUserId', piUserId)
                     fieldsMap.set('piName', piName)
                 }, LOCAL_ORIGIN)
+                markEdited('piUserId', 'piName')
             },
         }),
-        [provider, fieldsMap, isSynced],
+        [provider, fieldsMap, isSynced, editedKeys, markEdited],
     )
 }
 


### PR DESCRIPTION
### Changes
1. **Green checkmark** (QA issue 1) — `SaveStatusIndicator` renders `CheckCircleIcon` (fill, `green.9`) + green text for the saved state, matching the [Figma example](https://www.figma.com/design/84pQzoYf7rKqOjo4qsDOeG/Card-59-69-71---Result-step?node-id=10928-17754&m=dev) and the existing pattern in `panel.tsx`. "Saving…" stays dimmed. Applies to every surface using the shared component (proposal fields, collaborative editors, resubmission note).
2. **Per-field gating** (QA issue 2) — `useYjsFormMap` now tracks `editedKeys` from `pushField`/`pushPI`. Each field's indicator stays idle until *that* field is edited in the current session. Initial-value seeding and remote collaborator edits never mark a field as edited. Edited flags reset on provider reconnect, mirroring the existing status-latch behavior.
3. **Title spacing** (QA issue 3) — the Study Title indicator moved into the word-counter row (left slot, alongside any validation error), so it sits directly under the input like the other fields.

### Testing
- New unit tests: green checkmark rendering; seeding does not mark fields edited; only actually-written fields are marked; no-op pushes and remote updates don't mark; `pushPI` marks both PI keys.
- Updated `yjsForm` stubs in `use-resubmit-proposal.test.ts` / `use-submit-proposal.test.ts` for the new `editedKeys` field.