### PR TITLE
Fix Claude Code deny rules: use Edit(.env) instead of deprecated Write(.env)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,8 +31,8 @@
     "deny": [
       "Read(.env)",
       "Read(.env.*)",
-      "Write(.env)",
-      "Write(.env.*)"
+      "Edit(.env)",
+      "Edit(.env.*)"
     ]
   },
   "enabledMcpjsonServers": [


### PR DESCRIPTION
## What

Replaces the two deprecated `Write(...)` deny rules in `.claude/settings.json` with `Edit(...)`:

```diff
 "deny": [
   "Read(.env)",
   "Read(.env.*)",
-  "Write(.env)",
-  "Write(.env.*)"
+  "Edit(.env)",
+  "Edit(.env.*)"
 ]
```

## Why

Claude Code **v2.1.210** (released 2026-07-15) added a startup warning for `Write(path)`, `NotebookEdit(path)`, and `Glob(path)` permission rules. File-path permission matching is now keyed only off `Edit(path)` and `Read(path)` rules, so the old `Write(.env)` / `Write(.env.*)` deny rules were being silently ignored, i.e. not actually blocking writes to `.env` files.

## The syntax change

Claude Code consolidated file-editing permission checks so that a single rule type covers every file-mutating tool:

| Rule | Now covers |
|------|-----------|
| `Read(path)` | Read-only tools (Read, Glob, Grep); a `Read` deny also blocks Edit on the same path (v2.1.208+) |
| `Edit(path)` | **All file-editing tools: Edit, Write, and NotebookEdit** (also implicitly grants Read on those paths) |
| `Write(path)` | **Deprecated / no longer matched** for file-permission checks, triggers the startup warning |

Because `Write` and `NotebookEdit` are not covered by a `Read` deny rule, the correct way to make `.env` files unwritable by any tool is an explicit `Edit(...)` deny rule. Keeping the existing `Read(.env)` / `Read(.env.*)` deny rules blocks reads; adding `Edit(.env)` / `Edit(.env.*)` blocks Edit, Write, and NotebookEdit. Together they close the gap.

Timeline (from the Claude Code changelog):
- `v2.1.89` symlink-aware `Edit(//path/**)` / `Read(//path/**)` allow rules
- `v2.1.208` a `Read` deny rule also blocks the Edit tool on the same path
- `v2.1.210` startup warning added for `Write(path)` / `NotebookEdit(path)` / `Glob(path)` rules