### PR TITLE
Speed up the Checks CI workflow: Turbopack build cache + cache/Postgres/concurrency tuning

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -145,10 +145,11 @@ jobs:
                     POSTGRES_USER: si
                     POSTGRES_DB: si_test
                     POSTGRES_PASSWORD: si
-                # Poll pg_isready every 2s (not 10s): the runner just waits for Docker to
-                # report the container healthy, so a shorter interval cuts the idle wait
-                # after Postgres is actually ready. Same check, faster detection.
-                options: --health-cmd pg_isready --health-interval 2s --health-timeout 5s --health-retries 5
+                # Poll pg_isready every 2s (not 10s) so the runner detects "healthy" sooner
+                # and cuts the idle wait after Postgres is ready. Raise retries 5 -> 25 so the
+                # total startup grace stays ~50s (2s x 25 = 50s), matching the old 10s x 5;
+                # faster polling must not shrink the tolerance for a slow cold start.
+                options: --health-cmd pg_isready --health-interval 2s --health-timeout 5s --health-retries 25
         env:
             DATABASE_URL: 'postgres://si:si@localhost:5432/si_test'
             SIMULATE_CODE_BUILD: 't'
@@ -221,10 +222,11 @@ jobs:
                     POSTGRES_USER: si
                     POSTGRES_DB: si_test
                     POSTGRES_PASSWORD: si
-                # Poll pg_isready every 2s (not 10s): the runner just waits for Docker to
-                # report the container healthy, so a shorter interval cuts the idle wait
-                # after Postgres is actually ready. Same check, faster detection.
-                options: --health-cmd pg_isready --health-interval 2s --health-timeout 5s --health-retries 5
+                # Poll pg_isready every 2s (not 10s) so the runner detects "healthy" sooner
+                # and cuts the idle wait after Postgres is ready. Raise retries 5 -> 25 so the
+                # total startup grace stays ~50s (2s x 25 = 50s), matching the old 10s x 5;
+                # faster polling must not shrink the tolerance for a slow cold start.
+                options: --health-cmd pg_isready --health-interval 2s --health-timeout 5s --health-retries 25
         env:
             DATABASE_URL: 'postgres://si:si@localhost:5432/si_test'
             SIMULATE_CODE_BUILD: 't'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,6 +20,13 @@ on:
             - main
     pull_request: {}
 
+# Cancel superseded runs on the same PR ref so an outdated commit's jobs free the runner
+# for the newest push. Gated to pull_request only: push-to-main runs never cancel, so they
+# always finish and seed the shared build cache + coverage baseline.
+concurrency:
+    group: checks-${{ github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
     lint:
         timeout-minutes: 5
@@ -133,7 +140,10 @@ jobs:
                     POSTGRES_USER: si
                     POSTGRES_DB: si_test
                     POSTGRES_PASSWORD: si
-                options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+                # Poll pg_isready every 2s (not 10s): the runner just waits for Docker to
+                # report the container healthy, so a shorter interval cuts the idle wait
+                # after Postgres is actually ready. Same check, faster detection.
+                options: --health-cmd pg_isready --health-interval 2s --health-timeout 5s --health-retries 5
         env:
             DATABASE_URL: 'postgres://si:si@localhost:5432/si_test'
             SIMULATE_CODE_BUILD: 't'
@@ -206,7 +216,10 @@ jobs:
                     POSTGRES_USER: si
                     POSTGRES_DB: si_test
                     POSTGRES_PASSWORD: si
-                options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+                # Poll pg_isready every 2s (not 10s): the runner just waits for Docker to
+                # report the container healthy, so a shorter interval cuts the idle wait
+                # after Postgres is actually ready. Same check, faster detection.
+                options: --health-cmd pg_isready --health-interval 2s --health-timeout 5s --health-retries 5
         env:
             DATABASE_URL: 'postgres://si:si@localhost:5432/si_test'
             SIMULATE_CODE_BUILD: 't'
@@ -241,14 +254,15 @@ jobs:
               with:
                   node-version: 22
                   cache: 'pnpm'
-            # Next build cache — keyed on lockfile + source so an unchanged tree restores
-            # the previous .next/cache and skips most of the build.
+            # Next build cache (restore/save split). We RESTORE on every run but only SAVE on
+            # push-to-main (see the save step after the tests): the save uploads ~400MB and
+            # would add ~50s to every PR's critical path. PR runs instead restore main's cache
+            # via the `tpc1-<lockfileHash>-` restore-keys prefix and rebuild incrementally.
             # The `tpc1` token namespaces the Turbopack persistent build cache (enabled via
             # TURBOPACK_FS_CACHE) and lets us bust it with a one-character bump if a cached
-            # build ever misbehaves. The exact key includes a source hash so each run saves a
-            # fresh entry; restore-keys falls back to the latest prior cache for incremental
-            # rebuilds when only source (not the lockfile) changed.
-            - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+            # build ever misbehaves.
+            - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+              id: next_cache
               with: # https://nextjs.org/docs/pages/guides/ci-build-caching
                   key: ${{ runner.os }}-nextjs-tpc1-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
                   path: ${{ github.workspace }}/.next/cache
@@ -270,16 +284,50 @@ jobs:
               run: aws --endpoint-url http://127.0.0.1:8333 s3 mb s3://mgmt-app-local
             - name: pnpm install
               run: pnpm install --frozen-lockfile
+            # Playwright's system-dep install (apt) and, on a cache miss, the browser download
+            # are independent of the app build, so run them in the background and let them
+            # overlap the db provision + build below. The whole subshell is redirected to a
+            # log so it never holds this step's stdout open (which would hang the step); the
+            # exit code lands in a sentinel the wait step checks before the tests run.
+            - name: Install Playwright deps (background)
+              run: |
+                  if [ "${{ steps.pw-cache.outputs.cache-hit }}" = "true" ]; then
+                      CMD="pnpm exec playwright install-deps chromium"
+                  else
+                      CMD="pnpm exec playwright install --with-deps --only-shell chromium"
+                  fi
+                  echo "starting in background: $CMD"
+                  rm -f .pw-deps.exit
+                  # set +e so a failing install still records its exit code (the default
+                  # shell runs with -e, which would otherwise abort before the sentinel write
+                  # and hang the wait step).
+                  ( set +e; $CMD > pw_deps.log 2>&1; echo $? > .pw-deps.exit ) &
+                  echo "playwright deps installing in background (pid $!)"
             - name: provision db
               run: pnpm run db:migrate
             - name: build and run server
               run: pnpm run ci:server -- server_output.log
-            - name: install playwright dependencies
-              if: steps.pw-cache.outputs.cache-hit != 'true'
-              run: pnpm exec playwright install --with-deps --only-shell chromium
-            - name: pnpm exec playwright install-deps (cached browser)
-              if: steps.pw-cache.outputs.cache-hit == 'true'
-              run: pnpm exec playwright install-deps chromium
+            # Barrier: the background playwright install must be finished (and successful)
+            # before the tests launch a browser. Fails loudly with the install log on error.
+            - name: Wait for Playwright deps
+              run: |
+                  echo "waiting for playwright deps to finish..."
+                  for i in $(seq 1 300); do
+                      [ -f .pw-deps.exit ] && break
+                      sleep 1
+                  done
+                  if [ ! -f .pw-deps.exit ]; then
+                      echo "playwright deps did not finish within 300s"
+                      cat pw_deps.log || true
+                      exit 1
+                  fi
+                  code=$(cat .pw-deps.exit)
+                  cat pw_deps.log || true
+                  if [ "$code" != "0" ]; then
+                      echo "playwright deps install FAILED (exit $code)"
+                      exit 1
+                  fi
+                  echo "playwright deps ready"
             - name: pnpm run test:e2e
               run: pnpm run test:e2e
             - name: upload e2e coverage
@@ -289,6 +337,14 @@ jobs:
                   path: test-results/e2e/coverage/raw
                   retention-days: 1
                   if-no-files-found: ignore
+            # Save the Next build cache ONLY on push-to-main (see the restore step above).
+            # Runs only on success, so a failed build/test never persists a poisoned cache.
+            - name: Save Next build cache (main only)
+              if: github.event_name == 'push'
+              uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+              with:
+                  key: ${{ steps.next_cache.outputs.cache-primary-key }}
+                  path: ${{ github.workspace }}/.next/cache
             - name: Display server log
               run: if [ -f server_output.log ]; then cat server_output.log; fi
               if: always()

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -218,6 +218,13 @@ jobs:
             SINGLE_USER_EDITING: 't'
             NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: 'pk_test_ZHVtbXktZm9yLWUyZS5jbGVyay5hY2NvdW50cy5kZXYk'
             NEXT_PUBLIC_CI: 'true'
+            # Opt this build into Turbopack's persistent filesystem cache (experimental in
+            # Next 16, off by default). next.config.ts reads TURBOPACK_FS_CACHE and enables
+            # turbopackFileSystemCacheForBuild only when set, so it applies to this CI e2e
+            # build alone and never to the production deploy build. Turbopack writes the
+            # cache into .next/cache, which the actions/cache step below persists between
+            # runs to make incremental rebuilds fast.
+            TURBOPACK_FS_CACHE: '1'
             S3_ENDPOINT: 'http://127.0.0.1:8333'
             S3_BROWSER_ENDPOINT: 'http://127.0.0.1:8333'
             AWS_ACCESS_KEY_ID: 'si-local-s3'
@@ -236,12 +243,17 @@ jobs:
                   cache: 'pnpm'
             # Next build cache — keyed on lockfile + source so an unchanged tree restores
             # the previous .next/cache and skips most of the build.
+            # The `tpc1` token namespaces the Turbopack persistent build cache (enabled via
+            # TURBOPACK_FS_CACHE) and lets us bust it with a one-character bump if a cached
+            # build ever misbehaves. The exact key includes a source hash so each run saves a
+            # fresh entry; restore-keys falls back to the latest prior cache for incremental
+            # rebuilds when only source (not the lockfile) changed.
             - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
               with: # https://nextjs.org/docs/pages/guides/ci-build-caching
-                  key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+                  key: ${{ runner.os }}-nextjs-tpc1-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
                   path: ${{ github.workspace }}/.next/cache
                   restore-keys: |
-                      ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
+                      ${{ runner.os }}-nextjs-tpc1-${{ hashFiles('**/pnpm-lock.yaml') }}-
             # Cache the Playwright browser binaries so they aren't re-downloaded every run.
             # Keyed on the installed Playwright version (from the lockfile).
             - name: Resolve Playwright version

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -317,10 +317,15 @@ jobs:
             # Save the Next build cache ONLY on push-to-main (see the restore step above).
             # Runs only on success, so a failed build/test never persists a poisoned cache.
             - name: Save Next build cache (main only)
-              # Guard on both the event and the ref: `push` is only configured for `main`, but a
-              # merged `pull_request` run also reports github.ref == refs/heads/main, so the
-              # event check keeps the save strictly on push-to-main even if triggers change later.
-              if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+              # Guard on event, ref, and cache-hit:
+              #  - `push` is only configured for `main`, and a `pull_request` run reports
+              #    refs/pull/<n>/merge (not refs/heads/main), so today the event check alone
+              #    would suffice. The ref check is belt-and-braces so the save stays strictly on
+              #    push-to-main if a future `pull_request_target` or other trigger is added.
+              #  - cache-hit != 'true' skips the save when the exact primary key was already
+              #    restored (e.g. re-running a main run on an unchanged commit); otherwise
+              #    actions/cache spends minutes taring ~430 MB only to fail reserving the key.
+              if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.next_cache.outputs.cache-hit != 'true'
               uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
               with:
                   key: ${{ steps.next_cache.outputs.cache-primary-key }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,11 +20,16 @@ on:
             - main
     pull_request: {}
 
-# Cancel superseded runs on the same PR ref so an outdated commit's jobs free the runner
-# for the newest push. Gated to pull_request only: push-to-main runs never cancel, so they
-# always finish and seed the shared build cache + coverage baseline.
+# PR runs share one group per PR ref, so a newer commit cancels the older run
+# (cancel-in-progress) and frees the runner. Push runs (e.g. main) get a UNIQUE group per
+# run via github.run_id, so they are never grouped, never queued behind or superseded by
+# another run, and always finish and seed the shared build cache. This keeps main behaving
+# exactly as it did before this workflow gained a concurrency block: GitHub drops an older
+# *pending* run whenever a newer one queues in the same group (regardless of
+# cancel-in-progress), so a per-run group is what preserves that "every main run completes"
+# guarantee.
 concurrency:
-    group: checks-${{ github.ref }}
+    group: ${{ github.event_name == 'pull_request' && format('checks-{0}', github.ref) || format('checks-{0}', github.run_id) }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -317,7 +317,10 @@ jobs:
             # Save the Next build cache ONLY on push-to-main (see the restore step above).
             # Runs only on success, so a failed build/test never persists a poisoned cache.
             - name: Save Next build cache (main only)
-              if: github.event_name == 'push'
+              # Guard on both the event and the ref: `push` is only configured for `main`, but a
+              # merged `pull_request` run also reports github.ref == refs/heads/main, so the
+              # event check keeps the save strictly on push-to-main even if triggers change later.
+              if: github.event_name == 'push' && github.ref == 'refs/heads/main'
               uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
               with:
                   key: ${{ steps.next_cache.outputs.cache-primary-key }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -284,50 +284,20 @@ jobs:
               run: aws --endpoint-url http://127.0.0.1:8333 s3 mb s3://mgmt-app-local
             - name: pnpm install
               run: pnpm install --frozen-lockfile
-            # Playwright's system-dep install (apt) and, on a cache miss, the browser download
-            # are independent of the app build, so run them in the background and let them
-            # overlap the db provision + build below. The whole subshell is redirected to a
-            # log so it never holds this step's stdout open (which would hang the step); the
-            # exit code lands in a sentinel the wait step checks before the tests run.
-            - name: Install Playwright deps (background)
-              run: |
-                  if [ "${{ steps.pw-cache.outputs.cache-hit }}" = "true" ]; then
-                      CMD="pnpm exec playwright install-deps chromium"
-                  else
-                      CMD="pnpm exec playwright install --with-deps --only-shell chromium"
-                  fi
-                  echo "starting in background: $CMD"
-                  rm -f .pw-deps.exit
-                  # set +e so a failing install still records its exit code (the default
-                  # shell runs with -e, which would otherwise abort before the sentinel write
-                  # and hang the wait step).
-                  ( set +e; $CMD > pw_deps.log 2>&1; echo $? > .pw-deps.exit ) &
-                  echo "playwright deps installing in background (pid $!)"
             - name: provision db
               run: pnpm run db:migrate
             - name: build and run server
               run: pnpm run ci:server -- server_output.log
-            # Barrier: the background playwright install must be finished (and successful)
-            # before the tests launch a browser. Fails loudly with the install log on error.
-            - name: Wait for Playwright deps
-              run: |
-                  echo "waiting for playwright deps to finish..."
-                  for i in $(seq 1 300); do
-                      [ -f .pw-deps.exit ] && break
-                      sleep 1
-                  done
-                  if [ ! -f .pw-deps.exit ]; then
-                      echo "playwright deps did not finish within 300s"
-                      cat pw_deps.log || true
-                      exit 1
-                  fi
-                  code=$(cat .pw-deps.exit)
-                  cat pw_deps.log || true
-                  if [ "$code" != "0" ]; then
-                      echo "playwright deps install FAILED (exit $code)"
-                      exit 1
-                  fi
-                  echo "playwright deps ready"
+            # Playwright deps run synchronously here. Backgrounding them to overlap the build
+            # was tried and reverted: `playwright install-deps` shells out to sudo/apt, which
+            # hangs intermittently when detached from the step (~1 in 3 runs), violating the
+            # zero-flake rule. The ~12s saving is not worth an intermittent CI hang.
+            - name: install playwright dependencies
+              if: steps.pw-cache.outputs.cache-hit != 'true'
+              run: pnpm exec playwright install --with-deps --only-shell chromium
+            - name: pnpm exec playwright install-deps (cached browser)
+              if: steps.pw-cache.outputs.cache-hit == 'true'
+              run: pnpm exec playwright install-deps chromium
             - name: pnpm run test:e2e
               run: pnpm run test:e2e
             - name: upload e2e coverage

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,14 @@ const isDev = Boolean(process.env.CI || process.env.NODE_ENV === 'development')
 // (flag unset) are untouched. See src/lib/clerk-fake/README intent in server.ts.
 const fakeClerk = Boolean(process.env.E2E_FAKE_CLERK)
 
+// Turbopack's persistent filesystem cache for `next build` is experimental (opt-in) in
+// Next 16, so it's gated behind TURBOPACK_FS_CACHE and only turned on for the CI e2e build
+// (see .github/workflows/checks.yml), never for the production deploy build. It writes to
+// .next/cache, which CI persists across runs to make incremental rebuilds much faster. If
+// a cached build ever looks wrong it fails loudly at build time (never a false-green test
+// run); bust it by bumping the cache-key token in the workflow.
+const turbopackFsCache = Boolean(process.env.TURBOPACK_FS_CACHE)
+
 const securityHeaders = [
     // Clickjacking protection (SIINFOSEC-470, ZAP-10020).
     // We never want this app embedded in a frame; DENY is stricter than SAMEORIGIN
@@ -70,6 +78,7 @@ const nextConfig: NextConfig = {
         return config
     },
     experimental: {
+        ...(turbopackFsCache ? { turbopackFileSystemCacheForBuild: true } : {}),
         // https://github.com/phosphor-icons/react?tab=readme-ov-file#nextjs-specific-optimizations
         optimizePackageImports: ['@phosphor-icons/react'],
         serverActions: {

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,9 +12,11 @@ const fakeClerk = Boolean(process.env.E2E_FAKE_CLERK)
 // Turbopack's persistent filesystem cache for `next build` is experimental (opt-in) in
 // Next 16, so it's gated behind TURBOPACK_FS_CACHE and only turned on for the CI e2e build
 // (see .github/workflows/checks.yml), never for the production deploy build. It writes to
-// .next/cache, which CI persists across runs to make incremental rebuilds much faster. If
-// a cached build ever looks wrong it fails loudly at build time (never a false-green test
-// run); bust it by bumping the cache-key token in the workflow.
+// .next/cache, which CI persists across runs to make incremental rebuilds much faster.
+// A corrupt cache fails loudly at build time (a red build, never a false-green test run). The
+// rarer, quieter risk is a stale build if invalidation ever missed a change; content-hash change
+// detection plus a cache key that hashes every source file make this unlikely, but if a build is
+// ever suspected stale, bust the cache by bumping the tpc token in the workflow cache key.
 const turbopackFsCache = Boolean(process.env.TURBOPACK_FS_CACHE)
 
 const securityHeaders = [


### PR DESCRIPTION
## Summary

This PR speeds up the **Checks** CI workflow. Measured across full runs on this branch, the whole workflow dropped from **~5m12s to ~4m16s, an average of ~56s (~18%) faster**, and the `e2e` job (the former long pole) from **~4m36s to ~3m23s (~26% faster)**. It's now balanced with the unit shards instead of gating the run.

All changes are correctness-neutral: no test was weakened, retries stay at 0, and every optimization either fails loudly or was reverted (see "Tried and reverted").

## What changed

1. **Turbopack persistent build cache for the CI e2e build.** This repo is on Next 16, where `next build` uses Turbopack, whose filesystem build cache is experimental and off by default. The workflow's `.next/cache` step was therefore caching an almost-empty directory (~434 KB), so every build ran cold (~77s). Enabling `experimental.turbopackFileSystemCacheForBuild` (gated behind a new `TURBOPACK_FS_CACHE` env var set only on the CI e2e job, never on the production deploy build) makes Turbopack write a real ~430 MB cache into `.next/cache`. Warm builds drop to ~52s.

2. **Next cache: restore-always, save-on-main-only** (`actions/cache/restore` + `actions/cache/save` split). The ~430 MB cache upload added ~52s to the post-job phase of every PR run. We now save only on push to `main`; PRs restore `main`'s cache via the `tpc1-<lockfileHash>-` restore-keys prefix and rebuild incrementally. This removes the single biggest chunk of PR e2e time. A `tpc1` token in the cache key allows a one-character cache bust.

3. **Faster Postgres service startup** on both `unit` and `e2e`: `--health-interval 10s` to `2s`. The runner only waits for Docker to report the container healthy, so a shorter poll cuts the idle wait after Postgres is ready. "Initialize containers" went from ~22s to ~9s. Same `pg_isready` check.

4. **Concurrency group** that cancels superseded runs on the same PR ref (frees runner capacity, faster feedback on rapid re-pushes). Push runs get a unique group per run (`github.run_id`), so main is never grouped and every main run completes and seeds the cache, that is, main behaves exactly as it did before this change.

## Benchmark results

Baseline is PR #857 (predates this branch: no Turbopack cache, no items above). "After" is the average of the last 6 successful Checks runs on this branch.

| Metric | Before (PR #857) | After (avg of last 6) | Improvement |
|---|---|---|---|
| **Full Checks workflow** | 5m12s (312s) | **~4m16s (256s)** _(range 4m08s–4m32s)_ | **~56s (~18%)** |
| **e2e job** | 4m36s (276s) | **~3m23s (203s)** _(range 3m04s–3m46s)_ | **~73s (~26%)** |

Where the e2e time went (before → after):

| e2e step | Before | After | Cause |
|---|---|---|---|
| build and run server | ~77s (cold) | ~52s (warm) | Turbopack build cache (1) |
| Post cache save | ~52s | 0s on PRs (skipped) | save-on-main split (2) |
| Initialize containers (Postgres) | ~22s | ~9s | health-interval 2s (3) |

The full e2e suite passed at `retries: 0` on every reliable run.

### Turbopack build-cache warm/cold samples (earlier, item 1 in isolation)

| Run | Cache state | build time |
|---|---|---|
| Cold (seed) | seeding | 78s |
| Warm 1-4 | restored (restore-key) | 57s / 55s / 51s / 53s |

## Is the experimental Turbopack flag safe here?

Yes, and the CI e2e build is one of the safer places for it:

- Next's docs label the FileSystem Cache "stable for development and experimental for production builds." There is no documented case of it silently producing stale or wrong output; the identical cache engine has been stable and on-by-default for `next dev` since 16.1.
- The realistic failure mode is loud: known issues (e.g. a `Z_BUF_ERROR`) are build failures fixed by a clean-cache rebuild. A broken build fails the `build and run server` step and turns the job red; it cannot produce a false-green test run, because a broken build means no server for Playwright to hit.
- Change detection is content-hash + dependency-graph based, and our cache key also hashes every `.ts/.tsx`, so any source change misses the exact key and rebuilds incrementally.
- Bust it by bumping the `tpc1` token (or clearing `.next/cache`). The flag is scoped to CI via `TURBOPACK_FS_CACHE`, so the production Jenkins deploy build is unaffected and keeps building clean.

## Tried and reverted (kept out for correctness)

- **Backgrounding the Playwright install to overlap the build (~12s).** `playwright install-deps` shells out to `sudo`/apt, which hangs intermittently (~1 in 3 runs) when detached from the step, violating the zero-flake rule. Its ~12s benefit was also lost in run-to-run noise. Reverted to a synchronous install; a code comment records why.
- **`postgres:15-alpine`** (smaller pull). Alpine uses musl libc with different default text collation than the Debian image, which can change `ORDER BY` results and cause flaky tests. Kept the Debian image; the health-interval change delivers the win risk-free.

## Cache retention note

GitHub evicts caches automatically (7-day-since-last-access and a 10 GB per-repo LRU), so nothing needs manual cleanup. The `tpc1` cache is read on every e2e run, so it stays at the recently-used end and is not an eviction candidate; stale legacy caches are evicted first.

