### PR TITLE
Fix incorrect GitHub Actions caching behavior and optimize CI cache reuse

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -138,7 +138,7 @@ jobs:
         permissions: {}
         services:
             db:
-                image: postgres:15
+                image: postgres:16
                 ports:
                     - 5432:5432
                 env:
@@ -215,7 +215,7 @@ jobs:
         permissions: {}
         services:
             db:
-                image: postgres:15
+                image: postgres:16
                 ports:
                     - 5432:5432
                 env:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -261,36 +261,69 @@ jobs:
               with:
                   node-version: 22
                   cache: 'pnpm'
+            # Cache key prefix, computed once so the exact `key` and the restore-keys tiers stay
+            # in sync. `gen` (YYYY-MM) rolls the key monthly so the Turbopack cache reseeds cold
+            # about once a month, bounding accretion (Turbopack has no GC / size cap). `node<major>`
+            # busts the cache on a Node upgrade, whose on-disk cache format is not guaranteed to be
+            # reusable across versions.
+            - name: Compute Next cache key prefix
+              id: cachekey
+              run: |
+                  gen=$(date -u +%Y-%m)
+                  # Previous month (via "first of this month minus one day") for the PR-only
+                  # fallback tier: at a month boundary, before the first main push of the new
+                  # month has reseeded `gen`, PRs would otherwise miss every tier and build cold.
+                  prev=$(date -u -d "$(date -u +%Y-%m-01) -1 day" +%Y-%m)
+                  node_major=$(node -v | sed 's/v\([0-9]*\).*/\1/')
+                  base="${{ runner.os }}-nextjs-tpc1"
+                  echo "prefix=${base}-${gen}-node${node_major}" >> "$GITHUB_OUTPUT"
+                  echo "prev_prefix=${base}-${prev}-node${node_major}" >> "$GITHUB_OUTPUT"
             # Next build cache (restore/save split). We RESTORE on every run but only SAVE on
-            # push-to-main (see the save step after the tests): the save uploads ~400MB and
-            # would add ~50s to every PR's critical path. PR runs instead restore main's cache
-            # via the `tpc1-<lockfileHash>-` restore-keys prefix and rebuild incrementally.
-            # The `tpc1` token namespaces the Turbopack persistent build cache (enabled via
-            # TURBOPACK_FS_CACHE) and lets us bust it with a one-character bump if a cached
-            # build ever misbehaves.
+            # push-to-main (see the save step after the tests): the save uploads ~400MB and would
+            # add ~50s to every PR's critical path. PR runs restore main's cache via the tiers
+            # below and rebuild incrementally. The `tpc1` token namespaces the Turbopack
+            # persistent build cache (enabled via TURBOPACK_FS_CACHE) and lets us bust it with a
+            # one-character bump if a cached build ever misbehaves.
             - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
               id: next_cache
               with: # https://nextjs.org/docs/pages/guides/ci-build-caching
-                  key: ${{ runner.os }}-nextjs-tpc1-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+                  key: ${{ steps.cachekey.outputs.prefix }}-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
                   path: ${{ github.workspace }}/.next/cache
+                  # Tier 2: same deps, any source change -> warm incremental rebuild.
+                  # Tier 3 (PR only): drop the lockfile hash so a dep-changing PR still restores
+                  # main's cache; Turbopack content-hashes its inputs and rebuilds only the
+                  # affected modules, so a dep change is a warm partial rebuild, not a cold one.
+                  # Tier 4 (PR only): previous month's prefix, so PRs stay warm during the window
+                  # at the start of a new month before the first main push reseeds `gen`.
+                  # Tiers 3 and 4 are omitted on push-to-main (they evaluate to empty strings,
+                  # which the cache action drops), so each month main still reseeds one compact
+                  # cache from cold instead of inheriting last month's accreted one.
                   restore-keys: |
-                      ${{ runner.os }}-nextjs-tpc1-${{ hashFiles('**/pnpm-lock.yaml') }}-
-            # Cache the Playwright browser binaries so they aren't re-downloaded every run.
-            # Keyed on the installed Playwright version (from the lockfile).
-            - name: Resolve Playwright version
-              id: pw
-              run: echo "version=$(node -p "require('@playwright/test/package.json').version" 2>/dev/null || echo unknown)" >> "$GITHUB_OUTPUT"
-            - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-              id: pw-cache
-              with:
-                  path: ~/.cache/ms-playwright
-                  key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}
+                      ${{ steps.cachekey.outputs.prefix }}-${{ hashFiles('**/pnpm-lock.yaml') }}-
+                      ${{ github.event_name == 'pull_request' && format('{0}-', steps.cachekey.outputs.prefix) || '' }}
+                      ${{ github.event_name == 'pull_request' && format('{0}-', steps.cachekey.outputs.prev_prefix) || '' }}
             - name: Start SeaweedFS
               run: ./bin/ci-seaweedfs
             - name: Create S3 bucket
               run: aws --endpoint-url http://127.0.0.1:8333 s3 mb s3://mgmt-app-local
             - name: pnpm install
               run: pnpm install --frozen-lockfile
+            # Cache the Playwright browser binaries so they aren't re-downloaded every run.
+            # Keyed on the installed Playwright version. Runs AFTER `pnpm install` so `require`
+            # resolves the real version; running it before install (as it used to) left
+            # node_modules absent, so the version silently fell back to "unknown" and the key
+            # never busted on a Playwright upgrade, risking stale cached browsers. A failed
+            # resolve now fails the step loudly rather than poisoning the key with a constant.
+            - name: Resolve Playwright version
+              id: pw
+              run: |
+                  version=$(node -p "require('@playwright/test/package.json').version")
+                  echo "version=$version" >> "$GITHUB_OUTPUT"
+            - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+              id: pw-cache
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}
             - name: provision db
               run: pnpm run db:migrate
             - name: build and run server

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -261,23 +261,12 @@ jobs:
               with:
                   node-version: 22
                   cache: 'pnpm'
-            # Cache key prefix, computed once so the exact `key` and the restore-keys tiers stay
-            # in sync. `gen` (YYYY-MM) rolls the key monthly so the Turbopack cache reseeds cold
-            # about once a month, bounding accretion (Turbopack has no GC / size cap). `node<major>`
-            # busts the cache on a Node upgrade, whose on-disk cache format is not guaranteed to be
-            # reusable across versions.
+            # Compute the cache key prefix (and previous-month variant) as step outputs, so the
+            # exact `key` and the restore-keys tiers below stay in sync. Logic lives in the script;
+            # see it for why the key carries a monthly generation token and the Node major.
             - name: Compute Next cache key prefix
               id: cachekey
-              run: |
-                  gen=$(date -u +%Y-%m)
-                  # Previous month (via "first of this month minus one day") for the PR-only
-                  # fallback tier: at a month boundary, before the first main push of the new
-                  # month has reseeded `gen`, PRs would otherwise miss every tier and build cold.
-                  prev=$(date -u -d "$(date -u +%Y-%m-01) -1 day" +%Y-%m)
-                  node_major=$(node -v | sed 's/v\([0-9]*\).*/\1/')
-                  base="${{ runner.os }}-nextjs-tpc1"
-                  echo "prefix=${base}-${gen}-node${node_major}" >> "$GITHUB_OUTPUT"
-                  echo "prev_prefix=${base}-${prev}-node${node_major}" >> "$GITHUB_OUTPUT"
+              run: ./bin/ci-next-cache-key
             # Next build cache (restore/save split). We RESTORE on every run but only SAVE on
             # push-to-main (see the save step after the tests): the save uploads ~400MB and would
             # add ~50s to every PR's critical path. PR runs restore main's cache via the tiers

--- a/bin/ci-next-cache-key
+++ b/bin/ci-next-cache-key
@@ -19,10 +19,17 @@
 set -e
 
 gen=$(date -u +%Y-%m)
-# Previous month via "first of this month minus one day" (robust across month lengths and year
-# rollover). At a month boundary, before the first main push of the new month has reseeded `gen`,
-# PRs would otherwise miss every tier and build cold; the prev_prefix tier keeps them warm.
-prev=$(date -u -d "$(date -u +%Y-%m-01) -1 day" +%Y-%m)
+# Previous month via plain arithmetic on `gen`, so this stays portable POSIX shell and avoids the
+# GNU-only `date -d`. At a month boundary, before the first main push of the new month has reseeded
+# `gen`, PRs would otherwise miss every tier and build cold; the prev_prefix tier keeps them warm.
+year=${gen%-*}
+month=${gen#*-}
+month=${month#0} # strip a leading zero so 08/09 are not read as invalid octal inside $(( ))
+if [ "$month" -eq 1 ]; then
+    prev="$((year - 1))-12"
+else
+    prev=$(printf '%d-%02d' "$year" "$((month - 1))")
+fi
 node_major=$(node -v | sed 's/v\([0-9]*\).*/\1/')
 base="${RUNNER_OS}-nextjs-tpc1"
 

--- a/bin/ci-next-cache-key
+++ b/bin/ci-next-cache-key
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Compute the Next/Turbopack build-cache key prefix for the e2e job (checks.yml) and expose it,
+# plus a previous-month variant, as step outputs via $GITHUB_OUTPUT. Kept in a script so the
+# workflow stays declarative instead of carrying a block of inline shell.
+#
+#   prefix      = <os>-nextjs-tpc1-<YYYY-MM>-node<major>   stem for the exact key + restore tiers
+#   prev_prefix = same, but for last month                 for the PR-only month-boundary fallback
+#
+# Why these dimensions:
+#  - gen (YYYY-MM) rolls the key monthly, so the cache reseeds cold about once a month. That
+#    bounds accretion: Turbopack has no cache GC or size cap, and only main saves, so a fresh
+#    stem each month keeps main's cache compact instead of growing forever.
+#  - node<major> busts the cache on a Node upgrade, whose on-disk cache format is not guaranteed
+#    to be reusable across versions.
+#
+# RUNNER_OS and GITHUB_OUTPUT are provided by GitHub Actions and inherited by this child process,
+# so RUNNER_OS matches ${{ runner.os }} used elsewhere in the workflow and no args are needed.
+
+set -e
+
+gen=$(date -u +%Y-%m)
+# Previous month via "first of this month minus one day" (robust across month lengths and year
+# rollover). At a month boundary, before the first main push of the new month has reseeded `gen`,
+# PRs would otherwise miss every tier and build cold; the prev_prefix tier keeps them warm.
+prev=$(date -u -d "$(date -u +%Y-%m-01) -1 day" +%Y-%m)
+node_major=$(node -v | sed 's/v\([0-9]*\).*/\1/')
+base="${RUNNER_OS}-nextjs-tpc1"
+
+echo "prefix=${base}-${gen}-node${node_major}" >> "$GITHUB_OUTPUT"
+echo "prev_prefix=${base}-${prev}-node${node_major}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Follow-up to [#863](https://github.com/safeinsights/management-app/pull/863). That PR made `main` save a real ~434 MB Turbopack persistent build cache and PRs restore it, and it works. This PR closes the one gap it left (dependency PRs miss the cache entirely), bounds the cache's growth, and fixes a latent Playwright browser-cache bug found while investigating.

All changes are confined to the `e2e` job, plus one new POSIX helper `bin/ci-next-cache-key`. Nothing weakens a test, changes retries, or touches the production deploy build.

This PR also upgrades the Postgres service image in both the `unit` and `e2e` CI jobs from 15 to 16 so GitHub Actions matches the Postgres version used in production (and in the local/dev docker-compose files).

Key format note: below, `LOCKHASH` is the `pnpm-lock.yaml` hash, `SRCHASH` is the hash of all `*.ts/tsx/js/jsx`, and the prefix stem is `Linux-nextjs-tpc1-YYYY-MM-nodeN` (OS, namespace, monthly generation token, Node major). A concrete July / Node 22 prefix is `Linux-nextjs-tpc1-2026-07-node22`.

## Background: what #863 established, and the gap

#863's design is restore-on-every-run, save-only-on-push-to-`main`. Verified against the live Actions data: the merge run seeded a ~434 MB entry (`Linux-nextjs-tpc1-LOCKHASH-SRCHASH`) on `refs/heads/main`, and lockfile-neutral PRs restore it and build warm (~54 s vs ~77 s cold).

The gap: the restore key's fallback prefix included the **lockfile hash**. So any PR that changes `pnpm-lock.yaml` cannot match main's cache and builds cold on **every** push until it merges.

This is not hypothetical. [#869](https://github.com/safeinsights/management-app/pull/869) removes an unused dependency, which rewrites the lockfile. Its e2e restore logged, verbatim:

```
Cache not found for input keys:
  Linux-nextjs-tpc1-e2a43cbf...-SRCHASH,
  Linux-nextjs-tpc1-e2a43cbf...-
```

so it rebuilt cold (~77 s) on every push, while main's cache sat under a different lockfile hash (`3b16d77d...`). A dependency change, the exact case where you have already paid to rebuild, is penalized the hardest.

## Why decoupling reads from the lockfile is safe (the key decision)

The fix is a PR-only restore tier that **drops the lockfile hash**, so a dep-changing PR reuses main's cache and rebuilds incrementally. This is safe because of how Turbopack's persistent cache works, confirmed against Next.js' documentation and Turbopack's cache design:

- Turbopack **content-hashes its own task inputs** (source, config, and the actual dependency module contents) and **self-invalidates per module**. Restoring a cache built under a different lockfile therefore produces a *partial incremental rebuild* of the modules whose inputs changed, not stale or incorrect output. The lockfile hash was only ever a coarse cache-busting proxy, not a correctness mechanism.
- The realistic failure modes of the experimental FS cache are **loud, not silent**: known issues surface as build failures (e.g. the `Z_BUF_ERROR` class), which fail the `build and run server` step and turn the job red. A broken cache cannot produce a false-green test run, because a failed build means there is no server for Playwright to hit. There is no documented case of it silently emitting wrong output.

So the worst case of a cross-lockfile restore is a slightly larger incremental rebuild; the common case is a near-warm build.

## What changed

1. **Tiered restore keys (A).** Four tiers, first match wins. Tiers 3 and 4 are `pull_request`-only (they evaluate to empty strings on push, which the cache action drops), so `main` stays strict.
   - Tier 1 (exact `key`): `Linux-nextjs-tpc1-2026-07-node22-LOCKHASH-SRCHASH`
   - Tier 2: `Linux-nextjs-tpc1-2026-07-node22-LOCKHASH-` (same deps, any source change)
   - Tier 3 (PR only): `Linux-nextjs-tpc1-2026-07-node22-` (deps changed, still reuse main's cache)
   - Tier 4 (PR only): `Linux-nextjs-tpc1-2026-06-node22-` (previous month, see the month-boundary note below)

2. **Node major + monthly generation in the key (G, F).** The prefix stem is now `Linux-nextjs-tpc1-YYYY-MM-nodeN`.
   - The `nodeN` segment busts the cache on a Node upgrade, whose on-disk cache format is not guaranteed reusable across versions.
   - The `YYYY-MM` segment rolls the key monthly. Turbopack's persistent cache has **no garbage collection and no size cap** (a repeatedly restored-and-resaved archive grows monotonically; dev caches have been reported growing into the multi-GB range), so a monthly cold reseed on `main` keeps the saved cache compact instead of accreting forever. Because only `main` saves, each month `main` reseeds one clean cache; PRs never write, so they never contribute to growth.

3. **Previous-month fallback tier (F, month-boundary fix).** Without it, on the first day(s) of a new month, before `main`'s first push reseeds the new generation, every PR would miss all tiers and build cold. Tier 4 lets PRs fall back to the previous month's cache during that window. `main` deliberately has no Tier 4, so its monthly cold reseed (and the compact-cache reset) is preserved. PRs never save, so reusing last month's cache costs nothing.

4. **Playwright cache-key fix (I, correctness).** "Resolve Playwright version" ran *before* `pnpm install`, so `require('@playwright/test/package.json')` failed and the key silently became the constant `Linux-playwright-unknown`. That key never busts, so the next Playwright upgrade would restore stale browsers, take the cache-hit path (skipping the download), and turn e2e red until someone deleted the cache by hand. The step now runs *after* `pnpm install` and **fails loudly** if the version cannot be resolved.

5. **Extract logic to `bin/ci-next-cache-key`.** The key-prefix computation lives in a small POSIX script alongside the other `ci-*` helpers, so `checks.yml` stays declarative. It reads `RUNNER_OS` (equal to `runner.os`) and writes `prefix` / `prev_prefix` to `$GITHUB_OUTPUT`, both provided by the runner, so the result is identical to the previous inline shell.

6. **Upgrade CI Postgres 15 to 16.** Both the `unit` and `e2e` jobs used `postgres:15` while production (and the local/dev `docker-compose.yml` / `docker-compose.testunit.yml`) runs Postgres 16. Updated the service image tags so CI matches production exactly.

## Why not save the cache from PR branches too

The obvious alternative (let dep-PRs save their own cache so push 2 and later are warm) was considered and rejected on the numbers. Break-even is roughly 3 subsequent completed runs (the ~52 s upload amortized against ~23 s saved per warm run). Across the last 70 merged PRs, 9 touched the lockfile and the **median had exactly one run** (mostly one-shot dependency/security bumps). Summed, PR-side saving would have been a net loss, and its ~52 s upload lands on the critical path (e2e gates the coverage job) while the payoff is contingent on pushes that usually never happen. Read-side tiering captures most of the benefit at zero upload cost. If a specific long-lived dep branch ever wants it, PR-side saving is best added later behind an opt-in label.

## Effect on cache read/write behavior

- **Reads (restore):** lockfile-neutral PRs unchanged (warm). Dep-changing PRs go from cold-every-push to semi-warm-every-push. New-month PRs stay warm via Tier 4.
- **Writes (save):** unchanged posture, still `push`-to-`main` only, on success, and still skipped on an exact `cache-hit` (re-running an unchanged commit). Only `main` writes the shared Turbopack cache, so PR-restored caches cannot poison it. The one added write pattern is one deliberate cold reseed per month.
- On a dependency bump merged to `main`: the push misses (new lockfile hash), rebuilds, and the save step writes a fresh entry under the new key, which then becomes the warm base for subsequent same-lockfile PRs (Tier 2) and dep-changing PRs (Tier 3).

Note: the Playwright browser cache is separate and intentionally not main-only. It uses the combined `actions/cache` action, which only uploads on a cache miss (i.e. when the Playwright version changes), so it carries no per-PR upload cost and does not need the restore/save split.

## Correctness and rollback

- Content-hash caching cannot hide a changed input; Turbopack rebuilds affected modules on any restore.
- A poisoned cache fails the build loudly and is never saved (the save runs only on job success).
- Bust everything with a one-character bump of the `tpc1` token, or clear `.next/cache`. The FS cache stays scoped to CI via `TURBOPACK_FS_CACHE`, so the production build is unaffected.

## Validation

- `pnpm run validate-actions` passes; workflow parses; the four restore tiers render as expected (Tiers 3 and 4 gated to `pull_request`).
- `bin/ci-next-cache-key`: `sh -n` clean; produces a `prefix` of `Linux-nextjs-tpc1-YYYY-MM-nodeN` and the previous-month variant. Previous-month math checked across boundaries (month lengths, 31st into Feb, Jan into Dec year rollover).
- Step order verified: compute-key precedes restore; `pnpm install` precedes the Playwright resolve; the browser cache precedes the conditional deps-install steps.

## First live run

The Checks workflow has already run against this PR and passed, which confirms the new keys behave as designed:

- The four restore tiers rendered correctly, with Tiers 3 and 4 present only because it is a `pull_request`.
- The Turbopack tiers all miss for now, because `main`'s existing cache is still under the old key format (no `YYYY-MM-nodeN` segment). They will warm once this merges and `main` reseeds under the new format. This is the expected one-time cost of the key change, not a regression.
- The Playwright step resolved the real version and saved `Linux-playwright-1.60.0`, replacing the broken constant `unknown` key.