### PR TITLE
Update dataset field to basic multiselect-no-search

### DIFF
--- a/src/components/dataset-multi-select.tsx
+++ b/src/components/dataset-multi-select.tsx
@@ -1,13 +1,9 @@
 'use client'
 
-import { FC, useState } from 'react'
-import { Combobox, Group, Pill, PillsInput, Text, useCombobox, CheckIcon } from '@mantine/core'
+import { FC } from 'react'
+import { MultiSelect } from '@mantine/core'
+import { CaretUpDownIcon } from '@phosphor-icons/react'
 import { useOrgDataSources } from '@/hooks/use-org-data-sources'
-
-export interface DatasetOption {
-    value: string
-    label: string
-}
 
 interface DatasetMultiSelectProps {
     id: string
@@ -27,90 +23,18 @@ export const DatasetMultiSelect: FC<DatasetMultiSelectProps> = ({
     orgSlug,
 }) => {
     const { options } = useOrgDataSources(orgSlug)
-    const [search, setSearch] = useState('')
-    const combobox = useCombobox({
-        onDropdownClose: () => combobox.resetSelectedOption(),
-        onDropdownOpen: () => combobox.updateSelectedOptionIndex('active'),
-    })
-
-    const handleValueSelect = (val: string) => {
-        if (value.includes(val)) {
-            onChange(value.filter((v) => v !== val))
-        } else {
-            onChange([...value, val])
-        }
-    }
-
-    const handleValueRemove = (val: string) => {
-        onChange(value.filter((v) => v !== val))
-    }
-
-    const filteredOptions = options.filter((item) => item.label.toLowerCase().includes(search.trim().toLowerCase()))
-
-    const pills = value.map((val) => {
-        const option = options.find((o) => o.value === val)
-        if (!option) return null
-        return (
-            <Pill key={val} withRemoveButton onRemove={() => handleValueRemove(val)} disabled={disabled}>
-                {option.label}
-            </Pill>
-        )
-    })
-
-    const comboboxOptions = filteredOptions.map((item) => {
-        const isSelected = value.includes(item.value)
-        return (
-            <Combobox.Option value={item.value} key={item.value} active={isSelected}>
-                <Group gap="sm">
-                    {isSelected && <CheckIcon size={12} />}
-                    <span>{item.label}</span>
-                </Group>
-            </Combobox.Option>
-        )
-    })
 
     return (
-        <Combobox store={combobox} onOptionSubmit={handleValueSelect}>
-            <Combobox.DropdownTarget>
-                <PillsInput onClick={() => combobox.openDropdown()} disabled={disabled}>
-                    <Pill.Group>
-                        {pills}
-                        <Combobox.EventsTarget>
-                            <PillsInput.Field
-                                id={id}
-                                onFocus={() => combobox.openDropdown()}
-                                onBlur={() => combobox.closeDropdown()}
-                                value={search}
-                                placeholder={value.length === 0 ? placeholder : undefined}
-                                onChange={(event) => {
-                                    combobox.updateSelectedOptionIndex()
-                                    setSearch(event.currentTarget.value)
-                                }}
-                                onKeyDown={(event) => {
-                                    if (event.key === 'Backspace' && search.length === 0) {
-                                        event.preventDefault()
-                                        handleValueRemove(value[value.length - 1])
-                                    }
-                                }}
-                            />
-                        </Combobox.EventsTarget>
-                    </Pill.Group>
-                </PillsInput>
-            </Combobox.DropdownTarget>
-
-            <Combobox.Dropdown>
-                <Combobox.Options>
-                    {comboboxOptions.length > 0 ? (
-                        comboboxOptions
-                    ) : (
-                        <Combobox.Empty>
-                            <Text size="sm" c="dimmed">
-                                No datasets found
-                            </Text>
-                        </Combobox.Empty>
-                    )}
-                </Combobox.Options>
-            </Combobox.Dropdown>
-        </Combobox>
+        <MultiSelect
+            id={id}
+            data={options}
+            value={value}
+            onChange={onChange}
+            placeholder={value.length === 0 ? placeholder : undefined}
+            disabled={disabled}
+            searchable={false}
+            rightSection={<CaretUpDownIcon size={18} />}
+            rightSectionPointerEvents="none"
+        />
     )
 }


### PR DESCRIPTION
[Issue](https://openstax.atlassian.net/browse/OTTER-657): Datasets of Interest: searchable field → simple multiselect dropdown

### Summary
Usability testing found that users mistake the **"Dataset(s) of interest"** field for a free-text input. Because the previous widget was a *searchable* combobox with a text-entry field, users typed arbitrary text, never selected a real dataset, and then couldn't tell why the form wouldn't submit.

### What changed
Replaced the custom `Combobox` + `PillsInput` widget in [`src/components/dataset-multi-select.tsx`](src/components/dataset-multi-select.tsx) with Mantine's stock [`MultiSelect`](https://mantine.dev/combobox/?e=BasicMultiSelect):

- `searchable={false}` → the input is read-only, so **no typing is possible**.
- Selection is click-only; multiple datasets render as removable pills.
- Added the up/down caret affordance (`CaretUpDownIcon`) on the right per the [Figma design](https://www.figma.com/design/1XmdwEp8VY4J3m1CdaApXL/Card-47--Study-proposal-form?node-id=228-4980), so the field clearly reads as a dropdown.
- Kept the same props/signature, so both call sites (study proposal form and edit-and-resubmit) are untouched. Options still come from `useOrgDataSources`, and value/validation (`datasets: z.array(z.string()).min(1)`) are unchanged.