### PR TITLE
remove reject code option

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-client.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-client.test.tsx
@@ -79,7 +79,7 @@ describe('CodeReviewClient decision selector', () => {
         })
     })
 
-    it('renders all three decision options with their titles and descriptions', async () => {
+    it('renders both decision options with their titles and descriptions', async () => {
         const { study, job, orgSlug, previousHref } = await setupValidReviewableJob('Rice University')
         renderWithProviders(
             <CodeReviewClient
@@ -93,11 +93,12 @@ describe('CodeReviewClient decision selector', () => {
 
         expect(screen.getByTestId('code-review-decision-approve')).toBeInTheDocument()
         expect(screen.getByTestId('code-review-decision-needs-clarification')).toBeInTheDocument()
-        expect(screen.getByTestId('code-review-decision-reject')).toBeInTheDocument()
+        // OTTER-650: the "Reject and end study" option was removed as an interim step.
+        expect(screen.queryByTestId('code-review-decision-reject')).not.toBeInTheDocument()
 
         expect(screen.getByText('Approve and run code')).toBeInTheDocument()
         expect(screen.getByText('Request revision')).toBeInTheDocument()
-        expect(screen.getByText('Reject and end study')).toBeInTheDocument()
+        expect(screen.queryByText('Reject and end study')).not.toBeInTheDocument()
 
         expect(
             screen.getByText(
@@ -109,12 +110,6 @@ describe('CodeReviewClient decision selector', () => {
                 /Return this code submission to Rice University for necessary updates, additional information, or specific changes\./,
             ),
         ).toBeInTheDocument()
-        expect(
-            screen.getByText(
-                /Permanently end this study due to major, unresolvable issues\. Share rationale with Rice University\./,
-            ),
-        ).toBeInTheDocument()
-        expect(screen.getByText('Warning: This terminates the study and cannot be undone.')).toBeInTheDocument()
     })
 
     it('renders the editable review form (not "Code review is closed") for an APPROVED study with a reviewable job', async () => {
@@ -170,28 +165,27 @@ describe('CodeReviewClient decision selector', () => {
         expect(screen.getByTestId('code-review-submit')).toBeDisabled()
     })
 
-    it.each([
-        ['code-review-decision-approve'],
-        ['code-review-decision-needs-clarification'],
-        ['code-review-decision-reject'],
-    ])('enables Submit when %s is selected with valid feedback and criteria', async (decisionTestId) => {
-        const user = userEvent.setup()
-        const { study, job, orgSlug, previousHref } = await setupValidReviewableJob()
-        renderWithProviders(
-            <CodeReviewClient
-                orgSlug={orgSlug}
-                study={study}
-                job={job}
-                latestJobStatus="CODE-SUBMITTED"
-                previousHref={previousHref}
-            />,
-        )
+    it.each([['code-review-decision-approve'], ['code-review-decision-needs-clarification']])(
+        'enables Submit when %s is selected with valid feedback and criteria',
+        async (decisionTestId) => {
+            const user = userEvent.setup()
+            const { study, job, orgSlug, previousHref } = await setupValidReviewableJob()
+            renderWithProviders(
+                <CodeReviewClient
+                    orgSlug={orgSlug}
+                    study={study}
+                    job={job}
+                    latestJobStatus="CODE-SUBMITTED"
+                    previousHref={previousHref}
+                />,
+            )
 
-        await fillAllCriteria(user)
-        await user.click(screen.getByTestId(decisionTestId))
+            await fillAllCriteria(user)
+            await user.click(screen.getByTestId(decisionTestId))
 
-        expect(screen.getByTestId('code-review-submit')).toBeEnabled()
-    })
+            expect(screen.getByTestId('code-review-submit')).toBeEnabled()
+        },
+    )
 
     it('opens the non-destructive confirmation modal when submitting with needs-clarification', async () => {
         const user = userEvent.setup()
@@ -216,31 +210,6 @@ describe('CodeReviewClient decision selector', () => {
             'Please confirm you are ready to submit this code review. Further edits are not permitted once submitted.',
         )
         expect(screen.getByRole('button', { name: 'Yes, submit review' })).toBeInTheDocument()
-    })
-
-    it('opens the destructive reject modal with the warning paragraph when submitting with reject', async () => {
-        const user = userEvent.setup()
-        const { study, job, orgSlug, previousHref } = await setupValidReviewableJob()
-        renderWithProviders(
-            <CodeReviewClient
-                orgSlug={orgSlug}
-                study={study}
-                job={job}
-                latestJobStatus="CODE-SUBMITTED"
-                previousHref={previousHref}
-            />,
-        )
-
-        await fillAllCriteria(user)
-        await user.click(screen.getByTestId('code-review-decision-reject'))
-        await user.click(screen.getByTestId('code-review-submit'))
-
-        const dialog = await screen.findByRole('dialog')
-        expect(dialog).toHaveTextContent('Reject study code?')
-        expect(dialog).toHaveTextContent(
-            /Rejection: This is intended as a last resort due to major, unresolvable issues and will end this study\. This action cannot be undone\./,
-        )
-        expect(screen.getByRole('button', { name: 'Reject study code' })).toBeInTheDocument()
     })
 
     it('calls submitReview with decision=needs-clarification on confirm', async () => {

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-client.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-client.tsx
@@ -8,7 +8,7 @@ import type { Route } from 'next'
 import { useRouter } from 'next/navigation'
 import { CaretLeftIcon } from '@phosphor-icons/react'
 
-import { ReviewConfirmationModal, REJECTION_WARNING } from '@/components/modals/review-confirmation-modal'
+import { ReviewConfirmationModal } from '@/components/modals/review-confirmation-modal'
 import { useCodeReviewMutation } from '@/hooks/use-code-review-mutation'
 import { useReviewDecision } from '@/hooks/use-review-decision'
 import { useReviewFeedback } from '@/hooks/use-review-feedback'
@@ -64,7 +64,6 @@ function useCodeReview({
     const decision = useReviewDecision()
     const router = useRouter()
     const [confirmOpen, { open: openConfirm, close: closeConfirm }] = useDisclosure(false)
-    const [rejectOpen, { open: openReject, close: closeReject }] = useDisclosure(false)
 
     const evaluationForm = useForm<{ criteria: CodeReviewCriteriaDraft }>({
         initialValues: {
@@ -91,12 +90,7 @@ function useCodeReview({
 
     const handleSubmit = () => {
         if (!hasDecision) return
-
-        if (decision.selected === 'reject') {
-            openReject()
-        } else {
-            openConfirm()
-        }
+        openConfirm()
     }
 
     const handleConfirmSubmit = () => {
@@ -118,8 +112,6 @@ function useCodeReview({
         handleSubmit,
         confirmOpen,
         closeConfirm,
-        rejectOpen,
-        closeReject,
         handleConfirmSubmit,
         isPending,
     }
@@ -213,8 +205,6 @@ export function CodeReviewClient({ orgSlug, study, job, latestJobStatus, previou
         handleSubmit,
         confirmOpen,
         closeConfirm,
-        rejectOpen,
-        closeReject,
         handleConfirmSubmit,
         isPending,
     } = useCodeReview({ orgSlug, studyId: study.id, jobId: job.id, tabSessionId, previousHref })
@@ -263,18 +253,6 @@ export function CodeReviewClient({ orgSlug, study, job, latestJobStatus, previou
                 confirmLabel="Yes, submit review"
             >
                 <Text size="md">{CONFIRM_BODY}</Text>
-            </ReviewConfirmationModal>
-            <ReviewConfirmationModal
-                isOpen={rejectOpen}
-                onClose={closeReject}
-                onConfirm={handleConfirmSubmit}
-                isPending={isPending}
-                title="Reject study code?"
-                confirmLabel="Reject study code"
-                variant="destructive"
-            >
-                <Text size="md">{CONFIRM_BODY}</Text>
-                {REJECTION_WARNING}
             </ReviewConfirmationModal>
         </StudyKickOutProvider>
     )

--- a/src/app/[orgSlug]/study/[studyId]/review/code-review-feedback-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review-feedback-section.tsx
@@ -105,20 +105,6 @@ const buildDecisionOptions = (labName: string): DecisionOption[] => [
         ),
         testId: 'code-review-decision-needs-clarification',
     },
-    {
-        value: 'reject',
-        title: 'Reject and end study',
-        description: (
-            <Text component="span" size="sm" c="grey.7">
-                Permanently end this study due to major, unresolvable issues. Share rationale with {labName}.
-                <br />
-                <Text component="span" size="sm" c="grey.7" fw={600}>
-                    Warning: This terminates the study and cannot be undone.
-                </Text>
-            </Text>
-        ),
-        testId: 'code-review-decision-reject',
-    },
 ]
 
 const RADIO_STYLES = {

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -8,7 +8,13 @@ import {
     withRole,
     type Page,
 } from './e2e.helpers'
-import { seedApprovedNoCode, seedCodeApprovedJobReady, seedCodeSubmitted, seedProposalPendingReview } from './e2e.seed'
+import {
+    seedApprovedNoCode,
+    seedCodeApprovedJobReady,
+    seedCodeRejected,
+    seedCodeSubmitted,
+    seedProposalPendingReview,
+} from './e2e.seed'
 import { execSync } from 'child_process'
 
 // E2e study-lifecycle coverage. Governing rule: every distinct UI surface is
@@ -676,37 +682,19 @@ test('Code change request and resubmission', async ({ browser, studyFeatures }) 
     })
 })
 
-// Owns the reviewer hard-reject-code surface (terminal) + the researcher terminal
-// rejected-code view. Seeds CODE-SUBMITTED.
+// Owns the reviewer post-code-rejection surface (terminal) + the researcher terminal
+// rejected-code view. OTTER-650 removed the DP "Reject and end study" option, so the
+// CODE-REJECTED state can no longer be reached through the UI; we seed it directly to
+// keep coverage of the preserved post-rejection views.
 test('Code rejection ends the study', async ({ browser, studyFeatures }) => {
     const studyTitle = studyFeatures.uniqueTitle('code-hard-rej')
-    await seedCodeSubmitted(studyTitle)
+    const { studyId } = await seedCodeRejected(studyTitle)
 
     await withRole(browser, 'reviewer', async (page) => {
-        await openCodeReviewEditor(page, studyTitle)
-
-        await fillCodeCriteria(page, 'no')
-        // Reject -> CODE-REJECTED (study ends). Destructive confirm modal ("Reject study code?").
-        await page.getByTestId('code-review-decision-reject').click()
-        const feedbackEditor = page.getByTestId('code-review-section').locator('[contenteditable="true"]').first()
-        await expect(feedbackEditor).toBeVisible()
-        await feedbackEditor.click()
-        await page.keyboard.type('Rejecting submitted code — it cannot run against this dataset.')
-
-        await page.getByTestId('code-review-submit').click()
-        const dialog = page.getByRole('dialog')
-        await expect(dialog).toBeVisible()
-        await dialog.getByRole('button', { name: /^Reject study code$/i }).click()
-        await expect(dialog).toBeHidden()
+        await goto(page, `/openstax/study/${studyId}/review`)
 
         await expect(page.getByText(/Rejected on/)).toBeVisible()
         await expect(page.getByTestId('decision-banner-code-rejected')).toBeVisible()
-        await page.getByTestId('go-to-dashboard').click()
-        await page.waitForURL('**/dashboard')
-
-        const rejectedRow = page.getByRole('row').filter({ hasText: studyTitle })
-        await expect(rejectedRow).toBeVisible()
-        await expect(rejectedRow.getByText(/REJECTED/i)).toBeVisible()
     })
 
     await withRole(browser, 'researcher', async (page) => {


### PR DESCRIPTION
## OTTER-650: Remove the "Reject and end study" option from the DP Code Review page

Issue: https://openstax.atlassian.net/browse/OTTER-650

### Summary

UX and Product are re-conceptualizing how studies are "ended." As an interim step,
leadership asked to remove the **"Reject and end study"** option from the Data Partner
(DP) Code Review page. This PR removes only that option (the user-facing entry point)
and deliberately leaves the surrounding reject infrastructure in place so it can be
re-wired into a new pathway later.

### What changed

- **Removed the `reject` decision option** from the code-review decision group
  (`code-review-feedback-section.tsx`). A Data Partner now sees only **Approve and run
  code** and **Request revision**.

### Intentionally left untouched (per the card)

These are preserved so the future pathway can reuse them — none are removed:

- The "Reject study code?" confirmation modal in `code-review-client.tsx`
- The `'reject'` value in the `Decision` type
- The reject branch of `submitCodeReviewDecisionAction`
- The DP/RL post-code-rejection views (`post-feedback-view.tsx`)

They are unreachable via the UI now but remain fully wired.

### Tests

- **`code-review-client.test.tsx`** — updated the decision-options test to assert the
  reject option is absent, dropped the reject case from the enable-submit `it.each`, and
  removed the "opens the destructive reject modal" test (that flow is no longer reachable
  through the UI).
- **`study-flow.spec.ts`** — the "Code rejection ends the study" e2e test no longer drives
  the removed button. It now seeds a `CODE-REJECTED` study directly via the existing
  `seedCodeRejected` helper and verifies the preserved reviewer + researcher terminal
  views, keeping coverage of the post-rejection pages.