### PR TITLE
OTTER-621: derive proposal decision from approvedAt/rejectedAt

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-proposal-feedback-screen.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-proposal-feedback-screen.tsx
@@ -1,7 +1,7 @@
 import { isSubmittedStudy } from '@/schema/study'
 import { isActionError } from '@/lib/errors'
 import { AlertNotFound } from '@/components/errors'
-import { PROPOSAL_STATUS_TO_REVIEW_DECISION } from '@/lib/review-decision'
+import { proposalReviewDecision } from '@/lib/review-decision'
 import { getProposalFeedbackForStudyAction } from '@/server/actions/study.actions'
 import { PostFeedbackView } from '../review/post-feedback-view'
 import type { ScreenComponentProps } from './types'
@@ -12,7 +12,7 @@ export async function ReviewerProposalFeedbackScreen({ study, orgSlug }: ScreenC
     }
     const entries = await getProposalFeedbackForStudyAction({ studyId: study.id })
     const safeEntries = isActionError(entries) ? [] : entries
-    const decision = PROPOSAL_STATUS_TO_REVIEW_DECISION[study.status]
+    const decision = proposalReviewDecision(study)
     const fallback = decision
         ? { decision, timestamp: study.approvedAt ?? study.rejectedAt ?? study.createdAt }
         : undefined

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal/page.test.tsx
@@ -1,7 +1,7 @@
 import type React from 'react'
 import { beforeEach, describe, it, expect, vi } from 'vitest'
 import { redirect } from 'next/navigation'
-import { insertTestStudyOnly, mockSessionWithTestData, setTestStudyStatus } from '@/tests/unit.helpers'
+import { db, insertTestStudyOnly, mockSessionWithTestData, setTestStudyStatus } from '@/tests/unit.helpers'
 import ReviewProposalPage from './page'
 import { ProposalReviewView } from '../proposal-review-view'
 import { PostFeedbackView } from '../post-feedback-view'
@@ -30,6 +30,24 @@ describe('ReviewProposalPage', () => {
         const page = await callPage(org.slug, study.id)
 
         expect(page?.type).toBe(PostFeedbackView)
+    })
+
+    // Submitting code flips study.status back to PENDING-REVIEW while approvedAt still records the
+    // decision — the page must keep rendering the decided proposal, not the code-review screen.
+    it('renders the decided proposal feedback when code submission reset the status to PENDING-REVIEW', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+        const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
+        await db
+            .updateTable('study')
+            .set({ status: 'PENDING-REVIEW', approvedAt: new Date() })
+            .where('id', '=', study.id)
+            .execute()
+
+        const page = await callPage(org.slug, study.id)
+
+        expect(page?.type).toBe(PostFeedbackView)
+        const props = page?.props as React.ComponentProps<typeof PostFeedbackView>
+        expect(props.fallback?.decision).toBe('APPROVE')
     })
 
     it('falls through to the editable proposal review when the proposal is not yet decided', async () => {

--- a/src/app/[orgSlug]/study/[studyId]/review/proposal/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/proposal/page.tsx
@@ -2,17 +2,17 @@
 
 import { AlertNotFound } from '@/components/errors'
 import { Routes } from '@/lib/routes'
-import { PROPOSAL_STATUS_TO_REVIEW_DECISION } from '@/lib/review-decision'
+import { proposalReviewDecision } from '@/lib/review-decision'
 import { rawStudyStateForStudy } from '@/server/db/study-state-query'
 import { renderStudyScreen } from '../../_screens/render-screen'
 import { ReviewerProposalFeedbackScreen } from '../../_screens/reviewer-proposal-feedback-screen'
 import { reviewerPageGuard } from '../reviewer-page-guard'
 
 // The "View approved initial request" link opens this route in a new tab to always show the DECIDED
-// proposal, even when the study's canonical /review screen is code-stage. When the proposal has no
-// decision yet (PENDING-REVIEW), there's nothing for the read-only feedback view to render, so fall
-// through to the canonical /review screen (editable proposal review) — matching the legacy
-// from=initial-request branch, which fell through rather than rendering a blank page.
+// proposal, even when the study's canonical /review screen is code-stage. Decided-ness comes from
+// proposalReviewDecision, not raw status — code submissions flip status back to PENDING-REVIEW.
+// A truly undecided proposal has nothing for the read-only feedback view to render, so it falls
+// through to the canonical /review screen (editable proposal review) instead of a blank page.
 export default async function ReviewProposalPage(props: { params: Promise<{ orgSlug: string; studyId: string }> }) {
     const { orgSlug, studyId } = await props.params
 
@@ -23,7 +23,7 @@ export default async function ReviewProposalPage(props: { params: Promise<{ orgS
     const raw = await rawStudyStateForStudy(studyId)
     if (!raw) return <AlertNotFound title="Study was not found" message="No such study exists" />
 
-    if (!PROPOSAL_STATUS_TO_REVIEW_DECISION[study.status]) {
+    if (!proposalReviewDecision(study)) {
         return renderStudyScreen({
             role: 'reviewer',
             raw,

--- a/src/lib/review-decision.test.ts
+++ b/src/lib/review-decision.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import type { StudyStatus } from '@/database/types'
+import { proposalReviewDecision } from './review-decision'
+
+const study = (status: StudyStatus, overrides: { approvedAt?: Date | null; rejectedAt?: Date | null } = {}) => ({
+    status,
+    approvedAt: overrides.approvedAt ?? null,
+    rejectedAt: overrides.rejectedAt ?? null,
+})
+
+describe('proposalReviewDecision', () => {
+    it('maps decided statuses directly', () => {
+        expect(proposalReviewDecision(study('APPROVED'))).toBe('APPROVE')
+        expect(proposalReviewDecision(study('REJECTED'))).toBe('REJECT')
+        expect(proposalReviewDecision(study('CHANGE-REQUESTED'))).toBe('NEEDS-CLARIFICATION')
+    })
+
+    it('falls back to approvedAt when code submission reset the status', () => {
+        expect(proposalReviewDecision(study('PENDING-REVIEW', { approvedAt: new Date() }))).toBe('APPROVE')
+    })
+
+    it('falls back to rejectedAt when the status no longer carries the decision', () => {
+        expect(proposalReviewDecision(study('PENDING-REVIEW', { rejectedAt: new Date() }))).toBe('REJECT')
+    })
+
+    it('prefers the explicit status over stale timestamps', () => {
+        expect(proposalReviewDecision(study('CHANGE-REQUESTED', { approvedAt: new Date() }))).toBe(
+            'NEEDS-CLARIFICATION',
+        )
+    })
+
+    it('returns undefined for a proposal that was never decided', () => {
+        expect(proposalReviewDecision(study('PENDING-REVIEW'))).toBeUndefined()
+        expect(proposalReviewDecision(study('DRAFT'))).toBeUndefined()
+    })
+})

--- a/src/lib/review-decision.ts
+++ b/src/lib/review-decision.ts
@@ -25,6 +25,21 @@ export const PROPOSAL_STATUS_TO_REVIEW_DECISION: Partial<Record<StudyStatus, Rev
     'CHANGE-REQUESTED': 'NEEDS-CLARIFICATION',
 }
 
+// Code submit/resubmit flips study.status back to PENDING-REVIEW, so status alone can't say
+// whether the proposal was ever decided. approvedAt/rejectedAt survive those flips (approval and
+// rejection clear each other), making them the durable record once the study is code-stage.
+export function proposalReviewDecision(study: {
+    status: StudyStatus
+    approvedAt: Date | null
+    rejectedAt: Date | null
+}): ReviewDecision | undefined {
+    const byStatus = PROPOSAL_STATUS_TO_REVIEW_DECISION[study.status]
+    if (byStatus) return byStatus
+    if (study.approvedAt) return 'APPROVE'
+    if (study.rejectedAt) return 'REJECT'
+    return undefined
+}
+
 // A code decision can be written (proposal approve/reject path) without a code-review comment, so
 // the code feedback view synthesizes the decision from the job's CODE-* status when no comment rows
 // exist — keeps the page on the code post-feedback view rather than blanking out.


### PR DESCRIPTION
### Problem
With a study in code-needs-review, "View approved initial request" opened
/review/proposal but rendered the code-review screen instead of the decided
proposal (or a blank page when no feedback rows existed). Intermittent — only
while code was awaiting review.

### Cause
Code submit/resubmit flips study.status back to PENDING-REVIEW. The proposal
page and feedback screen checked PROPOSAL_STATUS_TO_REVIEW_DECISION[study.status],
which has no PENDING-REVIEW entry, so a decided proposal looked undecided.

### Changes
- New proposalReviewDecision() in src/lib/review-decision.ts: status map first,
  then fall back to approvedAt/rejectedAt (they survive the status flip and
  mutually clear each other)
- /review/proposal page and ReviewerProposalFeedbackScreen now use it;
  undecided proposals still fall through to the editable review

### Testing
- New review-decision.test.ts (map, timestamp fallbacks, precedence)
- Regression test: PENDING-REVIEW + approvedAt renders PostFeedbackView with
  APPROVE fallback (the staging scenario from the ticket video)
- /review page + reviewer-screen-rules suites pass; lint/tsc clean