### PR TITLE
OTTER-516: preview png plots in code file view modals

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-interactive.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-interactive.tsx
@@ -19,8 +19,8 @@ import { useEffect, useState } from 'react'
 import Markdown, { type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { useMutation, useQuery, useQueryClient } from '@/common'
-import { CodeViewer } from '@/components/file-viewers'
-import { decodeFileContents } from '@/lib/file-content-helpers'
+import { CodeViewer, ImageViewer } from '@/components/file-viewers'
+import { decodeFileContents, imageMimeType } from '@/lib/file-content-helpers'
 import { highlightLanguageForFile } from '@/lib/languages'
 import { studyCodeURL } from '@/lib/paths'
 import {
@@ -509,6 +509,15 @@ function StudyCodeBody({
             </Alert>
         )
     }
+    const mime = imageMimeType(activeFile.name)
+    if (mime) {
+        return (
+            <div data-testid="study-code-body">
+                <ImageViewer name={activeFile.name} contents={data.contents} mime={mime} />
+            </div>
+        )
+    }
+
     const code = decodeFileContents(data.contents)
     return (
         <div data-testid="study-code-body">

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-interactive.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-interactive.tsx
@@ -20,6 +20,7 @@ import Markdown, { type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { useMutation, useQuery, useQueryClient } from '@/common'
 import { CodeViewer } from '@/components/file-viewers'
+import { decodeFileContents } from '@/lib/file-content-helpers'
 import { highlightLanguageForFile } from '@/lib/languages'
 import { studyCodeURL } from '@/lib/paths'
 import {
@@ -508,9 +509,10 @@ function StudyCodeBody({
             </Alert>
         )
     }
+    const code = decodeFileContents(data.contents)
     return (
         <div data-testid="study-code-body">
-            <CodeViewer code={data.contents} language={highlightLanguageForFile(activeFile.name)} withBorder />
+            <CodeViewer code={code} language={highlightLanguageForFile(activeFile.name)} withBorder />
         </div>
     )
 }

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/server/db/queries'
 import { SubmittedCodeSection, latestCodeSubmittedAt } from './submitted-code-section'
 import { AiSummaryCollapsible, splitVisibleFiles, truncateFileName } from './submitted-code-interactive'
+import { fetchFileContents } from '@/server/storage'
 
 vi.mock('@/server/storage', async () => {
     const actual = await vi.importActual<typeof import('@/server/storage')>('@/server/storage')
@@ -698,6 +699,27 @@ describe("SubmittedCodeSection — Displaying RL's code", () => {
         expect(body).toHaveTextContent('print')
         expect(body).toHaveTextContent('hello from main.R')
         expect(body).toHaveTextContent('main.R')
+    })
+
+    // OTTER-516 follow-up: a png submitted alongside code (e.g. an IDE-generated plot) can be an
+    // active tab here, so the body must render it as an image rather than decoding its bytes to text.
+    it('renders a png tab as an image instead of decoded text', async () => {
+        vi.mocked(fetchFileContents).mockImplementation(async (path: string) =>
+            path.endsWith('.png')
+                ? new Blob([new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])])
+                : new Blob(['print("hello from main.R")\n']),
+        )
+        const fixture = await setupFilesFixture(['main.R', 'plot.png'])
+        await renderSection(fixture)
+        const user = userEvent.setup()
+
+        const plotTab = screen.getAllByTestId('study-code-file-tab').find((tab) => tab.title === 'plot.png')!
+        await user.click(plotTab)
+
+        const body = await screen.findByTestId('study-code-body')
+        await waitFor(() => {
+            expect(within(body).getByAltText('plot.png')).toBeInTheDocument()
+        })
     })
 
     it('renders a download link on every visible file tab (OTTER-608)', async () => {

--- a/src/components/encrypted-files-panel.tsx
+++ b/src/components/encrypted-files-panel.tsx
@@ -1,8 +1,6 @@
-import { FilePreviewModal } from '@/components/modals/file-preview-modal'
-import { ImagePreviewModal } from '@/components/modals/image-preview-modal'
+import { FileOrImagePreviewModal } from '@/components/modals/file-or-image-preview-modal'
 import { DownloadBlobLink } from '@/components/download-blob-link'
 import { useEncryptedFilesPanel, type UnifiedFileRow } from '@/hooks/use-encrypted-files-panel'
-import { decodeFileContents, imageMimeType } from '@/lib/file-content-helpers'
 import { formatBytes } from '@/lib/format'
 import type { JobFile, JobFileInfo } from '@/lib/types'
 import type { LatestJobForStudy } from '@/server/db/queries'
@@ -129,13 +127,6 @@ const UnifiedFileRow: FC<UnifiedFileRowProps> = ({ row, onView }) => {
 }
 
 const DecryptedFilePreview: FC<{ file: JobFile | null; onClose: () => void }> = ({ file, onClose }) => {
-    if (!file) return null
-
-    const mime = imageMimeType(file.path)
-    if (mime) {
-        return <ImagePreviewModal isVisible name={file.path} contents={file.contents} mime={mime} onClose={onClose} />
-    }
-
-    const previewFile = { name: file.path, contents: decodeFileContents(file.contents) }
-    return <FilePreviewModal file={previewFile} onClose={onClose} />
+    const previewFile = file ? { name: file.path, contents: file.contents } : null
+    return <FileOrImagePreviewModal file={previewFile} onClose={onClose} />
 }

--- a/src/components/file-viewers/image-viewer.stories.tsx
+++ b/src/components/file-viewers/image-viewer.stories.tsx
@@ -1,0 +1,26 @@
+import type { Story } from '@ladle/react'
+import { Box } from '@mantine/core'
+import { ImageViewer } from './image-viewer'
+
+// ImageViewer is presentational: it takes raw image bytes + a mime type and renders
+// them through an object URL. A tiny inline png keeps the story self-contained.
+const meta = { title: 'File viewers / Image viewer' }
+export default meta
+
+const ONE_BY_ONE_PNG_BASE64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+
+function pngBytes(): ArrayBuffer {
+    const binary = atob(ONE_BY_ONE_PNG_BASE64)
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i)
+    }
+    return bytes.buffer
+}
+
+export const PngPlot: Story = () => (
+    <Box p="xl">
+        <ImageViewer name="plot.png" contents={pngBytes()} mime="image/png" />
+    </Box>
+)

--- a/src/components/file-viewers/image-viewer.tsx
+++ b/src/components/file-viewers/image-viewer.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState, type FC } from 'react'
+import { Center, Image } from '@mantine/core'
+
+type ImageViewerProps = {
+    name: string
+    contents: ArrayBuffer
+    mime: string
+}
+
+export const ImageViewer: FC<ImageViewerProps> = ({ name, contents, mime }) => {
+    const [src, setSrc] = useState('')
+
+    useEffect(() => {
+        const url = URL.createObjectURL(new Blob([contents], { type: mime }))
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setSrc(url)
+        return () => URL.revokeObjectURL(url)
+    }, [contents, mime])
+
+    return <Center>{src && <Image src={src} alt={name} fit="contain" mah={600} />}</Center>
+}

--- a/src/components/file-viewers/index.tsx
+++ b/src/components/file-viewers/index.tsx
@@ -5,6 +5,7 @@ import { logViewer } from './log-viewer'
 import { textViewer } from './text-viewer'
 
 export { CodeViewer } from './code-viewer'
+export { ImageViewer } from './image-viewer'
 
 const viewers = [codeViewer, csvViewer, logViewer, textViewer]
 

--- a/src/components/modals/file-or-image-preview-modal.tsx
+++ b/src/components/modals/file-or-image-preview-modal.tsx
@@ -1,0 +1,22 @@
+import { FilePreviewModal } from '@/components/modals/file-preview-modal'
+import { ImagePreviewModal } from '@/components/modals/image-preview-modal'
+import { decodeFileContents, imageMimeType } from '@/lib/file-content-helpers'
+
+type PreviewFile = {
+    name: string
+    contents: ArrayBuffer | null
+}
+
+// Callers hand over raw bytes so binary files like png plots survive the trip intact;
+// decoding to utf-8 happens here and only for non-image files (OTTER-516).
+export function FileOrImagePreviewModal({ file, onClose }: { file: PreviewFile | null; onClose: () => void }) {
+    if (!file) return null
+
+    const mime = imageMimeType(file.name)
+    if (mime && file.contents) {
+        return <ImagePreviewModal isVisible name={file.name} contents={file.contents} mime={mime} onClose={onClose} />
+    }
+
+    const textFile = { name: file.name, contents: file.contents === null ? null : decodeFileContents(file.contents) }
+    return <FilePreviewModal file={textFile} onClose={onClose} />
+}

--- a/src/components/modals/image-preview-modal.tsx
+++ b/src/components/modals/image-preview-modal.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react'
-import { Center, Group, Image } from '@mantine/core'
+import { Group } from '@mantine/core'
 import { AppModal } from '@/components/modals/app-modal'
 import { DownloadBlobLink } from '@/components/download-blob-link'
+import { ImageViewer } from '@/components/file-viewers'
 
 type ImagePreviewModalProps = {
     isVisible: boolean
@@ -12,16 +12,6 @@ type ImagePreviewModalProps = {
 }
 
 export function ImagePreviewModal({ isVisible, name, contents, mime, onClose }: ImagePreviewModalProps) {
-    const [src, setSrc] = useState('')
-
-    useEffect(() => {
-        if (!mime) return
-        const url = URL.createObjectURL(new Blob([contents], { type: mime }))
-        // eslint-disable-next-line react-hooks/set-state-in-effect
-        setSrc(url)
-        return () => URL.revokeObjectURL(url)
-    }, [contents, mime])
-
     if (!isVisible || !mime) return null
 
     const title = (
@@ -33,7 +23,7 @@ export function ImagePreviewModal({ isVisible, name, contents, mime, onClose }: 
 
     return (
         <AppModal isOpen onClose={onClose} title={title} size="xl">
-            <Center>{src && <Image src={src} alt={name} fit="contain" mah={600} />}</Center>
+            <ImageViewer name={name} contents={contents} mime={mime} />
         </AppModal>
     )
 }

--- a/src/components/study/study-code-panel.test.tsx
+++ b/src/components/study/study-code-panel.test.tsx
@@ -71,4 +71,18 @@ describe('StudyCodePanel', () => {
         renderWithProviders(<StudyCodePanel ide={ide} studyTitle="My Study" footer={null} />)
         expect(screen.queryByRole('button', { name: /edit files in ide/i })).not.toBeInTheDocument()
     })
+
+    it('shows an image preview when viewing a png file (OTTER-516)', () => {
+        const contents = new TextEncoder().encode('fake-png-bytes').buffer
+        const ide = createMockIde({ viewingFile: { name: 'plot.png', contents } })
+        renderWithProviders(<StudyCodePanel ide={ide} studyTitle="My Study" footer={null} />)
+        expect(screen.getByAltText('plot.png')).toBeInTheDocument()
+    })
+
+    it('shows a text preview when viewing a code file', () => {
+        const contents = new TextEncoder().encode('print(1)').buffer
+        const ide = createMockIde({ viewingFile: { name: 'main.R', contents } })
+        renderWithProviders(<StudyCodePanel ide={ide} studyTitle="My Study" footer={null} />)
+        expect(screen.getByText(/print/)).toBeInTheDocument()
+    })
 })

--- a/src/components/study/study-code-panel.tsx
+++ b/src/components/study/study-code-panel.tsx
@@ -1,7 +1,7 @@
 import { useRef, type ReactNode } from 'react'
 import { Divider, Group, Paper, Skeleton, Stack, Text, Title } from '@mantine/core'
 import { useIDEFiles } from '@/hooks/use-ide-files'
-import { FilePreviewModal } from '@/components/modals/file-preview-modal'
+import { FileOrImagePreviewModal } from '@/components/modals/file-or-image-preview-modal'
 import { InfoTooltip } from '@/components/tooltip'
 import { LaunchIdeButton } from './launch-ide-button'
 import { LaunchProgress } from './launch-progress'
@@ -118,7 +118,7 @@ export const StudyCodePanel = ({
 
             {footer}
 
-            <FilePreviewModal file={ide.viewingFile} onClose={ide.closeFileViewer} />
+            <FileOrImagePreviewModal file={ide.viewingFile} onClose={ide.closeFileViewer} />
         </>
     )
 }

--- a/src/components/study/submitted-code-table.test.tsx
+++ b/src/components/study/submitted-code-table.test.tsx
@@ -29,13 +29,15 @@ const buildFile = (overrides: Partial<LatestJobForStudy['files'][number]>): Late
     ...overrides,
 })
 
+const bytes = (text: string) => new TextEncoder().encode(text).buffer
+
 describe('SubmittedCodeTable', () => {
     beforeEach(() => {
         mockFetch.mockReset()
     })
 
     it('opens the preview modal with a loader while contents are fetching, then renders the code', async () => {
-        let resolveFetch: (v: { fileName: string; contents: string }) => void = () => {}
+        let resolveFetch: (v: { fileName: string; contents: ArrayBuffer }) => void = () => {}
         mockFetch.mockReturnValue(
             new Promise((resolve) => {
                 resolveFetch = resolve
@@ -50,7 +52,7 @@ describe('SubmittedCodeTable', () => {
 
         expect(await screen.findByTestId('file-preview-loading')).toBeInTheDocument()
 
-        resolveFetch({ fileName: 'main.py', contents: 'print("hi")' })
+        resolveFetch({ fileName: 'main.py', contents: bytes('print("hi")') })
 
         await waitFor(() => {
             expect(screen.queryByTestId('file-preview-loading')).not.toBeInTheDocument()
@@ -73,8 +75,20 @@ describe('SubmittedCodeTable', () => {
         expect(helper).toHaveAttribute('href', '/dl/study-code/job-1/helper.py')
     })
 
+    it('opens an image preview for a png file (OTTER-516)', async () => {
+        mockFetch.mockResolvedValue({ fileName: 'plot.png', contents: bytes('fake-png-bytes') })
+
+        const files = [buildFile({ name: 'plot.png', fileType: 'SUPPLEMENTAL-CODE' })]
+        renderWithProviders(<SubmittedCodeTable jobId="job-1" files={files} />)
+
+        const interact = userEvent.setup()
+        await interact.click(screen.getByRole('button', { name: 'View plot.png' }))
+
+        expect(await screen.findByAltText('plot.png')).toBeInTheDocument()
+    })
+
     it('closes the modal when onClose is fired', async () => {
-        mockFetch.mockResolvedValue({ fileName: 'main.py', contents: 'x = 1' })
+        mockFetch.mockResolvedValue({ fileName: 'main.py', contents: bytes('x = 1') })
 
         renderWithProviders(<SubmittedCodeTable jobId="job-1" files={[buildFile({ name: 'main.py' })]} />)
 

--- a/src/components/study/submitted-code-table.tsx
+++ b/src/components/study/submitted-code-table.tsx
@@ -4,7 +4,7 @@ import { useState, type FC } from 'react'
 import { useQuery } from '@/common'
 import { fetchStudyJobCodeFileAction } from '@/server/actions/study-job.actions'
 import type { LatestJobForStudy } from '@/server/db/queries'
-import { FilePreviewModal } from '@/components/modals/file-preview-modal'
+import { FileOrImagePreviewModal } from '@/components/modals/file-or-image-preview-modal'
 import { SubmittedCodeTableView } from './submitted-code-table-view'
 
 interface SubmittedCodeTableProps {
@@ -29,7 +29,7 @@ export const SubmittedCodeTable: FC<SubmittedCodeTableProps> = ({ jobId, files }
     return (
         <>
             <SubmittedCodeTableView jobId={jobId} files={files} onPreview={(file) => setPreviewFileName(file.name)} />
-            {!!files?.length && <FilePreviewModal file={previewFile} onClose={() => setPreviewFileName(null)} />}
+            {!!files?.length && <FileOrImagePreviewModal file={previewFile} onClose={() => setPreviewFileName(null)} />}
         </>
     )
 }

--- a/src/hooks/use-ide-files.test.ts
+++ b/src/hooks/use-ide-files.test.ts
@@ -82,3 +82,34 @@ describe('useIDEFiles userEditedFiles (OTTER-558)', () => {
         await waitFor(() => expect(result.current.userEditedFiles).toBe(true))
     })
 })
+
+// OTTER-516 regression: viewFile must round-trip the file's exact bytes. Reading a png as
+// utf-8 corrupts it beyond rendering, so the action hands back an ArrayBuffer as stored.
+describe('useIDEFiles viewFile (OTTER-516)', () => {
+    beforeEach(() => {
+        delete process.env.CODER_FILES
+    })
+
+    afterEach(async () => {
+        await cleanupWorkspaceDirs(workspaceRoots)
+    })
+
+    it('returns binary files as their exact bytes', async () => {
+        const study = await setupResubmittableStudy()
+        const root = await createWorkspaceDir('use-ide-files-view')
+        workspaceRoots.push(root)
+        // PNG magic header followed by bytes that are not valid utf-8
+        const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xc3, 0x28])
+        await writeWorkspaceFiles(root, study.id, { 'plot.png': pngBytes })
+
+        const { result } = renderIDEFiles(study.id)
+        await waitFor(() => expect(result.current.files).toContain('plot.png'))
+
+        await act(async () => {
+            await result.current.viewFile('plot.png')
+        })
+
+        expect(result.current.viewingFile?.name).toBe('plot.png')
+        expect(new Uint8Array(result.current.viewingFile!.contents)).toEqual(pngBytes)
+    })
+})

--- a/src/hooks/use-ide-files.ts
+++ b/src/hooks/use-ide-files.ts
@@ -55,7 +55,7 @@ export function useIDEFiles({ studyId, onSubmitSuccess }: UseIDEFilesOptions) {
     const router = useRouter()
 
     const [mainFileOverride, setMainFileOverride] = useState<string | null>(null)
-    const [viewingFile, setViewingFile] = useState<{ name: string; contents: string } | null>(null)
+    const [viewingFile, setViewingFile] = useState<{ name: string; contents: ArrayBuffer } | null>(null)
     // OTTER-558: tracks whether the user actually edited files THIS session (uploaded, deleted, or
     // picked a main file). The resubmit footer keys its Cancel-vs-Save-and-exit toggle on this, NOT
     // on `filesChanged` — the latter compares workspace mtimes to the last submission and is already

--- a/src/server/actions/study-job.actions.ts
+++ b/src/server/actions/study-job.actions.ts
@@ -210,8 +210,9 @@ export const fetchStudyJobCodeFileAction = new Action('fetchStudyJobCodeFileActi
         )
         if (!file) throw new ActionFailure({ file: `Code file "${fileName}" not found` })
 
+        // Raw bytes, not text: code submissions can include binary files like png plots (OTTER-516)
         const blob = await fetchFileContents(file.path)
-        const contents = await blob.text()
+        const contents = await blob.arrayBuffer()
         return { fileName: file.name, contents }
     })
 

--- a/src/server/actions/workspace-files.actions.ts
+++ b/src/server/actions/workspace-files.actions.ts
@@ -42,8 +42,9 @@ export const readWorkspaceFileAction = new Action('readWorkspaceFileAction', {})
         const coderFilesPath = await getStudyFilesPath(studyId)
         const sanitized = sanitizeFileName(fileName)
         const filePath = path.join(coderFilesPath, sanitized)
-        const contents = await fs.readFile(filePath, 'utf-8')
-        return { fileName: sanitized, contents }
+        // Raw bytes, not utf-8: workspace files include binary artifacts like png plots (OTTER-516)
+        const contents = await fs.readFile(filePath)
+        return { fileName: sanitized, contents: new Uint8Array(contents).buffer }
     })
 
 export const deleteWorkspaceFileAction = new Action('deleteWorkspaceFileAction', { performsMutations: true })

--- a/tests/unit.helpers.tsx
+++ b/tests/unit.helpers.tsx
@@ -742,7 +742,11 @@ export const createWorkspaceDir = async (prefix: string) => {
     return root
 }
 
-export const writeWorkspaceFiles = async (root: string, studyId: string, files: Record<string, string>) => {
+export const writeWorkspaceFiles = async (
+    root: string,
+    studyId: string,
+    files: Record<string, string | Uint8Array>,
+) => {
     const { CODER_DISABLED } = await import('@/server/config')
     const workspaceDir = CODER_DISABLED ? root : path.join(root, studyId)
     await fs.promises.mkdir(workspaceDir, { recursive: true })


### PR DESCRIPTION
###Problem: #818 fixed the results page, but png plots still didn't render in the view modal on the study code Review files page or the Submitted code table (QA follow-up on the ticket). Both paths decoded file bytes to utf-8 strings server-side — fs.readFile(path, 'utf-8') in readWorkspaceFileAction, blob.text() in fetchStudyJobCodeFileAction — which corrupts binary files.

##Fix: Both actions return raw bytes like the results path does, and the image-vs-text dispatch from encrypted-files-panel moves to a shared FileOrImagePreviewModal used by all three preview sites. The reviewer's inline code viewer decodes at point of use; text previews are unchanged.

##Tests: unit for the png preview on both screens, plus a byte-exact round-trip of non-utf-8 bytes through readWorkspaceFileAction.