### PR TITLE
Update color of star denoting selected main  file in study proposal view

### DIFF
--- a/src/components/study/submitted-code-table-view.tsx
+++ b/src/components/study/submitted-code-table-view.tsx
@@ -18,6 +18,11 @@ const formatUpdatedAt = (date: Date | string) =>
         minute: '2-digit',
     })
 
+// Post-submission the main file is locked in, so the star renders in the disabled
+// grey style (still filled to show it's selected) rather than the active indigo used
+// while the researcher is choosing their main file.
+const STAR_COLOR = 'var(--mantine-color-gray-5)'
+
 const SubmittedCodeRow: FC<{
     file: SubmittedFile
     jobId: string
@@ -25,10 +30,6 @@ const SubmittedCodeRow: FC<{
 }> = ({ file, jobId, onPreview }) => {
     const isMain = file.fileType === 'MAIN-CODE'
     const starWeight = isMain ? 'fill' : 'regular'
-    // Post-submission the main file is locked in, so the star renders in the disabled
-    // grey style (still filled to show it's selected) rather than the active indigo used
-    // while the researcher is choosing their main file.
-    const starColor = 'var(--mantine-color-gray-5)'
     const starLabel = isMain ? 'Main file' : 'Supplemental file'
     const tooltipDisabled = file.name.length <= 48
     const lastUpdated = formatUpdatedAt(file.createdAt)
@@ -36,7 +37,7 @@ const SubmittedCodeRow: FC<{
     return (
         <Table.Tr>
             <Table.Td>
-                <StarIcon size={20} weight={starWeight} color={starColor} aria-label={starLabel} />
+                <StarIcon size={20} weight={starWeight} color={STAR_COLOR} aria-label={starLabel} />
             </Table.Td>
             <Table.Td>
                 <Tooltip label={file.name} disabled={tooltipDisabled}>

--- a/src/components/study/submitted-code-table-view.tsx
+++ b/src/components/study/submitted-code-table-view.tsx
@@ -25,7 +25,10 @@ const SubmittedCodeRow: FC<{
 }> = ({ file, jobId, onPreview }) => {
     const isMain = file.fileType === 'MAIN-CODE'
     const starWeight = isMain ? 'fill' : 'regular'
-    const starColor = isMain ? 'var(--mantine-color-indigo-6)' : 'var(--mantine-color-gray-5)'
+    // Post-submission the main file is locked in, so the star renders in the disabled
+    // grey style (still filled to show it's selected) rather than the active indigo used
+    // while the researcher is choosing their main file.
+    const starColor = 'var(--mantine-color-gray-5)'
     const starLabel = isMain ? 'Main file' : 'Supplemental file'
     const tooltipDisabled = file.name.length <= 48
     const lastUpdated = formatUpdatedAt(file.createdAt)


### PR DESCRIPTION
Issue: [OTTER-590](https://openstax.atlassian.net/browse/OTTER-590)

## Summary

Updates the "Main file" star on the post-submission study code view to use the **disabled grey** style instead of the active blue (indigo), matching the Figma design.

Per UX guidance:
- The **blue** star represents an *active choice* — used while the researcher is choosing which file is their main file (the upload/selection flow).
- The **grey** star represents a *submitted, locked* state — the main file has already been selected and can no longer be changed. It stays filled to show it's still selected, but the greyed styling communicates that changes are disabled.

The post-submission view (and the post-decision view, which shares the same table component) is a read-only, locked context, so it should reflect the disabled grey version.

## Changes

- `src/components/study/submitted-code-table-view.tsx`: the main-file star now renders with `--mantine-color-gray-5` instead of `--mantine-color-indigo-6`. It keeps the `fill` weight so it still reads as "selected," while supplemental files remain grey outlines. The active indigo styling remains untouched in `file-review-table.tsx` where main-file selection actually happens.


[OTTER-590]: https://openstax.atlassian.net/browse/OTTER-590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ