### PR TITLE
OTTER-646: add 1h escalation tooltip to reviewer code processing status

### DIFF
--- a/src/components/study/display-study-status.test.tsx
+++ b/src/components/study/display-study-status.test.tsx
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { renderWithProviders } from '@/tests/unit.helpers'
-import { screen } from '@testing-library/react'
+import { renderWithProviders, screen, userEvent, waitFor } from '@/tests/unit.helpers'
 import { DisplayStudyStatus } from '@/components/study/display-study-status'
 import { REVIEWER_STATUS_LABELS, RESEARCHER_STATUS_LABELS } from '@/lib/status-labels'
 import type { AllStatus } from '@/lib/types'
@@ -28,6 +27,21 @@ describe('DisplayStudyStatus', () => {
             const textEl = screen.getByText(expectedText)
             expect(textEl).toBeDefined()
             expect(textEl.parentElement?.textContent?.trim()).toBe(expectedText)
+        })
+
+        it('shows the escalation tooltip when hovering the JOB-RUNNING pill', async () => {
+            const user = userEvent.setup()
+            renderWithProviders(<DisplayStudyStatus status={REVIEWER_STATUS_LABELS['JOB-RUNNING']!} />)
+
+            await user.hover(screen.getByText('Code processing'))
+
+            await waitFor(() => {
+                expect(
+                    screen.getByText(
+                        'The code is now running against the enclave. If it stays in this status for over 1h, contact your Org Admin.',
+                    ),
+                ).toBeDefined()
+            })
         })
     })
 

--- a/src/components/study/display-study-status.test.tsx
+++ b/src/components/study/display-study-status.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { renderWithProviders, screen, userEvent, waitFor } from '@/tests/unit.helpers'
+import { renderWithProviders, screen, userEvent } from '@/tests/unit.helpers'
 import { DisplayStudyStatus } from '@/components/study/display-study-status'
 import { REVIEWER_STATUS_LABELS, RESEARCHER_STATUS_LABELS } from '@/lib/status-labels'
 import type { AllStatus } from '@/lib/types'
@@ -35,13 +35,11 @@ describe('DisplayStudyStatus', () => {
 
             await user.hover(screen.getByText('Code processing'))
 
-            await waitFor(() => {
-                expect(
-                    screen.getByText(
-                        'The code is now running against the enclave. If it stays in this status for over 1h, contact your Org Admin.',
-                    ),
-                ).toBeDefined()
-            })
+            expect(
+                await screen.findByText(
+                    'The code is now running against the enclave. If it stays in this status for over 1h, contact your Org Admin.',
+                ),
+            ).toBeVisible()
         })
     })
 

--- a/src/lib/status-labels.ts
+++ b/src/lib/status-labels.ts
@@ -111,7 +111,7 @@ export const REVIEWER_STATUS_LABELS: Partial<Record<AllStatus, StatusLabel>> = {
         stage: 'Code',
         label: 'Processing',
         tooltip:
-            "The code is now running against the enclave. You'll receive an email once results are ready for review.",
+            'The code is now running against the enclave. If it stays in this status for over 1h, contact your Org Admin.',
         colors: COLORS.default,
     },
     'JOB-ERRORED': {


### PR DESCRIPTION
fix: reviewer `JOB-RUNNING` ("Code processing") tooltip on the DP dashboard now reads "The code is now running against the enclave. If it stays in this status for over 1h, contact your Org Admin." (was the "you'll receive an email once results are ready" copy)

test: add hover test asserting the new tooltip in `display-study-status.test.tsx`