### PR TITLE
OTTER 651: Fix email leaking

### DIFF
--- a/src/server/mailer.test.ts
+++ b/src/server/mailer.test.ts
@@ -2,7 +2,7 @@ import { db } from '@/database'
 import * as mailgun from '@/server/mailer'
 import { insertTestOrgStudyJobUsers } from '@/tests/unit.helpers'
 import { describe, expect, it, Mock, vi } from 'vitest'
-import { deliver } from './mailgun'
+import { deliver, SI_EMAIL } from './mailgun'
 
 vi.mock('./mailgun')
 
@@ -28,7 +28,7 @@ describe('mailgun email functions', () => {
         )
     })
 
-    it('sendStudyProposalEmails calls deliver for reviewers', async () => {
+    it('sendStudyProposalEmails sends all org members in Bcc, not To (OTTER-651)', async () => {
         const { study, org, user1 } = await insertTestOrgStudyJobUsers()
 
         const researcher = await getUser(study.researcherId)
@@ -37,7 +37,7 @@ describe('mailgun email functions', () => {
 
         expect(deliver).toHaveBeenCalledWith(
             expect.objectContaining({
-                to: expect.stringContaining(user1.email || researcher.email || ''),
+                to: SI_EMAIL,
                 bcc: expect.stringContaining(user1.email || ''),
                 subject: expect.stringContaining('New study proposal'),
                 template: 'vb - new research proposal',
@@ -51,7 +51,7 @@ describe('mailgun email functions', () => {
         )
     })
 
-    it('sendStudyCodeSubmittedEmail calls deliver for reviewers', async () => {
+    it('sendStudyCodeSubmittedEmail sends all org members in Bcc, not To (OTTER-651)', async () => {
         const { study, user1 } = await insertTestOrgStudyJobUsers()
         const researcher = await getUser(study.researcherId)
 
@@ -59,7 +59,7 @@ describe('mailgun email functions', () => {
 
         expect(deliverMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                to: expect.stringContaining(user1.email || researcher.email || ''),
+                to: SI_EMAIL,
                 bcc: expect.stringContaining(user1.email || ''),
                 subject: 'Study code submitted for review',
                 template: 'vb - new code submission',

--- a/src/server/mailer.test.ts
+++ b/src/server/mailer.test.ts
@@ -114,6 +114,37 @@ describe('mailgun email functions', () => {
         )
     })
 
+    it('mass emails never put recipient addresses in To (OTTER-651 regression)', async () => {
+        const { study } = await insertTestOrgStudyJobUsers()
+
+        const orgMembers = await db
+            .selectFrom('user')
+            .innerJoin('orgUser', 'user.id', 'orgUser.userId')
+            .distinctOn('user.id')
+            .select(['user.email'])
+            .where('orgUser.orgId', '=', study.orgId)
+            .execute()
+        const allEmails = orgMembers.map((m) => m.email).filter(Boolean)
+
+        expect(allEmails.length).toBeGreaterThan(1)
+
+        await mailgun.sendStudyProposalEmails(study.id)
+        const proposalCall = deliverMock.mock.calls.at(-1)![0] as { to: string; bcc?: string }
+        expect(proposalCall.to).toBe(SI_EMAIL)
+        for (const email of allEmails) {
+            expect(proposalCall.to).not.toContain(email)
+            expect(proposalCall.bcc).toContain(email)
+        }
+
+        await mailgun.sendStudyCodeSubmittedEmail(study.id)
+        const codeCall = deliverMock.mock.calls.at(-1)![0] as { to: string; bcc?: string }
+        expect(codeCall.to).toBe(SI_EMAIL)
+        for (const email of allEmails) {
+            expect(codeCall.to).not.toContain(email)
+            expect(codeCall.bcc).toContain(email)
+        }
+    })
+
     it('sendResultsReadyForReviewEmail calls deliver for reviewer', async () => {
         const { study, user1: reviewer } = await insertTestOrgStudyJobUsers()
         await db.updateTable('study').set({ reviewerId: reviewer.id }).where('id', '=', study.id).execute()

--- a/src/server/mailer.ts
+++ b/src/server/mailer.ts
@@ -3,7 +3,7 @@ import { getStudyAndOrgDisplayInfo } from '@/server/db/queries'
 import dayjs from 'dayjs'
 import { APP_BASE_URL } from './config'
 import logger from '@/lib/logger'
-import { deliver } from './mailgun'
+import { deliver, SI_EMAIL } from './mailgun'
 
 // For local testing, send to a fixed 'to' email address that is authorized to
 // receive emails from Mailgun, and remove the 'vb -' prefix from the template name.
@@ -45,16 +45,17 @@ export const sendStudyProposalEmails = async (studyId: string) => {
     const study = await getStudyAndOrgDisplayInfo(studyId)
     const reviewers = await getOrgMembers(study.orgId)
     const emails = reviewers.map((r) => r.email).filter(Boolean)
-    const to = study.reviewerEmail ?? emails.join(', ')
 
-    if (!to) {
+    if (emails.length === 0) {
         logger.warn(`No recipients for study proposal email, studyId: ${studyId}`)
         return
     }
 
+    // All recipients go in Bcc so no one sees another's address (OTTER-651).
+    // Mailgun requires at least one "To", so we use the no-reply sender.
     await deliver({
-        to,
-        ...(emails.length > 0 && { bcc: emails.join(', ') }),
+        to: SI_EMAIL,
+        bcc: emails.join(', '),
         subject: 'New study proposal',
         template: 'vb - new research proposal',
         vars: {
@@ -69,16 +70,16 @@ export const sendStudyCodeSubmittedEmail = async (studyId: string) => {
     const study = await getStudyAndOrgDisplayInfo(studyId)
     const reviewers = await getOrgMembers(study.orgId)
     const emails = reviewers.map((reviewer) => reviewer.email).filter((email) => email)
-    const to = study.reviewerEmail ?? emails.join(', ')
 
-    if (!to) {
+    if (emails.length === 0) {
         logger.warn(`No recipients for study code submitted email, studyId: ${studyId}`)
         return
     }
 
+    // See OTTER-651: never put multiple recipient addresses in "To".
     await deliver({
-        to,
-        ...(emails.length > 0 && { bcc: emails.join(', ') }),
+        to: SI_EMAIL,
+        bcc: emails.join(', '),
         subject: 'Study code submitted for review',
         template: 'vb - new code submission',
         vars: {

--- a/src/server/mailgun.ts
+++ b/src/server/mailgun.ts
@@ -2,7 +2,7 @@ import Mailgun from 'mailgun.js'
 import logger from '@/lib/logger'
 import { getConfigValue, CI_ENV, APP_BASE_URL, PROD_BUILD } from './config'
 
-const SI_EMAIL = 'SafeInsights <no-reply@safeinsights.org>'
+export const SI_EMAIL = 'SafeInsights <no-reply@safeinsights.org>'
 
 let _mg: null | ReturnType<Mailgun['client']> = null
 let _domain = ''


### PR DESCRIPTION
see [OTTER-651](https://openstax.atlassian.net/browse/OTTER-651)

- Fixed review notification emails that were leaking all recipient addresses in the "To" field, exposing PII to every recipient
- Changed both study proposal and study code submitted emails to place all recipients in Bcc, with the no-reply sender address as the sole "To" recipient
- Added a regression test that verifies no org member email appears in "To" and all appear in "Bcc" for mass notification emails

[OTTER-651]: https://openstax.atlassian.net/browse/OTTER-651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ