### PR TITLE
OTTER-649: rework security scan log display (per-tool status + download)

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
@@ -366,57 +366,76 @@ describe('SubmittedCodeSection — AI summary', () => {
 
 describe('SubmittedCodeSection — Security scan log', () => {
     // These tests render the component with a known `scan` value passed directly,
-    // rather than going through `jobScanResultForJob`. The query's own behavior
-    // is covered by queries.test.ts; here we only care that the component
-    // renders the right icon/body for each scan status. Mocking the underlying
-    // `fetchFileContents` import was tried but the storage module ends up
-    // loaded twice in this test's graph, so `vi.mock` only catches one copy.
-    const scanWithStatus = (status: JobScanResult['status']): JobScanResult => ({
-        status,
-        logFile: { id: 'scan-log-id', name: 'security-scan.log', path: 'studies/x/security-scan.log' },
+    // rather than going through `jobScanResultForJob`. The query's own parsing is
+    // covered by queries.test.ts; here we only care that the component renders the
+    // right per-tool status text, warning icon, and download affordance.
+    const scanResult = (trivy: JobScanResult['trivy'], sonarqube: JobScanResult['sonarqube']): JobScanResult => ({
+        trivy,
+        sonarqube,
+        logFile: { id: 'scan-log-id', name: 'security-scan-log.txt', path: 'studies/x/security-scan-log.txt' },
     })
 
-    const scanWithoutLogFile: JobScanResult = { status: 'IN-PROGRESS', logFile: null }
+    const scanInProgress: JobScanResult = { trivy: null, sonarqube: null, logFile: null }
 
-    it('renders section title "Security scan log"', async () => {
+    it('renders section title "Security scan log" with no status icon in the title', async () => {
         const fixture = await setupBaseFixture()
-        await renderSection(fixture, scanWithoutLogFile)
+        await renderSection(fixture, scanResult('PASSED', 'PASSED'))
         expect(screen.getByTestId('security-scan-log')).toHaveTextContent('Security scan log')
     })
 
-    it('renders the scan log file name when a log is attached', async () => {
+    it('renders both static tool labels in order', async () => {
         const fixture = await setupBaseFixture()
-        await renderSection(fixture, scanWithStatus('PASSED'))
-        expect(screen.getByTestId('security-scan-log-file')).toHaveTextContent('security-scan.log')
+        await renderSection(fixture, scanResult('PASSED', 'PASSED'))
+        expect(screen.getByTestId('security-scan-trivy')).toHaveTextContent('Trivy Filesystem Scan:')
+        expect(screen.getByTestId('security-scan-sonarqube')).toHaveTextContent('SonarQube Quality Gate:')
     })
 
-    it('shows an in-progress indicator when no scan log exists yet', async () => {
+    it('shows Trivy "No vulnerabilities found" with no warning icon when it passed', async () => {
         const fixture = await setupBaseFixture()
-        await renderSection(fixture, scanWithoutLogFile)
+        await renderSection(fixture, scanResult('PASSED', 'PASSED'))
+        const row = screen.getByTestId('security-scan-trivy')
+        expect(row).toHaveTextContent('No vulnerabilities found')
+        expect(row.querySelector('[data-icon="warning"]')).toBeNull()
+    })
+
+    it('shows Trivy "Vulnerabilities found" with a warning icon when it failed', async () => {
+        const fixture = await setupBaseFixture()
+        await renderSection(fixture, scanResult('FAILED', 'PASSED'))
+        const row = screen.getByTestId('security-scan-trivy')
+        expect(row).toHaveTextContent('Vulnerabilities found')
+        expect(row.querySelector('[data-icon="warning"]')).not.toBeNull()
+    })
+
+    it('shows SonarQube "Passed" with no warning icon when it passed', async () => {
+        const fixture = await setupBaseFixture()
+        await renderSection(fixture, scanResult('PASSED', 'PASSED'))
+        const row = screen.getByTestId('security-scan-sonarqube')
+        expect(row).toHaveTextContent('Passed')
+        expect(row.querySelector('[data-icon="warning"]')).toBeNull()
+    })
+
+    it('shows SonarQube "Needs review" with a warning icon when it failed', async () => {
+        const fixture = await setupBaseFixture()
+        await renderSection(fixture, scanResult('PASSED', 'FAILED'))
+        const row = screen.getByTestId('security-scan-sonarqube')
+        expect(row).toHaveTextContent('Needs review')
+        expect(row.querySelector('[data-icon="warning"]')).not.toBeNull()
+    })
+
+    it('shows a download link to the plaintext scan log when a log file is present', async () => {
+        const fixture = await setupBaseFixture()
+        await renderSection(fixture, scanResult('PASSED', 'PASSED'))
+        const link = screen.getByTestId('security-scan-log-download')
+        expect(link).toHaveTextContent('Download')
+        expect(link).toHaveAttribute('href', `/dl/scan-log/${fixture.job.id}`)
+    })
+
+    it('shows an in-progress indicator and no download link when no scan log exists yet', async () => {
+        const fixture = await setupBaseFixture()
+        await renderSection(fixture, scanInProgress)
         expect(screen.getByTestId('security-scan-log-pending')).toHaveTextContent('Scan in progress')
-        const icon = screen.getByTestId('security-scan-log').querySelector('[data-icon]')
-        expect(icon?.getAttribute('data-icon')).toBe('in-progress')
-    })
-
-    it("displays a green icon when the log contents contain 'OK'", async () => {
-        const fixture = await setupBaseFixture()
-        await renderSection(fixture, scanWithStatus('PASSED'))
-        const icon = screen.getByTestId('security-scan-log').querySelector('[data-icon]')
-        expect(icon?.getAttribute('data-icon')).toBe('pass')
-    })
-
-    it("displays a red icon when the log contents do not contain 'OK'", async () => {
-        const fixture = await setupBaseFixture()
-        await renderSection(fixture, scanWithStatus('FAILED'))
-        const icon = screen.getByTestId('security-scan-log').querySelector('[data-icon]')
-        expect(icon?.getAttribute('data-icon')).toBe('fail')
-    })
-
-    it('falls back to in-progress when the log file is unreadable', async () => {
-        const fixture = await setupBaseFixture()
-        await renderSection(fixture, scanWithStatus('IN-PROGRESS'))
-        const icon = screen.getByTestId('security-scan-log').querySelector('[data-icon]')
-        expect(icon?.getAttribute('data-icon')).toBe('in-progress')
+        expect(screen.queryByTestId('security-scan-log-download')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('security-scan-trivy')).not.toBeInTheDocument()
     })
 })
 

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
@@ -430,12 +430,19 @@ describe('SubmittedCodeSection — Security scan log', () => {
         expect(link).toHaveAttribute('href', `/dl/scan-log/${fixture.job.id}`)
     })
 
-    it('shows an in-progress indicator and no download link when no scan log exists yet', async () => {
+    it('keeps both labeled rows in a pending state, with no icon or download, when no scan log exists yet', async () => {
         const fixture = await setupBaseFixture()
         await renderSection(fixture, scanInProgress)
-        expect(screen.getByTestId('security-scan-log-pending')).toHaveTextContent('Scan in progress')
+        const trivy = screen.getByTestId('security-scan-trivy')
+        const sonar = screen.getByTestId('security-scan-sonarqube')
+        expect(trivy).toHaveTextContent('Trivy Filesystem Scan:')
+        expect(trivy).toHaveTextContent('Scan in progress')
+        expect(sonar).toHaveTextContent('SonarQube Quality Gate:')
+        expect(sonar).toHaveTextContent('Scan in progress')
+        // No fabricated pass/fail while the status is unknown.
+        expect(trivy.querySelector('[data-icon="warning"]')).toBeNull()
+        expect(sonar.querySelector('[data-icon="warning"]')).toBeNull()
         expect(screen.queryByTestId('security-scan-log-download')).not.toBeInTheDocument()
-        expect(screen.queryByTestId('security-scan-trivy')).not.toBeInTheDocument()
     })
 })
 

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.tsx
@@ -1,7 +1,8 @@
 import { Anchor, Divider, Group, Paper, Pill, Stack, Text, Title } from '@mantine/core'
-import { ArrowSquareOut, CheckCircle, CircleNotch, XCircle } from '@phosphor-icons/react/dist/ssr'
+import { ArrowSquareOut, DownloadSimple, WarningCircle } from '@phosphor-icons/react/dist/ssr'
 import { Routes } from '@/lib/routes'
-import type { JobScanResult, JobScanStatus, LatestJobForStudy, StudyReviewWithMeta } from '@/server/db/queries'
+import { scanLogDownloadURL } from '@/lib/paths'
+import type { JobScanResult, ScanToolStatus, LatestJobForStudy, StudyReviewWithMeta } from '@/server/db/queries'
 import type { SelectedStudy } from '@/server/actions/study.actions'
 import { AiSummaryCollapsible, StudyCodeViewer } from './submitted-code-interactive'
 import { filterAndOrderCodeFiles } from './study-code-files'
@@ -49,35 +50,57 @@ function DatasetPills({ names }: { names: string[] }) {
     )
 }
 
-function ScanStatusIcon({ status }: { status: JobScanStatus }) {
-    if (status === 'PASSED') {
-        return (
-            <CheckCircle
-                size={20}
-                weight="fill"
-                color="var(--mantine-color-green-6)"
-                data-icon="pass"
-                aria-hidden="true"
-            />
-        )
-    }
-    if (status === 'FAILED') {
-        return (
-            <XCircle size={20} weight="fill" color="var(--mantine-color-red-6)" data-icon="fail" aria-hidden="true" />
-        )
-    }
-    return <CircleNotch size={20} color="var(--mantine-color-charcoal-6)" data-icon="in-progress" aria-hidden="true" />
+type ScanRowProps = {
+    label: string
+    status: ScanToolStatus | null
+    passedLabel: string
+    failedLabel: string
+    testId: string
+}
+
+function ScanWarningIcon({ isVisible }: { isVisible: boolean }) {
+    if (!isVisible) return null
+    return <WarningCircle size={20} color="var(--mantine-color-red-9)" data-icon="warning" aria-hidden="true" />
+}
+
+// A tool's result: plain text when it passed, otherwise a warning icon paired
+// with the failure phrasing. Deliberately no "pass" icon — we only flag the
+// results that need a human to look (OTTER-649).
+function ScanRow({ label, status, passedLabel, failedLabel, testId }: ScanRowProps) {
+    const passed = status === 'PASSED'
+    return (
+        <Group gap="xs" wrap="nowrap" align="center" data-testid={testId}>
+            <Text size="sm">{label}</Text>
+            <Group gap={4} wrap="nowrap" align="center">
+                <ScanWarningIcon isVisible={!passed} />
+                <Text size="sm" fw={600}>
+                    {passed ? passedLabel : failedLabel}
+                </Text>
+            </Group>
+        </Group>
+    )
+}
+
+function ScanLogDownload({ jobId, isVisible }: { jobId: string; isVisible: boolean }) {
+    if (!isVisible) return null
+    return (
+        <Anchor
+            href={scanLogDownloadURL(jobId)}
+            download
+            size="sm"
+            fw={600}
+            display="inline-flex"
+            style={{ alignItems: 'center', gap: 4, width: 'fit-content' }}
+            data-testid="security-scan-log-download"
+        >
+            <DownloadSimple size={16} />
+            Download
+        </Anchor>
+    )
 }
 
 function ScanLogBody({ scan }: { scan: JobScanResult }) {
-    if (scan.logFile) {
-        return (
-            <Text size="sm" data-testid="security-scan-log-file">
-                Scan log: {scan.logFile.name}
-            </Text>
-        )
-    }
-    if (scan.status === 'IN-PROGRESS') {
+    if (!scan.logFile) {
         return (
             <Text size="sm" c="dimmed" data-testid="security-scan-log-pending">
                 Scan in progress…
@@ -85,20 +108,33 @@ function ScanLogBody({ scan }: { scan: JobScanResult }) {
         )
     }
     return (
-        <Text size="sm" c="dimmed" data-testid="security-scan-log-empty">
-            No scan log available.
-        </Text>
+        <Stack gap="sm">
+            <ScanRow
+                label="Trivy Filesystem Scan:"
+                status={scan.trivy}
+                passedLabel="No vulnerabilities found"
+                failedLabel="Vulnerabilities found"
+                testId="security-scan-trivy"
+            />
+            <ScanRow
+                label="SonarQube Quality Gate:"
+                status={scan.sonarqube}
+                passedLabel="Passed"
+                failedLabel="Needs review"
+                testId="security-scan-sonarqube"
+            />
+        </Stack>
     )
 }
 
-function SecurityScanLog({ scan }: { scan: JobScanResult }) {
+function SecurityScanLog({ scan, jobId }: { scan: JobScanResult; jobId: string }) {
     return (
-        <Stack gap="xs" data-testid="security-scan-log">
-            <Group gap="xs" wrap="nowrap">
-                <Text fw={700}>Security scan log</Text>
-                <ScanStatusIcon status={scan.status} />
-            </Group>
+        <Stack gap="lg" data-testid="security-scan-log">
+            <Text fw={700} fz={16}>
+                Security scan log
+            </Text>
             <ScanLogBody scan={scan} />
+            <ScanLogDownload jobId={jobId} isVisible={scan.logFile != null} />
         </Stack>
     )
 }
@@ -144,7 +180,7 @@ export function SubmittedCodeSection({
                             />
                         </Paper>
                         <Paper withBorder p="lg" radius={0}>
-                            <SecurityScanLog scan={scan} />
+                            <SecurityScanLog scan={scan} jobId={job.id} />
                         </Paper>
                     </Group>
                     <Divider />

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.tsx
@@ -64,7 +64,7 @@ function ScanWarningIcon({ isVisible }: { isVisible: boolean }) {
 }
 
 // A tool's result: plain text when it passed, otherwise a warning icon paired
-// with the failure phrasing. Deliberately no "pass" icon — we only flag the
+// with the failure phrasing. Deliberately no "pass" icon; we only flag the
 // results that need a human to look (OTTER-649).
 function ScanRow({ label, status, passedLabel, failedLabel, testId }: ScanRowProps) {
     const passed = status === 'PASSED'

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.tsx
@@ -63,20 +63,42 @@ function ScanWarningIcon({ isVisible }: { isVisible: boolean }) {
     return <WarningCircle size={20} color="var(--mantine-color-red-9)" data-icon="warning" aria-hidden="true" />
 }
 
-// A tool's result: plain text when it passed, otherwise a warning icon paired
-// with the failure phrasing. Deliberately no "pass" icon; we only flag the
-// results that need a human to look (OTTER-649).
-function ScanRow({ label, status, passedLabel, failedLabel, testId }: ScanRowProps) {
+// A tool's result: plain text when it passed, a warning icon plus the failure
+// phrasing when it failed, and a neutral pending note while the scan has not
+// reported (status null). Deliberately no "pass" icon, and never a fabricated
+// pass/fail when the status is unknown; we only flag what needs a human (OTTER-649).
+function ScanRowValue({
+    status,
+    passedLabel,
+    failedLabel,
+}: {
+    status: ScanToolStatus | null
+    passedLabel: string
+    failedLabel: string
+}) {
+    if (status === null) {
+        return (
+            <Text size="sm" c="dimmed">
+                Scan in progress…
+            </Text>
+        )
+    }
     const passed = status === 'PASSED'
+    return (
+        <Group gap={4} wrap="nowrap" align="center">
+            <ScanWarningIcon isVisible={!passed} />
+            <Text size="sm" fw={600}>
+                {passed ? passedLabel : failedLabel}
+            </Text>
+        </Group>
+    )
+}
+
+function ScanRow({ label, status, passedLabel, failedLabel, testId }: ScanRowProps) {
     return (
         <Group gap="xs" wrap="nowrap" align="center" data-testid={testId}>
             <Text size="sm">{label}</Text>
-            <Group gap={4} wrap="nowrap" align="center">
-                <ScanWarningIcon isVisible={!passed} />
-                <Text size="sm" fw={600}>
-                    {passed ? passedLabel : failedLabel}
-                </Text>
-            </Group>
+            <ScanRowValue status={status} passedLabel={passedLabel} failedLabel={failedLabel} />
         </Group>
     )
 }
@@ -99,14 +121,10 @@ function ScanLogDownload({ jobId, isVisible }: { jobId: string; isVisible: boole
     )
 }
 
+// The two labeled rows are always shown (the AC lists them as static elements).
+// Their values come from the parsed log; when no log has been read yet, each row
+// shows a pending note rather than a status.
 function ScanLogBody({ scan }: { scan: JobScanResult }) {
-    if (!scan.logFile) {
-        return (
-            <Text size="sm" c="dimmed" data-testid="security-scan-log-pending">
-                Scan in progress…
-            </Text>
-        )
-    }
     return (
         <Stack gap="sm">
             <ScanRow

--- a/src/app/dl/scan-log/[jobId]/route.test.ts
+++ b/src/app/dl/scan-log/[jobId]/route.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+import * as apiHandler from './route'
+import { db } from '@/database'
+import { insertTestStudyJobData, mockSessionWithTestData } from '@/tests/unit.helpers'
+
+// The route only reads the DB row for the file path; stub the signed-URL helper so
+// the redirect case doesn't need S3.
+vi.mock('@/server/storage', async () => {
+    const actual = await vi.importActual<typeof import('@/server/storage')>('@/server/storage')
+    return { ...actual, urlForFile: vi.fn(async () => 'https://signed.example/security-scan-log.txt') }
+})
+
+function request() {
+    return new Request('http://localhost/dl/scan-log/x', { method: 'GET' })
+}
+
+async function insertScanLog(studyJobId: string) {
+    await db
+        .insertInto('studyJobFile')
+        .values({
+            studyJobId,
+            name: 'security-scan-log.txt',
+            path: `studies/x/jobs/${studyJobId}/results/security-scan-log.txt`,
+            fileType: 'SECURITY-SCAN-LOG',
+        })
+        .execute()
+}
+
+describe('GET /dl/scan-log/[jobId]', () => {
+    it('returns 404 when the job has no plaintext scan log', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+        const { job } = await insertTestStudyJobData({ org, researcherId: user.id })
+
+        const resp = await apiHandler.GET(request(), { params: Promise.resolve({ jobId: job.id }) })
+
+        expect(resp.status).toBe(404)
+    })
+
+    it('returns 401 when the requester cannot view the job (different org)', async () => {
+        // Job is created under its own org; the session below belongs to a different org.
+        const { job } = await insertTestStudyJobData()
+        await insertScanLog(job.id)
+
+        await mockSessionWithTestData({ orgType: 'enclave' })
+
+        const resp = await apiHandler.GET(request(), { params: Promise.resolve({ jobId: job.id }) })
+
+        expect(resp.status).toBe(401)
+    })
+
+    it('redirects to the signed URL when the log exists and the user can view it', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+        const { job } = await insertTestStudyJobData({ org, researcherId: user.id })
+        await insertScanLog(job.id)
+
+        const resp = await apiHandler.GET(request(), { params: Promise.resolve({ jobId: job.id }) })
+
+        expect(resp.status).toBe(307)
+        expect(resp.headers.get('location')).toBe('https://signed.example/security-scan-log.txt')
+    })
+})

--- a/src/app/dl/scan-log/[jobId]/route.test.ts
+++ b/src/app/dl/scan-log/[jobId]/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import * as apiHandler from './route'
 import { db } from '@/database'
-import { insertTestStudyJobData, mockSessionWithTestData } from '@/tests/unit.helpers'
+import { BLANK_UUID, insertTestStudyJobData, mockSessionWithTestData } from '@/tests/unit.helpers'
 
 // The route only reads the DB row for the file path; stub the signed-URL helper so
 // the redirect case doesn't need S3.
@@ -34,6 +34,14 @@ describe('GET /dl/scan-log/[jobId]', () => {
         const resp = await apiHandler.GET(request(), { params: Promise.resolve({ jobId: job.id }) })
 
         expect(resp.status).toBe(404)
+    })
+
+    it('returns 401 (not 404) for an unknown job, so job existence is not disclosed', async () => {
+        await mockSessionWithTestData({ orgType: 'enclave' })
+
+        const resp = await apiHandler.GET(request(), { params: Promise.resolve({ jobId: BLANK_UUID }) })
+
+        expect(resp.status).toBe(401)
     })
 
     it('returns 401 when the requester cannot view the job (different org)', async () => {

--- a/src/app/dl/scan-log/[jobId]/route.test.ts
+++ b/src/app/dl/scan-log/[jobId]/route.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import * as apiHandler from './route'
 import { db } from '@/database'
+import { urlForFile } from '@/server/storage'
 import { BLANK_UUID, insertTestStudyJobData, mockSessionWithTestData } from '@/tests/unit.helpers'
 
 // The route only reads the DB row for the file path; stub the signed-URL helper so
@@ -59,11 +60,35 @@ describe('GET /dl/scan-log/[jobId]', () => {
     it('redirects to the signed URL when the log exists and the user can view it', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
         const { job } = await insertTestStudyJobData({ org, researcherId: user.id })
-        await insertScanLog(job.id)
+        const createdAt = new Date('2026-01-01T00:00:00Z')
+        await db
+            .insertInto('studyJobFile')
+            .values([
+                {
+                    id: '00000000-0000-7000-8000-000000000001',
+                    studyJobId: job.id,
+                    name: 'old-security-scan-log.txt',
+                    path: `studies/x/jobs/${job.id}/results/old-security-scan-log.txt`,
+                    fileType: 'SECURITY-SCAN-LOG',
+                    createdAt,
+                },
+                {
+                    id: '00000000-0000-7000-8000-000000000002',
+                    studyJobId: job.id,
+                    name: 'security-scan-log.txt',
+                    path: `studies/x/jobs/${job.id}/results/security-scan-log.txt`,
+                    fileType: 'SECURITY-SCAN-LOG',
+                    createdAt,
+                },
+            ])
+            .execute()
 
         const resp = await apiHandler.GET(request(), { params: Promise.resolve({ jobId: job.id }) })
 
         expect(resp.status).toBe(307)
         expect(resp.headers.get('location')).toBe('https://signed.example/security-scan-log.txt')
+        expect(vi.mocked(urlForFile)).toHaveBeenCalledWith(`studies/x/jobs/${job.id}/results/security-scan-log.txt`, {
+            ResponseContentDisposition: 'attachment; filename="security-scan-log.txt"',
+        })
     })
 })

--- a/src/app/dl/scan-log/[jobId]/route.ts
+++ b/src/app/dl/scan-log/[jobId]/route.ts
@@ -12,16 +12,19 @@ export const GET = async (_: Request, { params }: { params: Promise<{ jobId: str
         return NextResponse.json({ error: 'no job id provided' }, { status: 400 })
     }
 
+    // Authorize before touching the file, so a denied requester can't infer from a
+    // 404-vs-401 whether another org's job produced a scan log. An unknown job and an
+    // unauthorized one both return 401 rather than disclosing which case applied.
+    const job = await jobInfoForJobId(jobId).catch(() => null)
+
+    if (!job || !(await canViewStudyJob(job))) {
+        return NextResponse.json({ error: 'permission denied' }, { status: 401 })
+    }
+
     const file = await getStudyJobFileOfType(jobId, 'SECURITY-SCAN-LOG', false)
 
     if (!file) {
         return NextResponse.json({ error: 'scan log not found' }, { status: 404 })
-    }
-
-    const job = await jobInfoForJobId(jobId)
-
-    if (!(await canViewStudyJob(job))) {
-        return NextResponse.json({ error: 'permission denied' }, { status: 401 })
     }
 
     const url = await urlForFile(file.path)

--- a/src/app/dl/scan-log/[jobId]/route.ts
+++ b/src/app/dl/scan-log/[jobId]/route.ts
@@ -27,6 +27,11 @@ export const GET = async (_: Request, { params }: { params: Promise<{ jobId: str
         return NextResponse.json({ error: 'scan log not found' }, { status: 404 })
     }
 
-    const url = await urlForFile(file.path)
+    // Pin the download: the anchor's `download` attribute doesn't survive the cross-origin
+    // redirect to S3, so force a Content-Disposition rather than relying on the stored
+    // object's content type (uploads set none today, but that could change).
+    const url = await urlForFile(file.path, {
+        ResponseContentDisposition: 'attachment; filename="security-scan-log.txt"',
+    })
     return NextResponse.redirect(url)
 }

--- a/src/app/dl/scan-log/[jobId]/route.ts
+++ b/src/app/dl/scan-log/[jobId]/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server'
+import { urlForFile } from '@/server/storage'
+import { getStudyJobFileOfType, jobInfoForJobId } from '@/server/db/queries'
+import { canViewStudyJob } from '@/server/auth'
+
+// Serves the plaintext SECURITY-SCAN-LOG .txt for a job. The encrypted zip is
+// intentionally not downloadable here (OTTER-649: ZIPs are not offered).
+export const GET = async (_: Request, { params }: { params: Promise<{ jobId: string }> }) => {
+    const { jobId } = await params
+
+    if (!jobId) {
+        return NextResponse.json({ error: 'no job id provided' }, { status: 400 })
+    }
+
+    const file = await getStudyJobFileOfType(jobId, 'SECURITY-SCAN-LOG', false)
+
+    if (!file) {
+        return NextResponse.json({ error: 'scan log not found' }, { status: 404 })
+    }
+
+    const job = await jobInfoForJobId(jobId)
+
+    if (!(await canViewStudyJob(job))) {
+        return NextResponse.json({ error: 'permission denied' }, { status: 401 })
+    }
+
+    const url = await urlForFile(file.path)
+    return NextResponse.redirect(url)
+}

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -45,6 +45,8 @@ export const studyDocumentURL = (studyId: string, type: StudyDocumentType, fileN
 
 export const studyCodeURL = (jobId: string, fileName: string) => `/dl/study-code/${jobId}/${fileName}`
 
+export const scanLogDownloadURL = (jobId: string) => `/dl/scan-log/${jobId}`
+
 export const coderUserInfoPath = (username: CoderUsername) => `/api/v2/users/${username}`
 export const coderUsersPath = () => `/api/v2/users`
 export const coderOrgsPath = () => `/api/v2/organizations`

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -530,7 +530,7 @@ export function parseSonarqubeStatus(log: string): ScanToolStatus {
 
 // Reads the plaintext SECURITY-SCAN-LOG (not the encrypted zip) and derives a
 // per-tool status from its text. No log row yet, or an unreadable file, is
-// treated as "not reported" — no statuses and no download affordance.
+// treated as "not reported" (no statuses and no download affordance).
 export async function jobScanResultForJob(studyJobId: string): Promise<JobScanResult> {
     const logFile = await Action.db
         .selectFrom('studyJobFile')

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -502,34 +502,53 @@ export type StudyReviewWithMeta = {
     files: { name: string; fileType: FileType }[]
 }
 
-export type JobScanStatus = 'PASSED' | 'FAILED' | 'IN-PROGRESS'
+// Trivy and SonarQube report independently. Per OTTER-649 we cannot say with
+// confidence that a scan "failed"; we only assert PASSED when the log carries an
+// explicit clean signal and otherwise surface the result for human review.
+export type ScanToolStatus = 'PASSED' | 'FAILED'
 
 export type JobScanResult = {
-    status: JobScanStatus
+    // null when the scan hasn't reported yet (no readable plaintext log).
+    trivy: ScanToolStatus | null
+    sonarqube: ScanToolStatus | null
+    // Present only when a downloadable plaintext scan log exists (ZIPs are not offered).
     logFile: { id: string; name: string; path: string } | null
 }
 
-// Per @nathanstitt: there's no clear-cut success/failure signal in the tools, so
-// the first-pass heuristic is to read the scan log and check for 'OK'. If the
-// log row doesn't exist yet (or the file can't be read), treat as in-progress.
+// Trivy passes only on the explicit clean line the scanner emits; anything else
+// (findings, "no results", or an unrecognized log) is flagged for review.
+export function parseTrivyStatus(log: string): ScanToolStatus {
+    return /trivy (?:filesystem|image) scan:\s*no vulnerabilities found/i.test(log) ? 'PASSED' : 'FAILED'
+}
+
+// SonarQube passes only when its quality gate reports OK. Any other gate status,
+// or a missing SonarQube section (skipped/unavailable), needs human review.
+export function parseSonarqubeStatus(log: string): ScanToolStatus {
+    const match = log.match(/sonarqube quality gate:\s*(\S+)/i)
+    return match?.[1]?.toUpperCase() === 'OK' ? 'PASSED' : 'FAILED'
+}
+
+// Reads the plaintext SECURITY-SCAN-LOG (not the encrypted zip) and derives a
+// per-tool status from its text. No log row yet, or an unreadable file, is
+// treated as "not reported" — no statuses and no download affordance.
 export async function jobScanResultForJob(studyJobId: string): Promise<JobScanResult> {
     const logFile = await Action.db
         .selectFrom('studyJobFile')
         .select(['id', 'name', 'path'])
         .where('studyJobId', '=', studyJobId)
-        .where('fileType', '=', 'ENCRYPTED-SECURITY-SCAN-LOG')
+        .where('fileType', '=', 'SECURITY-SCAN-LOG')
         .orderBy('createdAt', 'desc')
         .limit(1)
         .executeTakeFirst()
 
-    if (!logFile) return { status: 'IN-PROGRESS', logFile: null }
+    if (!logFile) return { trivy: null, sonarqube: null, logFile: null }
 
     try {
         const blob = await fetchFileContents(logFile.path)
         const contents = await blob.text()
-        return { status: contents.includes('OK') ? 'PASSED' : 'FAILED', logFile }
+        return { trivy: parseTrivyStatus(contents), sonarqube: parseSonarqubeStatus(contents), logFile }
     } catch {
-        return { status: 'IN-PROGRESS', logFile }
+        return { trivy: null, sonarqube: null, logFile: null }
     }
 }
 

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -374,6 +374,7 @@ export async function getStudyJobFileOfType(
         // A resubmission can leave more than one row of a given type for a job; take the
         // newest so this matches the log the displayed scan statuses were parsed from.
         .orderBy('studyJobFile.createdAt', 'desc')
+        .orderBy('studyJobFile.id', 'desc')
         .executeTakeFirst()
 
     if (!file && throwIfNotFound) {
@@ -541,6 +542,7 @@ export async function jobScanResultForJob(studyJobId: string): Promise<JobScanRe
         .where('studyJobId', '=', studyJobId)
         .where('fileType', '=', 'SECURITY-SCAN-LOG')
         .orderBy('createdAt', 'desc')
+        .orderBy('id', 'desc')
         .limit(1)
         .executeTakeFirst()
 

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -371,6 +371,9 @@ export async function getStudyJobFileOfType(
         .select(['studyJobFile.id', 'studyJobFile.name', 'studyJobFile.path', 'study.orgId', 'study.submittedByOrgId'])
         .where('studyJobId', '=', studyJobId)
         .where('fileType', '=', fileType)
+        // A resubmission can leave more than one row of a given type for a job; take the
+        // newest so this matches the log the displayed scan statuses were parsed from.
+        .orderBy('studyJobFile.createdAt', 'desc')
         .executeTakeFirst()
 
     if (!file && throwIfNotFound) {
@@ -548,7 +551,10 @@ export async function jobScanResultForJob(studyJobId: string): Promise<JobScanRe
         const contents = await blob.text()
         return { trivy: parseTrivyStatus(contents), sonarqube: parseSonarqubeStatus(contents), logFile }
     } catch {
-        return { trivy: null, sonarqube: null, logFile: null }
+        // A transient read/parse failure shouldn't hide the download: the route serves the
+        // file from the DB row + a signed URL and doesn't depend on this fetch. Keep the log
+        // downloadable with unknown (null) statuses rather than pretending the scan is pending.
+        return { trivy: null, sonarqube: null, logFile }
     }
 }
 

--- a/src/server/db/scan-log.test.ts
+++ b/src/server/db/scan-log.test.ts
@@ -45,6 +45,19 @@ describe('parseSonarqubeStatus', () => {
     it('needs review when the SonarQube section is absent (skipped/unavailable)', () => {
         expect(parseSonarqubeStatus(TRIVY_CLEAN)).toBe('FAILED')
     })
+
+    // The scanner (iac fetchSonarQualityGate) can emit these non-OK statuses; all mean "needs review".
+    it.each(['ERROR', 'WARN', 'NONE', 'TIMEOUT', 'UNKNOWN'])('needs review for non-OK gate status %s', (status) => {
+        expect(
+            parseSonarqubeStatus(
+                `Trivy Filesystem Scan: no vulnerabilities found\n\nSonarQube Quality Gate: ${status}`,
+            ),
+        ).toBe('FAILED')
+    })
+
+    it('matches OK case-insensitively', () => {
+        expect(parseSonarqubeStatus('sonarqube quality gate: ok')).toBe('PASSED')
+    })
 })
 
 describe('jobScanResultForJob', () => {

--- a/src/server/db/scan-log.test.ts
+++ b/src/server/db/scan-log.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { insertTestStudyJobData, mockSessionWithTestData } from '@/tests/unit.helpers'
 import { s3Available } from '@/tests/s3.helpers'
 import { storeStudyLogFile } from '@/server/storage'
+import { db } from '@/database'
 import { jobScanResultForJob, parseTrivyStatus, parseSonarqubeStatus } from './queries'
 
 // Real scanner output (see iac codebuild/scripts/common.ts injectScanResults):
@@ -68,6 +69,28 @@ describe('jobScanResultForJob', () => {
         const result = await jobScanResultForJob(job.id)
 
         expect(result).toEqual({ trivy: null, sonarqube: null, logFile: null })
+    })
+
+    it('keeps the log downloadable with unknown statuses when the file cannot be read', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+        const { job } = await insertTestStudyJobData({ org, researcherId: user.id })
+
+        // Row exists but no object was stored, so fetchFileContents throws and the parse fails.
+        await db
+            .insertInto('studyJobFile')
+            .values({
+                studyJobId: job.id,
+                name: 'security-scan-log.txt',
+                path: `studies/x/jobs/${job.id}/results/security-scan-log.txt`,
+                fileType: 'SECURITY-SCAN-LOG',
+            })
+            .execute()
+
+        const result = await jobScanResultForJob(job.id)
+
+        expect(result.trivy).toBeNull()
+        expect(result.sonarqube).toBeNull()
+        expect(result.logFile?.name).toBe('security-scan-log.txt')
     })
 
     it.skipIf(!s3Available)('parses per-tool statuses from the stored plaintext log', async () => {

--- a/src/server/db/scan-log.test.ts
+++ b/src/server/db/scan-log.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { insertTestStudyJobData, mockSessionWithTestData } from '@/tests/unit.helpers'
+import { s3Available } from '@/tests/s3.helpers'
+import { storeStudyLogFile } from '@/server/storage'
+import { jobScanResultForJob, parseTrivyStatus, parseSonarqubeStatus } from './queries'
+
+// Real scanner output (see iac codebuild/scripts/common.ts injectScanResults):
+// the Trivy section comes first, then an optional SonarQube section.
+const TRIVY_CLEAN = 'Trivy Filesystem Scan: no vulnerabilities found'
+const TRIVY_FINDINGS = [
+    'Trivy Filesystem Scan Results',
+    'Target: package-lock.json',
+    '  HIGH CVE-2024-1234 lodash 4.17.0 (fix: 4.17.21) - Prototype pollution',
+].join('\n')
+const SONAR_OK = 'SonarQube Quality Gate: OK'
+const SONAR_ERROR = ['SonarQube Quality Gate: ERROR', '  new_coverage: ERROR'].join('\n')
+
+describe('parseTrivyStatus', () => {
+    it('passes on the explicit clean line', () => {
+        expect(parseTrivyStatus(`${TRIVY_CLEAN}\n\n${SONAR_OK}`)).toBe('PASSED')
+    })
+
+    it('fails when Trivy reports findings', () => {
+        expect(parseTrivyStatus(`${TRIVY_FINDINGS}\n\n${SONAR_OK}`)).toBe('FAILED')
+    })
+
+    it('fails on "no results" (scanner produced no output) rather than claiming a pass', () => {
+        expect(parseTrivyStatus('Trivy Filesystem Scan: no results')).toBe('FAILED')
+    })
+
+    it('also recognizes the image-scan label', () => {
+        expect(parseTrivyStatus('Trivy Image Scan: no vulnerabilities found')).toBe('PASSED')
+    })
+})
+
+describe('parseSonarqubeStatus', () => {
+    it('passes only when the quality gate is OK', () => {
+        expect(parseSonarqubeStatus(`${TRIVY_CLEAN}\n\n${SONAR_OK}`)).toBe('PASSED')
+    })
+
+    it('needs review when the quality gate errored', () => {
+        expect(parseSonarqubeStatus(`${TRIVY_CLEAN}\n\n${SONAR_ERROR}`)).toBe('FAILED')
+    })
+
+    it('needs review when the SonarQube section is absent (skipped/unavailable)', () => {
+        expect(parseSonarqubeStatus(TRIVY_CLEAN)).toBe('FAILED')
+    })
+})
+
+describe('jobScanResultForJob', () => {
+    it('reports no statuses and no log file when the scan has not reported yet', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+        const { job } = await insertTestStudyJobData({ org, researcherId: user.id })
+
+        const result = await jobScanResultForJob(job.id)
+
+        expect(result).toEqual({ trivy: null, sonarqube: null, logFile: null })
+    })
+
+    it.skipIf(!s3Available)('parses per-tool statuses from the stored plaintext log', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
+        const { study, job } = await insertTestStudyJobData({ org, researcherId: user.id })
+
+        const file = new File([`${TRIVY_FINDINGS}\n\n${SONAR_OK}`], 'security-scan-log.txt', { type: 'text/plain' })
+        await storeStudyLogFile({ orgSlug: org.slug, studyId: study.id, studyJobId: job.id }, file, 'SECURITY-SCAN-LOG')
+
+        const result = await jobScanResultForJob(job.id)
+
+        expect(result.trivy).toBe('FAILED')
+        expect(result.sonarqube).toBe('PASSED')
+        expect(result.logFile?.name).toBe('security-scan-log.txt')
+    })
+})

--- a/src/server/db/scan-log.test.ts
+++ b/src/server/db/scan-log.test.ts
@@ -74,16 +74,29 @@ describe('jobScanResultForJob', () => {
     it('keeps the log downloadable with unknown statuses when the file cannot be read', async () => {
         const { org, user } = await mockSessionWithTestData({ orgType: 'enclave' })
         const { job } = await insertTestStudyJobData({ org, researcherId: user.id })
+        const createdAt = new Date('2026-01-01T00:00:00Z')
 
-        // Row exists but no object was stored, so fetchFileContents throws and the parse fails.
+        // Neither object is stored, so fetchFileContents throws after the newest row is selected.
         await db
             .insertInto('studyJobFile')
-            .values({
-                studyJobId: job.id,
-                name: 'security-scan-log.txt',
-                path: `studies/x/jobs/${job.id}/results/security-scan-log.txt`,
-                fileType: 'SECURITY-SCAN-LOG',
-            })
+            .values([
+                {
+                    id: '00000000-0000-7000-8000-000000000001',
+                    studyJobId: job.id,
+                    name: 'old-security-scan-log.txt',
+                    path: `studies/x/jobs/${job.id}/results/old-security-scan-log.txt`,
+                    fileType: 'SECURITY-SCAN-LOG',
+                    createdAt,
+                },
+                {
+                    id: '00000000-0000-7000-8000-000000000002',
+                    studyJobId: job.id,
+                    name: 'security-scan-log.txt',
+                    path: `studies/x/jobs/${job.id}/results/security-scan-log.txt`,
+                    fileType: 'SECURITY-SCAN-LOG',
+                    createdAt,
+                },
+            ])
             .execute()
 
         const result = await jobScanResultForJob(job.id)

--- a/src/server/storage.ts
+++ b/src/server/storage.ts
@@ -13,8 +13,11 @@ export async function fetchFileContents(filePath: string) {
     return new Blob(chunks as BlobPart[])
 }
 
-export async function urlForFile(filePath: string): Promise<string> {
-    return await signedUrlForFile(filePath)
+export async function urlForFile(
+    filePath: string,
+    commandOverrides: Partial<{ ResponseContentDisposition: string }> = {},
+): Promise<string> {
+    return await signedUrlForFile(filePath, commandOverrides)
 }
 
 export async function urlForStudyJobCodeFile(info: MinimalJobInfo, fileName: string) {


### PR DESCRIPTION
see [OTTER-649](https://openstax.atlassian.net/browse/OTTER-649)

## What
Reworks the &#34;Security scan log&#34; panel on the reviewer Code Review page so it no longer asserts an overall pass/fail with a check/X icon in the title. Instead it shows two independent, programmatically derived statuses and a download link for the plaintext log, per the Figma designs.

- Title &#34;Security scan log&#34; with no status icon.
- Row &#34;Trivy Filesystem Scan:&#34; `No vulnerabilities found` when clean, otherwise a red warning icon + `Vulnerabilities found`.
- Row &#34;SonarQube Quality Gate:&#34; `Passed` when the gate is OK, otherwise a red warning icon + `Needs review`.
- A `Download` link, shown whenever a plaintext scan log file exists.

## Why
Per the card, we cannot say with confidence that a scan &#34;failed&#34;, only whether it passed or needs human review. The old UI derived a single status by reading the encrypted zip and checking for the substring `OK`, which is unreliable. Scan log text files are effectively always present and reviewers need to download them (ZIPs are not offered).

## How
- Status is now parsed from the plaintext `SECURITY-SCAN-LOG` text file, not the encrypted zip. Safety bias: only report PASSED on an explicit clean signal, otherwise flag for review.
  - Trivy PASSED only on the scanner&#39;s `no vulnerabilities found` line; anything else (findings, `no results`, unrecognized) is flagged.
  - SonarQube PASSED only when the quality gate reports `OK`; any other status (ERROR, WARN, NONE, TIMEOUT, UNKNOWN) or a missing SonarQube section needs review.
- New authenticated download route `GET /dl/scan-log/[jobId]` serves the plaintext `.txt`. It authorizes the job (`canViewStudyJob`) before looking up the file, so a denied requester cannot infer from a 404-vs-401 whether another org&#39;s job produced a scan log; an unknown job and an unauthorized one both return 401. The lookup returns the newest `SECURITY-SCAN-LOG` row (`getStudyJobFileOfType` orders `createdAt` desc), so on a resubmission the download matches the log the displayed statuses were parsed from. The response forces `Content-Disposition: attachment; filename="security-scan-log.txt"` so the download survives the cross-origin redirect to S3 regardless of the stored object&#39;s content type. The encrypted zip is intentionally not downloadable here.
- `JobScanResult` now carries independent `trivy` / `sonarqube` statuses plus the log file; consumers (`code-review`, `post-feedback-view`, `reviewer-code-feedback-screen`) pass it through unchanged.

The plaintext scan log format is produced by the CodeBuild scanner in the `iac` repo (`codebuild/scripts/common.ts`), which the parser targets.

## The two static rows are always shown
The two labeled rows (&#34;Trivy Filesystem Scan:&#34; and &#34;SonarQube Quality Gate:&#34;) are always rendered, matching the acceptance criteria that lists them as static elements. Their statuses are derived from the log, so when no log has been read yet each row shows a neutral &#34;Scan in progress...&#34; value (no icon, and never a fabricated pass/fail). The Download link is shown whenever a scan log file exists, independently of the parsed statuses: if a log row exists but its contents can&#39;t be read (a transient S3 read/parse failure), the statuses stay unknown (&#34;Scan in progress...&#34;) but the log remains downloadable, since the download route only needs the DB row and a signed URL. In the normal reviewer flow the log is present and readable by the time the page is viewed, so the derived statuses are shown.

## Tests
- Component: title without icon, both static labels, per-tool pass/fail text and warning icon, download link + href, and the pending (no-log) state (rows present, no icon, no download).
- `jobScanResultForJob` and the pure parsers, including the full SonarQube status vocabulary and case-insensitivity, plus an S3-backed integration test, and the unreadable-log case (log row present, contents unreadable: null statuses but still downloadable).
- Download route: `404` (authorized but no log), `401` (different-org requester), `401` (unknown job, so existence is not disclosed), and the authorized redirect to a signed URL.

Verified visually against the Figma frames across all states (all passed, Trivy-only, SonarQube-only, both failed, and the pending state).

[OTTER-649]: https://openstax.atlassian.net/browse/OTTER-649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ