### PR TITLE
OTTER-658 follow-up: align resubmission note size test with raised 100kb Lexical JSON bound

### DIFF
--- a/src/server/actions/resubmit-proposal.test.ts
+++ b/src/server/actions/resubmit-proposal.test.ts
@@ -503,7 +503,7 @@ describe('saveProposalResubmissionNoteDraftAction', () => {
         expect(row.proposalResubmissionNoteDraft).toBe('co-author note')
     })
 
-    it('rejects payloads larger than 10kb', async () => {
+    it('rejects payloads larger than 100kb', async () => {
         const { org, user } = await mockSessionWithTestData({ orgSlug: 'lab-prop-note-3', orgType: 'lab' })
         const { study } = await insertTestStudyJobData({
             org,
@@ -511,7 +511,9 @@ describe('saveProposalResubmissionNoteDraftAction', () => {
             studyStatus: 'CHANGE-REQUESTED',
         })
 
-        const tooLong = 'x'.repeat(10_001)
+        // The draft is serialized Lexical JSON since OTTER-658, so the schema bound is
+        // 100_000 chars; a legitimate heavily-formatted note can exceed the old 10kb limit.
+        const tooLong = 'x'.repeat(100_001)
         const result = await saveProposalResubmissionNoteDraftAction({ studyId: study.id, note: tooLong })
         expect(result).toHaveProperty('error')
     })


### PR DESCRIPTION
see [OTTER-658](https://openstax.atlassian.net/browse/OTTER-658)

## What this fixes

Fixes the failing `unit (3)` job on `main`:

```
AssertionError: expected { …(2) } to have property "error"
 ❯ src/server/actions/resubmit-proposal.test.ts:516
   saveProposalResubmissionNoteDraftAction > rejects payloads larger than 10kb
```

This test has been red on `main` since **PR #878** (`OTTER-658: make proposal resubmission note collaborative, fix duplicate saved checkmark`, merged 2026-07-14). Every branch cut from `main` afterward inherits the failure.

## Why it was failing

PR #878 made the proposal resubmission note collaborative by serializing it as **Lexical JSON** instead of plain text. Because that format is verbose (per-word formatting inflates the character count), the same PR deliberately raised the Zod bound on `saveProposalResubmissionNoteDraftAction` from `max(10_000)` to `max(100_000)`:

```ts
// src/server/actions/study-request.ts
// 100_000: the draft is serialized Lexical JSON since OTTER-658, and heavy
// per-word formatting can push a legitimate 300-word note past lower bounds.
.params(z.object({ studyId: z.string().uuid(), note: z.string().max(100_000) }))
```

The test still used `'x'.repeat(10_001)` and asserted an `error`. Under the new bound a 10,001-char note is perfectly valid, so no `error` is returned and the assertion fails. The behavior change was intentional; the test was simply not updated alongside it.

## The fix

Aligns the test with the intended `100_000` bound while keeping its real purpose (the schema rejects oversized payloads) intact:

- Payload changed to `'x'.repeat(100_001)` so it exceeds the current limit.
- Renamed to `rejects payloads larger than 100kb`.
- Assertion (`expect(result).toHaveProperty('error')`) unchanged: a param over the Zod `.max()` still yields the `{ error }` result the test relies on.

The assertion was not weakened, skipped, or made to pass trivially. It now faithfully verifies the size guard at the bound the feature actually enforces.

## Note on process

PR #878's own head commit already had `unit (3)` red before merge. `main` currently has no required-status-checks rule (only one approval is required), so a red build can be merged past review. Worth adding `unit` / `lint` / `e2e` as required checks separately so this class of regression is blocked at merge time.

[OTTER-658]: https://openstax.atlassian.net/browse/OTTER-658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ