### PR TITLE
update "View approved initial request" UI element and icon

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.tsx
@@ -3,7 +3,7 @@
 import { type FC, type ReactNode } from 'react'
 import type { Route } from 'next'
 import { Anchor, Box, Collapse, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
-import { ArrowSquareOut, CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
+import { ArrowSquareOutIcon, CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
 import { AlertNotFound } from '@/components/errors'
 import { ButtonLink } from '@/components/links'
 import { PageBreadcrumbs } from '@/components/page-breadcrumbs'
@@ -231,7 +231,7 @@ const SubmittedCodePanel: FC<SubmittedCodePanelProps> = ({
                             data-testid="view-approved-initial-request"
                         >
                             View approved initial request
-                            <ArrowSquareOut size={14} />
+                            <ArrowSquareOutIcon size={14} />
                         </Anchor>
                     </Group>
                     <Divider />


### PR DESCRIPTION
[Issue](https://openstax.atlassian.net/browse/OTTER-587): Fix "View approved initial request" UI element and icon

### Summary
Updates the icon import for the "View approved initial request" link in the submitted-code panel of the study post-decision view to use Phosphor's `*Icon` export naming convention.

### Changes
- Rename the icon import from `ArrowSquareOut` to `ArrowSquareOutIcon` in `src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.tsx`, aligning with the `@phosphor-icons/react` `*Icon` naming convention used elsewhere in the codebase.