### PR TITLE
OTTER-644: fix ai summary loading state

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/code-review.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/code-review.tsx
@@ -11,7 +11,7 @@ import { Box, Stack, Title } from '@mantine/core'
 import type { CodeReviewFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
 import { CodeReviewClient } from './code-review-client'
 import { CODE_REVIEW_BANNER_CRITERIA } from './code-review-criteria'
-import { SubmittedCodeSection } from './submitted-code-section'
+import { SubmittedCodeSection, latestCodeSubmittedAt } from './submitted-code-section'
 
 type CodeReviewProps = {
     orgSlug: string
@@ -124,7 +124,7 @@ export async function CodeReview({ orgSlug, study, entries }: CodeReviewProps) {
                 </Title>
                 <CodeReviewSection
                     study={study}
-                    submittedAt={job.createdAt}
+                    submittedAt={latestCodeSubmittedAt(job)}
                     isResubmission={isResubmission}
                     version={version}
                 />

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-interactive.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-interactive.tsx
@@ -113,20 +113,22 @@ const AI_SUMMARY_TIMEOUT_MS = 180_000
 // generation that hangs without writing a (success or failure) row eventually
 // surfaces as an error instead of spinning forever. `since` may be a string —
 // timestamps serialize to ISO strings across the server/client boundary.
-function useElapsedSince(since: Date | string, ms: number): boolean {
-    const sinceMs = new Date(since).getTime()
-    const [elapsed, setElapsed] = useState(() => Date.now() - sinceMs >= ms)
+function useElapsedSince(since: Date | string, ms: number) {
+    const initialSinceMs = new Date(since).getTime()
+    const [startedAt, setStartedAt] = useState(initialSinceMs)
+    const [elapsed, setElapsed] = useState(() => Date.now() - initialSinceMs >= ms)
     useEffect(() => {
-        const remaining = Math.max(0, ms - (Date.now() - sinceMs))
-        if (remaining === 0) {
-            setElapsed(true)
-            return
-        }
-        setElapsed(false)
+        const remaining = Math.max(0, ms - (Date.now() - startedAt))
         const id = setTimeout(() => setElapsed(true), remaining)
         return () => clearTimeout(id)
-    }, [sinceMs, ms])
-    return elapsed
+    }, [startedAt, ms])
+    return {
+        elapsed,
+        reset: () => {
+            setStartedAt(Date.now())
+            setElapsed(false)
+        },
+    }
 }
 
 // The review row is written by a deferred background task triggered at code
@@ -257,9 +259,9 @@ export function AiSummaryCollapsible({
     const { data: review, error } = useStudyReviewPoll(studyJobId, initialReview)
     // A successful retry is a new generation request, so it needs its own
     // timeout window instead of inheriting the original submission's age.
-    const [generationStartedAt, setGenerationStartedAt] = useState<Date | string>(submittedAt)
-    const retry = useRetryStudyReview(studyJobId, () => setGenerationStartedAt(new Date()))
-    const timedOut = useElapsedSince(generationStartedAt, timeoutMs)
+    const timeout = useElapsedSince(submittedAt, timeoutMs)
+    const retry = useRetryStudyReview(studyJobId, timeout.reset)
+    const timedOut = timeout.elapsed
     const summary = review?.report?.codeExplanation ?? null
 
     const onRetry = () => retry.mutate()

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-interactive.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-interactive.tsx
@@ -117,13 +117,15 @@ function useElapsedSince(since: Date | string, ms: number): boolean {
     const sinceMs = new Date(since).getTime()
     const [elapsed, setElapsed] = useState(() => Date.now() - sinceMs >= ms)
     useEffect(() => {
-        if (elapsed) return
-        // Clamp to 0 rather than setting state synchronously here; the timer
-        // fires the update on the next tick, out of the effect body.
         const remaining = Math.max(0, ms - (Date.now() - sinceMs))
+        if (remaining === 0) {
+            setElapsed(true)
+            return
+        }
+        setElapsed(false)
         const id = setTimeout(() => setElapsed(true), remaining)
         return () => clearTimeout(id)
-    }, [sinceMs, ms, elapsed])
+    }, [sinceMs, ms])
     return elapsed
 }
 
@@ -223,12 +225,13 @@ function AiSummaryContent({ summary, isExpanded, onToggle }: AiSummaryContentPro
 
 // Clears the failed row server-side, re-fires generation, then resets the
 // cached review to null so the poll resumes and the UI drops back to pending.
-function useRetryStudyReview(studyJobId: string) {
+function useRetryStudyReview(studyJobId: string, onRetryStarted: () => void) {
     const queryClient = useQueryClient()
     return useMutation({
         mutationFn: () => regenerateStudyReviewAction({ studyJobId }),
         onSuccess: () => {
             queryClient.setQueryData(['study-review', studyJobId], null)
+            onRetryStarted()
         },
     })
 }
@@ -252,8 +255,11 @@ export function AiSummaryCollapsible({
 }: AiSummaryProps) {
     const { isExpanded, toggle } = useAiSummaryToggle()
     const { data: review, error } = useStudyReviewPoll(studyJobId, initialReview)
-    const retry = useRetryStudyReview(studyJobId)
-    const timedOut = useElapsedSince(submittedAt, timeoutMs)
+    // A successful retry is a new generation request, so it needs its own
+    // timeout window instead of inheriting the original submission's age.
+    const [generationStartedAt, setGenerationStartedAt] = useState<Date | string>(submittedAt)
+    const retry = useRetryStudyReview(studyJobId, () => setGenerationStartedAt(new Date()))
+    const timedOut = useElapsedSince(generationStartedAt, timeoutMs)
     const summary = review?.report?.codeExplanation ?? null
 
     const onRetry = () => retry.mutate()

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-interactive.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-interactive.tsx
@@ -109,10 +109,15 @@ const REVIEW_POLL_INTERVAL_MS = 5_000
 // above a normal generation; past it with no row we assume it's stuck.
 const AI_SUMMARY_TIMEOUT_MS = 180_000
 
-// Returns true once `ms` have elapsed since `since`. Used as a backstop so a
-// generation that hangs without writing a (success or failure) row eventually
-// surfaces as an error instead of spinning forever. `since` may be a string —
-// timestamps serialize to ISO strings across the server/client boundary.
+// Returns `{ elapsed, reset }`: `elapsed` becomes true once `ms` have passed
+// since the start time, and `reset()` re-arms the timer from now. Used as a
+// backstop so a generation that hangs without writing a (success or failure)
+// row eventually surfaces as an error instead of spinning forever, while a
+// retry can restart the clock. `since` is read once on mount to seed the start
+// time; later prop changes are ignored, so a new submission must arrive via a
+// fresh server render (or an explicit reset()), not a changed `since`. `since`
+// may be a string — timestamps serialize to ISO strings across the
+// server/client boundary.
 function useElapsedSince(since: Date | string, ms: number) {
     const initialSinceMs = new Date(since).getTime()
     const [startedAt, setStartedAt] = useState(initialSinceMs)

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
@@ -246,6 +246,34 @@ describe('SubmittedCodeSection — AI summary', () => {
         expect(screen.queryByText('Overview')).not.toBeInTheDocument()
     })
 
+    it('keeps loading for a complex resubmission on a reused job', async () => {
+        const resubmissionFixture = await setupBaseFixture()
+        const oldJobCreatedAt = new Date(Date.now() - 10 * 60_000)
+        const resubmittedAt = new Date()
+
+        await db
+            .updateTable('studyJob')
+            .set({ createdAt: oldJobCreatedAt })
+            .where('id', '=', resubmissionFixture.job.id)
+            .execute()
+        await db
+            .insertInto('jobStatusChange')
+            .values([
+                {
+                    studyJobId: resubmissionFixture.job.id,
+                    status: 'CODE-CHANGES-REQUESTED',
+                    createdAt: new Date(resubmittedAt.getTime() - 1_000),
+                },
+                { studyJobId: resubmissionFixture.job.id, status: 'CODE-SUBMITTED', createdAt: resubmittedAt },
+            ])
+            .execute()
+
+        await renderSection(await refreshFixtureJob(resubmissionFixture))
+
+        expect(await screen.findByTestId('ai-summary-pending')).toHaveTextContent('AI Summary is loading')
+        expect(screen.queryByTestId('ai-summary-error')).not.toBeInTheDocument()
+    })
+
     it('surfaces the error + retry state immediately when a failed review row exists', async () => {
         const failedFixture = await setupBaseFixture()
         await insertFailedStudyReview(failedFixture.job.id)
@@ -254,7 +282,7 @@ describe('SubmittedCodeSection — AI summary', () => {
             <AiSummaryCollapsible
                 studyJobId={failedFixture.job.id}
                 initialReview={initialReview}
-                submittedAt={failedFixture.job.createdAt}
+                submittedAt={new Date(Date.now() - 10 * 60_000)}
             />,
         )
 
@@ -275,15 +303,15 @@ describe('SubmittedCodeSection — AI summary', () => {
             <AiSummaryCollapsible
                 studyJobId={failedFixture.job.id}
                 initialReview={initialReview}
-                submittedAt={failedFixture.job.createdAt}
+                submittedAt={new Date(Date.now() - 10 * 60_000)}
             />,
         )
 
         const user = userEvent.setup()
         await user.click(await screen.findByTestId('ai-summary-retry'))
 
-        // The action deletes the failed row and re-fires generation; the panel
-        // resets to the pending spinner while it polls for the new result.
+        // A retry is a new generation request, so it resets an already-elapsed
+        // backstop and returns to pending while the new result is polled.
         await waitFor(() => expect(screen.getByTestId('ai-summary-pending')).toBeInTheDocument())
         const remaining = await getStudyReviewForJob(failedFixture.job.id)
         expect(remaining?.summaryFailedAt ?? null).toBeNull()

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
@@ -278,8 +278,8 @@ describe('SubmittedCodeSection — AI summary', () => {
     // latestCodeSubmittedAt's own unit tests only exercise a hand-built statusChanges
     // array. This drives the same shape through the real query (latestJobForStudy's
     // jsonArrayFrom + orderBy) with two full resubmission rounds on one reused job, so
-    // a regression in the ORDER BY (e.g. losing the `id desc` tiebreak) would surface
-    // here even though every row shares no obvious natural order otherwise.
+    // a regression that dropped the latest CODE-SUBMITTED (e.g. picking the original
+    // createdAt instead) would surface here through the real serialized payload.
     it('keeps loading across two resubmission rounds on the same reused job', async () => {
         const resubmissionFixture = await setupBaseFixture()
         const day = 24 * 60 * 60 * 1000
@@ -302,7 +302,7 @@ describe('SubmittedCodeSection — AI summary', () => {
             .execute()
 
         const job = await latestJobForStudy(resubmissionFixture.study.id)
-        expect(latestCodeSubmittedAt(job)).not.toBe(originalSubmittedAt)
+        expect(new Date(latestCodeSubmittedAt(job)).getTime()).toBe(statuses[3].createdAt.getTime())
 
         await renderSection(await refreshFixtureJob(resubmissionFixture))
 
@@ -314,11 +314,13 @@ describe('SubmittedCodeSection — AI summary', () => {
         const failedFixture = await setupBaseFixture()
         await insertFailedStudyReview(failedFixture.job.id)
         const initialReview = await getStudyReviewForJob(failedFixture.job.id)
+        // Anchor submittedAt to now so the backstop has *not* elapsed: the error
+        // can then only come from the persisted failure row, not from `timedOut`.
         renderWithProviders(
             <AiSummaryCollapsible
                 studyJobId={failedFixture.job.id}
                 initialReview={initialReview}
-                submittedAt={new Date(Date.now() - 10 * 60_000)}
+                submittedAt={new Date()}
             />,
         )
 
@@ -727,6 +729,20 @@ describe('SubmittedCodeSection — pure helpers', () => {
                 { status: 'CODE-SUBMITTED' as const, createdAt: recent },
                 { status: 'CODE-CHANGES-REQUESTED' as const, createdAt: '2026-06-01T00:00:00.000Z' },
                 { status: 'CODE-SUBMITTED' as const, createdAt: old },
+            ],
+        }
+        expect(latestCodeSubmittedAt(job)).toBe(recent)
+    })
+
+    it('latestCodeSubmittedAt picks the newest even when the array is not desc-ordered', () => {
+        const old = '2026-01-01T00:00:00.000Z'
+        const recent = '2026-07-10T00:00:00.000Z'
+        const job = {
+            createdAt: new Date(old),
+            statusChanges: [
+                { status: 'CODE-SUBMITTED' as const, createdAt: old },
+                { status: 'CODE-CHANGES-REQUESTED' as const, createdAt: '2026-06-01T00:00:00.000Z' },
+                { status: 'CODE-SUBMITTED' as const, createdAt: recent },
             ],
         }
         expect(latestCodeSubmittedAt(job)).toBe(recent)

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
@@ -22,7 +22,7 @@ import {
     latestJobForStudy,
     type LatestJobForStudy,
 } from '@/server/db/queries'
-import { SubmittedCodeSection } from './submitted-code-section'
+import { SubmittedCodeSection, latestCodeSubmittedAt } from './submitted-code-section'
 import { AiSummaryCollapsible, splitVisibleFiles, truncateFileName } from './submitted-code-interactive'
 
 vi.mock('@/server/storage', async () => {
@@ -658,5 +658,41 @@ describe('SubmittedCodeSection — pure helpers', () => {
         expect(visible.map((f) => f.name)).toEqual(['m', 'a', 'b'])
         expect(hidden.map((f) => f.name)).toEqual(['c', 'd', 'e'])
         expect(hiddenCount).toBe(3)
+    })
+
+    it('latestCodeSubmittedAt returns the CODE-SUBMITTED event timestamp when present', () => {
+        const createdAt = new Date('2026-01-01')
+        const resubmittedAt = '2026-07-10T00:00:00.000Z'
+        const job = {
+            createdAt,
+            statusChanges: [
+                { status: 'CODE-SUBMITTED' as const, createdAt: resubmittedAt },
+                { status: 'CODE-CHANGES-REQUESTED' as const, createdAt: '2026-07-09T00:00:00.000Z' },
+            ],
+        }
+        expect(latestCodeSubmittedAt(job)).toBe(resubmittedAt)
+    })
+
+    it('latestCodeSubmittedAt falls back to createdAt when no CODE-SUBMITTED event exists', () => {
+        const createdAt = new Date('2026-01-01')
+        const job = {
+            createdAt,
+            statusChanges: [{ status: 'INITIATED' as const, createdAt: createdAt.toISOString() }],
+        }
+        expect(latestCodeSubmittedAt(job)).toBe(createdAt)
+    })
+
+    it('latestCodeSubmittedAt uses the newest CODE-SUBMITTED event (array is desc-ordered)', () => {
+        const old = '2026-01-01T00:00:00.000Z'
+        const recent = '2026-07-10T00:00:00.000Z'
+        const job = {
+            createdAt: new Date(old),
+            statusChanges: [
+                { status: 'CODE-SUBMITTED' as const, createdAt: recent },
+                { status: 'CODE-CHANGES-REQUESTED' as const, createdAt: '2026-06-01T00:00:00.000Z' },
+                { status: 'CODE-SUBMITTED' as const, createdAt: old },
+            ],
+        }
+        expect(latestCodeSubmittedAt(job)).toBe(recent)
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
@@ -1,4 +1,5 @@
 import { getStudyAction, type SelectedStudy } from '@/server/actions/study.actions'
+import type { StudyJobStatus } from '@/database/types'
 import {
     actionResult,
     db,
@@ -267,6 +268,41 @@ describe('SubmittedCodeSection — AI summary', () => {
                 { studyJobId: resubmissionFixture.job.id, status: 'CODE-SUBMITTED', createdAt: resubmittedAt },
             ])
             .execute()
+
+        await renderSection(await refreshFixtureJob(resubmissionFixture))
+
+        expect(await screen.findByTestId('ai-summary-pending')).toHaveTextContent('AI Summary is loading')
+        expect(screen.queryByTestId('ai-summary-error')).not.toBeInTheDocument()
+    })
+
+    // latestCodeSubmittedAt's own unit tests only exercise a hand-built statusChanges
+    // array. This drives the same shape through the real query (latestJobForStudy's
+    // jsonArrayFrom + orderBy) with two full resubmission rounds on one reused job, so
+    // a regression in the ORDER BY (e.g. losing the `id desc` tiebreak) would surface
+    // here even though every row shares no obvious natural order otherwise.
+    it('keeps loading across two resubmission rounds on the same reused job', async () => {
+        const resubmissionFixture = await setupBaseFixture()
+        const day = 24 * 60 * 60 * 1000
+        const originalSubmittedAt = new Date(Date.now() - 5 * day)
+
+        await db
+            .updateTable('studyJob')
+            .set({ createdAt: originalSubmittedAt })
+            .where('id', '=', resubmissionFixture.job.id)
+            .execute()
+        const statuses: { status: StudyJobStatus; createdAt: Date }[] = [
+            { status: 'CODE-CHANGES-REQUESTED', createdAt: new Date(Date.now() - 4 * day) },
+            { status: 'CODE-SUBMITTED', createdAt: new Date(Date.now() - 3 * day) },
+            { status: 'CODE-CHANGES-REQUESTED', createdAt: new Date(Date.now() - 2 * day) },
+            { status: 'CODE-SUBMITTED', createdAt: new Date() },
+        ]
+        await db
+            .insertInto('jobStatusChange')
+            .values(statuses.map((change) => ({ ...change, studyJobId: resubmissionFixture.job.id })))
+            .execute()
+
+        const job = await latestJobForStudy(resubmissionFixture.study.id)
+        expect(latestCodeSubmittedAt(job)).not.toBe(originalSubmittedAt)
 
         await renderSection(await refreshFixtureJob(resubmissionFixture))
 

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.tsx
@@ -106,7 +106,7 @@ function SecurityScanLog({ scan }: { scan: JobScanResult }) {
 type SubmittedCodeSectionProps = {
     orgSlug: string
     study: SelectedStudy
-    job: Pick<LatestJobForStudy, 'id' | 'files' | 'createdAt'>
+    job: Pick<LatestJobForStudy, 'id' | 'files' | 'createdAt' | 'statusChanges'>
     review: StudyReviewWithMeta | null
     scan: JobScanResult
     codeInitiallyExpanded?: boolean
@@ -126,6 +126,10 @@ export function SubmittedCodeSection({
     const datasetNames = study.orgDataSources.map((ds) => ds.name)
     const proposalHref = Routes.studyReviewProposal({ orgSlug, studyId: study.id })
     const codeFiles = filterAndOrderCodeFiles(job.files)
+    // A complex resubmission reuses its study job, so createdAt can predate the
+    // generation request by days. The latest CODE-SUBMITTED event is the only
+    // timestamp that accurately anchors the summary-generation timeout.
+    const submittedAt = job.statusChanges.find((change) => change.status === 'CODE-SUBMITTED')?.createdAt ?? job.createdAt
 
     return (
         <Paper p="xxl" data-testid="submitted-code-section">
@@ -140,7 +144,7 @@ export function SubmittedCodeSection({
                             <AiSummaryCollapsible
                                 studyJobId={job.id}
                                 initialReview={review}
-                                submittedAt={job.createdAt}
+                                submittedAt={submittedAt}
                             />
                         </Paper>
                         <Paper withBorder p="lg" radius={0}>

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.tsx
@@ -112,6 +112,14 @@ type SubmittedCodeSectionProps = {
     codeInitiallyExpanded?: boolean
 }
 
+// A complex resubmission reuses its study job, so createdAt can predate the
+// generation request by days. The latest CODE-SUBMITTED event is the only
+// timestamp that accurately anchors the summary-generation timeout (and the
+// "Submitted/Resubmitted on" header label).
+export function latestCodeSubmittedAt(job: Pick<LatestJobForStudy, 'createdAt' | 'statusChanges'>): Date | string {
+    return job.statusChanges.find((change) => change.status === 'CODE-SUBMITTED')?.createdAt ?? job.createdAt
+}
+
 // Data fetching lives in the parent (CodeReview) so this component
 // stays a plain sync function. Nested async server components don't render
 // under testing-library / happy-dom — the parent's await is what tests rely on.
@@ -126,11 +134,7 @@ export function SubmittedCodeSection({
     const datasetNames = study.orgDataSources.map((ds) => ds.name)
     const proposalHref = Routes.studyReviewProposal({ orgSlug, studyId: study.id })
     const codeFiles = filterAndOrderCodeFiles(job.files)
-    // A complex resubmission reuses its study job, so createdAt can predate the
-    // generation request by days. The latest CODE-SUBMITTED event is the only
-    // timestamp that accurately anchors the summary-generation timeout.
-    const submittedAt =
-        job.statusChanges.find((change) => change.status === 'CODE-SUBMITTED')?.createdAt ?? job.createdAt
+    const submittedAt = latestCodeSubmittedAt(job)
 
     return (
         <Paper p="xxl" data-testid="submitted-code-section">

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.tsx
@@ -129,7 +129,8 @@ export function SubmittedCodeSection({
     // A complex resubmission reuses its study job, so createdAt can predate the
     // generation request by days. The latest CODE-SUBMITTED event is the only
     // timestamp that accurately anchors the summary-generation timeout.
-    const submittedAt = job.statusChanges.find((change) => change.status === 'CODE-SUBMITTED')?.createdAt ?? job.createdAt
+    const submittedAt =
+        job.statusChanges.find((change) => change.status === 'CODE-SUBMITTED')?.createdAt ?? job.createdAt
 
     return (
         <Paper p="xxl" data-testid="submitted-code-section">

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.tsx
@@ -115,9 +115,15 @@ type SubmittedCodeSectionProps = {
 // A complex resubmission reuses its study job, so createdAt can predate the
 // generation request by days. The latest CODE-SUBMITTED event is the only
 // timestamp that accurately anchors the summary-generation timeout (and the
-// "Submitted/Resubmitted on" header label).
+// "Submitted/Resubmitted on" header label). We scan for the max createdAt rather
+// than relying on statusChanges arriving in any particular order, so a caller
+// passing an unsorted array still gets the newest submission back.
 export function latestCodeSubmittedAt(job: Pick<LatestJobForStudy, 'createdAt' | 'statusChanges'>): Date | string {
-    return job.statusChanges.find((change) => change.status === 'CODE-SUBMITTED')?.createdAt ?? job.createdAt
+    const submissions = job.statusChanges.filter((change) => change.status === 'CODE-SUBMITTED')
+    if (submissions.length === 0) return job.createdAt
+    return submissions.reduce((latest, change) =>
+        new Date(change.createdAt).getTime() > new Date(latest.createdAt).getTime() ? change : latest,
+    ).createdAt
 }
 
 // Data fetching lives in the parent (CodeReview) so this component


### PR DESCRIPTION
see [OTTER-644](https://openstax.atlassian.net/browse/OTTER-644)

- Fixed the AI summary panel showing an error immediately on complex resubmissions by anchoring the generation timeout to the latest code-submitted event instead of the original job creation date
- Added a reset on retry so the timeout backstop restarts its clock when a reviewer retries a failed AI summary, showing the spinner instead of a stale error
- Fixed the "Submitted on / Resubmitted on" header timestamp on the code review page to also use the latest submission event, so reused jobs show the correct date
- Extracted the submission-timestamp lookup into a shared helper used by both the AI summary panel and the code review header
- Added unit tests covering the resubmission loading state, the retry-reset behavior, and the shared helper's edge cases

[OTTER-644]: https://openstax.atlassian.net/browse/OTTER-644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ