### PR TITLE
OTTER-637: fix UI inconsistencies

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/edit-initial-request-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/edit-initial-request-section.tsx
@@ -66,8 +66,11 @@ export const EditInitialRequestSection: FC<EditInitialRequestSectionProps> = ({
             <Paper p="xxl">
                 <Stack gap="xxl">
                     <Box>
-                        <Title order={4} c="charcoal.9">
-                            Edit Initial Request
+                        <Text fz={10} fw={700} c="charcoal.7" pb={4}>
+                            STEP 2
+                        </Text>
+                        <Title fz={20} order={4} c="charcoal.9">
+                            Edit proposal
                         </Title>
                         <Divider my="md" />
                         <Text>

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/edit-initial-request-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/edit-initial-request-section.tsx
@@ -70,16 +70,18 @@ export const EditInitialRequestSection: FC<EditInitialRequestSectionProps> = ({
                             Edit Initial Request
                         </Title>
                         <Divider my="md" />
-                        <Text mb="xl">
-                            Use this form to revise your study proposal in response to {orgName}. Auto-saving keeps your
-                            progress while you work.
+                        <Text>
+                            Use this form to submit your proposal. The information you share will help {orgName} assess
+                            the feasibility, scientific value, and potential impact of your proposed research on
+                            instructional practice. On review, they may approve or decline the request.
                         </Text>
                     </Box>
 
                     <Box>
                         <FormFieldLabel label="Study title" required inputId="title" />
                         <Text size="xs" c="charcoal.7" mb="xs">
-                            Give your study a short, clear title.
+                            Give your study a short, clear title. This will help identify and reference your project on
+                            SafeInsights.
                         </Text>
                         <TextInput
                             id="title"
@@ -102,7 +104,8 @@ export const EditInitialRequestSection: FC<EditInitialRequestSectionProps> = ({
                     <Box>
                         <FormFieldLabel label="Dataset(s) of interest" required inputId="datasets" />
                         <Text size="xs" mb="xs" c="charcoal.7">
-                            Select the dataset(s) you’d like to use for your research.
+                            Select the dataset(s) you’d like to use for your research. You’ll find options based on the
+                            selected Data Partner in Step 1 and its data availability.
                         </Text>
                         <Group align="center" gap="xxl">
                             <Box w="50%">


### PR DESCRIPTION
see [OTTER-637](https://openstax.atlassian.net/browse/OTTER-637)

- Updated the page description to explain how the Data Partner evaluates the proposal and what outcomes to expect.
- Added clearer helper text under the study title and dataset fields to guide researchers.
- Adjusted the spacing between the page description and the study title to match the design spec.
- Added a "STEP 2" label and changed the section heading to "Edit proposal" so the page aligns with the rest of the researcher flow.

[OTTER-637]: https://openstax.atlassian.net/browse/OTTER-637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ