### PR TITLE
OTTER-652: align status banner background colors with UX spec

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/post-feedback-view.tsx
@@ -6,6 +6,7 @@ import { FeedbackAndNotesSection } from '@/components/study/feedback-and-notes'
 import { ProposalRequest } from '@/components/study/proposal-initial-request'
 import { ProposalStepHeader } from '@/components/study/proposal-step-header'
 import { Routes } from '@/lib/routes'
+import { STATUS_BANNER_BG } from '@/lib/status-banner-colors'
 import { type Submitted } from '@/schema/study'
 import { Box, Button, Collapse, Group, Stack, Text, Title } from '@mantine/core'
 import { CaretLeftIcon } from '@phosphor-icons/react'
@@ -65,7 +66,7 @@ const PROPOSAL_DECISION_COPY: Record<ReviewDecision, DecisionCopy> = {
     APPROVE: {
         timestampLabel: 'Approved on',
         banner: {
-            bg: 'green.1',
+            bg: STATUS_BANNER_BG.approved,
             testId: 'decision-banner-approved',
             copy: "This initial request has been approved. You'll receive email notifications when the researcher proceeds to the next step.",
         },
@@ -73,7 +74,7 @@ const PROPOSAL_DECISION_COPY: Record<ReviewDecision, DecisionCopy> = {
     'NEEDS-CLARIFICATION': {
         timestampLabel: 'Clarification requested on',
         banner: {
-            bg: 'yellow.1',
+            bg: STATUS_BANNER_BG.changesRequestedReviewer,
             testId: 'decision-banner-clarification',
             copy: 'You have requested clarification. The researcher has been notified, and we will inform you once they resubmit.',
         },
@@ -81,7 +82,7 @@ const PROPOSAL_DECISION_COPY: Record<ReviewDecision, DecisionCopy> = {
     REJECT: {
         timestampLabel: 'Rejected on',
         banner: {
-            bg: 'red.1',
+            bg: STATUS_BANNER_BG.rejected,
             testId: 'decision-banner-rejected',
             copy: 'This initial request has been rejected. No further action is required at this time.',
         },
@@ -92,7 +93,7 @@ const CODE_DECISION_COPY: Partial<Record<ReviewDecision, DecisionCopy>> = {
     APPROVE: {
         timestampLabel: 'Approved on',
         banner: {
-            bg: 'green.1',
+            bg: STATUS_BANNER_BG.approved,
             testId: 'decision-banner-code-approved',
             copy: 'This study code has been approved. You will be notified when the study results are available for review.',
         },
@@ -100,7 +101,7 @@ const CODE_DECISION_COPY: Partial<Record<ReviewDecision, DecisionCopy>> = {
     'NEEDS-CLARIFICATION': {
         timestampLabel: 'Change requested on',
         banner: {
-            bg: 'yellow.1',
+            bg: STATUS_BANNER_BG.changesRequestedReviewer,
             testId: 'decision-banner-code-change-requested',
             copy: 'You have requested changes or more information about the study code. The researcher has been notified, and you will be notified once they resubmit.',
         },
@@ -108,7 +109,7 @@ const CODE_DECISION_COPY: Partial<Record<ReviewDecision, DecisionCopy>> = {
     REJECT: {
         timestampLabel: 'Rejected on',
         banner: {
-            bg: 'red.1',
+            bg: STATUS_BANNER_BG.rejected,
             testId: 'decision-banner-code-rejected',
             copy: 'This study code was rejected and the study was ended. No further action is required at this time.',
         },

--- a/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/proposal-submitted.tsx
@@ -14,6 +14,7 @@ import { ProposalHeader } from '../../request/page-header'
 import { Routes } from '@/lib/routes'
 import { Link } from '@/components/links'
 import { effectiveProposalStatus } from '@/lib/review-decision'
+import { STATUS_BANNER_BG } from '@/lib/status-banner-colors'
 
 interface ProposalSubmittedProps {
     orgSlug: string
@@ -32,6 +33,7 @@ function proposalHeading(studyVersion: number): string {
 
 type ProposalBannerConfig = {
     color: string
+    bg?: string
     message: (orgName: string) => string
     statusBadge?: string
 }
@@ -44,18 +46,21 @@ const PROPOSAL_BANNERS: Partial<Record<StudyStatus, ProposalBannerConfig>> = {
     },
     APPROVED: {
         color: 'green',
+        bg: STATUS_BANNER_BG.approved,
         statusBadge: 'Approved on',
         message: (orgName) =>
             `${displayOrgName(orgName)} has reviewed and approved your initial request. Review their feedback below, then proceed to Step 3 - Agreements to sign the required legal documents.`,
     },
     REJECTED: {
         color: 'red',
+        bg: STATUS_BANNER_BG.rejected,
         statusBadge: 'Rejected on',
         message: (orgName) =>
             `${displayOrgName(orgName)} has reviewed your initial request and is unable to support it at this time. Please review their feedback below for more details.`,
     },
     'CHANGE-REQUESTED': {
-        color: 'blue',
+        color: 'purple',
+        bg: STATUS_BANNER_BG.changesRequestedResearcher,
         statusBadge: 'Clarification requested on',
         message: (orgName) =>
             `${displayOrgName(orgName)} has reviewed your initial request and has requested clarifications. Please review their feedback below. You can revise and resubmit your request to address their questions.`,
@@ -81,7 +86,7 @@ function StatusBanner({
         : config.message(orgName)
 
     return (
-        <Alert color={config.color} mb="md" data-testid={`status-banner-${proposalStatus}`}>
+        <Alert color={config.color} bg={config.bg} mb="md" data-testid={`status-banner-${proposalStatus}`}>
             {message}
         </Alert>
     )

--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.tsx
@@ -14,6 +14,7 @@ import { filterAndOrderCodeFiles } from '@/app/[orgSlug]/study/[studyId]/review/
 import { StudyCodeToggle, useExpandable } from './study-code-collapse'
 import { displayOrgName } from '@/lib/string'
 import { Routes } from '@/lib/routes'
+import { STATUS_BANNER_BG } from '@/lib/status-banner-colors'
 import { type Submitted } from '@/schema/study'
 import type { CodeReviewFeedbackEntry, SelectedStudy } from '@/server/actions/study.actions'
 import type { LatestJobForStudy } from '@/server/db/queries'
@@ -55,21 +56,21 @@ type DecisionCopy = {
 const DECISION_COPY: Record<CodeDecisionStatus, DecisionCopy> = {
     'CODE-APPROVED': {
         timestampLabel: 'Approved on',
-        bannerBg: 'green.1',
+        bannerBg: STATUS_BANNER_BG.approved,
         bannerTestId: 'decision-banner-code-approved',
         banner: (orgName) =>
             `${displayOrgName(orgName)} has reviewed and approved your study code. Your code will now proceed to run in the secure enclave.`,
     },
     'CODE-CHANGES-REQUESTED': {
         timestampLabel: 'Change requested on',
-        bannerBg: 'purple.1',
+        bannerBg: STATUS_BANNER_BG.changesRequestedResearcher,
         bannerTestId: 'decision-banner-code-change-requested',
         banner: (orgName) =>
             `${displayOrgName(orgName)} has reviewed your code and has requested information and/or changes. Please review the feedback below. You can update your code and resubmit it to address their comments.`,
     },
     'CODE-REJECTED': {
         timestampLabel: 'Rejected on',
-        bannerBg: 'red.1',
+        bannerBg: STATUS_BANNER_BG.rejected,
         bannerTestId: 'decision-banner-code-rejected',
         banner: (orgName) =>
             `${displayOrgName(orgName)} has determined this code does not meet the requirements to proceed. Please review their feedback below. No further code submissions will be accepted for this study, but you may submit a new study proposal. If you believe this decision was made in error, contact SafeInsights.`,

--- a/src/lib/status-banner-colors.test.ts
+++ b/src/lib/status-banner-colors.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { theme } from '@/theme'
+import { STATUS_BANNER_BG } from './status-banner-colors'
+
+// Resolve a Mantine "color.shade" token (e.g. "green.0") to its concrete hex via the theme palette.
+function resolveToken(token: string): string {
+    const [color, shade] = token.split('.')
+    const tuple = theme.colors?.[color as keyof typeof theme.colors]
+    return tuple?.[Number(shade)] ?? ''
+}
+
+// OTTER-652: the status-banner backgrounds must resolve to these exact hexes, which mirror the
+// Figma design-system "Light" semantic tokens. Locking the token -> hex mapping catches both an
+// accidental token change here and a palette reorder in theme.ts.
+describe('STATUS_BANNER_BG', () => {
+    it.each([
+        ['approved', '#E8F8EB'], // Figma Color/Success/Light
+        ['rejected', '#FFE0E0'], // Figma Color/Error/Light
+        ['changesRequestedReviewer', '#FFF9E5'], // Figma Color/Warning/Light
+        ['changesRequestedResearcher', '#EAE8FC'], // Figma Color/Brand/Light
+    ] as const)('%s resolves to %s', (key, hex) => {
+        expect(resolveToken(STATUS_BANNER_BG[key]).toUpperCase()).toBe(hex)
+    })
+})

--- a/src/lib/status-banner-colors.ts
+++ b/src/lib/status-banner-colors.ts
@@ -1,0 +1,10 @@
+// Single source of truth for the large status-banner background colors shown on the proposal and
+// code feedback pages (OTTER-652). Values mirror the Figma design-system semantic tokens and resolve
+// to the theme palette's lightest shade (index 0). Change-requested differs by perspective: the
+// reviewer (DP) sees the warning tint, the researcher (RL) sees the brand tint.
+export const STATUS_BANNER_BG = {
+    approved: 'green.0', // #E8F8EB (Figma Color/Success/Light)
+    rejected: 'red.0', // #FFE0E0 (Figma Color/Error/Light)
+    changesRequestedReviewer: 'yellow.0', // #FFF9E5 (Figma Color/Warning/Light)
+    changesRequestedResearcher: 'purple.0', // #EAE8FC (Figma Color/Brand/Light)
+} as const


### PR DESCRIPTION
see [OTTER-652](https://openstax.atlassian.net/browse/OTTER-652)

## Problem

Status banner background colors on the proposal and code feedback pages did not match the UX spec and risked accessibility issues. The same states were also colored differently across three separate files, which is the "inconsistency" called out in the ticket.

## Root cause

Each banner hardcoded its own Mantine palette shade, mostly the `.1` (second-lightest) shade. The spec wants the `.0` (lightest) shade, which already exists in the theme palette and matches Figma's semantic `*/Light` design tokens exactly.

Verified against the Figma nodes linked in the ticket:

| State | Figma token | Hex | Theme token |
|---|---|---|---|
| Approved (DP & RL) | `Color/Success/Light` | `#E8F8EB` | `green.0` |
| Rejected (DP & RL) | `Color/Error/Light` | `#FFE0E0` | `red.0` |
| Change requested, reviewer (DP) | `Color/Warning/Light` | `#FFF9E5` | `yellow.0` |
| Change requested, researcher (RL) | `Color/Brand/Light` | `#EAE8FC` | `purple.0` |

## Changes

- **New `src/lib/status-banner-colors.ts`**: a single `STATUS_BANNER_BG` map with semantic keys (`approved`, `rejected`, `changesRequestedReviewer`, `changesRequestedResearcher`) resolving to existing palette tokens. This reuses the theme rather than adding a parallel color system, and centralizes the reviewer-vs-researcher difference for change-requested.
- **`post-feedback-view.tsx`** (reviewer, proposal + code): swapped `green.1` / `yellow.1` / `red.1` to the shared map.
- **`code-post-decision-view.tsx`** (researcher, code): swapped `green.1` / `purple.1` / `red.1` to the shared map.
- **`proposal-submitted.tsx`** (researcher, proposal): the `<Alert>` now takes an explicit `bg` token from the map; change-requested moves from the blue family (`#ECF3FF`) to purple to match `purple.0`.
- **New `status-banner-colors.test.ts`**: a deterministic regression test asserting each semantic token resolves to the exact required hex, so a palette reorder or accidental token change is caught.

## Scope

Kept to the six banner states listed in the ticket. The small dashboard status pills (`status-labels.ts`), the "under review" banners, and the review-criteria banners are intentionally left unchanged.

## Testing

- `pnpm run checks` passes (typecheck, lint, action validation).
- Existing banner tests assert on `data-testid` presence, not colors, so they are unaffected.

[OTTER-652]: https://openstax.atlassian.net/browse/OTTER-652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ