### PR TITLE
OTTER-545 follow-up: restore real PR coverage deltas via push-to-main wiki baseline

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -421,7 +421,7 @@ jobs:
                   name: coverage-summary
                   path: test-results/coverage/coverage-summary.json
                   retention-days: 1
-                  if-no-files-found: ignore
+                  if-no-files-found: error
             - name: Coverage Diff
               # PR-only: reads the wiki baseline (kept fresh by the push-only
               # `coverage-baseline` job) and posts the delta comment. This job never writes
@@ -445,18 +445,19 @@ jobs:
     #     never trigger, so no PR-controlled code ever executes with this token (GitHub
     #     also downgrades fork-PR tokens to read-only regardless of this block);
     #   - it runs NO `pnpm install` and NO app/test code: it only downloads the
-    #     already-merged coverage-summary.json artifact and lets coverage-diff-action
-    #     push it to the wiki, keeping the code under contents:write minimal.
+    #     already-merged coverage-summary.json artifact, checks the current main ref,
+    #     and lets coverage-diff-action push it to the wiki, keeping the code under
+    #     contents:write minimal.
     # Do NOT add a `pull_request` trigger or a same-repo-PR gate to this job, do NOT add
     # any stored repository secrets (anything under `secrets.*` other than the automatic
     # `GITHUB_TOKEN`), and do NOT check out PR head; each of those reopens OTTER-545.
     coverage-baseline:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         # Serialize baseline writes across concurrent main runs (the workflow-level group
-        # keys push runs by run_id, so they run in parallel). Without this, two main pushes
-        # can race the wiki push (non-fast-forward failure) or overwrite the baseline out of
-        # order, leaving it stale. cancel-in-progress lets the newer run win. Safe for the
-        # build cache: that is seeded in `e2e`, which finishes before this job starts.
+        # keys push runs by run_id, so they run in parallel). GitHub does not guarantee the
+        # order of jobs in a concurrency group, so the main-HEAD check below prevents an
+        # older run that arrives late from overwriting a newer baseline. Safe for the build
+        # cache: that is seeded in `e2e`, which finishes before this job starts.
         concurrency:
             group: coverage-baseline-${{ github.ref }}
             cancel-in-progress: true
@@ -474,7 +475,20 @@ jobs:
               with:
                   name: coverage-summary
                   path: test-results/coverage
+            - name: check whether this run is current main HEAD
+              id: main-head
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  head_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
+                  if [[ "$head_sha" == "$GITHUB_SHA" ]]; then
+                      echo "is-current=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "is-current=false" >> "$GITHUB_OUTPUT"
+                      echo "Skipping baseline refresh: $GITHUB_SHA is no longer main HEAD ($head_sha)."
+                  fi
             - name: Push coverage baseline to wiki
+              if: steps.main-head.outputs.is-current == 'true'
               uses: bultkrantz/coverage-diff-action@4b5175f210f33024e9725a59f6be6ba407bec8cd # v5.0.1
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,8 +18,9 @@
 # is OTTER-545-safe because it runs ONLY on push to main (guarded by both the event
 # and `github.ref == 'refs/heads/main'`): trusted, post-merge code that a PR/fork
 # can never trigger, and it runs no pnpm install and no app/test code (see the
-# comment on that job). Every `pull_request`-reachable job here still holds no write
-# scope and no secrets.
+# comment on that job). Every `pull_request`-reachable job here still holds no
+# `contents: write` and no stored repository secrets: the only token in scope is the
+# automatic, ephemeral, job-scoped `GITHUB_TOKEN`, bounded by each job's `permissions:`.
 name: Checks
 on:
     push:
@@ -447,9 +448,18 @@ jobs:
     #     already-merged coverage-summary.json artifact and lets coverage-diff-action
     #     push it to the wiki, keeping the code under contents:write minimal.
     # Do NOT add a `pull_request` trigger or a same-repo-PR gate to this job, do NOT add
-    # any `secrets.*`, and do NOT check out PR head; each of those reopens OTTER-545.
+    # any stored repository secrets (anything under `secrets.*` other than the automatic
+    # `GITHUB_TOKEN`), and do NOT check out PR head; each of those reopens OTTER-545.
     coverage-baseline:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        # Serialize baseline writes across concurrent main runs (the workflow-level group
+        # keys push runs by run_id, so they run in parallel). Without this, two main pushes
+        # can race the wiki push (non-fast-forward failure) or overwrite the baseline out of
+        # order, leaving it stale. cancel-in-progress lets the newer run win. Safe for the
+        # build cache: that is seeded in `e2e`, which finishes before this job starts.
+        concurrency:
+            group: coverage-baseline-${{ github.ref }}
+            cancel-in-progress: true
         timeout-minutes: 10
         runs-on: ubuntu-latest
         needs: [coverage]

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,10 +15,11 @@
 # runs here. Use Dependabot to update the SHAs.
 #
 # Exception to rule 2: the `coverage-baseline` job holds `contents: write`. That
-# is OTTER-545-safe because it runs ONLY on push to main (`if: github.event_name
-# == 'push'`) — trusted, post-merge code that a PR/fork can never trigger — and it
-# runs no pnpm install and no app/test code (see the comment on that job). Every
-# `pull_request`-reachable job here still holds no write scope and no secrets.
+# is OTTER-545-safe because it runs ONLY on push to main (guarded by both the event
+# and `github.ref == 'refs/heads/main'`): trusted, post-merge code that a PR/fork
+# can never trigger, and it runs no pnpm install and no app/test code (see the
+# comment on that job). Every `pull_request`-reachable job here still holds no write
+# scope and no secrets.
 name: Checks
 on:
     push:
@@ -413,7 +414,7 @@ jobs:
             # job so it can refresh the wiki baseline without re-running the merge (or any
             # pnpm install / app code) under contents:write. See that job for the rationale.
             - name: upload merged coverage summary (for baseline refresh on main)
-              if: github.event_name == 'push'
+              if: github.event_name == 'push' && github.ref == 'refs/heads/main'
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: coverage-summary
@@ -435,17 +436,20 @@ jobs:
 
     # SECURITY (OTTER-545): refreshes the wiki coverage baseline that the PR `coverage`
     # job diffs against. This job holds `contents: write`, but it is safe because:
-    #   - it runs ONLY on push to main (`if: github.event_name == 'push'`) — trusted,
-    #     post-merge code that a PR or fork can never trigger, so no PR-controlled code
-    #     ever executes with this token (GitHub also downgrades fork-PR tokens to
-    #     read-only regardless of this block);
+    #   - it runs ONLY on push to main. The `github.ref == 'refs/heads/main'` check is
+    #     belt-and-braces (today `push` is configured for `main` only, so the event check
+    #     alone suffices) that keeps it strictly on push-to-main even if a future
+    #     `pull_request_target` or extra push branch is added (same guard as the "Save
+    #     Next build cache" step above). Trusted, post-merge code that a PR or fork can
+    #     never trigger, so no PR-controlled code ever executes with this token (GitHub
+    #     also downgrades fork-PR tokens to read-only regardless of this block);
     #   - it runs NO `pnpm install` and NO app/test code: it only downloads the
     #     already-merged coverage-summary.json artifact and lets coverage-diff-action
     #     push it to the wiki, keeping the code under contents:write minimal.
     # Do NOT add a `pull_request` trigger or a same-repo-PR gate to this job, do NOT add
-    # any `secrets.*`, and do NOT check out PR head — each of those reopens OTTER-545.
+    # any `secrets.*`, and do NOT check out PR head; each of those reopens OTTER-545.
     coverage-baseline:
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         timeout-minutes: 10
         runs-on: ubuntu-latest
         needs: [coverage]

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,6 +13,12 @@
 # Third-party actions are pinned to commit SHAs (with the version tag in a
 # trailing comment) so a compromised upstream tag cannot silently change what
 # runs here. Use Dependabot to update the SHAs.
+#
+# Exception to rule 2: the `coverage-baseline` job holds `contents: write`. That
+# is OTTER-545-safe because it runs ONLY on push to main (`if: github.event_name
+# == 'push'`) — trusted, post-merge code that a PR/fork can never trigger — and it
+# runs no pnpm install and no app/test code (see the comment on that job). Every
+# `pull_request`-reachable job here still holds no write scope and no secrets.
 name: Checks
 on:
     push:
@@ -403,10 +409,58 @@ jobs:
               run: |
                   cat test-results/coverage/coverage-summary.md >> $GITHUB_STEP_SUMMARY
                   cat test-results/coverage/coverage-details.md >> $GITHUB_STEP_SUMMARY
+            # On push to main, hand the merged summary to the push-only `coverage-baseline`
+            # job so it can refresh the wiki baseline without re-running the merge (or any
+            # pnpm install / app code) under contents:write. See that job for the rationale.
+            - name: upload merged coverage summary (for baseline refresh on main)
+              if: github.event_name == 'push'
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: coverage-summary
+                  path: test-results/coverage/coverage-summary.json
+                  retention-days: 1
+                  if-no-files-found: ignore
             - name: Coverage Diff
-              # PR-only; on the default branch the action needs contents:write to push the
-              # baseline to the wiki, which we withhold (OTTER-545), so it 403s — skip it.
+              # PR-only: reads the wiki baseline (kept fresh by the push-only
+              # `coverage-baseline` job) and posts the delta comment. This job never writes
+              # the baseline, so it needs no contents:write (OTTER-545).
               if: github.event_name == 'pull_request'
+              uses: bultkrantz/coverage-diff-action@4b5175f210f33024e9725a59f6be6ba407bec8cd # v5.0.1
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  base-summary-filename: base-summary.json
+                  coverage-filename: test-results/coverage/coverage-summary.json
+                  allowed-to-fail: true
+                  badge-enabled: false
+
+    # SECURITY (OTTER-545): refreshes the wiki coverage baseline that the PR `coverage`
+    # job diffs against. This job holds `contents: write`, but it is safe because:
+    #   - it runs ONLY on push to main (`if: github.event_name == 'push'`) — trusted,
+    #     post-merge code that a PR or fork can never trigger, so no PR-controlled code
+    #     ever executes with this token (GitHub also downgrades fork-PR tokens to
+    #     read-only regardless of this block);
+    #   - it runs NO `pnpm install` and NO app/test code: it only downloads the
+    #     already-merged coverage-summary.json artifact and lets coverage-diff-action
+    #     push it to the wiki, keeping the code under contents:write minimal.
+    # Do NOT add a `pull_request` trigger or a same-repo-PR gate to this job, do NOT add
+    # any `secrets.*`, and do NOT check out PR head — each of those reopens OTTER-545.
+    coverage-baseline:
+        if: github.event_name == 'push'
+        timeout-minutes: 10
+        runs-on: ubuntu-latest
+        needs: [coverage]
+        permissions:
+            contents: write
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  persist-credentials: false
+            - name: download merged coverage summary
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+              with:
+                  name: coverage-summary
+                  path: test-results/coverage
+            - name: Push coverage baseline to wiki
               uses: bultkrantz/coverage-diff-action@4b5175f210f33024e9725a59f6be6ba407bec8cd # v5.0.1
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
see [OTTER-545](https://openstax.atlassian.net/browse/OTTER-545)

## What this fixes

The coverage comment on PRs (e.g. #889) shows a correct absolute total (~95% lines) but nonsensical deltas: `+2.74%` total and hundreds of files at `(+100.00%)` on a tiny change. The absolute numbers are real; the deltas are not.

## Root cause

The comment is posted by `bultkrantz/coverage-diff-action`, which computes the delta as *current merged coverage vs a baseline `base-summary.json` stored in the repo wiki*:

- On **push to the default branch** it *writes* the fresh baseline to the wiki (needs `contents: write`).
- On a **PR** it only *reads* the wiki and posts the comment (`pull-requests: write`); it never writes.

The OTTER-545 remediation removed `contents: write` from the `coverage` job (correctly, because that job runs PR-controlled code). As a side effect, the push-to-main baseline write stopped working, so the wiki baseline **froze**. Every PR is now diffed against that stale snapshot, so the "delta" is drift-since-freeze rather than the PR's effect.

## The fix

Split the baseline write off into a dedicated job that runs only on push to main, keeping the PR path read-only. All changes are in `.github/workflows/checks.yml`:

- The existing `coverage` job is unchanged in permissions (`pull-requests: write` only). On push to main it uploads the merged `coverage-summary.json` as an artifact. On PRs it still reads the wiki baseline and posts the delta comment. A missing merged summary now fails clearly at the upload step instead of producing a later, confusing artifact-not-found error.
- A new `coverage-baseline` job runs only on push to main (`if: github.event_name == 'push' && github.ref == 'refs/heads/main'`), holds `contents: write`, downloads that artifact, and lets the action push the fresh baseline to the wiki. It runs no `pnpm install` and no app or test code.
- The `coverage-baseline` job has its own concurrency group (`cancel-in-progress: true`) to serialize wiki writes without affecting the rest of concurrent main workflows or build-cache seeding. GitHub does not guarantee execution order within a concurrency group, so the job queries the live `main` ref immediately before writing and only runs the baseline action when `GITHUB_SHA` is still the current main HEAD. A late older run skips successfully instead of overwriting a newer baseline. The query uses the same automatic `GITHUB_TOKEN` already held by the job and requires no additional permissions or repository secret.

The report format is unchanged (one comment per PR, whole-project totals plus per-file table). After this lands on `main`, the first current-HEAD push refreshes the baseline and deltas become correct.

## Why this does not violate OTTER-545

OTTER-545's rule is that no job which runs PR-controlled code may hold secrets or write permissions; its principle is "PR code runs without secrets; secrets-using code runs only on trusted refs." The writeup's recommended fix (Pattern A) gates the privileged job with `push OR same-repo PR`.

This change conforms, in a stricter form:

- The only job with `contents: write` (`coverage-baseline`) is gated `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`, a strict subset of Pattern A (not even same-repo PRs). A PR or fork can never trigger it, so no PR-controlled code ever executes with that token. The explicit `github.ref` check is belt-and-braces (today `push` is configured for `main` only, so the event check alone suffices) mirroring the existing "Save Next build cache" step, so the job stays strictly on push-to-main even if a future trigger is added. GitHub additionally force-downgrades fork-PR tokens to read-only and withholds secrets regardless of the `permissions:` block, and `pull_request_target` is not used anywhere.
- Extra hardening beyond Pattern A: the privileged job runs no `pnpm install` and no app or test code. It only downloads the already-merged summary artifact, reads the current main ref through the GitHub API, and pushes the summary, so the code executing under `contents: write` is minimal.
- Every in-repo control from the 2026-05-15 remediation is preserved: the PR-triggered `coverage` job keeps `pull-requests: write` only (no `contents: write`, no stored repository secrets); the `SONAR_TOKEN`/`infosec` split, `persist-credentials: false` on all checkouts (including the new job), job timeouts, SHA-pinned actions, and `claude.yml` are all untouched. No stored repository secret is added to any job (the new job uses only the automatic `GITHUB_TOKEN`), so the documented invalidation conditions are not tripped, and the external attestations (rotated credentials, throwaway-isolated CI Clerk instance) are undisturbed.
- One documented line-item is deliberately reversed but relocated: the remediation disabled the wiki push so a token leaked from the test job could only post comments. This restores the push only on the push-to-main job, never on the PR/test path, so that intent is fully preserved.

Residual, stated honestly: the write capability now rests on merges to main being reviewed, which is the same trust boundary that already guards secret access on push-to-main (the `infosec` job with `SONAR_TOKEN`). Main requires an approval today. Inline threat-model comments were added at the top of the workflow and on the new job, including the modifications that would reopen the vulnerability (do not add a `pull_request` trigger or same-repo-PR gate to `coverage-baseline`, do not add stored secrets to it, do not check out PR head).

## Verification

- `pnpm run checks` passes, including TypeScript, ESLint, Prettier, and Actions validation.
- `pnpm run validate-actions` passes independently.
- After merge: confirm `coverage-baseline` runs on the push event and the wiki `base-summary.json` gets a new commit; then open a small well-tested PR and confirm the deltas are sensible (no blanket `+100.00%`).

[OTTER-545]: https://openstax.atlassian.net/browse/OTTER-545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ