### PR TITLE
OTTER-640: add more regression tests

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/view/code/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code/page.test.tsx
@@ -29,20 +29,8 @@ const addJobStatus = async (studyId: string, status: StudyJobStatus) => {
         .execute()
 }
 
-const seedResultsStudy = async () => {
-    const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
-    const { study } = await insertTestStudyJobData({
-        org,
-        researcherId: user.id,
-        studyStatus: 'APPROVED',
-        jobStatus: 'CODE-SUBMITTED',
-    })
-    await addJobStatus(study.id, 'CODE-APPROVED')
-    await addJobStatus(study.id, 'FILES-APPROVED')
-    return { org, study }
-}
-
-const seedRunningOrErroredCodeStudy = async (statuses: StudyJobStatus[]) => {
+// A CODE-APPROVED study with the given trailing job statuses appended (execution/results substatuses).
+const seedCodeStudy = async (statuses: StudyJobStatus[]) => {
     const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
     const { study } = await insertTestStudyJobData({
         org,
@@ -54,6 +42,8 @@ const seedRunningOrErroredCodeStudy = async (statuses: StudyJobStatus[]) => {
     for (const status of statuses) await addJobStatus(study.id, status)
     return { org, study }
 }
+
+const seedResultsStudy = () => seedCodeStudy(['FILES-APPROVED'])
 
 describe('StudyViewCode (/view/code)', () => {
     it('shows the approved-code page with a "Proceed to step 5" forward for a results study', async () => {
@@ -87,11 +77,18 @@ describe('StudyViewCode (/view/code)', () => {
 
     // OTTER-640: normal /view hides submitted code while execution or an unreviewed error is presented
     // as "Code approved". The read-only /view/code step must still expose it behind this collapsed control.
+    // The first two shapes keep isExecuting true (a hidden error doesn't close the append-only execution
+    // window); the bare JOB-ERRORED shape (a packaging failure before any JOB-RUNNING substatus) is the
+    // only one where isExecuting is false and the hidden-errored result alone would drive the /view hide.
     it.each([
         ['the code is running in the enclave', ['JOB-RUNNING']],
-        ['the run errored before the reviewer recorded a files decision', ['JOB-RUNNING', 'JOB-ERRORED']],
+        [
+            'the run errored after starting, before the reviewer recorded a files decision',
+            ['JOB-RUNNING', 'JOB-ERRORED'],
+        ],
+        ['the run errored before any enclave execution, before a files decision', ['JOB-ERRORED']],
     ] as const)('shows the submitted-code control when %s', async (_description, statuses) => {
-        const { org, study } = await seedRunningOrErroredCodeStudy([...statuses])
+        const { org, study } = await seedCodeStudy([...statuses])
 
         const page = await StudyViewCode({
             params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),

--- a/src/app/[orgSlug]/study/[studyId]/view/code/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code/page.test.tsx
@@ -42,6 +42,19 @@ const seedResultsStudy = async () => {
     return { org, study }
 }
 
+const seedRunningOrErroredCodeStudy = async (statuses: StudyJobStatus[]) => {
+    const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+    const { study } = await insertTestStudyJobData({
+        org,
+        researcherId: user.id,
+        studyStatus: 'APPROVED',
+        jobStatus: 'CODE-SUBMITTED',
+    })
+    await addJobStatus(study.id, 'CODE-APPROVED')
+    for (const status of statuses) await addJobStatus(study.id, status)
+    return { org, study }
+}
+
 describe('StudyViewCode (/view/code)', () => {
     it('shows the approved-code page with a "Proceed to step 5" forward for a results study', async () => {
         const { org, study } = await seedResultsStudy()
@@ -70,6 +83,26 @@ describe('StudyViewCode (/view/code)', () => {
 
         expect(page?.props.dashboardHref).toBe(`/${org.slug}/dashboard`)
         expect(page?.props.resultsHref).toBe(`/${org.slug}/study/${study.id}/view?returnTo=org`)
+    })
+
+    // OTTER-640: normal /view hides submitted code while execution or an unreviewed error is presented
+    // as "Code approved". The read-only /view/code step must still expose it behind this collapsed control.
+    it.each([
+        ['the code is running in the enclave', ['JOB-RUNNING']],
+        ['the run errored before the reviewer recorded a files decision', ['JOB-RUNNING', 'JOB-ERRORED']],
+    ] as const)('shows the submitted-code control when %s', async (_description, statuses) => {
+        const { org, study } = await seedRunningOrErroredCodeStudy([...statuses])
+
+        const page = await StudyViewCode({
+            params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+            searchParams: Promise.resolve({}),
+        })
+
+        expect(page?.type).toBe(CodePostDecisionView)
+        expect(page?.props.showStudyCode).toBe(true)
+
+        renderWithProviders(page!)
+        expect(screen.getByTestId('study-code-toggle')).toHaveTextContent('View submitted study code')
     })
 
     it('404s for an APPROVED study that has not submitted code (cannot jump ahead)', async () => {


### PR DESCRIPTION
see [OTTER-640](https://openstax.atlassian.net/browse/OTTER-640)

this issue seems fixed and all my tests conclude it's not an issue anymore. This PR only increases a regression test for it (was not existing before).

- Add regression coverage ensuring researchers can view submitted code after an enclave run is in progress or errors before review.

[OTTER-640]: https://openstax.atlassian.net/browse/OTTER-640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ