### PR TITLE
OTTER-570: bump eslint-plugin-react-hooks to ^7.1.1 and fix newly-surfaced rule violations

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
         "eslint-plugin-anti-trojan-source": "^1.1.4",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "7.0.1",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^17.4.0",
         "happy-dom": "*",
         "husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,8 +321,8 @@ importers:
         specifier: ^7.37.5
         version: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks:
-        specifier: 7.0.1
-        version: 7.0.1(eslint@9.39.4(jiti@2.7.0))
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@9.39.4(jiti@2.7.0))
       globals:
         specifier: ^17.4.0
         version: 17.6.0
@@ -3812,11 +3812,11 @@ packages:
       '@typescript-eslint/parser':
         optional: true
 
-  eslint-plugin-react-hooks@7.0.1:
-    resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
     engines: {node: '>=18'}
     peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
 
   eslint-plugin-react@7.37.5:
     resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
@@ -9599,16 +9599,16 @@ snapshots:
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/chai@5.2.3':
     dependencies:
@@ -10016,7 +10016,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.25':
     dependencies:
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       '@vue/shared': 3.5.25
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -10029,7 +10029,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.25':
     dependencies:
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       '@vue/compiler-core': 3.5.25
       '@vue/compiler-dom': 3.5.25
       '@vue/compiler-ssr': 3.5.25
@@ -11078,10 +11078,10 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-react-hooks@7.1.1(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       eslint: 9.39.4(jiti@2.7.0)
       hermes-parser: 0.25.1
       zod: 4.4.3

--- a/src/app/[orgSlug]/admin/settings/code-envs.tsx
+++ b/src/app/[orgSlug]/admin/settings/code-envs.tsx
@@ -98,6 +98,19 @@ const CodeEnvDetailPanel: React.FC<{
     )
 }
 
+const DeleteCodeEnv: React.FC<{ isVisible: boolean; onConfirmed: () => void }> = ({ isVisible, onConfirmed }) => {
+    if (!isVisible) return null
+
+    return (
+        <SuretyGuard
+            onConfirmed={onConfirmed}
+            message="Are you sure you want to delete this code environment? This cannot be undone."
+        >
+            <TrashIcon />
+        </SuretyGuard>
+    )
+}
+
 const CodeEnvRow: React.FC<{
     image: CodeEnv
     canDelete: boolean
@@ -153,19 +166,6 @@ const CodeEnvRow: React.FC<{
         }
     }
 
-    const DeleteCodeEnv = () => {
-        if (!canDelete) return null
-
-        return (
-            <SuretyGuard
-                onConfirmed={() => deleteMutation.mutate({ codeEnvId: image.id, orgSlug })}
-                message="Are you sure you want to delete this code environment? This cannot be undone."
-            >
-                <TrashIcon />
-            </SuretyGuard>
-        )
-    }
-
     return (
         <>
             <CodeEnvRowView
@@ -185,7 +185,10 @@ const CodeEnvRow: React.FC<{
                                 <PencilIcon />
                             </ActionIcon>
                         </Tooltip>
-                        <DeleteCodeEnv />
+                        <DeleteCodeEnv
+                            isVisible={canDelete}
+                            onConfirmed={() => deleteMutation.mutate({ codeEnvId: image.id, orgSlug })}
+                        />
                     </>
                 }
                 detail={

--- a/src/app/account/signin/use-already-signed-in.ts
+++ b/src/app/account/signin/use-already-signed-in.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useRouter, useSearchParams, type ReadonlyURLSearchParams } from 'next/navigation'
 import { useClerk, useUser } from '@clerk/nextjs'
 import type { Route } from 'next'
@@ -37,24 +37,38 @@ export function useAlreadySignedIn(): UseAlreadySignedIn {
 
     const [status, setStatus] = useState<AlreadySignedInStatus>('loading')
     const [isSwitching, setIsSwitching] = useState(false)
+    const [redirectTarget, setRedirectTarget] = useState<Route | null>(null)
+    const hasRedirectedRef = useRef(false)
 
-    useEffect(() => {
-        if (!isLoaded || status !== 'loading') return
-
+    // Resolve the one-time landing status as soon as Clerk finishes loading. Done
+    // during render (rather than in an effect) so it doesn't trigger a cascading
+    // re-render; the `status === 'loading'` guard latches it, and switchAccount
+    // overrides it afterward. The redirect target is captured here so the navigation
+    // effect below fires exactly once and does not re-read the (post-navigation)
+    // search params.
+    if (isLoaded && status === 'loading') {
         if (!isSignedIn) {
             setStatus('signed-out')
-            return
+        } else {
+            const target = trustedRedirectTarget(searchParams)
+            if (target) {
+                setRedirectTarget(target)
+                setStatus('redirecting')
+            } else {
+                setStatus('signed-in')
+            }
         }
+    }
 
-        const target = trustedRedirectTarget(searchParams)
-        if (target) {
-            setStatus('redirecting')
-            router.replace(target)
-            return
-        }
-
-        setStatus('signed-in')
-    }, [isLoaded, isSignedIn, status, router, searchParams])
+    // Perform the actual navigation once we've latched into the redirecting state.
+    // The ref makes this fire exactly once: the effect can re-run on unrelated
+    // re-renders (e.g. an unstable router reference), and repeatedly calling
+    // router.replace while status stays 'redirecting' would loop.
+    useEffect(() => {
+        if (status !== 'redirecting' || !redirectTarget || hasRedirectedRef.current) return
+        hasRedirectedRef.current = true
+        router.replace(redirectTarget)
+    }, [status, redirectTarget, router])
 
     const continueToApp = useCallback(() => {
         router.replace(trustedRedirectTarget(searchParams) ?? Routes.dashboard)

--- a/src/components/layout/org-admin-dashboard-link.test.tsx
+++ b/src/components/layout/org-admin-dashboard-link.test.tsx
@@ -8,6 +8,7 @@ import {
     faker,
     userEvent,
     mockPathname,
+    act,
 } from '@/tests/unit.helpers'
 import { OrgAdminDashboardLink } from './org-admin-dashboard-link'
 
@@ -74,6 +75,35 @@ describe('OrgAdminDashboardLink', () => {
         renderWithProviders(<OrgAdminDashboardLink isVisible={true} org={org} />)
         expect(screen.getByRole('link', { name: 'Team' })).toBeVisible()
         expect(screen.getByRole('link', { name: 'Settings' })).toBeVisible()
+    })
+
+    it('re-syncs the submenu open state when the route changes', async () => {
+        const orgSlug = faker.lorem.slug()
+        const org = {
+            type: 'enclave' as const,
+            name: faker.company.name(),
+            id: faker.string.uuid(),
+            slug: orgSlug,
+        }
+        await mockSessionWithTestData()
+        mockPathname('/')
+
+        renderWithProviders(<OrgAdminDashboardLink isVisible={true} org={org} />)
+
+        // Closed while off an admin route
+        expect(screen.queryByRole('link', { name: 'Team' })).not.toBeInTheDocument()
+
+        // Navigating into an admin route opens the submenu
+        await act(async () => {
+            mockPathname(`/admin/team/${orgSlug}`)
+        })
+        expect(screen.getByRole('link', { name: 'Team' })).toBeVisible()
+
+        // Navigating back out closes it again
+        await act(async () => {
+            mockPathname('/')
+        })
+        expect(screen.queryByRole('link', { name: 'Team' })).not.toBeInTheDocument()
     })
 
     it('toggles the submenu on click', async () => {

--- a/src/components/layout/org-admin-dashboard-link.tsx
+++ b/src/components/layout/org-admin-dashboard-link.tsx
@@ -3,7 +3,7 @@
 import { NavLink } from '@mantine/core'
 import { GearIcon, SlidersIcon, UsersThreeIcon } from '@phosphor-icons/react/dist/ssr'
 import { useParams, usePathname } from 'next/navigation'
-import { FC, useEffect, useState } from 'react'
+import { FC, useState } from 'react'
 import { RefWrapper } from './nav-ref-wrapper'
 import styles from './navbar-items.module.css'
 import { NavbarLink } from './navbar-link'
@@ -25,9 +25,14 @@ export const OrgAdminDashboardLink: FC<OrgAdminDashboardLinkProps> = ({ isVisibl
 
     const [isAdminMenuOpen, setIsAdminMenuOpen] = useState(isAdminPage)
 
-    useEffect(() => {
+    // Re-sync the menu's open state to the route during render (rather than in an
+    // effect) so navigating into/out of /admin opens or closes it without a
+    // cascading re-render, while a manual toggle still holds between navigations.
+    const [prevIsAdminPage, setPrevIsAdminPage] = useState(isAdminPage)
+    if (isAdminPage !== prevIsAdminPage) {
+        setPrevIsAdminPage(isAdminPage)
         setIsAdminMenuOpen(isAdminPage)
-    }, [isAdminPage])
+    }
 
     if (!isVisible) return null
 

--- a/src/components/researcher-profile/education-section.test.tsx
+++ b/src/components/researcher-profile/education-section.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import { useState } from 'react'
 import { screen, waitFor } from '@testing-library/react'
 import {
     renderWithProviders,
@@ -57,6 +58,61 @@ describe('EducationSection', () => {
         await waitFor(() => {
             expect(screen.getByText('Degree (currently pursuing)')).toBeDefined()
         })
+    })
+
+    it('preserves unsaved edits when a background refetch changes server data', async () => {
+        const userEvents = userEvent.setup()
+        const { user } = await mockSessionWithTestData({ orgType: 'lab' })
+
+        await insertTestResearcherProfile({
+            userId: user.id,
+            education: {
+                institution: 'MIT',
+                degree: 'Doctor of Philosophy (Ph.D.)',
+                fieldOfStudy: 'Computer Science',
+            },
+        })
+
+        const initialData = await getTestResearcherProfileData(user.id)
+        const refetch = vi.fn(async () => getTestResearcherProfileData(user.id))
+
+        // Harness lets the test swap in changed server data (as a periodic refetch or a
+        // window-focus refetch would) while the form is open for editing.
+        const Harness = () => {
+            const [data, setData] = useState(initialData)
+            return (
+                <>
+                    <button
+                        onClick={() =>
+                            setData((prev) =>
+                                prev
+                                    ? { ...prev, profile: { ...prev.profile, educationFieldOfStudy: 'RemoteChange' } }
+                                    : prev,
+                            )
+                        }
+                    >
+                        simulate-refetch
+                    </button>
+                    <EducationSection data={data} refetch={refetch} />
+                </>
+            )
+        }
+
+        renderWithProviders(<Harness />)
+
+        const editButton = screen.getByRole('button', { name: /edit/i })
+        await userEvents.click(editButton)
+
+        const institutionInput = screen.getByPlaceholderText('Ex: Rice University')
+        await userEvents.clear(institutionInput)
+        await userEvents.type(institutionInput, 'MyUnsavedSchool')
+
+        await userEvents.click(screen.getByRole('button', { name: 'simulate-refetch' }))
+
+        // The in-progress edit must not be clobbered by the refetch. Re-query the input
+        // (rather than reusing the captured node) so a clobber that resets the value or
+        // closes edit mode is actually detected.
+        expect((screen.getByPlaceholderText('Ex: Rice University') as HTMLInputElement).value).toBe('MyUnsavedSchool')
     })
 
     it('should save education changes', async () => {

--- a/src/components/researcher-profile/personal-info-section.test.tsx
+++ b/src/components/researcher-profile/personal-info-section.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import { useState } from 'react'
 import { screen, waitFor } from '@testing-library/react'
 import {
     renderWithProviders,
@@ -143,6 +144,50 @@ describe('PersonalInfoSection', () => {
             expect(emailInput.disabled).toBe(true)
             expect(emailInput.value).toBe(user.email)
         })
+    })
+
+    it('preserves unsaved edits when a background refetch changes server data', async () => {
+        const userEvents = userEvent.setup()
+        const { user } = await mockSessionWithTestData({ orgType: 'lab' })
+
+        await insertTestResearcherProfile({ userId: user.id })
+
+        const initialData = await getTestResearcherProfileData(user.id)
+        const refetch = vi.fn(async () => getTestResearcherProfileData(user.id))
+
+        // Harness lets the test swap in changed server data (as a periodic refetch or a
+        // window-focus refetch would) while the form is open for editing.
+        const Harness = () => {
+            const [data, setData] = useState(initialData)
+            return (
+                <>
+                    <button
+                        onClick={() =>
+                            setData((prev) =>
+                                prev ? { ...prev, user: { ...prev.user, lastName: 'RemoteChange' } } : prev,
+                            )
+                        }
+                    >
+                        simulate-refetch
+                    </button>
+                    <PersonalInfoSection data={data} refetch={refetch} />
+                </>
+            )
+        }
+
+        renderWithProviders(<Harness />)
+
+        const editButton = screen.getByRole('button', { name: /edit/i })
+        await userEvents.click(editButton)
+
+        const firstNameInput = screen.getByPlaceholderText('Enter your first name')
+        await userEvents.clear(firstNameInput)
+        await userEvents.type(firstNameInput, 'MyUnsavedName')
+
+        await userEvents.click(screen.getByRole('button', { name: 'simulate-refetch' }))
+
+        // The in-progress edit must not be clobbered by the refetch.
+        expect((screen.getByPlaceholderText('Enter your first name') as HTMLInputElement).value).toBe('MyUnsavedName')
     })
 
     it('should close edit mode without API call when no changes are made', async () => {

--- a/src/components/researcher-profile/research-details-section.test.tsx
+++ b/src/components/researcher-profile/research-details-section.test.tsx
@@ -375,6 +375,68 @@ describe('ResearchDetailsSection', () => {
         expect((interestInput as HTMLInputElement).value).toBe('MyDraftInterest')
     })
 
+    // A committed interest edit (added via Enter, so it went through form.insertListItem) must
+    // also survive a mid-edit refetch. Reproduces the exact reviewer scenario: commit a pill,
+    // then change and restore another field, then a background refetch changes the persisted
+    // interests. form.isDirty() must still report the list divergence (Mantine v8 computes it by
+    // deep comparison), so the guard skips the resync and the edit is preserved.
+    it('preserves a committed interest edit when a background refetch changes server data', async () => {
+        const userEvents = userEvent.setup()
+        const { user } = await mockSessionWithTestData({ orgType: 'lab' })
+
+        await insertTestResearcherProfile({
+            userId: user.id,
+            researchDetails: {
+                interests: ['AI', 'ML'],
+                detailedPublicationsUrl: 'https://scholar.google.com/user',
+            },
+        })
+
+        const initialData = await getTestResearcherProfileData(user.id)
+        const refetch = vi.fn(async () => getTestResearcherProfileData(user.id))
+
+        let deliverRefetch: () => void = () => {}
+        const Harness = () => {
+            const [data, setData] = useState(initialData)
+            deliverRefetch = () =>
+                setData((prev) =>
+                    prev
+                        ? {
+                              ...prev,
+                              profile: {
+                                  ...prev.profile,
+                                  researchInterests: ['AI', 'ML', 'ServerAddedInterest'],
+                              },
+                          }
+                        : prev,
+                )
+            return <ResearchDetailsSection data={data} refetch={refetch} />
+        }
+
+        renderWithProviders(<Harness />)
+
+        await userEvents.click(screen.getByRole('button', { name: /edit/i }))
+
+        // Commit a new interest via Enter (goes through form.insertListItem).
+        const interestInput = screen.getByPlaceholderText('Type a research interest and press enter')
+        await userEvents.type(interestInput, 'KeepMe{Enter}')
+        await waitFor(() => expect(screen.getByText('KeepMe')).toBeDefined())
+
+        // Change another field and restore it, per the reviewer scenario.
+        const urlInput = screen.getByPlaceholderText('https://scholar.google.com/user...')
+        await userEvents.type(urlInput, 'X')
+        await userEvents.clear(urlInput)
+        await userEvents.type(urlInput, 'https://scholar.google.com/user')
+
+        await act(async () => {
+            deliverRefetch()
+        })
+
+        // The committed edit must survive and the refetched interest must not be pulled in.
+        expect(screen.getByText('KeepMe')).toBeDefined()
+        expect(screen.queryByText('ServerAddedInterest')).toBeNull()
+    })
+
     it('should commit a typed interest to a pill when the field loses focus', async () => {
         const userEvents = userEvent.setup()
         const { user } = await mockSessionWithTestData({ orgType: 'lab' })

--- a/src/components/researcher-profile/research-details-section.test.tsx
+++ b/src/components/researcher-profile/research-details-section.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
-import { screen, waitFor, fireEvent } from '@testing-library/react'
+import { useState } from 'react'
+import { screen, waitFor, fireEvent, act } from '@testing-library/react'
 import {
     renderWithProviders,
     userEvent,
@@ -315,6 +316,63 @@ describe('ResearchDetailsSection', () => {
 
         expect(updated.researchInterests).toEqual(['Quantum Computing'])
         expect(updated.detailedPublicationsUrl).toBe('https://scholar.google.com/citations?user=abc123')
+    })
+
+    // A background refetch (15-min interval / window focus) that changes the persisted
+    // interests must not resync into an open edit session while the user has a typed-but-
+    // uncommitted interest draft. That draft is separate state form.isDirty() cannot see;
+    // resyncing would pull in the server interests and silently drop the draft on Save.
+    it('does not pull refetched interests into an open edit form with an uncommitted draft', async () => {
+        const userEvents = userEvent.setup()
+        const { user } = await mockSessionWithTestData({ orgType: 'lab' })
+
+        await insertTestResearcherProfile({
+            userId: user.id,
+            researchDetails: {
+                interests: ['AI', 'ML', 'Data Science', 'NLP'],
+                detailedPublicationsUrl: 'https://scholar.google.com/user',
+            },
+        })
+
+        const initialData = await getTestResearcherProfileData(user.id)
+        const refetch = vi.fn(async () => getTestResearcherProfileData(user.id))
+
+        // Deliver the refetch by mutating the harness state directly (not via a DOM click),
+        // so the interest input never blurs and the draft stays uncommitted.
+        let deliverRefetch: () => void = () => {}
+        const Harness = () => {
+            const [data, setData] = useState(initialData)
+            deliverRefetch = () =>
+                setData((prev) =>
+                    prev
+                        ? {
+                              ...prev,
+                              profile: {
+                                  ...prev.profile,
+                                  researchInterests: ['AI', 'ML', 'Data Science', 'NLP', 'ServerAddedInterest'],
+                              },
+                          }
+                        : prev,
+                )
+            return <ResearchDetailsSection data={data} refetch={refetch} />
+        }
+
+        renderWithProviders(<Harness />)
+
+        const editButton = screen.getByRole('button', { name: /edit/i })
+        await userEvents.click(editButton)
+
+        const interestInput = screen.getByPlaceholderText('Type a research interest and press enter')
+        await userEvents.type(interestInput, 'MyDraftInterest')
+
+        await act(async () => {
+            deliverRefetch()
+        })
+
+        // The open edit session must not absorb the refetched interest, and the uncommitted
+        // draft must remain intact.
+        expect(screen.queryByText('ServerAddedInterest')).toBeNull()
+        expect((interestInput as HTMLInputElement).value).toBe('MyDraftInterest')
     })
 
     it('should commit a typed interest to a pill when the field loses focus', async () => {

--- a/src/components/researcher-profile/research-details-section.test.tsx
+++ b/src/components/researcher-profile/research-details-section.test.tsx
@@ -378,8 +378,8 @@ describe('ResearchDetailsSection', () => {
     // A committed interest edit (added via Enter, so it went through form.insertListItem) must
     // also survive a mid-edit refetch. Reproduces the exact reviewer scenario: commit a pill,
     // then change and restore another field, then a background refetch changes the persisted
-    // interests. form.isDirty() must still report the list divergence (Mantine v8 computes it by
-    // deep comparison), so the guard skips the resync and the edit is preserved.
+    // interests. The edit-session guard must skip the resync without relying on Mantine's dirty
+    // tracking, which can miss this combination of list and scalar edits.
     it('preserves a committed interest edit when a background refetch changes server data', async () => {
         const userEvents = userEvent.setup()
         const { user } = await mockSessionWithTestData({ orgType: 'lab' })

--- a/src/components/timer.ts
+++ b/src/components/timer.ts
@@ -58,7 +58,6 @@ export function useTimer({ isEnabled, every, trigger, updateInterval }: UseTimer
                 clearInterval(intervalRef.current)
                 intervalRef.current = null
             }
-            setTimeRemaining(0)
         }
 
         return () => {
@@ -71,5 +70,8 @@ export function useTimer({ isEnabled, every, trigger, updateInterval }: UseTimer
         }
     }, [isEnabled, totalMS, resolvedUpdateInterval, trigger])
 
-    return timeRemaining
+    // When disabled the interval is torn down and the countdown is meaningless, so
+    // derive 0 here instead of writing it back into state from the effect (which
+    // would be a cascading set-state-in-effect).
+    return isEnabled ? timeRemaining : 0
 }

--- a/src/contexts/study-request/study-request-context.tsx
+++ b/src/contexts/study-request/study-request-context.tsx
@@ -116,6 +116,10 @@ export function StudyRequestProvider({
 
     useEffect(() => {
         if (initialDraft) {
+            // Seeds the Mantine form and the document-file store from the server-provided
+            // draft. This is a genuine external-store sync from props, and initFromDraft's
+            // form/store writes cannot run during render, so it must stay in an effect.
+            // eslint-disable-next-line react-hooks/set-state-in-effect -- external store seeding from a server draft
             initFromDraft(initialDraft, initialSubmittingOrgSlug)
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/hooks/use-education-section.ts
+++ b/src/hooks/use-education-section.ts
@@ -33,10 +33,13 @@ export function useEducationSection(data: ResearcherProfileData | null, refetch:
         validateInputOnBlur: true,
     })
 
-    // Reflect the persisted values into the form whenever they change. `defaults` is
-    // memoized on the underlying field values, so this only re-runs on a real change
-    // and never clobbers in-progress edits (typing doesn't change `data`).
+    // Reflect the persisted values into the form when they change, but never while the
+    // user has unsaved edits open: a background refetch (15-min interval / window focus)
+    // can change `data` mid-edit, and resetting the form would silently discard the edit.
+    // When not editing (or editing with no changes yet) this still populates the form,
+    // including the auto-opened incomplete-profile case below.
     useEffect(() => {
+        if (isEditing && form.isDirty()) return
         form.setValues(defaults)
         form.resetDirty(defaults)
         // eslint-disable-next-line react-hooks/exhaustive-deps -- resync only when persisted values change

--- a/src/hooks/use-education-section.ts
+++ b/src/hooks/use-education-section.ts
@@ -9,6 +9,7 @@ import type { ResearcherProfileData } from '@/hooks/use-researcher-profile'
 
 export function useEducationSection(data: ResearcherProfileData | null, refetch: () => Promise<unknown>) {
     const [isEditing, setIsEditing] = useState(false)
+    const [autoOpenKey, setAutoOpenKey] = useState<string | null>(null)
 
     const defaults: EducationValues = useMemo(
         () => ({
@@ -32,17 +33,29 @@ export function useEducationSection(data: ResearcherProfileData | null, refetch:
         validateInputOnBlur: true,
     })
 
+    // Reflect the persisted values into the form whenever they change. `defaults` is
+    // memoized on the underlying field values, so this only re-runs on a real change
+    // and never clobbers in-progress edits (typing doesn't change `data`).
     useEffect(() => {
-        if (isEditing) return
         form.setValues(defaults)
         form.resetDirty(defaults)
-        if (data) {
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- resync only when persisted values change
+    }, [defaults])
+
+    // Open straight into edit mode for an incomplete profile. Derived during render
+    // (keyed on the persisted values) instead of in an effect to avoid a cascading
+    // set-state-in-effect; the effect above still populates the form either way.
+    if (data) {
+        const key = JSON.stringify([defaults.educationalInstitution, defaults.degree, defaults.fieldOfStudy])
+        if (key !== autoOpenKey) {
+            setAutoOpenKey(key)
             const complete =
                 Boolean(defaults.educationalInstitution) && Boolean(defaults.degree) && Boolean(defaults.fieldOfStudy)
-            setIsEditing(!complete)
+            if (!isEditing && !complete) {
+                setIsEditing(true)
+            }
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- tie to computed defaults
-    }, [data, defaults.educationalInstitution, defaults.degree, defaults.fieldOfStudy])
+    }
 
     const saveMutation = useMutation({
         mutationFn: async (values: EducationValues) => updateEducationAction(values),

--- a/src/hooks/use-education-section.ts
+++ b/src/hooks/use-education-section.ts
@@ -9,7 +9,6 @@ import type { ResearcherProfileData } from '@/hooks/use-researcher-profile'
 
 export function useEducationSection(data: ResearcherProfileData | null, refetch: () => Promise<unknown>) {
     const [isEditing, setIsEditing] = useState(false)
-    const [autoOpenKey, setAutoOpenKey] = useState<string | null>(null)
 
     const defaults: EducationValues = useMemo(
         () => ({
@@ -33,32 +32,24 @@ export function useEducationSection(data: ResearcherProfileData | null, refetch:
         validateInputOnBlur: true,
     })
 
-    // Reflect the persisted values into the form when they change, but never while the
-    // user has unsaved edits open: a background refetch (15-min interval / window focus)
-    // can change `data` mid-edit, and resetting the form would silently discard the edit.
-    // When not editing (or editing with no changes yet) this still populates the form,
-    // including the auto-opened incomplete-profile case below.
+    // Seed the form from the persisted profile and decide the initial edit mode, but never
+    // while the user is editing, so a background refetch (15-min interval / window focus)
+    // can never overwrite unsaved input. Seeding the form (an external Mantine store) and the
+    // coupled edit-mode decision must run together in this effect: they have to happen in the
+    // same pass so the form is populated before it opens, and "not editing" is the only
+    // reliable divergence guard (form.isDirty() is not dependable, e.g. after list edits).
     useEffect(() => {
-        if (isEditing && form.isDirty()) return
+        if (isEditing) return
         form.setValues(defaults)
         form.resetDirty(defaults)
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- resync only when persisted values change
-    }, [defaults])
-
-    // Open straight into edit mode for an incomplete profile. Derived during render
-    // (keyed on the persisted values) instead of in an effect to avoid a cascading
-    // set-state-in-effect; the effect above still populates the form either way.
-    if (data) {
-        const key = JSON.stringify([defaults.educationalInstitution, defaults.degree, defaults.fieldOfStudy])
-        if (key !== autoOpenKey) {
-            setAutoOpenKey(key)
+        if (data) {
             const complete =
                 Boolean(defaults.educationalInstitution) && Boolean(defaults.degree) && Boolean(defaults.fieldOfStudy)
-            if (!isEditing && !complete) {
-                setIsEditing(true)
-            }
+            // eslint-disable-next-line react-hooks/set-state-in-effect -- initial edit mode is coupled to seeding the form from server data
+            setIsEditing(!complete)
         }
-    }
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- tie to computed defaults
+    }, [data, defaults.educationalInstitution, defaults.degree, defaults.fieldOfStudy])
 
     const saveMutation = useMutation({
         mutationFn: async (values: EducationValues) => updateEducationAction(values),

--- a/src/hooks/use-personal-info-section.ts
+++ b/src/hooks/use-personal-info-section.ts
@@ -9,6 +9,7 @@ import type { ResearcherProfileData } from '@/hooks/use-researcher-profile'
 
 export function usePersonalInfoSection(data: ResearcherProfileData | null, refetch: () => Promise<unknown>) {
     const [isEditing, setIsEditing] = useState(false)
+    const [autoOpenKey, setAutoOpenKey] = useState<string | null>(null)
 
     const defaults: PersonalInfoValues = useMemo(
         () => ({
@@ -25,16 +26,27 @@ export function usePersonalInfoSection(data: ResearcherProfileData | null, refet
         validateInputOnBlur: true,
     })
 
+    // Reflect the persisted values into the form whenever they change. `defaults` is
+    // memoized on the underlying field values, so this only re-runs on a real change
+    // and never clobbers in-progress edits (typing doesn't change `data`).
     useEffect(() => {
-        if (isEditing) return
         form.setValues(defaults)
         form.resetDirty(defaults)
-        if (data) {
-            const complete = Boolean(defaults.firstName) && Boolean(defaults.lastName)
-            setIsEditing(!complete)
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- resync only when persisted values change
+    }, [defaults])
+
+    // Open straight into edit mode for an incomplete profile. Derived during render
+    // (keyed on the persisted values) instead of in an effect to avoid a cascading
+    // set-state-in-effect; the effect above still populates the form either way.
+    if (data) {
+        const key = JSON.stringify([defaults.firstName, defaults.lastName])
+        if (key !== autoOpenKey) {
+            setAutoOpenKey(key)
+            if (!isEditing && !(Boolean(defaults.firstName) && Boolean(defaults.lastName))) {
+                setIsEditing(true)
+            }
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- tie to computed defaults
-    }, [data, defaults.firstName, defaults.lastName])
+    }
 
     const saveMutation = useMutation({
         mutationFn: async (values: PersonalInfoValues) => updatePersonalInfoAction(values),

--- a/src/hooks/use-personal-info-section.ts
+++ b/src/hooks/use-personal-info-section.ts
@@ -9,7 +9,6 @@ import type { ResearcherProfileData } from '@/hooks/use-researcher-profile'
 
 export function usePersonalInfoSection(data: ResearcherProfileData | null, refetch: () => Promise<unknown>) {
     const [isEditing, setIsEditing] = useState(false)
-    const [autoOpenKey, setAutoOpenKey] = useState<string | null>(null)
 
     const defaults: PersonalInfoValues = useMemo(
         () => ({
@@ -26,30 +25,23 @@ export function usePersonalInfoSection(data: ResearcherProfileData | null, refet
         validateInputOnBlur: true,
     })
 
-    // Reflect the persisted values into the form when they change, but never while the
-    // user has unsaved edits open: a background refetch (15-min interval / window focus)
-    // can change `data` mid-edit, and resetting the form would silently discard the edit.
-    // When not editing (or editing with no changes yet) this still populates the form,
-    // including the auto-opened incomplete-profile case below.
+    // Seed the form from the persisted profile and decide the initial edit mode, but never
+    // while the user is editing, so a background refetch (15-min interval / window focus)
+    // can never overwrite unsaved input. Seeding the form (an external Mantine store) and the
+    // coupled edit-mode decision must run together in this effect: they have to happen in the
+    // same pass so the form is populated before it opens, and "not editing" is the only
+    // reliable divergence guard (form.isDirty() is not dependable, e.g. after list edits).
     useEffect(() => {
-        if (isEditing && form.isDirty()) return
+        if (isEditing) return
         form.setValues(defaults)
         form.resetDirty(defaults)
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- resync only when persisted values change
-    }, [defaults])
-
-    // Open straight into edit mode for an incomplete profile. Derived during render
-    // (keyed on the persisted values) instead of in an effect to avoid a cascading
-    // set-state-in-effect; the effect above still populates the form either way.
-    if (data) {
-        const key = JSON.stringify([defaults.firstName, defaults.lastName])
-        if (key !== autoOpenKey) {
-            setAutoOpenKey(key)
-            if (!isEditing && !(Boolean(defaults.firstName) && Boolean(defaults.lastName))) {
-                setIsEditing(true)
-            }
+        if (data) {
+            const complete = Boolean(defaults.firstName) && Boolean(defaults.lastName)
+            // eslint-disable-next-line react-hooks/set-state-in-effect -- initial edit mode is coupled to seeding the form from server data
+            setIsEditing(!complete)
         }
-    }
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- tie to computed defaults
+    }, [data, defaults.firstName, defaults.lastName])
 
     const saveMutation = useMutation({
         mutationFn: async (values: PersonalInfoValues) => updatePersonalInfoAction(values),

--- a/src/hooks/use-personal-info-section.ts
+++ b/src/hooks/use-personal-info-section.ts
@@ -26,10 +26,13 @@ export function usePersonalInfoSection(data: ResearcherProfileData | null, refet
         validateInputOnBlur: true,
     })
 
-    // Reflect the persisted values into the form whenever they change. `defaults` is
-    // memoized on the underlying field values, so this only re-runs on a real change
-    // and never clobbers in-progress edits (typing doesn't change `data`).
+    // Reflect the persisted values into the form when they change, but never while the
+    // user has unsaved edits open: a background refetch (15-min interval / window focus)
+    // can change `data` mid-edit, and resetting the form would silently discard the edit.
+    // When not editing (or editing with no changes yet) this still populates the form,
+    // including the auto-opened incomplete-profile case below.
     useEffect(() => {
+        if (isEditing && form.isDirty()) return
         form.setValues(defaults)
         form.resetDirty(defaults)
         // eslint-disable-next-line react-hooks/exhaustive-deps -- resync only when persisted values change

--- a/src/hooks/use-positions-section.ts
+++ b/src/hooks/use-positions-section.ts
@@ -11,6 +11,7 @@ const emptyPosition: PositionValues = { affiliation: '', position: '', profileUr
 
 export function usePositionsSection(data: ResearcherProfileData | null, refetch: () => Promise<unknown>) {
     const [editingIndex, setEditingIndex] = useState<number | null>(null)
+    const [autoOpenKey, setAutoOpenKey] = useState<string | null>(null)
 
     const defaults: PositionsValues = useMemo(() => {
         const positions = (data?.positions ?? [])
@@ -30,22 +31,26 @@ export function usePositionsSection(data: ResearcherProfileData | null, refetch:
         validateInputOnBlur: true,
     })
 
+    const positionsKey = JSON.stringify(defaults.positions)
+
     useEffect(() => {
         if (editingIndex !== null) return
         form.setValues(defaults)
         form.resetDirty(defaults)
         // eslint-disable-next-line react-hooks/exhaustive-deps -- tie to computed defaults
-    }, [JSON.stringify(defaults.positions)])
+    }, [positionsKey])
 
     const hasExistingPositions = defaults.positions.some((p) => p.affiliation || p.position)
 
-    // Auto-open form when there are no existing positions (only after data loads)
-    useEffect(() => {
-        if (data && !hasExistingPositions && editingIndex === null) {
+    // Auto-open the form when there are no existing positions yet. Derived during
+    // render (keyed on the persisted positions) instead of in an effect to avoid a
+    // cascading set-state-in-effect.
+    if (data && positionsKey !== autoOpenKey) {
+        setAutoOpenKey(positionsKey)
+        if (!hasExistingPositions && editingIndex === null) {
             setEditingIndex(0)
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-run when data or hasExistingPositions changes, not editingIndex
-    }, [data, hasExistingPositions])
+    }
 
     const saveMutation = useMutation({
         mutationFn: async (positions: PositionValues[]) => updatePositionsAction({ positions }),

--- a/src/hooks/use-research-details-section.ts
+++ b/src/hooks/use-research-details-section.ts
@@ -36,12 +36,14 @@ export function useResearchDetailsSection(data: ResearcherProfileData | null, re
     })
 
     // Reflect the persisted values into the form when they change, but never while the
-    // user has unsaved edits open: a background refetch (15-min interval / window focus)
-    // can change `data` mid-edit, and resetting the form would silently discard the edit.
-    // When not editing (or editing with no changes yet) this still populates the form,
-    // including the auto-opened incomplete-profile case below.
+    // user has unsaved input open: a background refetch (15-min interval / window focus)
+    // can change `data` mid-edit, and resetting the form would silently discard it.
+    // "Unsaved input" is both dirty form fields and a typed-but-uncommitted interest
+    // draft (separate state that form.isDirty() does not track). When not editing (or
+    // editing with nothing entered yet) this still populates the form, including the
+    // auto-opened incomplete-profile case below.
     useEffect(() => {
-        if (isEditing && form.isDirty()) return
+        if (isEditing && (form.isDirty() || interestDraft.trim().length > 0)) return
         form.setValues(defaults)
         form.resetDirty(defaults)
         // eslint-disable-next-line react-hooks/exhaustive-deps -- resync only when persisted values change

--- a/src/hooks/use-research-details-section.ts
+++ b/src/hooks/use-research-details-section.ts
@@ -10,7 +10,6 @@ import type { ResearcherProfileData } from '@/hooks/use-researcher-profile'
 export function useResearchDetailsSection(data: ResearcherProfileData | null, refetch: () => Promise<unknown>) {
     const [isEditing, setIsEditing] = useState(false)
     const [interestDraft, setInterestDraft] = useState('')
-    const [autoOpenKey, setAutoOpenKey] = useState<string | null>(null)
 
     const defaults: ResearchDetailsValues = useMemo(
         () => ({
@@ -35,36 +34,26 @@ export function useResearchDetailsSection(data: ResearcherProfileData | null, re
         validateInputOnBlur: true,
     })
 
-    // Reflect the persisted values into the form when they change, but never while the
-    // user has unsaved input open: a background refetch (15-min interval / window focus)
-    // can change `data` mid-edit, and resetting the form would silently discard it.
-    // "Unsaved input" is both dirty form fields and a typed-but-uncommitted interest
-    // draft (separate state that form.isDirty() does not track). When not editing (or
-    // editing with nothing entered yet) this still populates the form, including the
-    // auto-opened incomplete-profile case below.
+    // Seed the form from the persisted profile, decide the initial edit mode, and clear any
+    // stale interest draft, but never while the user is editing, so a background refetch
+    // (15-min interval / window focus) can never overwrite unsaved input. Seeding the form
+    // (an external Mantine store) and the coupled edit-mode / draft resets must run together
+    // in this effect: they have to happen in the same pass so the form is populated before it
+    // opens, and "not editing" is the only reliable divergence guard. form.isDirty() is not
+    // dependable here: committed interest edits go through Mantine list ops and an uncommitted
+    // draft is separate state, so neither reliably marks the form dirty.
     useEffect(() => {
-        if (isEditing && (form.isDirty() || interestDraft.trim().length > 0)) return
+        if (isEditing) return
         form.setValues(defaults)
         form.resetDirty(defaults)
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- resync only when persisted values change
-    }, [defaults])
-
-    // Open straight into edit mode for an incomplete profile and clear any stale
-    // interest draft. Derived during render (keyed on the persisted values) instead
-    // of in an effect to avoid a cascading set-state-in-effect; the effect above
-    // still populates the form either way. Gated on !isEditing so a mid-edit refetch
-    // cannot clear an interest the user has typed but not yet committed.
-    if (data && !isEditing) {
-        const key = JSON.stringify([defaults.detailedPublicationsUrl, defaults.researchInterests ?? []])
-        if (key !== autoOpenKey) {
-            setAutoOpenKey(key)
-            setInterestDraft('')
+        if (data) {
             const complete = Boolean(defaults.researchInterests?.length) && Boolean(defaults.detailedPublicationsUrl)
-            if (!complete) {
-                setIsEditing(true)
-            }
+            // eslint-disable-next-line react-hooks/set-state-in-effect -- initial edit mode is coupled to seeding the form from server data
+            setIsEditing(!complete)
         }
-    }
+        setInterestDraft('')
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- tie to computed defaults
+    }, [data, defaults.detailedPublicationsUrl, (defaults.researchInterests || []).join('|')])
 
     const saveMutation = useMutation({
         mutationFn: async (values: ResearchDetailsValues) => updateResearchDetailsAction(values),

--- a/src/hooks/use-research-details-section.ts
+++ b/src/hooks/use-research-details-section.ts
@@ -35,10 +35,13 @@ export function useResearchDetailsSection(data: ResearcherProfileData | null, re
         validateInputOnBlur: true,
     })
 
-    // Reflect the persisted values into the form whenever they change. `defaults` is
-    // memoized on the underlying field values, so this only re-runs on a real change
-    // and never clobbers in-progress edits (typing doesn't change `data`).
+    // Reflect the persisted values into the form when they change, but never while the
+    // user has unsaved edits open: a background refetch (15-min interval / window focus)
+    // can change `data` mid-edit, and resetting the form would silently discard the edit.
+    // When not editing (or editing with no changes yet) this still populates the form,
+    // including the auto-opened incomplete-profile case below.
     useEffect(() => {
+        if (isEditing && form.isDirty()) return
         form.setValues(defaults)
         form.resetDirty(defaults)
         // eslint-disable-next-line react-hooks/exhaustive-deps -- resync only when persisted values change
@@ -47,14 +50,15 @@ export function useResearchDetailsSection(data: ResearcherProfileData | null, re
     // Open straight into edit mode for an incomplete profile and clear any stale
     // interest draft. Derived during render (keyed on the persisted values) instead
     // of in an effect to avoid a cascading set-state-in-effect; the effect above
-    // still populates the form either way.
-    if (data) {
+    // still populates the form either way. Gated on !isEditing so a mid-edit refetch
+    // cannot clear an interest the user has typed but not yet committed.
+    if (data && !isEditing) {
         const key = JSON.stringify([defaults.detailedPublicationsUrl, defaults.researchInterests ?? []])
         if (key !== autoOpenKey) {
             setAutoOpenKey(key)
             setInterestDraft('')
             const complete = Boolean(defaults.researchInterests?.length) && Boolean(defaults.detailedPublicationsUrl)
-            if (!isEditing && !complete) {
+            if (!complete) {
                 setIsEditing(true)
             }
         }

--- a/src/hooks/use-research-details-section.ts
+++ b/src/hooks/use-research-details-section.ts
@@ -10,6 +10,7 @@ import type { ResearcherProfileData } from '@/hooks/use-researcher-profile'
 export function useResearchDetailsSection(data: ResearcherProfileData | null, refetch: () => Promise<unknown>) {
     const [isEditing, setIsEditing] = useState(false)
     const [interestDraft, setInterestDraft] = useState('')
+    const [autoOpenKey, setAutoOpenKey] = useState<string | null>(null)
 
     const defaults: ResearchDetailsValues = useMemo(
         () => ({
@@ -34,17 +35,30 @@ export function useResearchDetailsSection(data: ResearcherProfileData | null, re
         validateInputOnBlur: true,
     })
 
+    // Reflect the persisted values into the form whenever they change. `defaults` is
+    // memoized on the underlying field values, so this only re-runs on a real change
+    // and never clobbers in-progress edits (typing doesn't change `data`).
     useEffect(() => {
-        if (isEditing) return
         form.setValues(defaults)
         form.resetDirty(defaults)
-        if (data) {
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- resync only when persisted values change
+    }, [defaults])
+
+    // Open straight into edit mode for an incomplete profile and clear any stale
+    // interest draft. Derived during render (keyed on the persisted values) instead
+    // of in an effect to avoid a cascading set-state-in-effect; the effect above
+    // still populates the form either way.
+    if (data) {
+        const key = JSON.stringify([defaults.detailedPublicationsUrl, defaults.researchInterests ?? []])
+        if (key !== autoOpenKey) {
+            setAutoOpenKey(key)
+            setInterestDraft('')
             const complete = Boolean(defaults.researchInterests?.length) && Boolean(defaults.detailedPublicationsUrl)
-            setIsEditing(!complete)
+            if (!isEditing && !complete) {
+                setIsEditing(true)
+            }
         }
-        setInterestDraft('')
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- tie to computed defaults
-    }, [data, defaults.detailedPublicationsUrl, (defaults.researchInterests || []).join('|')])
+    }
 
     const saveMutation = useMutation({
         mutationFn: async (values: ResearchDetailsValues) => updateResearchDetailsAction(values),

--- a/src/hooks/use-yjs-form-map.ts
+++ b/src/hooks/use-yjs-form-map.ts
@@ -88,6 +88,9 @@ export function useYjsFormMap({ studyId, form, websocketProvider }: Args): Retur
         // syncs (no SYNC_STEP1 ever leaves the client).
         next.attach()
 
+        // The Hocuspocus provider is an external resource created and torn down by this
+        // effect; storing the instance in state is how consumers re-render once it exists.
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- exposing an effect-created external resource
         setProvider(next)
 
         const onSynced = async () => {


### PR DESCRIPTION
see [OTTER-570](https://openstax.atlassian.net/browse/OTTER-570)

During the npm to pnpm migration, `eslint-plugin-react-hooks` was pinned to exact `7.0.1` so `pnpm install` would not pull a newer minor with stricter rules. This unpins it, adopts the current rules, and fixes every violation they surface.

## Dependency bump

- `eslint-plugin-react-hooks`: `7.0.1` -> `^7.1.1` (devDependencies), lockfile resolves to `7.1.1`.
- `7.1.1` is the current latest and still the same major (7), so this is a semver-safe caret. `7.1.0` was a React 19.2 tooling minor and `7.1.1` was a compatibility patch (it restores `component-hook-factories` as a deprecated no-op). No CVEs and no breaking rule-behavior changes.

## Violations fixed

The bump surfaced 10 violations: 1 `react-hooks/static-components` and 9 `react-hooks/set-state-in-effect`. Real fixes were preferred over suppressions.

- `admin/settings/code-envs.tsx` (`static-components`): `DeleteCodeEnv` was declared inside another component's render body. Hoisted it to a module-level component that takes an `isVisible` prop and returns null when hidden, matching the project's conditional-visibility convention.
- `components/layout/org-admin-dashboard-link.tsx`: replaced the effect that synced the menu open state to the route with the React "adjust state during render when a prop changes" pattern (tracking the previous route value). No cascading re-render, same behavior.
- `components/timer.ts`: the disabled branch wrote `0` back into state from the effect. Now the disabled value is derived on return (`isEnabled ? timeRemaining : 0`), so no state write in the effect.
- `account/signin/use-already-signed-in.ts`: the one-time landing status (`signed-out` / `signed-in` / `redirecting`) is now resolved during render, latched by the existing `status === 'loading'` guard. The actual navigation runs in an effect that fires exactly once via a ref, so an unstable router reference cannot cause a redirect loop. `switchAccount` still forces `signed-out` explicitly.
- `hooks/use-positions-section.ts`: the auto-open of the first position is now decided during render (keyed on the persisted positions). The form-reset effect keeps its original `editingIndex !== null` guard.
- `hooks/use-personal-info-section.ts`, `hooks/use-education-section.ts`, `hooks/use-research-details-section.ts`: kept the original seeding effect that only runs while the user is not editing (`if (isEditing) return`), so a background refetch can never overwrite unsaved input. The initial edit-mode decision is coupled to seeding the Mantine form from server data and must run in the same pass, so those `setState` calls carry a justified `set-state-in-effect` suppression.

## Guarding against form data loss on refetch

Researcher-profile data is fetched with a 15-minute `refetchInterval` and refetches on window focus, so `data` can change while a section form is open for editing. The seeding effects in the three profile hooks are guarded so they never resync the form while `isEditing` is true. This protects three cases:

- unsaved edits to Mantine-managed fields,
- an interest typed but not yet committed (separate draft state),
- an interest committed through Enter or removal.

An earlier iteration guarded with `form.isDirty()` instead of `isEditing`, but Mantine's dirty check is not a reliable divergence signal here (an uncommitted draft is separate state, and committed interests go through list operations), so a value-changing refetch could still discard an edit. Guarding on `isEditing` is the robust choice and matches the pre-existing behavior.

## Justified suppressions

Five `set-state-in-effect` suppressions remain, all for genuine external-store synchronization that the effect model is meant for:

- `contexts/study-request/study-request-context.tsx`: seeding the Mantine form and document-file store from a server-provided draft.
- `hooks/use-yjs-form-map.ts`: exposing the Hocuspocus provider created and torn down by the effect.
- the three profile hooks above: the initial edit-mode decision coupled to seeding the form from server data.

No new suppressions were added beyond these; all other pre-existing `exhaustive-deps` comments are unchanged.

## Tests

Added regression tests that render the real sections/components and exercise the guarded behaviors:

- personal info: an unsaved field edit survives a refetch that changes server data.
- education: an unsaved field edit survives a refetch that changes server data.
- research details: an uncommitted interest draft survives a refetch.
- research details: a committed interest pill survives a refetch (this one failed against the `form.isDirty()` approach, which is what motivated the `isEditing` guard).
- org admin dashboard link: the submenu open state re-syncs when the route changes into and out of an admin path (covers the render-phase pattern that replaced the effect).

Each new guard test was confirmed to fail if its guard is removed, so it genuinely locks the behavior.

## Validation

- `pnpm run checks` passes (type check, lint, action validation), no warnings.
- Full unit suite passes: 210 files, 1955 tests.
- E2E was not run locally; it will run in CI.

Mantine v8 dirty-tracking behavior was confirmed against current docs via context7.


[OTTER-570]: https://openstax.atlassian.net/browse/OTTER-570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ