### PR TITLE
OTTER-636: draft concept, immutable proposal snapshots + revision/code round architecture

### DIFF
--- a/services/editor/auth.test.ts
+++ b/services/editor/auth.test.ts
@@ -13,10 +13,12 @@ import {
     type AuthenticateDeps,
     type DbQuery,
     type StatelessSubmissionEvent,
+    type StudyStatus,
 } from './auth'
 
 const STUDY_ID = '019ddb2a-5f38-74ea-b401-94fd79839071'
 const JOB_ID = '019ddb2a-5f38-74ea-b401-94fd798390ff'
+const SUBMISSION_ID = '019ddb2a-5f38-74ea-b401-94fd7983a001'
 
 describe('parseDocumentName', () => {
     it.each([1, 2, 17, 123])('parses versioned review-feedback documents (v%i)', (version) => {
@@ -544,46 +546,50 @@ describe('authenticate', () => {
 })
 
 describe('isDocumentEditable', () => {
+    const snap = (status: StudyStatus, base: string | null = null) => ({
+        status,
+        proposalRevisionBaseSubmissionId: base,
+    })
+
     it('allows proposal kinds while DRAFT or CHANGE-REQUESTED', () => {
         for (const status of ['DRAFT', 'CHANGE-REQUESTED'] as const) {
-            expect(isDocumentEditable({ kind: 'proposal-fields', studyId: STUDY_ID }, { status })).toBe(true)
-            expect(isDocumentEditable({ kind: 'proposal-text', studyId: STUDY_ID, slug: 'impact' }, { status })).toBe(
+            expect(isDocumentEditable({ kind: 'proposal-fields', studyId: STUDY_ID }, snap(status))).toBe(true)
+            expect(isDocumentEditable({ kind: 'proposal-text', studyId: STUDY_ID, slug: 'impact' }, snap(status))).toBe(
                 true,
             )
         }
     })
 
     it('blocks proposal kinds once submitted', () => {
-        expect(isDocumentEditable({ kind: 'proposal-fields', studyId: STUDY_ID }, { status: 'PENDING-REVIEW' })).toBe(
-            false,
-        )
+        expect(isDocumentEditable({ kind: 'proposal-fields', studyId: STUDY_ID }, snap('PENDING-REVIEW'))).toBe(false)
     })
 
     it('allows review-feedback only while PENDING-REVIEW', () => {
         expect(
-            isDocumentEditable(
-                { kind: 'review-feedback', studyId: STUDY_ID, version: 1 },
-                { status: 'PENDING-REVIEW' },
-            ),
+            isDocumentEditable({ kind: 'review-feedback', studyId: STUDY_ID, version: 1 }, snap('PENDING-REVIEW')),
         ).toBe(true)
         for (const status of ['APPROVED', 'CHANGE-REQUESTED', 'REJECTED'] as const) {
-            expect(isDocumentEditable({ kind: 'review-feedback', studyId: STUDY_ID, version: 1 }, { status })).toBe(
+            expect(isDocumentEditable({ kind: 'review-feedback', studyId: STUDY_ID, version: 1 }, snap(status))).toBe(
                 false,
             )
         }
     })
 
-    it('allows the resubmission note only while CHANGE-REQUESTED (no note exists during DRAFT)', () => {
+    it('allows the resubmission note while CHANGE-REQUESTED or a revision draft, but not a fresh draft', () => {
         const parsed = { kind: 'proposal-resubmission-note', studyId: STUDY_ID, version: 2 } as const
-        expect(isDocumentEditable(parsed, { status: 'CHANGE-REQUESTED' })).toBe(true)
-        for (const status of ['DRAFT', 'PENDING-REVIEW', 'APPROVED', 'REJECTED', 'ARCHIVED'] as const) {
-            expect(isDocumentEditable(parsed, { status })).toBe(false)
+        expect(isDocumentEditable(parsed, snap('CHANGE-REQUESTED'))).toBe(true)
+        // OTTER-636: a revision draft (DRAFT with a base snapshot) keeps the note editable.
+        expect(isDocumentEditable(parsed, snap('DRAFT', SUBMISSION_ID))).toBe(true)
+        // A fresh draft (DRAFT, no base) has no note.
+        expect(isDocumentEditable(parsed, snap('DRAFT'))).toBe(false)
+        for (const status of ['PENDING-REVIEW', 'APPROVED', 'REJECTED', 'ARCHIVED'] as const) {
+            expect(isDocumentEditable(parsed, snap(status))).toBe(false)
         }
     })
 
     it('always allows code-review-feedback regardless of study status (editor is not the enforcer)', () => {
         for (const status of ['DRAFT', 'PENDING-REVIEW', 'APPROVED', 'CHANGE-REQUESTED', 'REJECTED'] as const) {
-            expect(isDocumentEditable({ kind: 'code-review-feedback', jobId: JOB_ID }, { status })).toBe(true)
+            expect(isDocumentEditable({ kind: 'code-review-feedback', jobId: JOB_ID }, snap(status))).toBe(true)
         }
     })
 })
@@ -726,7 +732,9 @@ describe('assertStatelessEventConsistent', () => {
 })
 
 describe('shouldPersistDocument', () => {
-    const fakeDb = (rows: Array<{ status: string }>): DbQuery => ({
+    const fakeDb = (
+        rows: Array<{ status: string; proposal_revision_base_submission_id?: string | null }>,
+    ): DbQuery => ({
         query: (async () => ({ rows, rowCount: rows.length })) as DbQuery['query'],
     })
 
@@ -769,6 +777,24 @@ describe('shouldPersistDocument', () => {
                 shouldPersistDocument({ kind: 'review-feedback', studyId: STUDY_ID, version: 1 }, fakeDb([{ status }])),
             ).resolves.toBe(false)
         }
+    })
+
+    it('allows persistence for the resubmission note on a revision draft (DRAFT with a base snapshot)', async () => {
+        await expect(
+            shouldPersistDocument(
+                { kind: 'proposal-resubmission-note', studyId: STUDY_ID, version: 2 },
+                fakeDb([{ status: 'DRAFT', proposal_revision_base_submission_id: SUBMISSION_ID }]),
+            ),
+        ).resolves.toBe(true)
+    })
+
+    it('blocks persistence for the resubmission note on a fresh draft (no base snapshot)', async () => {
+        await expect(
+            shouldPersistDocument(
+                { kind: 'proposal-resubmission-note', studyId: STUDY_ID, version: 2 },
+                fakeDb([{ status: 'DRAFT', proposal_revision_base_submission_id: null }]),
+            ),
+        ).resolves.toBe(false)
     })
 
     it('blocks persistence when the study row has been deleted', async () => {

--- a/services/editor/auth.ts
+++ b/services/editor/auth.ts
@@ -104,6 +104,15 @@ export function requiredOrgIdForDocument(
 
 export type StudyEditabilitySnapshot = {
     status: StudyStatus
+    // OTTER-636: set on a revision DRAFT (a change-requested proposal whose first edit flipped it to
+    // DRAFT). Points at the immutable snapshot being revised. Null for a fresh draft or a submitted study.
+    proposalRevisionBaseSubmissionId: string | null
+}
+
+// A revision draft is a DRAFT that carries a base snapshot id: the researcher is mid-revision of a
+// change-requested proposal. Its proposal docs and resubmission note must stay editable.
+function isRevisionDraftSnapshot(snap: StudyEditabilitySnapshot): boolean {
+    return snap.status === 'DRAFT' && snap.proposalRevisionBaseSubmissionId != null
 }
 
 // Whether the canonical Yjs state for `parsed` may still be mutated given the
@@ -121,9 +130,11 @@ export function isDocumentEditable(parsed: ParsedDocumentName, snap: StudyEditab
         case 'proposal-fields':
         case 'proposal-text':
             return snap.status === 'DRAFT' || snap.status === 'CHANGE-REQUESTED'
-        // No note exists during DRAFT — only while answering a change request.
+        // The note exists while answering a change request: either the study is still CHANGE-REQUESTED,
+        // or its first edit has already flipped it to a revision DRAFT (OTTER-636). A fresh DRAFT (no
+        // base snapshot) has no note.
         case 'proposal-resubmission-note':
-            return snap.status === 'CHANGE-REQUESTED'
+            return snap.status === 'CHANGE-REQUESTED' || isRevisionDraftSnapshot(snap)
         case 'code-review-feedback':
             return true
     }
@@ -138,11 +149,17 @@ export function isDocumentEditable(parsed: ParsedDocumentName, snap: StudyEditab
 export async function shouldPersistDocument(parsed: ParsedDocumentName, db: Pick<DbQuery, 'query'>): Promise<boolean> {
     if (parsed.kind === 'code-review-feedback') return true
 
-    const row = await db.query<{ status: StudyStatus }>('SELECT status FROM study WHERE id = $1', [parsed.studyId])
-    const status = row.rows[0]?.status
-    if (!status) return false
+    const row = await db.query<{ status: StudyStatus; proposal_revision_base_submission_id: string | null }>(
+        'SELECT status, proposal_revision_base_submission_id FROM study WHERE id = $1',
+        [parsed.studyId],
+    )
+    const studyRow = row.rows[0]
+    if (!studyRow?.status) return false
 
-    return isDocumentEditable(parsed, { status })
+    return isDocumentEditable(parsed, {
+        status: studyRow.status,
+        proposalRevisionBaseSubmissionId: studyRow.proposal_revision_base_submission_id,
+    })
 }
 
 export type EventType = 'proposal-submitted' | 'proposal-review-submitted' | 'code-review-submitted'
@@ -350,10 +367,14 @@ export async function authenticate(
 
     const studyId = await studyIdForDocument(parsed, deps.db)
 
-    const studyRow = await deps.db.query<{ org_id: string; submitted_by_org_id: string; status: StudyStatus }>(
-        'SELECT org_id, submitted_by_org_id, status FROM study WHERE id = $1',
-        [studyId],
-    )
+    const studyRow = await deps.db.query<{
+        org_id: string
+        submitted_by_org_id: string
+        status: StudyStatus
+        proposal_revision_base_submission_id: string | null
+    }>('SELECT org_id, submitted_by_org_id, status, proposal_revision_base_submission_id FROM study WHERE id = $1', [
+        studyId,
+    ])
     const study = studyRow.rows[0]
     if (!study) throw new AuthFailureError('STUDY_NOT_FOUND', 'study not found')
 
@@ -379,7 +400,12 @@ export async function authenticate(
     // layer is the single enforcer of code-review versioning, and Hocuspocus
     // per-document room isolation prevents stale-round writes from leaking
     // into a different round's persisted state.
-    if (!isDocumentEditable(parsed, { status: study.status })) {
+    if (
+        !isDocumentEditable(parsed, {
+            status: study.status,
+            proposalRevisionBaseSubmissionId: study.proposal_revision_base_submission_id,
+        })
+    ) {
         throw new AuthFailureError('STUDY_NOT_EDITABLE', `study is not editable (status: ${study.status})`)
     }
 

--- a/src/app/[orgSlug]/study/[studyId]/_screens/render-screen.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/render-screen.tsx
@@ -11,6 +11,7 @@ import {
     type StudyRole,
 } from '@/lib/study-screen'
 import type { SelectedStudy } from '@/server/actions/study.actions'
+import { overlaidWithLatestProposalSnapshot } from '@/server/db/proposal-snapshot'
 import { SCREEN_COMPONENTS } from './registry'
 
 type RenderArgs = {
@@ -44,7 +45,8 @@ export async function renderStudyScreen(
         studyId: args.studyId,
         returnTo: args.returnTo,
     })
-    return renderScreen(descriptor, args)
+    const study = await overlaidWithLatestProposalSnapshot(args.studyId, args.study)
+    return renderScreen(descriptor, { ...args, study })
 }
 
 // /view/code dispatch: the read-only code screen, even after the study advanced to results. 404s

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/edit-initial-request-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/edit-initial-request-section.tsx
@@ -13,6 +13,7 @@ import { countWords } from '@/lib/lexical'
 import { Routes, ExternalLinks } from '@/lib/routes'
 import { WORD_LIMITS, type ProposalFormValues } from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
 import { useEditResubmit } from '@/contexts/edit-resubmit'
+import { useProposalRevision } from '@/hooks/use-start-proposal-revision'
 import { editableTextFields, type EditableTextField } from '@/app/[orgSlug]/study/[studyId]/proposal/field-config'
 import { CollaborativeProposalTextField } from '@/app/[orgSlug]/study/[studyId]/proposal/collaborative-proposal-text-field'
 import type { ProposalTextFieldKey } from '@/lib/collaboration-documents'
@@ -58,6 +59,7 @@ export const EditInitialRequestSection: FC<EditInitialRequestSectionProps> = ({
     enclaveOrgSlug,
 }) => {
     const { studyId, form, yjsForm, websocketProvider } = useEditResubmit()
+    const { signalRealEdit } = useProposalRevision()
     const titleWordCount = countWords(form.values.title)
     const titleInputProps = form.getInputProps('title')
 
@@ -94,6 +96,7 @@ export const EditInitialRequestSection: FC<EditInitialRequestSectionProps> = ({
                             onChange={(event) => {
                                 titleInputProps.onChange?.(event)
                                 yjsForm.pushField('title', event.currentTarget.value)
+                                signalRealEdit()
                             }}
                             value={form.values.title ?? ''}
                             error={!!form.errors.title}
@@ -118,6 +121,7 @@ export const EditInitialRequestSection: FC<EditInitialRequestSectionProps> = ({
                                     onChange={(val) => {
                                         form.setFieldValue('datasets', val)
                                         yjsForm.pushField('datasets', val)
+                                        signalRealEdit()
                                     }}
                                     orgSlug={enclaveOrgSlug}
                                 />
@@ -172,6 +176,7 @@ export const EditInitialRequestSection: FC<EditInitialRequestSectionProps> = ({
                                     form.setFieldValue('piUserId', piUserId)
                                     form.setFieldValue('piName', piName)
                                     yjsForm.pushPI(piUserId, piName)
+                                    signalRealEdit()
                                 }}
                                 error={!!form.errors.piName}
                             />

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.tsx
@@ -10,6 +10,7 @@ import { SubmitConfirmationModal } from '@/components/modals/submit-confirmation
 import { Routes } from '@/lib/routes'
 import { hasLexicalContent } from '@/lib/lexical'
 import { useEditResubmit } from '@/contexts/edit-resubmit'
+import { useProposalRevision } from '@/hooks/use-start-proposal-revision'
 import { useSaveProposalDraft } from '@/contexts/proposal/hooks/use-save-proposal-draft'
 import { ReviewerPreview } from '@/app/[orgSlug]/study/[studyId]/proposal/reviewer-preview'
 import { hasUserProvidedTitle } from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
@@ -24,6 +25,7 @@ export const EditResubmitFooter: FC<EditResubmitFooterProps> = ({ researcherName
     const router = useRouter()
     const { orgSlug } = useParams<{ orgSlug: string }>()
     const { studyId, form, noteForm, flushNote, resubmit, isSubmitting, isSavingNote } = useEditResubmit()
+    const { blockResubmit } = useProposalRevision()
     // omitBlankTitle: nulling the title column on a CHANGE-REQUESTED row would
     // violate the study_title_required_when_not_draft check constraint.
     const { saveDraft, isSaving } = useSaveProposalDraft(studyId, form, { omitBlankTitle: true })
@@ -73,7 +75,9 @@ export const EditResubmitFooter: FC<EditResubmitFooterProps> = ({ researcherName
                     <Button
                         size="md"
                         variant="primary"
-                        disabled={!isFormValid || isBusy}
+                        // OTTER-636: block resubmit until the first-edit DRAFT flip has committed, so a
+                        // revision can't be submitted on a status transition that failed or is in flight.
+                        disabled={!isFormValid || isBusy || blockResubmit}
                         loading={isSubmitting}
                         onClick={openConfirm}
                     >

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.tsx
@@ -10,6 +10,7 @@ import { SubmitConfirmationModal } from '@/components/modals/submit-confirmation
 import { Routes } from '@/lib/routes'
 import { hasLexicalContent } from '@/lib/lexical'
 import { useEditResubmit } from '@/contexts/edit-resubmit'
+import { useProposalRevision } from '@/hooks/use-start-proposal-revision'
 import { useSaveProposalDraft } from '@/contexts/proposal/hooks/use-save-proposal-draft'
 import { ReviewerPreview } from '@/app/[orgSlug]/study/[studyId]/proposal/reviewer-preview'
 import { hasUserProvidedTitle } from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
@@ -24,6 +25,7 @@ export const EditResubmitFooter: FC<EditResubmitFooterProps> = ({ researcherName
     const router = useRouter()
     const { orgSlug } = useParams<{ orgSlug: string }>()
     const { studyId, form, noteForm, flushNote, resubmit, isSubmitting, isSavingNote } = useEditResubmit()
+    const { blockResubmit } = useProposalRevision()
     // omitBlankTitle: nulling the title column on a CHANGE-REQUESTED row would
     // violate the study_title_required_when_not_draft check constraint.
     const { saveDraft, isSaving } = useSaveProposalDraft(studyId, form, { omitBlankTitle: true })
@@ -73,11 +75,11 @@ export const EditResubmitFooter: FC<EditResubmitFooterProps> = ({ researcherName
                     <Button
                         size="md"
                         variant="primary"
-                        // OTTER-636: resubmit is NOT gated on the first-edit DRAFT flip. The flip is a
-                        // best-effort display transition (it can no-op when a study has no base snapshot),
-                        // and resubmitProposalAction accepts both CHANGE-REQUESTED and a revision DRAFT, so
-                        // gating here would only risk stranding a researcher on a failed/slow flip.
-                        disabled={!isFormValid || isBusy}
+                        // OTTER-636 (architecture §4/§7): resubmitProposalAction accepts only a revision
+                        // DRAFT, so Resubmit stays disabled until the first-edit flip commits (blockResubmit
+                        // is true while it is pending or failed). The flip retries automatically and reports
+                        // a visible error if exhausted.
+                        disabled={!isFormValid || isBusy || blockResubmit}
                         loading={isSubmitting}
                         onClick={openConfirm}
                     >

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.tsx
@@ -10,7 +10,6 @@ import { SubmitConfirmationModal } from '@/components/modals/submit-confirmation
 import { Routes } from '@/lib/routes'
 import { hasLexicalContent } from '@/lib/lexical'
 import { useEditResubmit } from '@/contexts/edit-resubmit'
-import { useProposalRevision } from '@/hooks/use-start-proposal-revision'
 import { useSaveProposalDraft } from '@/contexts/proposal/hooks/use-save-proposal-draft'
 import { ReviewerPreview } from '@/app/[orgSlug]/study/[studyId]/proposal/reviewer-preview'
 import { hasUserProvidedTitle } from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
@@ -25,7 +24,6 @@ export const EditResubmitFooter: FC<EditResubmitFooterProps> = ({ researcherName
     const router = useRouter()
     const { orgSlug } = useParams<{ orgSlug: string }>()
     const { studyId, form, noteForm, flushNote, resubmit, isSubmitting, isSavingNote } = useEditResubmit()
-    const { blockResubmit } = useProposalRevision()
     // omitBlankTitle: nulling the title column on a CHANGE-REQUESTED row would
     // violate the study_title_required_when_not_draft check constraint.
     const { saveDraft, isSaving } = useSaveProposalDraft(studyId, form, { omitBlankTitle: true })
@@ -75,9 +73,11 @@ export const EditResubmitFooter: FC<EditResubmitFooterProps> = ({ researcherName
                     <Button
                         size="md"
                         variant="primary"
-                        // OTTER-636: block resubmit until the first-edit DRAFT flip has committed, so a
-                        // revision can't be submitted on a status transition that failed or is in flight.
-                        disabled={!isFormValid || isBusy || blockResubmit}
+                        // OTTER-636: resubmit is NOT gated on the first-edit DRAFT flip. The flip is a
+                        // best-effort display transition (it can no-op when a study has no base snapshot),
+                        // and resubmitProposalAction accepts both CHANGE-REQUESTED and a revision DRAFT, so
+                        // gating here would only risk stranding a researcher on a failed/slow flip.
+                        disabled={!isFormValid || isBusy}
                         loading={isSubmitting}
                         onClick={openConfirm}
                     >

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/form.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/form.tsx
@@ -9,6 +9,7 @@ import { FeedbackAndNotesSection } from '@/components/study/feedback-and-notes'
 import { CollaborativeResubmissionNoteSection } from '@/components/study/collaborative-resubmission-note-section'
 import { useSubmissionRedirectListener } from '@/hooks/use-submission-redirect-listener'
 import { StudyKickOutProvider } from '@/hooks/use-study-status-on-reconnect'
+import { ProposalRevisionProvider } from '@/hooks/use-start-proposal-revision'
 import { EditInitialRequestSection, type MemberOption } from './edit-initial-request-section'
 import { EditResubmitFooter } from './footer'
 
@@ -30,6 +31,11 @@ interface EditResubmitFormProps {
     noteVersion: number
     /** Persisted note draft; seeds the single-user editor. */
     initialNote: string
+    /**
+     * Server status at page load. CHANGE-REQUESTED means the first edit still needs to flip the study
+     * to a revision DRAFT; a revision DRAFT is already flipped (a page reload after the first edit).
+     */
+    initialStatus: 'CHANGE-REQUESTED' | 'DRAFT'
 }
 
 export const EditResubmitForm: FC<EditResubmitFormProps> = ({
@@ -41,6 +47,7 @@ export const EditResubmitForm: FC<EditResubmitFormProps> = ({
     feedbackEntries,
     noteVersion,
     initialNote,
+    initialStatus,
 }) => {
     const { studyId, noteForm, isSavingNote, noteLastSavedAt, websocketProvider, yjsForm, tabSessionId } =
         useEditResubmit()
@@ -60,34 +67,40 @@ export const EditResubmitForm: FC<EditResubmitFormProps> = ({
             editableStatuses={RESUBMIT_EDITABLE_STATUSES}
             redirectTarget="studySubmitted"
         >
-            <Stack gap="xxl">
-                <Title order={1}>Edit Initial Request</Title>
+            <ProposalRevisionProvider
+                studyId={studyId}
+                orgSlug={orgSlug}
+                enabled={initialStatus === 'CHANGE-REQUESTED'}
+            >
+                <Stack gap="xxl">
+                    <Title order={1}>Edit Initial Request</Title>
 
-                <EditInitialRequestSection
-                    orgName={orgName}
-                    members={members}
-                    researcherName={researcherName}
-                    enclaveOrgSlug={enclaveOrgSlug}
-                />
+                    <EditInitialRequestSection
+                        orgName={orgName}
+                        members={members}
+                        researcherName={researcherName}
+                        enclaveOrgSlug={enclaveOrgSlug}
+                    />
 
-                <FeedbackAndNotesSection entries={feedbackEntries} />
+                    <FeedbackAndNotesSection entries={feedbackEntries} />
 
-                <CollaborativeResubmissionNoteSection
-                    studyId={studyId}
-                    noteVersion={noteVersion}
-                    noteForm={noteForm}
-                    orgName={orgName}
-                    initialNote={initialNote}
-                    websocketProvider={websocketProvider}
-                    autosaveStatus={{ isSaving: isSavingNote, lastSavedAt: noteLastSavedAt }}
-                />
+                    <CollaborativeResubmissionNoteSection
+                        studyId={studyId}
+                        noteVersion={noteVersion}
+                        noteForm={noteForm}
+                        orgName={orgName}
+                        initialNote={initialNote}
+                        websocketProvider={websocketProvider}
+                        autosaveStatus={{ isSaving: isSavingNote, lastSavedAt: noteLastSavedAt }}
+                    />
 
-                <EditResubmitFooter
-                    researcherName={researcherName}
-                    researcherId={researcherId}
-                    enclaveOrgSlug={enclaveOrgSlug}
-                />
-            </Stack>
+                    <EditResubmitFooter
+                        researcherName={researcherName}
+                        researcherId={researcherId}
+                        enclaveOrgSlug={enclaveOrgSlug}
+                    />
+                </Stack>
+            </ProposalRevisionProvider>
         </StudyKickOutProvider>
     )
 }

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/form.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/form.tsx
@@ -13,8 +13,11 @@ import { EditInitialRequestSection, type MemberOption } from './edit-initial-req
 import { EditResubmitFooter } from './footer'
 
 // Change-requested proposals are co-editable by the whole lab; once any member
-// resubmits, the study leaves CHANGE-REQUESTED and the rest must be kicked out.
-const RESUBMIT_EDITABLE_STATUSES = ['CHANGE-REQUESTED'] as const
+// resubmits, the study leaves this editing flow (→ PENDING-REVIEW) and the rest
+// must be kicked out. OTTER-636: the first edit flips CHANGE-REQUESTED → a revision
+// DRAFT, so DRAFT is editable here too. The page guard guarantees any DRAFT reaching
+// this form is a revision draft (a fresh draft is served by /proposal, never here).
+const RESUBMIT_EDITABLE_STATUSES = ['CHANGE-REQUESTED', 'DRAFT'] as const
 
 interface EditResubmitFormProps {
     orgName: string

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/form.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/form.tsx
@@ -67,11 +67,7 @@ export const EditResubmitForm: FC<EditResubmitFormProps> = ({
             editableStatuses={RESUBMIT_EDITABLE_STATUSES}
             redirectTarget="studySubmitted"
         >
-            <ProposalRevisionProvider
-                studyId={studyId}
-                orgSlug={orgSlug}
-                enabled={initialStatus === 'CHANGE-REQUESTED'}
-            >
+            <ProposalRevisionProvider studyId={studyId} enabled={initialStatus === 'CHANGE-REQUESTED'}>
                 <Stack gap="xxl">
                     <Title order={1}>Edit Initial Request</Title>
 

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/page.test.tsx
@@ -2,7 +2,14 @@
 // submitting lab (not only the original researcher), and must stay closed to
 // users outside that lab.
 import { describe, it, expect } from 'vitest'
-import { insertTestStudyJobData, insertTestUser, mockClerkSession, mockSessionWithTestData } from '@/tests/unit.helpers'
+import {
+    db,
+    insertTestStudyJobData,
+    insertTestUser,
+    mockClerkSession,
+    mockSessionWithTestData,
+} from '@/tests/unit.helpers'
+import { writeProposalSubmissionSnapshot } from '@/server/db/proposal-snapshot'
 import StudyEditAndResubmitRoute from './page'
 
 describe('StudyEditAndResubmitRoute', () => {
@@ -32,6 +39,48 @@ describe('StudyEditAndResubmitRoute', () => {
         // Access is gated on lab membership, not authorship: a same-lab teammate
         // reaches the rendered page instead of being bounced to notFound().
         expect(page).toBeDefined()
+    })
+
+    // OTTER-636: the first edit flips a change-requested proposal to a revision DRAFT (a DRAFT with a
+    // base snapshot). That draft must keep rendering the revision editor rather than bouncing.
+    it('renders for a revision draft (DRAFT with a base snapshot)', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+        const { study } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'CHANGE-REQUESTED',
+        })
+        await writeProposalSubmissionSnapshot(db, study.id, user.id)
+        const snap = await db
+            .selectFrom('studyProposalSubmission')
+            .select('id')
+            .where('studyId', '=', study.id)
+            .executeTakeFirstOrThrow()
+        await db
+            .updateTable('study')
+            .set({ status: 'DRAFT', proposalRevisionBaseSubmissionId: snap.id })
+            .where('id', '=', study.id)
+            .execute()
+
+        const page = await StudyEditAndResubmitRoute({
+            params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+        })
+        expect(page).toBeDefined()
+    })
+
+    // A fresh DRAFT (no base snapshot) belongs to the /proposal editor, not here.
+    it('returns notFound for a fresh draft (DRAFT without a base snapshot)', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+        const { study } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'DRAFT',
+        })
+
+        const page = await StudyEditAndResubmitRoute({
+            params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+        })
+        expect(page).toBeUndefined()
     })
 
     it('returns notFound for a user outside the submitting lab', async () => {

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/page.tsx
@@ -17,7 +17,11 @@ export default async function StudyEditAndResubmitRoute(props: {
     const study = await getStudyAction({ studyId })
 
     if ('error' in study) return notFound()
-    if (study.status !== 'CHANGE-REQUESTED') return notFound()
+    // OTTER-636: this is the revision editor for a change-requested proposal AND its in-progress revision
+    // draft (a study whose first edit flipped it to DRAFT with a base snapshot). It reads the mutable row
+    // (the researcher's live edits); reviewers read the frozen snapshot elsewhere.
+    const isRevisionDraft = study.status === 'DRAFT' && study.proposalRevisionBaseSubmissionId != null
+    if (study.status !== 'CHANGE-REQUESTED' && !isRevisionDraft) return notFound()
 
     // OTTER-497: any member of the submitting lab may edit/resubmit a
     // change-requested proposal, so gate on lab membership (not the original

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/page.tsx
@@ -73,6 +73,7 @@ export default async function StudyEditAndResubmitRoute(props: {
                     feedbackEntries={entries}
                     noteVersion={noteVersion}
                     initialNote={initialNote}
+                    initialStatus={study.status === 'CHANGE-REQUESTED' ? 'CHANGE-REQUESTED' : 'DRAFT'}
                 />
             </EditResubmitProvider>
         </Stack>

--- a/src/app/[orgSlug]/study/[studyId]/edit/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit/page.test.tsx
@@ -10,6 +10,7 @@ import {
     screen,
     type Mock,
 } from '@/tests/unit.helpers'
+import { writeProposalSubmissionSnapshot } from '@/server/db/proposal-snapshot'
 import StudyEditPage from './page'
 
 const mockRedirect = vi.mocked(redirect)
@@ -50,6 +51,33 @@ describe('StudyEditPage', () => {
         // The Step 1 form's "Proceed to Step 2" footer button is the cheapest, most stable proof
         // that we rendered <StudyProposal /> (Step 1) rather than redirecting away.
         expect(screen.getByRole('button', { name: /Proceed to Step 2/i })).toBeInTheDocument()
+    })
+
+    // OTTER-636: a revision draft (DRAFT with a base snapshot) is edited on the lab-gated
+    // edit-and-resubmit flow, not this un-gated Step-1 route, so it must redirect there instead of
+    // rendering live revision content.
+    it('redirects a revision draft to the edit-and-resubmit flow', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+        const { study } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'CHANGE-REQUESTED',
+        })
+        await writeProposalSubmissionSnapshot(db, study.id, user.id)
+        const snap = await db
+            .selectFrom('studyProposalSubmission')
+            .select('id')
+            .where('studyId', '=', study.id)
+            .executeTakeFirstOrThrow()
+        await db
+            .updateTable('study')
+            .set({ status: 'DRAFT', proposalRevisionBaseSubmissionId: snap.id })
+            .where('id', '=', study.id)
+            .execute()
+
+        // redirect() is mocked to throw NEXT_REDIRECT (see beforeEach), so the route rejects.
+        await expect(renderRoute(org.slug, study.id)).rejects.toThrow('NEXT_REDIRECT')
+        expect(mockRedirect).toHaveBeenCalledWith(expect.stringContaining(`/study/${study.id}/edit-and-resubmit`))
     })
 
     it('shows the not-found message for non-DRAFT studies', async () => {

--- a/src/app/[orgSlug]/study/[studyId]/edit/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit/page.tsx
@@ -1,10 +1,12 @@
 import { db } from '@/database'
+import { redirect } from 'next/navigation'
+import { Routes } from '@/lib/routes'
 import { AlertNotFound } from '@/components/errors'
 import { StudyProposal } from '../../request/proposal'
 
 export default async function StudyEditPage(props: { params: Promise<{ studyId: string; orgSlug: string }> }) {
     const params = await props.params
-    const { studyId } = params
+    const { studyId, orgSlug } = params
 
     // TODO: validate that member from clerk session matches memberId from url
     const study = await db
@@ -13,6 +15,7 @@ export default async function StudyEditPage(props: { params: Promise<{ studyId: 
         .select([
             'study.id',
             'study.status',
+            'study.proposalRevisionBaseSubmissionId',
             'study.title',
             'study.piName',
             'study.piUserId',
@@ -37,6 +40,13 @@ export default async function StudyEditPage(props: { params: Promise<{ studyId: 
         return (
             <AlertNotFound title="Study was not found" message="Only studies that are in DRAFT status can be edited." />
         )
+    }
+
+    // OTTER-636: a revision draft (a change-requested proposal being revised) is also DRAFT, but this
+    // Step-1 editor reads the mutable row without a submitting-lab check. Route it to the edit-and-resubmit
+    // flow (which is lab-gated), so live revision content is never served here to an unrelated user.
+    if (study.proposalRevisionBaseSubmissionId !== null) {
+        redirect(Routes.studyEditAndResubmit({ orgSlug, studyId }))
     }
 
     // /edit is a revisitable step: an authorized DRAFT researcher can open it directly, forward or

--- a/src/app/[orgSlug]/study/[studyId]/proposal/collaborative-proposal-text-field.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/collaborative-proposal-text-field.tsx
@@ -8,6 +8,7 @@ import { FormFieldLabel } from '@/components/form-field-label'
 import { InputError } from '@/components/errors'
 import { WordCounter } from '@/components/word-counter'
 import { Editor } from '@/components/editable-text/editor'
+import { useProposalRevision } from '@/hooks/use-start-proposal-revision'
 import { proposalTextFieldDocName, type ProposalTextFieldKey } from '@/lib/collaboration-documents'
 import { countWordsFromLexical } from '@/lib/lexical'
 import { type EditableTextField } from './field-config'
@@ -36,6 +37,7 @@ type ProposalEditorProps = {
     placeholder: string | undefined
     ariaLabel: string
     onTextChange: (json: string) => void
+    onLocalUserEdit?: () => void
     websocketProvider: HocuspocusProviderWebsocket | null
 }
 
@@ -46,6 +48,7 @@ function ProposalTextEditor({
     placeholder,
     ariaLabel,
     onTextChange,
+    onLocalUserEdit,
     websocketProvider,
 }: ProposalEditorProps) {
     return (
@@ -58,6 +61,7 @@ function ProposalTextEditor({
             placeholder={placeholder}
             ariaLabel={ariaLabel}
             onChange={onTextChange}
+            onLocalUserEdit={onLocalUserEdit}
         />
     )
 }
@@ -72,6 +76,8 @@ export function CollaborativeProposalTextField({
 }: Props) {
     const [wordCount, setWordCount] = useState(() => countWordsFromLexical(initialValue))
     const docName = proposalTextFieldDocName(studyId, field.id as ProposalTextFieldKey)
+    // No-op outside the edit-and-resubmit flow (no provider mounted on the fresh-draft form).
+    const { signalRealEdit } = useProposalRevision()
 
     const onTextChange = (json: string) => {
         onChange(json)
@@ -93,6 +99,7 @@ export function CollaborativeProposalTextField({
                         placeholder={field.placeholder}
                         ariaLabel={field.label}
                         onTextChange={onTextChange}
+                        onLocalUserEdit={signalRealEdit}
                         websocketProvider={websocketProvider}
                     />
                     <Group justify={error ? 'space-between' : 'flex-end'} mt={4}>

--- a/src/app/[orgSlug]/study/[studyId]/proposal/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/page.tsx
@@ -17,10 +17,12 @@ export default async function StudyProposalRoute(props: { params: Promise<{ stud
         return notFound()
     }
 
-    // OTTER-636: /proposal is the FRESH-draft Step 2 editor. A change-requested proposal is revised on
-    // the edit-and-resubmit flow (which requires a resubmission note), never here — this closes the
-    // /proposal path that previously submitted a change-requested proposal without a note (Finding 3).
-    if (result.status === 'CHANGE-REQUESTED') {
+    // OTTER-636: /proposal is the FRESH-draft Step 2 editor. A change-requested proposal, and its
+    // in-progress revision draft (DRAFT with a base snapshot), are revised on the edit-and-resubmit
+    // flow (which requires a resubmission note), never here — this closes the /proposal path that
+    // previously submitted a change-requested proposal without a note (Finding 3).
+    const isRevisionDraft = result.status === 'DRAFT' && result.proposalRevisionBaseSubmissionId != null
+    if (result.status === 'CHANGE-REQUESTED' || isRevisionDraft) {
         redirect(Routes.studyEditAndResubmit({ orgSlug, studyId }))
     }
 

--- a/src/app/[orgSlug]/study/[studyId]/proposal/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/page.tsx
@@ -17,7 +17,14 @@ export default async function StudyProposalRoute(props: { params: Promise<{ stud
         return notFound()
     }
 
-    if (result.status !== 'DRAFT' && result.status !== 'CHANGE-REQUESTED') {
+    // OTTER-636: /proposal is the FRESH-draft Step 2 editor. A change-requested proposal is revised on
+    // the edit-and-resubmit flow (which requires a resubmission note), never here — this closes the
+    // /proposal path that previously submitted a change-requested proposal without a note (Finding 3).
+    if (result.status === 'CHANGE-REQUESTED') {
+        redirect(Routes.studyEditAndResubmit({ orgSlug, studyId }))
+    }
+
+    if (result.status !== 'DRAFT') {
         redirect(Routes.studyReview({ orgSlug, studyId }))
     }
 

--- a/src/app/[orgSlug]/study/[studyId]/review/reviewer-page-guard.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/reviewer-page-guard.tsx
@@ -3,13 +3,13 @@ import { AccessDeniedAlert, AlertNotFound } from '@/components/errors'
 import { isActionError } from '@/lib/errors'
 import { toRecord } from '@/lib/permissions'
 import { Routes } from '@/lib/routes'
-import { isSubmittedStudy, type Submitted } from '@/schema/study'
+import { isSubmittedStudy } from '@/schema/study'
 import { getStudyAction, type SelectedStudy } from '@/server/actions/study.actions'
 import { sessionFromClerk } from '@/server/clerk'
 import { redirect } from 'next/navigation'
 
 type ReviewerPageGuardResult =
-    | { ok: true; study: Submitted<SelectedStudy>; orgSlug: string; studyId: string }
+    | { ok: true; study: SelectedStudy; orgSlug: string; studyId: string }
     | { ok: false; render: React.ReactNode }
 
 // Shared access preamble for the reviewer entry points (/review and /review/proposal). Both pages
@@ -36,7 +36,11 @@ export async function reviewerPageGuard(orgSlug: string, studyId: string): Promi
         return { ok: false, render: <AccessDeniedAlert /> }
     }
 
-    if (!isSubmittedStudy(study)) return { ok: false, render: notFound }
+    // OTTER-636: a revision draft (a change-requested proposal the researcher is now editing) is not
+    // "submitted" (status DRAFT) but has submitted history to show read-only, so admit it alongside
+    // genuinely-submitted studies. A fresh draft (DRAFT, no base snapshot) stays not-found for reviewers.
+    const isRevisionDraft = study.status === 'DRAFT' && study.proposalRevisionBaseSubmissionId != null
+    if (!isSubmittedStudy(study) && !isRevisionDraft) return { ok: false, render: notFound }
 
     return { ok: true, study, orgSlug, studyId }
 }

--- a/src/app/[orgSlug]/study/[studyId]/submitted/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/submitted/page.tsx
@@ -1,4 +1,5 @@
 import { getStudyAction } from '@/server/actions/study.actions'
+import { overlaidWithLatestProposalSnapshot } from '@/server/db/proposal-snapshot'
 import { isActionError } from '@/lib/errors'
 import { AlertNotFound } from '@/components/errors'
 import { isSubmittedStudy } from '@/schema/study'
@@ -19,16 +20,20 @@ export default async function StudySubmittedRoute(props: {
         return <AlertNotFound title="Study was not found" message="No such study exists" />
     }
 
-    if (!isSubmittedStudy(result)) {
+    // OTTER-636: render the last immutable submitted snapshot, not the mutable row (which may hold live
+    // revision-draft edits). Overlay before the submitted-state narrowing so it still applies.
+    const study = await overlaidWithLatestProposalSnapshot(studyId, result)
+
+    if (!isSubmittedStudy(study)) {
         return <AlertNotFound title="Study was not found" message="This study has not been submitted yet" />
     }
 
-    const { orgName, entries, studyVersion, feedbackError } = await loadProposalSubmittedData(result)
+    const { orgName, entries, studyVersion, feedbackError } = await loadProposalSubmittedData(study)
 
     return (
         <ProposalSubmitted
             orgSlug={orgSlug}
-            study={result}
+            study={study}
             orgName={orgName}
             entries={entries}
             studyVersion={studyVersion}

--- a/src/components/dashboard/studies-table/dashboard-raw-state.test.ts
+++ b/src/components/dashboard/studies-table/dashboard-raw-state.test.ts
@@ -16,6 +16,7 @@ const row = (overrides: Partial<StudyRow>): StudyRow => ({
     createdBy: null,
     jobStatusChanges: [{ status: 'CODE-SUBMITTED' }, { status: 'CODE-APPROVED' }],
     researcherAgreementsAckedAt: null,
+    proposalRevisionBaseSubmissionId: null,
     piUserId: null,
     datasets: null,
     researchQuestions: null,

--- a/src/components/dashboard/studies-table/dashboard-raw-state.ts
+++ b/src/components/dashboard/studies-table/dashboard-raw-state.ts
@@ -23,6 +23,8 @@ export function dashboardRawStateFromRow(study: StudyRow): RawStudyState {
         reviewerAgreementsAckedAt: null,
         proposalResubmissionNoteDraft: null,
         codeResubmissionNoteDraft: null,
+        // OTTER-636: distinguishes a revision draft from a fresh draft (reviewer pill/routing).
+        proposalRevisionBaseSubmissionId: study.proposalRevisionBaseSubmissionId,
         // Step 2 fields drive hasStep2Progress so a reopened DRAFT resumes on the right step (OTTER-572).
         piUserId: study.piUserId,
         datasets: study.datasets,

--- a/src/components/dashboard/studies-table/studies-table-view.stories.tsx
+++ b/src/components/dashboard/studies-table/studies-table-view.stories.tsx
@@ -26,6 +26,7 @@ const study = (o: Partial<StudyRowType> = {}): StudyRowType => ({
     createdBy: 'Ada Lovelace',
     jobStatusChanges: [],
     researcherAgreementsAckedAt: null,
+    proposalRevisionBaseSubmissionId: null,
     piUserId: null,
     datasets: null,
     researchQuestions: null,

--- a/src/components/dashboard/studies-table/study-row.stories.tsx
+++ b/src/components/dashboard/studies-table/study-row.stories.tsx
@@ -25,6 +25,7 @@ const study = (o: Partial<StudyRowType> = {}): StudyRowType => ({
     createdBy: 'Ada Lovelace',
     jobStatusChanges: [],
     researcherAgreementsAckedAt: null,
+    proposalRevisionBaseSubmissionId: null,
     piUserId: null,
     datasets: null,
     researchQuestions: null,

--- a/src/components/dashboard/studies-table/study-row.test.tsx
+++ b/src/components/dashboard/studies-table/study-row.test.tsx
@@ -19,6 +19,7 @@ const baseStudy: StudyRowType = {
     createdBy: 'Person A',
     jobStatusChanges: [],
     researcherAgreementsAckedAt: null,
+    proposalRevisionBaseSubmissionId: null,
     piUserId: null,
     datasets: null,
     researchQuestions: null,

--- a/src/components/dashboard/studies-table/types.ts
+++ b/src/components/dashboard/studies-table/types.ts
@@ -18,6 +18,8 @@ export type StudyRow = {
     createdBy: string | null // researcher.fullName
     jobStatusChanges: Array<{ status: StudyJobStatus; userId?: string | null }>
     researcherAgreementsAckedAt: Date | null
+    // OTTER-636: non-null on a revision draft; drives the reviewer "Proposal Draft" pill and routing.
+    proposalRevisionBaseSubmissionId: string | null
     // Step 2 proposal fields — used to resume a reopened DRAFT on the step it was last left (OTTER-572).
     piUserId: string | null
     datasets: string[] | null

--- a/src/components/editable-text/collaborative-editor.tsx
+++ b/src/components/editable-text/collaborative-editor.tsx
@@ -106,7 +106,7 @@ function EditorChangePlugin({
     const [editor] = useLexicalComposerContext()
 
     useEffect(() => {
-        return editor.registerUpdateListener(({ editorState, tags }) => {
+        return editor.registerUpdateListener(({ editorState, dirtyElements, dirtyLeaves, tags }) => {
             const json = editorState.toJSON()
             // On mount, before Yjs syncs, Lexical's root briefly has no children.
             // That state is valid in memory but Lexical rejects it on re-hydration,
@@ -115,11 +115,13 @@ function EditorChangePlugin({
             // input still keeps an empty paragraph in children, so this only filters
             // the pre-sync state.
             if (!json.root?.children?.length) return
-            // OTTER-636: a local user edit is one that did NOT originate from Yjs sync
-            // (tagged `collaboration`) or the initial hydration merge (`history-merge`).
-            // A remote collaborator's change arrives tagged `collaboration`; their own
-            // client signals the transition for them, so we must not impersonate it here.
-            if (onLocalUserEdit && !tags.has('collaboration') && !tags.has('history-merge')) {
+            // OTTER-636: a local user edit is one that (a) actually mutated content, and (b) did NOT
+            // originate from Yjs sync (`collaboration`) or the initial hydration merge (`history-merge`).
+            // Lexical fires this listener on selection-only updates too (focus / cursor move), where
+            // dirtyElements+dirtyLeaves are empty — those are NOT edits (card non-trigger) and must never
+            // flip the study to a draft. A remote collaborator's own client signals for them.
+            const contentChanged = dirtyElements.size > 0 || dirtyLeaves.size > 0
+            if (onLocalUserEdit && contentChanged && !tags.has('collaboration') && !tags.has('history-merge')) {
                 onLocalUserEdit()
             }
             onChange?.(JSON.stringify(json))

--- a/src/components/editable-text/collaborative-editor.tsx
+++ b/src/components/editable-text/collaborative-editor.tsx
@@ -96,11 +96,17 @@ function ActiveEditorsList({
     )
 }
 
-function EditorChangePlugin({ onChange }: { onChange: (json: string) => void }) {
+function EditorChangePlugin({
+    onChange,
+    onLocalUserEdit,
+}: {
+    onChange?: (json: string) => void
+    onLocalUserEdit?: () => void
+}) {
     const [editor] = useLexicalComposerContext()
 
     useEffect(() => {
-        return editor.registerUpdateListener(({ editorState }) => {
+        return editor.registerUpdateListener(({ editorState, tags }) => {
             const json = editorState.toJSON()
             // On mount, before Yjs syncs, Lexical's root briefly has no children.
             // That state is valid in memory but Lexical rejects it on re-hydration,
@@ -109,9 +115,16 @@ function EditorChangePlugin({ onChange }: { onChange: (json: string) => void }) 
             // input still keeps an empty paragraph in children, so this only filters
             // the pre-sync state.
             if (!json.root?.children?.length) return
-            onChange(JSON.stringify(json))
+            // OTTER-636: a local user edit is one that did NOT originate from Yjs sync
+            // (tagged `collaboration`) or the initial hydration merge (`history-merge`).
+            // A remote collaborator's change arrives tagged `collaboration`; their own
+            // client signals the transition for them, so we must not impersonate it here.
+            if (onLocalUserEdit && !tags.has('collaboration') && !tags.has('history-merge')) {
+                onLocalUserEdit()
+            }
+            onChange?.(JSON.stringify(json))
         })
-    }, [editor, onChange])
+    }, [editor, onChange, onLocalUserEdit])
 
     return null
 }
@@ -180,6 +193,12 @@ export type CollaborativeEditorProps = {
     placeholder?: string
     ariaLabel?: string
     onChange?: (json: string) => void
+    /**
+     * OTTER-636: fires on the first and every subsequent *local* user edit (not on Yjs hydration or
+     * remote collaborator updates). Used to transition a change-requested proposal to a revision draft
+     * the moment the researcher actually edits it.
+     */
+    onLocalUserEdit?: () => void
     footerRight?: React.ReactNode
     /**
      * Called once Lexical's CollaborationPlugin instantiates the provider, and
@@ -235,6 +254,7 @@ export function CollaborativeEditor({
     placeholder,
     ariaLabel,
     onChange,
+    onLocalUserEdit,
     footerRight,
     onProviderReady,
 }: CollaborativeEditorProps) {
@@ -378,7 +398,9 @@ export function CollaborativeEditor({
                         cursorColor={cursorColor}
                         awarenessData={awarenessData}
                     />
-                    {onChange && <EditorChangePlugin onChange={onChange} />}
+                    {(onChange || onLocalUserEdit) && (
+                        <EditorChangePlugin onChange={onChange} onLocalUserEdit={onLocalUserEdit} />
+                    )}
                     <ListPlugin />
                     <TabIndentationPlugin />
                     <EscapeFocusPlugin />

--- a/src/components/editable-text/editor.tsx
+++ b/src/components/editable-text/editor.tsx
@@ -33,6 +33,8 @@ export type EditorProps = {
     placeholder?: string
     ariaLabel?: string
     onChange?: (json: string) => void
+    /** OTTER-636: fires on each local user edit (not Yjs hydration / remote updates). */
+    onLocalUserEdit?: () => void
     footerRight?: React.ReactNode
     onProviderReady?: (provider: HocuspocusProvider | null) => void
     /** Height of the skeleton shown while the collaborative chunk loads / before the websocket connects. */

--- a/src/components/editable-text/single-user-editor.tsx
+++ b/src/components/editable-text/single-user-editor.tsx
@@ -66,14 +66,26 @@ function EditorChangePlugin({
 
     useEffect(() => {
         return editor.registerUpdateListener(
-            ({ editorState, tags }: { editorState: EditorState; tags: Set<string> }) => {
+            ({
+                editorState,
+                dirtyElements,
+                dirtyLeaves,
+                tags,
+            }: {
+                editorState: EditorState
+                dirtyElements: Map<string, boolean>
+                dirtyLeaves: Set<string>
+                tags: Set<string>
+            }) => {
                 const json = editorState.toJSON()
                 // Mirror the collaborative editor: never persist an empty root, which
                 // Lexical rejects on re-hydration and would crash the read-only views.
                 if (!json.root?.children?.length) return
-                // OTTER-636: skip the initial hydration merge; any other content-ful update in
-                // single-user mode is a local user edit (there is no remote collaborator here).
-                if (onLocalUserEdit && !tags.has('history-merge')) onLocalUserEdit()
+                // OTTER-636: only a real content mutation is a local edit. Lexical fires this on
+                // selection-only updates (focus / cursor move) with empty dirty sets; those are not edits
+                // (card non-trigger) and must not flip the study to a draft. Skip the hydration merge too.
+                const contentChanged = dirtyElements.size > 0 || dirtyLeaves.size > 0
+                if (onLocalUserEdit && contentChanged && !tags.has('history-merge')) onLocalUserEdit()
                 onChange?.(JSON.stringify(json))
             },
         )

--- a/src/components/editable-text/single-user-editor.tsx
+++ b/src/components/editable-text/single-user-editor.tsx
@@ -35,6 +35,8 @@ export type SingleUserEditorProps = {
     placeholder?: string
     ariaLabel?: string
     onChange?: (json: string) => void
+    /** OTTER-636: fires on each local user edit (not the initial hydration). Mirrors CollaborativeEditor. */
+    onLocalUserEdit?: () => void
     footerRight?: React.ReactNode
     /** Extra plugins/children rendered inside the Lexical composer context. */
     children?: React.ReactNode
@@ -53,18 +55,29 @@ function createInitialConfig(id: string, initialValue: string | undefined) {
     }
 }
 
-function EditorChangePlugin({ onChange }: { onChange: (json: string) => void }) {
+function EditorChangePlugin({
+    onChange,
+    onLocalUserEdit,
+}: {
+    onChange?: (json: string) => void
+    onLocalUserEdit?: () => void
+}) {
     const [editor] = useLexicalComposerContext()
 
     useEffect(() => {
-        return editor.registerUpdateListener(({ editorState }: { editorState: EditorState }) => {
-            const json = editorState.toJSON()
-            // Mirror the collaborative editor: never persist an empty root, which
-            // Lexical rejects on re-hydration and would crash the read-only views.
-            if (!json.root?.children?.length) return
-            onChange(JSON.stringify(json))
-        })
-    }, [editor, onChange])
+        return editor.registerUpdateListener(
+            ({ editorState, tags }: { editorState: EditorState; tags: Set<string> }) => {
+                const json = editorState.toJSON()
+                // Mirror the collaborative editor: never persist an empty root, which
+                // Lexical rejects on re-hydration and would crash the read-only views.
+                if (!json.root?.children?.length) return
+                // OTTER-636: skip the initial hydration merge; any other content-ful update in
+                // single-user mode is a local user edit (there is no remote collaborator here).
+                if (onLocalUserEdit && !tags.has('history-merge')) onLocalUserEdit()
+                onChange?.(JSON.stringify(json))
+            },
+        )
+    }, [editor, onChange, onLocalUserEdit])
 
     return null
 }
@@ -77,6 +90,7 @@ export function SingleUserEditor({
     placeholder,
     ariaLabel,
     onChange,
+    onLocalUserEdit,
     footerRight,
     children,
 }: SingleUserEditorProps) {
@@ -116,7 +130,9 @@ export function SingleUserEditor({
                 <TabIndentationPlugin />
                 <EscapeFocusPlugin />
                 <LinkPlugin validateUrl={isValidUrl} />
-                {onChange && <EditorChangePlugin onChange={onChange} />}
+                {(onChange || onLocalUserEdit) && (
+                    <EditorChangePlugin onChange={onChange} onLocalUserEdit={onLocalUserEdit} />
+                )}
                 {children}
                 <Toolbar />
             </Paper>

--- a/src/components/study/collaborative-resubmission-note-section.tsx
+++ b/src/components/study/collaborative-resubmission-note-section.tsx
@@ -9,6 +9,7 @@ import { InputError } from '@/components/errors'
 import { WordCounter } from '@/components/word-counter'
 import { SaveStatusIndicator } from '@/components/save-status'
 import { Editor } from '@/components/editable-text/editor'
+import { useProposalRevision } from '@/hooks/use-start-proposal-revision'
 import { useSingleUserEditing } from '@/lib/realtime/yjs-websocket-context'
 import { proposalResubmissionNoteDocNameForVersion } from '@/lib/collaboration-documents'
 import {
@@ -64,6 +65,7 @@ export const CollaborativeResubmissionNoteSection: FC<CollaborativeResubmissionN
     autosaveStatus,
 }) => {
     const singleUserEditing = useSingleUserEditing()
+    const { signalRealEdit } = useProposalRevision()
     const value = noteForm.values.resubmissionNote
     const error = noteForm.errors.resubmissionNote as string | undefined
     const wordCount = resubmissionNoteWordCount(value)
@@ -92,6 +94,7 @@ export const CollaborativeResubmissionNoteSection: FC<CollaborativeResubmissionN
                         placeholder={PLACEHOLDER_TEXT}
                         ariaLabel="Resubmission Note"
                         onChange={onNoteChange}
+                        onLocalUserEdit={signalRealEdit}
                         footerRight={<WordCounter wordCount={wordCount} maxWords={RESUBMIT_NOTE_MAX_WORDS} />}
                         skeletonHeight={EDITOR_MIN_HEIGHT}
                     />

--- a/src/components/study/study-org-selector.tsx
+++ b/src/components/study/study-org-selector.tsx
@@ -7,6 +7,7 @@ import { useUser } from '@clerk/nextjs'
 import { Divider, Grid, Paper, Select, Stack, Text, Title } from '@mantine/core'
 import { UseFormReturnType } from '@mantine/form'
 import { useParams } from 'next/navigation'
+import { useState } from 'react'
 
 type Props = {
     form: UseFormReturnType<StudyProposalFormValues>
@@ -14,7 +15,13 @@ type Props = {
 
 export const StudyOrgSelector: React.FC<Props> = ({ form }) => {
     const { user, isLoaded } = useUser()
-    const { studyId } = useParams<{ studyId?: string }>()
+    const { studyId: routeStudyId } = useParams<{ studyId?: string }>()
+    // OTTER-636 Phase 7: the draft is now lazy-created on Data-Partner selection (before the URL gains a
+    // studyId). The request context stamps the new id into the form's `createdStudyId`; watch it so the
+    // selector locks once a draft exists. The Data Partner is fixed at creation (the update path does not
+    // change org), matching the edit flow.
+    const [createdStudyId, setCreatedStudyId] = useState(form.getValues().createdStudyId)
+    form.watch('createdStudyId', ({ value }) => setCreatedStudyId(value))
 
     const { data: orgs = [], isLoading } = useQuery({
         queryKey: ['orgs-with-languages'],
@@ -24,7 +31,7 @@ export const StudyOrgSelector: React.FC<Props> = ({ form }) => {
     if (!isLoaded || !user) return null
     const { titleSpan, inputSpan } = PROPOSAL_GRID_SPAN
 
-    const isExistingDraft = !!studyId
+    const isExistingDraft = !!routeStudyId || !!createdStudyId
 
     return (
         <Paper p="xxl">

--- a/src/contexts/edit-resubmit/hooks/use-resubmit-proposal.test.ts
+++ b/src/contexts/edit-resubmit/hooks/use-resubmit-proposal.test.ts
@@ -32,7 +32,25 @@ import {
     type ResubmitNoteValue,
 } from '@/app/[orgSlug]/study/[studyId]/edit-and-resubmit/schema'
 import { useYjsFormMap } from '@/hooks/use-yjs-form-map'
+import { writeProposalSubmissionSnapshot } from '@/server/db/proposal-snapshot'
 import { useResubmitProposal } from './use-resubmit-proposal'
+
+// OTTER-636: resubmit accepts only a revision draft. Put the study into that state directly: an
+// immutable snapshot plus a DRAFT row pointing at it as its base.
+const makeRevisionDraft = async (studyId: string, userId: string) => {
+    await writeProposalSubmissionSnapshot(db, studyId, userId)
+    const snap = await db
+        .selectFrom('studyProposalSubmission')
+        .select('id')
+        .where('studyId', '=', studyId)
+        .orderBy('version', 'desc')
+        .executeTakeFirstOrThrow()
+    await db
+        .updateTable('study')
+        .set({ status: 'DRAFT', proposalRevisionBaseSubmissionId: snap.id })
+        .where('id', '=', studyId)
+        .execute()
+}
 
 const buildValidProposalValues = (piUserId: string): ProposalFormValues => ({
     title: 'Resubmitted Title',
@@ -73,7 +91,7 @@ describe('useResubmitProposal', () => {
 
     it('successful resubmit broadcasts the proposal-submitted event and navigates', async () => {
         const { enclave, lab, studyId, user } = await createTestProposalDraft({ enclaveSlug: 'resubmit-happy' })
-        await setTestStudyStatus(studyId, 'CHANGE-REQUESTED')
+        await makeRevisionDraft(studyId, user.id)
         const { yjsForm, sendStateless } = buildStubYjsForm()
 
         const { result } = renderHook(

--- a/src/contexts/study-request/study-request-context.test.tsx
+++ b/src/contexts/study-request/study-request-context.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import type { ReactNode } from 'react'
+import {
+    act,
+    createTestQueryWrapper,
+    db,
+    insertTestOrg,
+    mockSessionWithTestData,
+    renderHook,
+    waitFor,
+} from '@/tests/unit.helpers'
+import { StudyRequestProvider, useStudyRequest } from './index'
+
+// OTTER-636 Phase 7: choosing a Data Partner is the first persistable Step-1 edit and must lazy-create
+// the draft, so a brand-new proposal is not lost if the researcher leaves before "Proceed to Step 2".
+const setupOrgs = async (slug: string) => {
+    const enclave = await insertTestOrg({ type: 'enclave', slug })
+    const lab = await insertTestOrg({ type: 'lab', slug: `${slug}-lab` })
+    await mockSessionWithTestData({ orgSlug: lab.slug, orgType: 'lab' })
+    return { enclave, lab }
+}
+
+const wrapperFor = (submittingOrgSlug: string) => {
+    const QueryWrapper = createTestQueryWrapper()
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+        <QueryWrapper>
+            <StudyRequestProvider submittingOrgSlug={submittingOrgSlug}>{children}</StudyRequestProvider>
+        </QueryWrapper>
+    )
+    return Wrapper
+}
+
+describe('StudyRequestProvider lazy-create (Phase 7)', () => {
+    it('creates a DRAFT the moment a Data Partner is selected', async () => {
+        const { enclave, lab } = await setupOrgs('lazy-create-enclave')
+
+        const { result } = renderHook(() => useStudyRequest(), { wrapper: wrapperFor(lab.slug) })
+        expect(result.current.studyId).toBeNull()
+
+        act(() => {
+            result.current.form.setFieldValue('orgSlug', enclave.slug)
+        })
+
+        await waitFor(() => expect(result.current.studyId).toBeTruthy())
+
+        const study = await db
+            .selectFrom('study')
+            .select(['status', 'orgId', 'submittedByOrgId'])
+            .where('id', '=', result.current.studyId as string)
+            .executeTakeFirstOrThrow()
+        expect(study.status).toBe('DRAFT')
+        expect(study.orgId).toBe(enclave.id)
+        expect(study.submittedByOrgId).toBe(lab.id)
+    })
+
+    it('creates exactly one draft even when Step-1 fields change repeatedly', async () => {
+        const { enclave, lab } = await setupOrgs('lazy-create-once-enclave')
+
+        const { result } = renderHook(() => useStudyRequest(), { wrapper: wrapperFor(lab.slug) })
+
+        act(() => {
+            result.current.form.setFieldValue('orgSlug', enclave.slug)
+        })
+        await waitFor(() => expect(result.current.studyId).toBeTruthy())
+
+        // Further Step-1 edits autosave onto the same row; they must never create a second draft.
+        act(() => {
+            result.current.form.setFieldValue('language', 'R')
+        })
+        await waitFor(() => expect(result.current.isSaving).toBe(false))
+
+        const rows = await db.selectFrom('study').select('id').where('submittedByOrgId', '=', lab.id).execute()
+        expect(rows).toHaveLength(1)
+    })
+})

--- a/src/contexts/study-request/study-request-context.tsx
+++ b/src/contexts/study-request/study-request-context.tsx
@@ -82,6 +82,10 @@ export function StudyRequestProvider({
         studyIdRef.current = studyId
     }, [studyId])
     const createInFlightRef = useRef(false)
+    // Set when a Step-1 field changes while the create is still in flight. The create captured an earlier
+    // snapshot of the form, so on success we run one follow-up save to persist whatever changed during
+    // that window (otherwise a language pick made mid-create would be lost until Proceed).
+    const pendingSaveRef = useRef(false)
 
     // Choosing a Data Partner is the first persistable edit. Fire the create once; the create captures
     // whatever else Step 1 already holds (e.g. a language picked first). Subsequent edits autosave below.
@@ -97,9 +101,15 @@ export function StudyRequestProvider({
                     // Stamp the new id into the form so the Data-Partner selector locks (it is fixed at
                     // creation) without coupling that component to this context.
                     form.setFieldValue('createdStudyId', newStudyId)
+                    // Flush any edit made while the create was in flight.
+                    if (pendingSaveRef.current) {
+                        pendingSaveRef.current = false
+                        saveDraftInternal(form.getValues())
+                    }
                 },
                 onError: () => {
                     createInFlightRef.current = false
+                    pendingSaveRef.current = false
                 },
             })
         },
@@ -109,11 +119,15 @@ export function StudyRequestProvider({
     // eslint-disable-next-line react-hooks/refs
     form.watch('orgSlug', onOrgSlugChange)
 
-    // Autosave a later Step-1 field change once the draft exists. Skips while the create is still in
-    // flight (studyId not yet known) so it can never create a duplicate draft; anything typed in that
-    // window is still persisted by the create itself or by Proceed.
+    // Autosave a later Step-1 field change once the draft exists. While the create is still in flight
+    // (studyId not yet known) we can't save without spawning a duplicate draft, so record that a save is
+    // owed and let the create's onSuccess flush it.
     const onLanguageChange = useCallback(() => {
-        if (!studyIdRef.current || createInFlightRef.current) return
+        if (createInFlightRef.current) {
+            pendingSaveRef.current = true
+            return
+        }
+        if (!studyIdRef.current) return
         saveDraftInternal(form.getValues())
     }, [saveDraftInternal, form])
     // Deferred watch callback (see above); ref reads run on change, not during render.

--- a/src/contexts/study-request/study-request-context.tsx
+++ b/src/contexts/study-request/study-request-context.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, useContext, useState, useCallback, useMemo, useEffect, type ReactNode } from 'react'
+import { createContext, useContext, useState, useCallback, useMemo, useEffect, useRef, type ReactNode } from 'react'
 import { useForm } from '@mantine/form'
 import { zodResolver } from '@/common'
 import {
@@ -73,8 +73,58 @@ export function StudyRequestProvider({
         onStudyCreated: setStudyId,
     })
 
+    // OTTER-636 Phase 7: lazy-create the draft on the first persistable Step-1 edit (choosing a Data
+    // Partner) instead of only on "Proceed to Step 2", so a brand-new proposal is never lost if the
+    // researcher leaves Step 1 early. `studyIdRef` mirrors `studyId` synchronously (state lags a render)
+    // so the watchers below can't spawn a second draft between create-success and the re-render.
+    const studyIdRef = useRef(studyId)
+    useEffect(() => {
+        studyIdRef.current = studyId
+    }, [studyId])
+    const createInFlightRef = useRef(false)
+
+    // Choosing a Data Partner is the first persistable edit. Fire the create once; the create captures
+    // whatever else Step 1 already holds (e.g. a language picked first). Subsequent edits autosave below.
+    // Wrapped in useCallback so the ref reads run in the deferred watch callback, never during render.
+    const onOrgSlugChange = useCallback(
+        ({ value }: { value: string }) => {
+            if (!value || studyIdRef.current || createInFlightRef.current) return
+            createInFlightRef.current = true
+            saveDraftInternal(form.getValues(), {
+                onSuccess: ({ studyId: newStudyId }) => {
+                    studyIdRef.current = newStudyId
+                    createInFlightRef.current = false
+                    // Stamp the new id into the form so the Data-Partner selector locks (it is fixed at
+                    // creation) without coupling that component to this context.
+                    form.setFieldValue('createdStudyId', newStudyId)
+                },
+                onError: () => {
+                    createInFlightRef.current = false
+                },
+            })
+        },
+        [saveDraftInternal, form],
+    )
+    // The watch callback fires on value change, never during render, so its ref reads are safe.
+    // eslint-disable-next-line react-hooks/refs
+    form.watch('orgSlug', onOrgSlugChange)
+
+    // Autosave a later Step-1 field change once the draft exists. Skips while the create is still in
+    // flight (studyId not yet known) so it can never create a duplicate draft; anything typed in that
+    // window is still persisted by the create itself or by Proceed.
+    const onLanguageChange = useCallback(() => {
+        if (!studyIdRef.current || createInFlightRef.current) return
+        saveDraftInternal(form.getValues())
+    }, [saveDraftInternal, form])
+    // Deferred watch callback (see above); ref reads run on change, not during render.
+    // eslint-disable-next-line react-hooks/refs
+    form.watch('language', onLanguageChange)
+
     const reset = useCallback(
         (preserveStudyId?: string) => {
+            // Keep the ref in lockstep with state so a fresh Data-Partner selection after reset triggers
+            // exactly one create (state updates lag a render; the watcher reads the ref).
+            studyIdRef.current = preserveStudyId ?? null
             setStudyId(preserveStudyId ?? null)
             setOrgSlug('')
             resetDocumentFiles()
@@ -92,6 +142,9 @@ export function StudyRequestProvider({
 
     const initFromDraft = useCallback(
         (draft: DraftStudyData, newSubmittingOrgSlug: string) => {
+            // Set the ref before form.setValues fires the orgSlug watcher, so loading an existing draft
+            // is never mistaken for a first-edit and re-created.
+            studyIdRef.current = draft.id
             setStudyId(draft.id)
             setOrgSlug(draft.orgSlug)
             setSubmittingOrgSlug(newSubmittingOrgSlug)

--- a/src/database/migrations/1780500000000_study_proposal_submission.ts
+++ b/src/database/migrations/1780500000000_study_proposal_submission.ts
@@ -1,0 +1,31 @@
+import { type Kysely, sql } from 'kysely'
+
+// OTTER-636: immutable per-version snapshot of a submitted proposal. Reviewer proposal views read the
+// latest snapshot for a study rather than the mutable `study` row / live Yjs docs, so a researcher
+// revising a change-requested proposal (which now literally re-enters DRAFT) can never leak in-progress
+// draft content to a reviewer. One row is written on each submission (fresh submit = v1, each resubmit
+// = next version). `snapshot` holds every reviewer-visible proposal field as one validated JSON object
+// (see the shared Zod schema/serializer in src/lib/proposal-snapshot.ts).
+export async function up(db: Kysely<unknown>): Promise<void> {
+    await db.schema
+        .createTable('study_proposal_submission')
+        .addColumn('id', 'uuid', (col) => col.primaryKey().defaultTo(sql`v7uuid()`))
+        .addColumn('study_id', 'uuid', (col) => col.notNull().references('study.id').onDelete('cascade'))
+        .addColumn('version', 'integer', (col) => col.notNull())
+        .addColumn('submitted_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+        .addColumn('submitted_by_user_id', 'uuid', (col) => col.notNull().references('user.id'))
+        .addColumn('schema_version', 'integer', (col) => col.notNull().defaultTo(1))
+        .addColumn('snapshot', 'jsonb', (col) => col.notNull())
+        .addUniqueConstraint('uq_study_proposal_submission_study_version', ['study_id', 'version'])
+        .execute()
+
+    await db.schema
+        .createIndex('idx_study_proposal_submission_study_version')
+        .on('study_proposal_submission')
+        .columns(['study_id', 'version desc'])
+        .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+    await db.schema.dropTable('study_proposal_submission').execute()
+}

--- a/src/database/migrations/1780500000001_add_proposal_revision_base.ts
+++ b/src/database/migrations/1780500000001_add_proposal_revision_base.ts
@@ -1,0 +1,28 @@
+import { type Kysely, sql } from 'kysely'
+
+// OTTER-636: the active-revision discriminator. A study.status of DRAFT is now ambiguous between a
+// brand-new fresh draft and a revision of a previously submitted (change-requested) proposal. This FK
+// resolves it:
+//   - NULL  + status DRAFT  -> fresh unsubmitted draft
+//   - set   + status DRAFT  -> revision draft, pointing at the immutable submitted snapshot being revised
+//   - NULL  for every non-DRAFT status
+// The check constraint enforces that a base id may only be set while the study is a DRAFT.
+export async function up(db: Kysely<unknown>): Promise<void> {
+    await db.schema
+        .alterTable('study')
+        .addColumn('proposal_revision_base_submission_id', 'uuid', (col) =>
+            col.references('study_proposal_submission.id'),
+        )
+        .execute()
+
+    await sql`
+        ALTER TABLE study
+        ADD CONSTRAINT proposal_revision_base_only_when_draft
+        CHECK (proposal_revision_base_submission_id IS NULL OR status = 'DRAFT')
+    `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+    await sql`ALTER TABLE study DROP CONSTRAINT IF EXISTS proposal_revision_base_only_when_draft`.execute(db)
+    await db.schema.alterTable('study').dropColumn('proposal_revision_base_submission_id').execute()
+}

--- a/src/database/migrations/1780500000002_backfill_proposal_submissions.ts
+++ b/src/database/migrations/1780500000002_backfill_proposal_submissions.ts
@@ -1,0 +1,46 @@
+import { type Kysely, sql } from 'kysely'
+
+// OTTER-636: seed one immutable proposal snapshot for every study that has already been submitted
+// (submitted_at IS NOT NULL). Version = 1 + number of prior resubmission notes, so an already-resubmitted
+// study lands at its latest version. Older versions cannot be reconstructed (historical field bodies were
+// overwritten in place before this table existed); only the latest canonical body is captured, and older
+// review comments remain as historical feedback. After this runs, reviewer proposal loaders read the
+// latest snapshot rather than the mutable study row.
+export async function up(db: Kysely<unknown>): Promise<void> {
+    await sql`
+        INSERT INTO study_proposal_submission
+            (study_id, version, submitted_at, submitted_by_user_id, schema_version, snapshot)
+        SELECT
+            s.id,
+            1 + COALESCE((
+                SELECT count(*) FROM study_proposal_comment c
+                WHERE c.study_id = s.id AND c.entry_type = 'RESUBMISSION-NOTE'
+            ), 0),
+            COALESCE(s.submitted_at, now()),
+            s.researcher_id,
+            1,
+            jsonb_build_object(
+                'title', s.title,
+                'piName', s.pi_name,
+                'piUserId', s.pi_user_id,
+                'language', s.language,
+                'datasets', s.datasets,
+                'dataSources', s.data_sources,
+                'researchQuestions', s.research_questions,
+                'projectSummary', s.project_summary,
+                'impact', s.impact,
+                'additionalNotes', s.additional_notes,
+                'irbProtocols', s.irb_protocols,
+                'descriptionDocPath', s.description_doc_path,
+                'irbDocPath', s.irb_doc_path,
+                'agreementDocPath', s.agreement_doc_path
+            )
+        FROM study s
+        WHERE s.submitted_at IS NOT NULL
+          AND NOT EXISTS (SELECT 1 FROM study_proposal_submission x WHERE x.study_id = s.id)
+    `.execute(db)
+}
+
+// Data backfill: the inverse is handled by dropping the table (migration 1780500000000 down). A no-op
+// here avoids deleting snapshots that later submissions legitimately added.
+export async function down(): Promise<void> {}

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -235,6 +235,7 @@ export interface Study {
     piUserId: string | null
     projectSummary: Json | null
     proposalResubmissionNoteDraft: string | null
+    proposalRevisionBaseSubmissionId: string | null
     rejectedAt: Timestamp | null
     researcherAgreementsAckedAt: Timestamp | null
     researcherId: string
@@ -283,6 +284,16 @@ export interface StudyProposalComment {
     entryType: StudyProposalCommentEntryType
     id: Generated<string>
     studyId: string
+    version: number
+}
+
+export interface StudyProposalSubmission {
+    id: Generated<string>
+    schemaVersion: Generated<number>
+    snapshot: Json
+    studyId: string
+    submittedAt: Generated<Timestamp>
+    submittedByUserId: string
     version: number
 }
 
@@ -354,6 +365,7 @@ export interface DB {
     studyJobFile: StudyJobFile
     studyJobFileRecipientKey: StudyJobFileRecipientKey
     studyProposalComment: StudyProposalComment
+    studyProposalSubmission: StudyProposalSubmission
     studyReview: StudyReview
     studyReviewComment: StudyReviewComment
     user: User

--- a/src/hooks/use-start-proposal-revision.test.ts
+++ b/src/hooks/use-start-proposal-revision.test.ts
@@ -34,12 +34,11 @@ const readStudy = (studyId: string) =>
 
 describe('useStartProposalRevision', () => {
     it('flips the study to a revision DRAFT on the first signalled edit when enabled', async () => {
-        const { org, study } = await setupChangeRequestedWithSnapshot('lab-hook-flip')
+        const { study } = await setupChangeRequestedWithSnapshot('lab-hook-flip')
 
-        const { result } = renderHook(
-            () => useStartProposalRevision({ studyId: study.id, orgSlug: org.slug, enabled: true }),
-            { wrapper: createTestQueryWrapper() },
-        )
+        const { result } = renderHook(() => useStartProposalRevision({ studyId: study.id, enabled: true }), {
+            wrapper: createTestQueryWrapper(),
+        })
 
         await act(async () => {
             result.current.signalRealEdit()
@@ -52,12 +51,11 @@ describe('useStartProposalRevision', () => {
     })
 
     it('does nothing when disabled (fresh draft or already-started revision)', async () => {
-        const { org, study } = await setupChangeRequestedWithSnapshot('lab-hook-disabled')
+        const { study } = await setupChangeRequestedWithSnapshot('lab-hook-disabled')
 
-        const { result } = renderHook(
-            () => useStartProposalRevision({ studyId: study.id, orgSlug: org.slug, enabled: false }),
-            { wrapper: createTestQueryWrapper() },
-        )
+        const { result } = renderHook(() => useStartProposalRevision({ studyId: study.id, enabled: false }), {
+            wrapper: createTestQueryWrapper(),
+        })
 
         await act(async () => {
             result.current.signalRealEdit()
@@ -70,12 +68,11 @@ describe('useStartProposalRevision', () => {
     })
 
     it('fires the transition at most once even when signalled repeatedly', async () => {
-        const { org, study } = await setupChangeRequestedWithSnapshot('lab-hook-once')
+        const { study } = await setupChangeRequestedWithSnapshot('lab-hook-once')
 
-        const { result } = renderHook(
-            () => useStartProposalRevision({ studyId: study.id, orgSlug: org.slug, enabled: true }),
-            { wrapper: createTestQueryWrapper() },
-        )
+        const { result } = renderHook(() => useStartProposalRevision({ studyId: study.id, enabled: true }), {
+            wrapper: createTestQueryWrapper(),
+        })
 
         await act(async () => {
             result.current.signalRealEdit()

--- a/src/hooks/use-start-proposal-revision.test.ts
+++ b/src/hooks/use-start-proposal-revision.test.ts
@@ -1,0 +1,97 @@
+import {
+    act,
+    createTestQueryWrapper,
+    db,
+    describe,
+    expect,
+    insertTestStudyJobData,
+    it,
+    mockSessionWithTestData,
+    renderHook,
+    waitFor,
+} from '@/tests/unit.helpers'
+import { writeProposalSubmissionSnapshot } from '@/server/db/proposal-snapshot'
+import { useStartProposalRevision } from './use-start-proposal-revision'
+
+const setupChangeRequestedWithSnapshot = async (orgSlug: string) => {
+    const { org, user } = await mockSessionWithTestData({ orgSlug, orgType: 'lab' })
+    const { study } = await insertTestStudyJobData({
+        org,
+        researcherId: user.id,
+        studyStatus: 'CHANGE-REQUESTED',
+        title: 'Original title',
+    })
+    await writeProposalSubmissionSnapshot(db, study.id, user.id)
+    return { org, user, study }
+}
+
+const readStudy = (studyId: string) =>
+    db
+        .selectFrom('study')
+        .select(['status', 'proposalRevisionBaseSubmissionId'])
+        .where('id', '=', studyId)
+        .executeTakeFirstOrThrow()
+
+describe('useStartProposalRevision', () => {
+    it('flips the study to a revision DRAFT on the first signalled edit when enabled', async () => {
+        const { org, study } = await setupChangeRequestedWithSnapshot('lab-hook-flip')
+
+        const { result } = renderHook(
+            () => useStartProposalRevision({ studyId: study.id, orgSlug: org.slug, enabled: true }),
+            { wrapper: createTestQueryWrapper() },
+        )
+
+        await act(async () => {
+            result.current.signalRealEdit()
+        })
+        await waitFor(() => expect(result.current.revisionStarted).toBe(true))
+
+        const after = await readStudy(study.id)
+        expect(after.status).toBe('DRAFT')
+        expect(after.proposalRevisionBaseSubmissionId).not.toBeNull()
+    })
+
+    it('does nothing when disabled (fresh draft or already-started revision)', async () => {
+        const { org, study } = await setupChangeRequestedWithSnapshot('lab-hook-disabled')
+
+        const { result } = renderHook(
+            () => useStartProposalRevision({ studyId: study.id, orgSlug: org.slug, enabled: false }),
+            { wrapper: createTestQueryWrapper() },
+        )
+
+        await act(async () => {
+            result.current.signalRealEdit()
+        })
+
+        expect(result.current.isStartingRevision).toBe(false)
+        const after = await readStudy(study.id)
+        expect(after.status).toBe('CHANGE-REQUESTED')
+        expect(after.proposalRevisionBaseSubmissionId).toBeNull()
+    })
+
+    it('fires the transition at most once even when signalled repeatedly', async () => {
+        const { org, study } = await setupChangeRequestedWithSnapshot('lab-hook-once')
+
+        const { result } = renderHook(
+            () => useStartProposalRevision({ studyId: study.id, orgSlug: org.slug, enabled: true }),
+            { wrapper: createTestQueryWrapper() },
+        )
+
+        await act(async () => {
+            result.current.signalRealEdit()
+            result.current.signalRealEdit()
+            result.current.signalRealEdit()
+        })
+        await waitFor(() => expect(result.current.revisionStarted).toBe(true))
+
+        const snaps = await db
+            .selectFrom('studyProposalSubmission')
+            .select('id')
+            .where('studyId', '=', study.id)
+            .execute()
+        // The action never writes a snapshot; the single pre-seeded one is all that should exist,
+        // confirming repeated signals did not spawn extra work.
+        expect(snaps).toHaveLength(1)
+        expect((await readStudy(study.id)).status).toBe('DRAFT')
+    })
+})

--- a/src/hooks/use-start-proposal-revision.ts
+++ b/src/hooks/use-start-proposal-revision.ts
@@ -7,13 +7,20 @@ import { reportMutationError } from '@/components/errors'
 import { actionResult } from '@/lib/utils'
 import { startProposalRevisionAction } from '@/server/actions/study-request'
 
-// Every dashboard query that shows proposal status. The flip removes a study from the reviewer's
-// actionable queue and relabels it "Proposal draft" for the researcher, so both must refetch.
-const RESEARCHER_DASHBOARD_KEYS = [['researcher-studies'], ['user-researcher-studies'], ['user-orgs']] as const
+// Every dashboard query family that could show this study. Invalidate by key PREFIX (no org slug / user
+// id), so BOTH the researcher lab dashboards AND the reviewer enclave dashboards refetch: the flip both
+// removes the study from the reviewer's actionable queue and relabels it "Proposal Draft". Keying the
+// reviewer's `org-studies` on the researcher's lab slug (as before) never matched, so it was stale.
+const DASHBOARD_KEYS = [
+    ['researcher-studies'],
+    ['user-researcher-studies'],
+    ['org-studies'],
+    ['user-reviewer-studies'],
+    ['user-orgs'],
+] as const
 
 type Args = {
     studyId: string
-    orgSlug: string
     /**
      * True only while the study still needs the flip (its initial status is CHANGE-REQUESTED). A
      * revision draft is already flipped and a fresh draft never flips, so both pass `false` and
@@ -40,7 +47,7 @@ export type ProposalRevisionSignal = {
  * autosaving through Yjs / the draft columns). This hook owns only the status transition and reports
  * its own pending/failed state so the Resubmit button can stay disabled until the flip lands.
  */
-export function useStartProposalRevision({ studyId, orgSlug, enabled }: Args): ProposalRevisionSignal {
+export function useStartProposalRevision({ studyId, enabled }: Args): ProposalRevisionSignal {
     const queryClient = useQueryClient()
     // Guards against re-firing while a request is in flight or after it has succeeded. Reset in
     // onError so the next local edit re-attempts once react-query's automatic retries are exhausted.
@@ -54,10 +61,9 @@ export function useStartProposalRevision({ studyId, orgSlug, enabled }: Args): P
             reportMutationError('Could not start your revision. Your edits are safe; keep typing to retry.')(err)
         },
         onSuccess: () => {
-            for (const queryKey of RESEARCHER_DASHBOARD_KEYS) {
+            for (const queryKey of DASHBOARD_KEYS) {
                 queryClient.invalidateQueries({ queryKey })
             }
-            queryClient.invalidateQueries({ queryKey: ['org-studies', orgSlug] })
         },
     })
 

--- a/src/hooks/use-start-proposal-revision.ts
+++ b/src/hooks/use-start-proposal-revision.ts
@@ -1,0 +1,107 @@
+'use client'
+
+import { createContext, createElement, useCallback, useContext, useRef, type ReactNode } from 'react'
+
+import { useMutation, useQueryClient } from '@/common'
+import { reportMutationError } from '@/components/errors'
+import { actionResult } from '@/lib/utils'
+import { startProposalRevisionAction } from '@/server/actions/study-request'
+
+// Every dashboard query that shows proposal status. The flip removes a study from the reviewer's
+// actionable queue and relabels it "Proposal draft" for the researcher, so both must refetch.
+const RESEARCHER_DASHBOARD_KEYS = [['researcher-studies'], ['user-researcher-studies'], ['user-orgs']] as const
+
+type Args = {
+    studyId: string
+    orgSlug: string
+    /**
+     * True only while the study still needs the flip (its initial status is CHANGE-REQUESTED). A
+     * revision draft is already flipped and a fresh draft never flips, so both pass `false` and
+     * `signalRealEdit` becomes a no-op.
+     */
+    enabled: boolean
+}
+
+export type ProposalRevisionSignal = {
+    /** Call on every local user edit; fires the transition at most once (see hook docs). */
+    signalRealEdit: () => void
+    isStartingRevision: boolean
+    revisionStartFailed: boolean
+    revisionStarted: boolean
+    /** True while the transition is pending or has failed — Resubmit must stay disabled. */
+    blockResubmit: boolean
+}
+
+/**
+ * OTTER-636: turns the first real local edit of a change-requested proposal into the server-side
+ * transition to a revision DRAFT. `signalRealEdit` is safe to call on every keystroke: it fires the
+ * transition at most once per mount (the action is also idempotent server-side), and re-arms only if
+ * the attempt failed so a later edit retries without the caller tracking state.
+ *
+ * Starting the revision and persisting content are independent operations (the editor keeps
+ * autosaving through Yjs / the draft columns). This hook owns only the status transition and reports
+ * its own pending/failed state so the Resubmit button can stay disabled until the flip lands.
+ */
+export function useStartProposalRevision({ studyId, orgSlug, enabled }: Args): ProposalRevisionSignal {
+    const queryClient = useQueryClient()
+    // Guards against re-firing while a request is in flight or after it has succeeded. Reset in
+    // onError so the next local edit re-attempts once react-query's automatic retries are exhausted.
+    const attemptedRef = useRef(false)
+
+    const { mutate, isPending, isError, isSuccess } = useMutation({
+        mutationFn: async () => actionResult(await startProposalRevisionAction({ studyId })),
+        retry: 2,
+        onError: (err) => {
+            attemptedRef.current = false
+            reportMutationError('Could not start your revision. Your edits are safe; keep typing to retry.')(err)
+        },
+        onSuccess: () => {
+            for (const queryKey of RESEARCHER_DASHBOARD_KEYS) {
+                queryClient.invalidateQueries({ queryKey })
+            }
+            queryClient.invalidateQueries({ queryKey: ['org-studies', orgSlug] })
+        },
+    })
+
+    const signalRealEdit = useCallback(() => {
+        if (!enabled || attemptedRef.current) return
+        attemptedRef.current = true
+        mutate()
+    }, [enabled, mutate])
+
+    return {
+        signalRealEdit,
+        isStartingRevision: isPending,
+        revisionStartFailed: isError,
+        revisionStarted: isSuccess,
+        blockResubmit: enabled && (isPending || isError),
+    }
+}
+
+// Disabled default so any editing surface can call `useProposalRevision()` unconditionally. The fresh
+// proposal form renders the same field components but mounts no provider, so it gets these no-ops.
+const DISABLED_SIGNAL: ProposalRevisionSignal = {
+    signalRealEdit: () => {},
+    isStartingRevision: false,
+    revisionStartFailed: false,
+    revisionStarted: false,
+    blockResubmit: false,
+}
+
+const ProposalRevisionContext = createContext<ProposalRevisionSignal>(DISABLED_SIGNAL)
+
+/** Read the revision signal. Returns no-ops when no provider is mounted (e.g. the fresh-draft form). */
+export function useProposalRevision(): ProposalRevisionSignal {
+    return useContext(ProposalRevisionContext)
+}
+
+type ProviderProps = Args & { children: ReactNode }
+
+/**
+ * Wraps the edit-and-resubmit form so its editable inputs can signal a real edit and its footer can
+ * gate Resubmit on the transition state, without threading callbacks through every layer.
+ */
+export function ProposalRevisionProvider({ children, ...args }: ProviderProps) {
+    const signal = useStartProposalRevision(args)
+    return createElement(ProposalRevisionContext.Provider, { value: signal }, children)
+}

--- a/src/hooks/use-start-proposal-revision.ts
+++ b/src/hooks/use-start-proposal-revision.ts
@@ -35,6 +35,12 @@ export type ProposalRevisionSignal = {
     isStartingRevision: boolean
     revisionStartFailed: boolean
     revisionStarted: boolean
+    /**
+     * OTTER-636 (architecture §4): true while the revision transition is pending or has failed. Resubmit
+     * must stay disabled until the flip commits, because resubmitProposalAction accepts only a revision
+     * DRAFT — submitting before the flip lands would be rejected.
+     */
+    blockResubmit: boolean
 }
 
 /**
@@ -78,6 +84,7 @@ export function useStartProposalRevision({ studyId, enabled }: Args): ProposalRe
         isStartingRevision: isPending,
         revisionStartFailed: isError,
         revisionStarted: isSuccess,
+        blockResubmit: enabled && (isPending || isError),
     }
 }
 
@@ -88,6 +95,7 @@ const DISABLED_SIGNAL: ProposalRevisionSignal = {
     isStartingRevision: false,
     revisionStartFailed: false,
     revisionStarted: false,
+    blockResubmit: false,
 }
 
 const ProposalRevisionContext = createContext<ProposalRevisionSignal>(DISABLED_SIGNAL)

--- a/src/hooks/use-start-proposal-revision.ts
+++ b/src/hooks/use-start-proposal-revision.ts
@@ -28,8 +28,6 @@ export type ProposalRevisionSignal = {
     isStartingRevision: boolean
     revisionStartFailed: boolean
     revisionStarted: boolean
-    /** True while the transition is pending or has failed — Resubmit must stay disabled. */
-    blockResubmit: boolean
 }
 
 /**
@@ -74,7 +72,6 @@ export function useStartProposalRevision({ studyId, orgSlug, enabled }: Args): P
         isStartingRevision: isPending,
         revisionStartFailed: isError,
         revisionStarted: isSuccess,
-        blockResubmit: enabled && (isPending || isError),
     }
 }
 
@@ -85,7 +82,6 @@ const DISABLED_SIGNAL: ProposalRevisionSignal = {
     isStartingRevision: false,
     revisionStartFailed: false,
     revisionStarted: false,
-    blockResubmit: false,
 }
 
 const ProposalRevisionContext = createContext<ProposalRevisionSignal>(DISABLED_SIGNAL)

--- a/src/hooks/use-study-status.ts
+++ b/src/hooks/use-study-status.ts
@@ -26,6 +26,9 @@ export const useStudyStatus = ({ studyStatus, audience, jobStatusChanges }: UseS
         reviewerAgreementsAckedAt: null,
         proposalResubmissionNoteDraft: null,
         codeResubmissionNoteDraft: null,
+        // Not received here; a reviewer-visible DRAFT is always a revision draft and the DRAFT pill
+        // label ("Proposal Draft") resolves the same either way, so null is safe for the pill.
+        proposalRevisionBaseSubmissionId: null,
         piUserId: null,
         datasets: null,
         researchQuestions: null,

--- a/src/lib/permission-types.ts
+++ b/src/lib/permission-types.ts
@@ -53,7 +53,7 @@ type Abilities =
     | Ability<'OrgMembers', 'view', { orgId?: UUID; orgSlug?: string }>
     | Ability<'Orgs', 'view', object>
     | Ability<'MFA', 'reset', object>
-    | Ability<'IDE', 'load', { researcherId: UUID }>
+    | Ability<'IDE', 'load', { researcherId?: UUID; submittedByOrgId?: UUID }>
     | Ability<
           'AgentContext',
           'create' | 'update' | 'view',

--- a/src/lib/permissions.test.ts
+++ b/src/lib/permissions.test.ts
@@ -69,6 +69,12 @@ test('researcher role', () => {
     expect(ability.can('delete', toRecord('Study', { submittedByOrgId: otherLabId }))).toBe(false)
     expect(ability.can('create', toRecord('StudyJob', { submittedByOrgId: otherLabId }))).toBe(false)
 
+    // OTTER-636: loading the IDE is scoped to studies the researcher's own lab submitted, plus
+    // studies they authored — never another lab's studies.
+    expect(ability.can('load', toRecord('IDE', { submittedByOrgId: ownLabId }))).toBe(true)
+    expect(ability.can('load', toRecord('IDE', { submittedByOrgId: otherLabId }))).toBe(false)
+    expect(ability.can('load', toRecord('IDE', { researcherId: session.user.id }))).toBe(true)
+
     // Researchers cannot invite users to their org (not admins)
     expect(ability.can('invite', toRecord('User', { orgId: ownLabId }))).toBe(false)
 

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -59,7 +59,10 @@ export function defineAbilityFor(session: UserSession) {
         permit('update', 'Study', { submittedByOrgId: { $in: usersResearcherOrgIds } })
         permit('delete', 'Study', { submittedByOrgId: { $in: usersResearcherOrgIds } })
         permit('create', 'StudyJob', { submittedByOrgId: { $in: usersResearcherOrgIds } })
-        permit('load', 'IDE')
+        // OTTER-636: scope the lab IDE grant to studies the user's own lab submitted, so a member of an
+        // unrelated lab can't open another lab's workspace. The author retains access via the
+        // researcherId grant above (line ~36); either match allows the load.
+        permit('load', 'IDE', { submittedByOrgId: { $in: usersResearcherOrgIds } })
     }
 
     // can view studies and jobs for all orgs that the user's org has submitted

--- a/src/lib/proposal-snapshot.test.ts
+++ b/src/lib/proposal-snapshot.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { parseProposalSnapshot, serializeProposalSnapshot, type ProposalSnapshotSource } from './proposal-snapshot'
+
+const source: ProposalSnapshotSource = {
+    title: 'A study',
+    piName: 'Dr. PI',
+    piUserId: 'pi-1',
+    language: 'R',
+    datasets: ['ds-1', 'ds-2'],
+    dataSources: ['all'],
+    researchQuestions: { root: 'rq' },
+    projectSummary: null,
+    impact: { root: 'impact' },
+    additionalNotes: null,
+    irbProtocols: 'https://example.com',
+    descriptionDocPath: 'desc.pdf',
+    irbDocPath: null,
+    agreementDocPath: null,
+}
+
+describe('proposal snapshot serializer', () => {
+    it('round-trips every reviewer-visible field', () => {
+        const snap = serializeProposalSnapshot(source)
+        expect(snap).toEqual({
+            title: 'A study',
+            piName: 'Dr. PI',
+            piUserId: 'pi-1',
+            language: 'R',
+            datasets: ['ds-1', 'ds-2'],
+            dataSources: ['all'],
+            researchQuestions: { root: 'rq' },
+            projectSummary: null,
+            impact: { root: 'impact' },
+            additionalNotes: null,
+            irbProtocols: 'https://example.com',
+            descriptionDocPath: 'desc.pdf',
+            irbDocPath: null,
+            agreementDocPath: null,
+        })
+        // A stored snapshot parses back to the same object.
+        expect(parseProposalSnapshot(snap)).toEqual(snap)
+    })
+
+    it('normalizes missing arrays and json bodies', () => {
+        const snap = serializeProposalSnapshot({
+            ...source,
+            dataSources: [],
+            datasets: null,
+            researchQuestions: undefined,
+        })
+        expect(snap.dataSources).toEqual([])
+        expect(snap.datasets).toBeNull()
+        expect(snap.researchQuestions).toBeNull()
+    })
+
+    it('rejects a malformed stored snapshot', () => {
+        expect(() => parseProposalSnapshot({ title: 'x' })).toThrow()
+        expect(() => parseProposalSnapshot({ ...source, language: 'JAVASCRIPT' })).toThrow()
+    })
+})

--- a/src/lib/proposal-snapshot.ts
+++ b/src/lib/proposal-snapshot.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod'
+
+// OTTER-636: the single validated shape of an immutable submitted-proposal snapshot. Every write to and
+// read from `study_proposal_submission.snapshot` goes through this schema + the serializer below — do
+// NOT hand-build partial snapshot objects in individual actions. It captures every reviewer-visible
+// proposal field (the funnel is getStudyAction -> ProposalRequest, plus the AI review agent), so a
+// reviewer never has to read the mutable `study` row or live Yjs docs.
+export const PROPOSAL_SNAPSHOT_SCHEMA_VERSION = 1
+
+export const proposalSnapshotSchema = z.object({
+    title: z.string().nullable(),
+    piName: z.string(),
+    piUserId: z.string().nullable(),
+    language: z.enum(['R', 'PYTHON']),
+    datasets: z.array(z.string()).nullable(),
+    dataSources: z.array(z.string()),
+    // Lexical JSON bodies are opaque here; they are validated by the editor/form layer on the way in.
+    researchQuestions: z.unknown().nullable(),
+    projectSummary: z.unknown().nullable(),
+    impact: z.unknown().nullable(),
+    additionalNotes: z.unknown().nullable(),
+    irbProtocols: z.string().nullable(),
+    descriptionDocPath: z.string().nullable(),
+    irbDocPath: z.string().nullable(),
+    agreementDocPath: z.string().nullable(),
+})
+
+export type ProposalSnapshot = z.infer<typeof proposalSnapshotSchema>
+
+// The canonical proposal columns as read off a `study` row (Kysely selects them as these types).
+export type ProposalSnapshotSource = {
+    title: string | null
+    piName: string
+    piUserId: string | null
+    language: 'R' | 'PYTHON'
+    datasets: string[] | null
+    dataSources: string[]
+    researchQuestions: unknown
+    projectSummary: unknown
+    impact: unknown
+    additionalNotes: unknown
+    irbProtocols: string | null
+    descriptionDocPath: string | null
+    irbDocPath: string | null
+    agreementDocPath: string | null
+}
+
+// Build the validated snapshot object from a study row's canonical proposal columns. Callers persist the
+// returned object as-is into `study_proposal_submission.snapshot`.
+export function serializeProposalSnapshot(source: ProposalSnapshotSource): ProposalSnapshot {
+    return proposalSnapshotSchema.parse({
+        title: source.title,
+        piName: source.piName,
+        piUserId: source.piUserId,
+        language: source.language,
+        datasets: source.datasets,
+        dataSources: source.dataSources ?? [],
+        researchQuestions: source.researchQuestions ?? null,
+        projectSummary: source.projectSummary ?? null,
+        impact: source.impact ?? null,
+        additionalNotes: source.additionalNotes ?? null,
+        irbProtocols: source.irbProtocols,
+        descriptionDocPath: source.descriptionDocPath,
+        irbDocPath: source.irbDocPath,
+        agreementDocPath: source.agreementDocPath,
+    })
+}
+
+// Validate a stored jsonb snapshot back into a typed ProposalSnapshot. Reviewer loaders use this so a
+// malformed/legacy row fails loudly rather than rendering partial data.
+export function parseProposalSnapshot(raw: unknown): ProposalSnapshot {
+    return proposalSnapshotSchema.parse(raw)
+}

--- a/src/lib/status-labels.ts
+++ b/src/lib/status-labels.ts
@@ -30,8 +30,17 @@ const COLORS = {
 
 // Proposal -> Code -> Results
 export const REVIEWER_STATUS_LABELS: Partial<Record<AllStatus, StatusLabel>> = {
-    // note: there is no 'DRAFT' label here even though that status exists on studies
-    // BECAUSE a reviewer should never see a DRAFT study
+    // OTTER-636: a reviewer never sees a FRESH draft (a brand-new proposal, filtered out of reviewer
+    // listings), but they DO see a REVISION draft: a change-requested proposal the researcher has begun
+    // editing. It shows here as a non-actionable "Proposal Draft" while they revise; reviewer actions
+    // stay unavailable until they resubmit (→ PENDING-REVIEW).
+    DRAFT: {
+        stage: 'Proposal',
+        label: 'Proposal Draft',
+        tooltip:
+            'The researcher is revising this proposal after your change request. You’ll be notified once they resubmit.',
+        colors: COLORS.draft,
+    },
 
     // Proposal
     'PENDING-REVIEW': {

--- a/src/lib/study-screen/code-predicates.test.ts
+++ b/src/lib/study-screen/code-predicates.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import type { StudyJobStatus } from '@/database/types'
+import {
+    canResubmitCode,
+    canReviewerReviewCode,
+    canStartCodeRevisionDraft,
+    canStartInitialCodeDraft,
+    canSubmitInitialCode,
+    hasOpenCodeDraftRound,
+    type CodeRoundStatuses,
+} from './code-predicates'
+
+const s = (latestAbsolute: StudyJobStatus[] | null, latestSubmitted: StudyJobStatus[] | null): CodeRoundStatuses => ({
+    latestAbsolute,
+    latestSubmitted,
+})
+
+describe('code predicates', () => {
+    it('detects an open draft round only when the absolute-latest round is INITIATED-only', () => {
+        expect(hasOpenCodeDraftRound(s(['INITIATED'], null))).toBe(true)
+        expect(hasOpenCodeDraftRound(s(['INITIATED'], ['CODE-SUBMITTED', 'CODE-CHANGES-REQUESTED']))).toBe(true)
+        expect(hasOpenCodeDraftRound(s(['INITIATED', 'CODE-SUBMITTED'], ['INITIATED', 'CODE-SUBMITTED']))).toBe(false)
+        expect(hasOpenCodeDraftRound(s(null, null))).toBe(false)
+    })
+
+    it('initial submit is allowed only with an open draft and no prior submitted round', () => {
+        expect(canSubmitInitialCode(s(['INITIATED'], null))).toBe(true)
+        // A prior submitted round exists → not the initial path (must resubmit with a note).
+        expect(canSubmitInitialCode(s(['INITIATED'], ['CODE-SUBMITTED', 'CODE-CHANGES-REQUESTED']))).toBe(false)
+        // Re-submitting the same un-reviewed round is still the initial path.
+        expect(canStartInitialCodeDraft(s(['INITIATED', 'CODE-SUBMITTED'], null))).toBe(true)
+    })
+
+    it('resubmit + revision-draft entry states: changes-requested, bare errored, files decisions', () => {
+        for (const submitted of [
+            ['CODE-SUBMITTED', 'CODE-CHANGES-REQUESTED'],
+            ['CODE-SUBMITTED', 'CODE-APPROVED', 'JOB-ERRORED'],
+            ['CODE-SUBMITTED', 'CODE-APPROVED', 'RUN-COMPLETE', 'FILES-APPROVED'],
+            ['CODE-SUBMITTED', 'CODE-APPROVED', 'RUN-COMPLETE', 'FILES-REJECTED'],
+        ] as StudyJobStatus[][]) {
+            expect(canResubmitCode(s(['INITIATED'], submitted))).toBe(true)
+            expect(canStartCodeRevisionDraft(s(submitted, submitted))).toBe(true)
+        }
+    })
+
+    it('non-entry states: terminal rejected, and normal approved/running', () => {
+        expect(canResubmitCode(s(null, ['CODE-SUBMITTED', 'CODE-REJECTED']))).toBe(false)
+        expect(canResubmitCode(s(null, ['CODE-SUBMITTED', 'CODE-APPROVED']))).toBe(false)
+        expect(canResubmitCode(s(null, ['CODE-SUBMITTED', 'CODE-APPROVED', 'JOB-RUNNING']))).toBe(false)
+        // Already awaiting review again after a resubmit → not resubmittable.
+        expect(canResubmitCode(s(null, ['INITIATED', 'CODE-SUBMITTED']))).toBe(false)
+    })
+
+    it('reviewer can review only an awaiting submitted round with no open draft masking it', () => {
+        expect(canReviewerReviewCode(s(['INITIATED', 'CODE-SUBMITTED'], ['INITIATED', 'CODE-SUBMITTED']))).toBe(true)
+        // Open draft round over a decided round → reviewer not actionable.
+        expect(canReviewerReviewCode(s(['INITIATED'], ['CODE-SUBMITTED', 'CODE-CHANGES-REQUESTED']))).toBe(false)
+        // Already decided → not awaiting.
+        expect(canReviewerReviewCode(s(null, ['CODE-SUBMITTED', 'CODE-APPROVED']))).toBe(false)
+    })
+})

--- a/src/lib/study-screen/code-predicates.ts
+++ b/src/lib/study-screen/code-predicates.ts
@@ -18,8 +18,9 @@ export const hasOpenCodeDraftRound = (s: CodeRoundStatuses): boolean =>
 
 // The latest submitted round is in a state the researcher may revise from: live changes-requested, a
 // bare errored run, or a results decision. Terminal CODE-REJECTED and a normal CODE-APPROVED
-// (provisioning/running, no error/results yet) are NOT revision entry states.
-const isRevisionEntry = (submitted: readonly StudyJobStatus[]): boolean => {
+// (provisioning/running, no error/results yet) are NOT revision entry states. Exported so the
+// round-creation helper (server/db/mutations.ts) opens a fresh draft round on exactly these states.
+export const isCodeRevisionEntry = (submitted: readonly StudyJobStatus[]): boolean => {
     if (has(submitted, 'CODE-REJECTED')) return false
     if (has(submitted, 'FILES-APPROVED') || has(submitted, 'FILES-REJECTED')) return true
     if (has(submitted, 'JOB-ERRORED')) return true
@@ -33,7 +34,7 @@ export const canStartInitialCodeDraft = (s: CodeRoundStatuses): boolean => s.lat
 
 // Eligible to open/continue a revision draft round over a submitted round in an entry state.
 export const canStartCodeRevisionDraft = (s: CodeRoundStatuses): boolean =>
-    !!s.latestSubmitted && isRevisionEntry(s.latestSubmitted)
+    !!s.latestSubmitted && isCodeRevisionEntry(s.latestSubmitted)
 
 // Positive gate for the INITIAL submission path (/code, no note): an open draft round exists and there
 // is no prior submitted round.
@@ -43,7 +44,7 @@ export const canSubmitInitialCode = (s: CodeRoundStatuses): boolean =>
 // Positive gate for the RESUBMISSION path (/resubmit, requires a note): the latest submitted round is
 // in a revision entry state.
 export const canResubmitCode = (s: CodeRoundStatuses): boolean =>
-    !!s.latestSubmitted && isRevisionEntry(s.latestSubmitted)
+    !!s.latestSubmitted && isCodeRevisionEntry(s.latestSubmitted)
 
 // Reviewer may act on code only when the latest submitted round is awaiting a decision and no open
 // draft round is masking it (the researcher's in-progress revision is never actionable by a reviewer).

--- a/src/lib/study-screen/code-predicates.ts
+++ b/src/lib/study-screen/code-predicates.ts
@@ -1,0 +1,59 @@
+import type { StudyJobStatus } from '@/database/types'
+
+// OTTER-636: central code-lifecycle predicates, computed from two named status sets so callers never
+// confuse "current round" (Draft display) with "reviewed round" (reviewer content). Every code
+// submission/route/round-creation gate derives from these — do not implement one as `!another`.
+export type CodeRoundStatuses = {
+    // Status set of the absolute-latest round (by UUIDv7 id); null when the study has no code rounds.
+    latestAbsolute: readonly StudyJobStatus[] | null
+    // Status set of the latest round that reached a submission (any non-INITIATED status); null when none.
+    latestSubmitted: readonly StudyJobStatus[] | null
+}
+
+const has = (set: readonly StudyJobStatus[] | null | undefined, s: StudyJobStatus) => !!set && set.includes(s)
+
+// An open, un-submitted draft round exists when the absolute-latest round carries only INITIATED.
+export const hasOpenCodeDraftRound = (s: CodeRoundStatuses): boolean =>
+    !!s.latestAbsolute && s.latestAbsolute.length > 0 && s.latestAbsolute.every((st) => st === 'INITIATED')
+
+// The latest submitted round is in a state the researcher may revise from: live changes-requested, a
+// bare errored run, or a results decision. Terminal CODE-REJECTED and a normal CODE-APPROVED
+// (provisioning/running, no error/results yet) are NOT revision entry states.
+const isRevisionEntry = (submitted: readonly StudyJobStatus[]): boolean => {
+    if (has(submitted, 'CODE-REJECTED')) return false
+    if (has(submitted, 'FILES-APPROVED') || has(submitted, 'FILES-REJECTED')) return true
+    if (has(submitted, 'JOB-ERRORED')) return true
+    if (has(submitted, 'CODE-CHANGES-REQUESTED')) return true
+    return false
+}
+
+// Initial code draft: the study has no submitted round yet (first-ever code work). Combine with the
+// proposal being APPROVED at the call site.
+export const canStartInitialCodeDraft = (s: CodeRoundStatuses): boolean => s.latestSubmitted == null
+
+// Eligible to open/continue a revision draft round over a submitted round in an entry state.
+export const canStartCodeRevisionDraft = (s: CodeRoundStatuses): boolean =>
+    !!s.latestSubmitted && isRevisionEntry(s.latestSubmitted)
+
+// Positive gate for the INITIAL submission path (/code, no note): an open draft round exists and there
+// is no prior submitted round.
+export const canSubmitInitialCode = (s: CodeRoundStatuses): boolean =>
+    hasOpenCodeDraftRound(s) && s.latestSubmitted == null
+
+// Positive gate for the RESUBMISSION path (/resubmit, requires a note): the latest submitted round is
+// in a revision entry state.
+export const canResubmitCode = (s: CodeRoundStatuses): boolean =>
+    !!s.latestSubmitted && isRevisionEntry(s.latestSubmitted)
+
+// Reviewer may act on code only when the latest submitted round is awaiting a decision and no open
+// draft round is masking it (the researcher's in-progress revision is never actionable by a reviewer).
+export const canReviewerReviewCode = (s: CodeRoundStatuses): boolean => {
+    if (hasOpenCodeDraftRound(s)) return false
+    const submitted = s.latestSubmitted
+    if (!submitted) return false
+    const submittedCount = submitted.filter((st) => st === 'CODE-SUBMITTED').length
+    const decisionCount = submitted.filter(
+        (st) => st === 'CODE-APPROVED' || st === 'CODE-REJECTED' || st === 'CODE-CHANGES-REQUESTED',
+    ).length
+    return submittedCount > 0 && decisionCount < submittedCount
+}

--- a/src/lib/study-screen/code-predicates.ts
+++ b/src/lib/study-screen/code-predicates.ts
@@ -36,10 +36,12 @@ export const canStartInitialCodeDraft = (s: CodeRoundStatuses): boolean => s.lat
 export const canStartCodeRevisionDraft = (s: CodeRoundStatuses): boolean =>
     !!s.latestSubmitted && isCodeRevisionEntry(s.latestSubmitted)
 
-// Positive gate for the INITIAL submission path (/code, no note): an open draft round exists and there
-// is no prior submitted round.
-export const canSubmitInitialCode = (s: CodeRoundStatuses): boolean =>
-    hasOpenCodeDraftRound(s) && s.latestSubmitted == null
+// Positive gate for the INITIAL submission path (/code, no note): valid only while the study has no
+// prior submitted round. The submit action itself opens the round if one is not already open, so this
+// does not require an open draft round — only that nothing has been submitted yet. Once a round has been
+// submitted (even before review), a further submission must use the resubmit-with-note path, so this
+// can never overwrite reviewed code or bypass the note (OTTER-636 Finding 6).
+export const canSubmitInitialCode = (s: CodeRoundStatuses): boolean => s.latestSubmitted == null
 
 // Positive gate for the RESUBMISSION path (/resubmit, requires a note): the latest submitted round is
 // in a revision entry state.

--- a/src/lib/study-screen/consistency.test.ts
+++ b/src/lib/study-screen/consistency.test.ts
@@ -9,6 +9,7 @@ const ctx = { orgSlug: 'lab', studyId: '01900000-0000-7000-8000-000000000001' }
 const full = (overrides: Partial<StudyState>): StudyState => ({
     status: 'DRAFT',
     isDraft: true,
+    isProposalRevisionDraft: false,
     hasStep2Progress: false,
     researcherAgreementsAcked: false,
     reviewerAgreementsAcked: false,

--- a/src/lib/study-screen/dashboard-rules.ts
+++ b/src/lib/study-screen/dashboard-rules.ts
@@ -18,6 +18,13 @@ const POST_SUBMISSION_STATUSES: ReadonlyArray<DashboardState['status']> = [
 ]
 
 export const DASHBOARD_RULES: DashboardRule[] = [
+    // OTTER-636: a revision draft (a change-requested proposal the researcher has begun editing) resumes
+    // directly on the edit-and-resubmit flow and has NO delete affordance — it carries submitted history
+    // and must be resubmitted, not deleted. Must precede the plain-DRAFT rules below (it is also isDraft).
+    {
+        when: (s) => s.isProposalRevisionDraft,
+        action: (ctx) => ({ label: 'Edit', href: Routes.studyEditAndResubmit(ctx) }),
+    },
     // DRAFT that already reached Step 2 → resume on Step 2 (the proposal editor) instead of the
     // Step 1 data-partner picker (OTTER-572). Must precede the plain-DRAFT rule below.
     {

--- a/src/lib/study-screen/dashboard.test.ts
+++ b/src/lib/study-screen/dashboard.test.ts
@@ -5,6 +5,7 @@ import { resolveDashboardAction } from './resolve'
 const dstate = (overrides: Partial<DashboardState>): DashboardState => ({
     status: 'DRAFT',
     isDraft: true,
+    isProposalRevisionDraft: false,
     hasStep2Progress: false,
     researcherAgreementsAcked: false,
     reviewerAgreementsAcked: false,
@@ -31,6 +32,18 @@ describe('resolveDashboardAction (researcher)', () => {
         expect(a.label).toBe('Edit')
         expect(a.secondaryAction).toBe('delete-draft')
         expect(a.href).toContain('/edit')
+    })
+    // OTTER-636: a revision draft resumes on the edit-and-resubmit flow and offers NO delete (it has
+    // submitted history). Must win over the plain-draft rules even though it is also isDraft.
+    it('revision draft → Edit + /edit-and-resubmit, no delete-draft', () => {
+        const a = resolveDashboardAction(
+            'researcher',
+            dstate({ status: 'DRAFT', isDraft: true, isProposalRevisionDraft: true, hasStep2Progress: true }),
+            ctx,
+        )
+        expect(a.label).toBe('Edit')
+        expect(a.secondaryAction).toBeUndefined()
+        expect(a.href).toContain('/edit-and-resubmit')
     })
     // OTTER-572: a draft that has reached Step 2 resumes on the proposal editor (Step 2), not the
     // Step 1 data-partner picker. Step 1 destination is /edit, Step 2 is /proposal.

--- a/src/lib/study-screen/eligibility.test.ts
+++ b/src/lib/study-screen/eligibility.test.ts
@@ -16,6 +16,7 @@ const stateFor = (jobs: RawJob[]): RawStudyState => ({
     reviewerAgreementsAckedAt: null,
     proposalResubmissionNoteDraft: null,
     codeResubmissionNoteDraft: null,
+    proposalRevisionBaseSubmissionId: null,
     piUserId: null,
     datasets: null,
     researchQuestions: null,

--- a/src/lib/study-screen/index.ts
+++ b/src/lib/study-screen/index.ts
@@ -9,3 +9,5 @@ export {
 } from './resolve'
 export { resolvePillStatus, resolveRowHighlight } from './pill'
 export { canResearcherResubmitCode } from './eligibility'
+export * from './proposal-predicates'
+export * from './code-predicates'

--- a/src/lib/study-screen/pill.test.ts
+++ b/src/lib/study-screen/pill.test.ts
@@ -5,6 +5,7 @@ import { resolvePillStatus, resolveRowHighlight } from './pill'
 const state = (overrides: Partial<StudyState>): StudyState => ({
     status: 'APPROVED',
     isDraft: false,
+    isProposalRevisionDraft: false,
     hasStep2Progress: false,
     researcherAgreementsAcked: false,
     reviewerAgreementsAcked: false,

--- a/src/lib/study-screen/proposal-predicates.test.ts
+++ b/src/lib/study-screen/proposal-predicates.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import {
+    canDeleteProposalDraft,
+    canEditProposalDraft,
+    canResubmitProposal,
+    canReviewerReviewProposal,
+    canStartProposalRevision,
+    isFreshProposalDraft,
+    isProposalRevisionDraft,
+    shouldReviewerSeeStudy,
+    type ProposalStudyFacts,
+} from './proposal-predicates'
+
+const facts = (o: Partial<ProposalStudyFacts>): ProposalStudyFacts => ({
+    status: 'DRAFT',
+    proposalRevisionBaseSubmissionId: null,
+    ...o,
+})
+
+const fresh = facts({ status: 'DRAFT', proposalRevisionBaseSubmissionId: null })
+const revision = facts({ status: 'DRAFT', proposalRevisionBaseSubmissionId: 'sub-1' })
+const changeRequested = facts({ status: 'CHANGE-REQUESTED' })
+const underReview = facts({ status: 'PENDING-REVIEW' })
+const approved = facts({ status: 'APPROVED' })
+
+describe('proposal predicates', () => {
+    it('distinguishes fresh vs revision draft by the base snapshot id, not status alone', () => {
+        expect(isFreshProposalDraft(fresh)).toBe(true)
+        expect(isProposalRevisionDraft(fresh)).toBe(false)
+        expect(isFreshProposalDraft(revision)).toBe(false)
+        expect(isProposalRevisionDraft(revision)).toBe(true)
+    })
+
+    it('only change-requested can start a revision', () => {
+        expect(canStartProposalRevision(changeRequested)).toBe(true)
+        expect(canStartProposalRevision(underReview)).toBe(false)
+        expect(canStartProposalRevision(revision)).toBe(false)
+    })
+
+    it('both draft flavors are editable; non-drafts are not', () => {
+        expect(canEditProposalDraft(fresh)).toBe(true)
+        expect(canEditProposalDraft(revision)).toBe(true)
+        expect(canEditProposalDraft(changeRequested)).toBe(false)
+        expect(canEditProposalDraft(approved)).toBe(false)
+    })
+
+    it('resubmit is revision-only; delete is fresh-only', () => {
+        expect(canResubmitProposal(revision)).toBe(true)
+        expect(canResubmitProposal(fresh)).toBe(false)
+        expect(canDeleteProposalDraft(fresh)).toBe(true)
+        expect(canDeleteProposalDraft(revision)).toBe(false)
+    })
+
+    it('reviewer can act only under review', () => {
+        expect(canReviewerReviewProposal(underReview)).toBe(true)
+        expect(canReviewerReviewProposal(changeRequested)).toBe(false)
+        expect(canReviewerReviewProposal(revision)).toBe(false)
+    })
+
+    it('reviewers see everything except a fresh draft', () => {
+        expect(shouldReviewerSeeStudy(fresh)).toBe(false)
+        expect(shouldReviewerSeeStudy(revision)).toBe(true)
+        expect(shouldReviewerSeeStudy(changeRequested)).toBe(true)
+        expect(shouldReviewerSeeStudy(underReview)).toBe(true)
+        expect(shouldReviewerSeeStudy(approved)).toBe(true)
+    })
+})

--- a/src/lib/study-screen/proposal-predicates.ts
+++ b/src/lib/study-screen/proposal-predicates.ts
@@ -1,0 +1,38 @@
+import type { StudyStatus } from '@/database/types'
+
+// OTTER-636: central proposal-lifecycle predicates. Routes, actions, dashboards, and editor gates must
+// derive from these rather than re-implementing ad hoc status checks. The active-revision discriminator
+// (proposalRevisionBaseSubmissionId) is the authoritative signal separating a fresh draft from a
+// revision draft — do NOT infer that distinction from submittedAt.
+export type ProposalStudyFacts = {
+    status: StudyStatus
+    proposalRevisionBaseSubmissionId: string | null
+}
+
+// Brand-new, never-submitted draft.
+export const isFreshProposalDraft = (s: ProposalStudyFacts): boolean =>
+    s.status === 'DRAFT' && s.proposalRevisionBaseSubmissionId == null
+
+// A revision of a previously submitted proposal that the researcher has started editing; it literally
+// uses status DRAFT but points at the immutable submitted snapshot it is revising.
+export const isProposalRevisionDraft = (s: ProposalStudyFacts): boolean =>
+    s.status === 'DRAFT' && s.proposalRevisionBaseSubmissionId != null
+
+// A change-requested proposal may begin a revision on the first real edit.
+export const canStartProposalRevision = (s: ProposalStudyFacts): boolean => s.status === 'CHANGE-REQUESTED'
+
+// Either draft flavor is editable (fresh via /edit + /proposal, revision via /edit-and-resubmit).
+export const canEditProposalDraft = (s: ProposalStudyFacts): boolean => s.status === 'DRAFT'
+
+// Only a revision draft can be resubmitted; a fresh draft is finalized (first submission) instead.
+export const canResubmitProposal = (s: ProposalStudyFacts): boolean => isProposalRevisionDraft(s)
+
+// Only a fresh draft may be deleted; a revision draft has submitted history and must not be destroyed.
+export const canDeleteProposalDraft = (s: ProposalStudyFacts): boolean => isFreshProposalDraft(s)
+
+// Reviewers may take a proposal decision only while it is under review.
+export const canReviewerReviewProposal = (s: ProposalStudyFacts): boolean => s.status === 'PENDING-REVIEW'
+
+// Reviewers list every study except a fresh (never-submitted) draft. A revision draft IS listed (as
+// Proposal Draft) but is not actionable.
+export const shouldReviewerSeeStudy = (s: ProposalStudyFacts): boolean => !isFreshProposalDraft(s)

--- a/src/lib/study-screen/resolve.test.ts
+++ b/src/lib/study-screen/resolve.test.ts
@@ -5,6 +5,7 @@ import { resolveScreen, resolveResearcherCodeScreen, resolveReviewerCodeScreen }
 const state = (overrides: Partial<StudyState>): StudyState => ({
     status: 'DRAFT',
     isDraft: true,
+    isProposalRevisionDraft: false,
     hasStep2Progress: false,
     researcherAgreementsAcked: false,
     reviewerAgreementsAcked: false,

--- a/src/lib/study-screen/reviewer-screen-rules.test.ts
+++ b/src/lib/study-screen/reviewer-screen-rules.test.ts
@@ -7,6 +7,7 @@ const ctx = { orgSlug: 'org', studyId: '01900000-0000-7000-8000-000000000001' }
 const st = (overrides: Partial<StudyState>): StudyState => ({
     status: 'PENDING-REVIEW',
     isDraft: false,
+    isProposalRevisionDraft: false,
     hasStep2Progress: false,
     researcherAgreementsAcked: false,
     reviewerAgreementsAcked: false,
@@ -39,6 +40,20 @@ describe('resolveScreen(reviewer)', () => {
         expect(screen(st({ status: 'APPROVED' }))).toBe('reviewer-proposal-feedback')
         expect(screen(st({ status: 'REJECTED' }))).toBe('reviewer-proposal-feedback')
         expect(screen(st({ status: 'CHANGE-REQUESTED' }))).toBe('reviewer-proposal-feedback')
+    })
+
+    // OTTER-636: a revision draft (a change-requested proposal being edited) reads DRAFT but must show
+    // the reviewer the read-only submitted feedback, never a fresh-draft/study-overview fallback.
+    it('revision draft → reviewer-proposal-feedback (read-only, not actionable)', () => {
+        expect(screen(st({ status: 'DRAFT', isDraft: true, isProposalRevisionDraft: true }))).toBe(
+            'reviewer-proposal-feedback',
+        )
+    })
+
+    // A fresh draft has no submitted history and should not reach a reviewer screen beyond the safe
+    // overview fallback (the page guard 404s it first).
+    it('fresh draft → study-overview fallback', () => {
+        expect(screen(st({ status: 'DRAFT', isDraft: true, isProposalRevisionDraft: false }))).toBe('study-overview')
     })
 
     it('code submitted, agreements NOT acked → reviewer-agreements (gate before review)', () => {

--- a/src/lib/study-screen/reviewer-screen-rules.ts
+++ b/src/lib/study-screen/reviewer-screen-rules.ts
@@ -21,20 +21,25 @@ export const REVIEWER_SCREEN_RULES = [
     // 4. Code submitted, awaiting a decision, agreements acked → active code review.
     ['reviewer-code-review', { when: (s) => s.codeAwaitingDecision }],
 
-    // 5. Proposal decided but no code yet → read-only proposal feedback.
+    // 5. Proposal decided but no code yet → read-only proposal feedback. OTTER-636: a revision draft
+    //    (a change-requested proposal the researcher is now editing) routes here too — the reviewer
+    //    sees the last submitted snapshot + prior feedback, read-only, with no actionable decision.
     [
         'reviewer-proposal-feedback',
         {
             when: (s) =>
                 !s.hasSubmittedCode &&
-                (s.status === 'APPROVED' || s.status === 'REJECTED' || s.status === 'CHANGE-REQUESTED'),
+                (s.status === 'APPROVED' ||
+                    s.status === 'REJECTED' ||
+                    s.status === 'CHANGE-REQUESTED' ||
+                    s.isProposalRevisionDraft),
         },
     ],
 
     // 6. Proposal under review → editable proposal review.
     ['reviewer-proposal-review', { when: (s) => s.status === 'PENDING-REVIEW' }],
 
-    // 7. Exhaustive fallback. DRAFT shouldn't reach a reviewer (the page's not-found guard handles
-    //    it), but the table stays total; study-overview is a safe read-only render.
+    // 7. Exhaustive fallback. A FRESH DRAFT shouldn't reach a reviewer (the page's not-found guard
+    //    handles it), but the table stays total; study-overview is a safe read-only render.
     ['study-overview', { when: () => true }],
 ] as const satisfies ReadonlyArray<ScreenRuleEntry>

--- a/src/lib/study-screen/state.shuffle.test.ts
+++ b/src/lib/study-screen/state.shuffle.test.ts
@@ -26,6 +26,7 @@ const base = (jobs: RawJob[]): RawStudyState => ({
     reviewerAgreementsAckedAt: null,
     proposalResubmissionNoteDraft: null,
     codeResubmissionNoteDraft: null,
+    proposalRevisionBaseSubmissionId: null,
     piUserId: null,
     datasets: null,
     researchQuestions: null,

--- a/src/lib/study-screen/state.test.ts
+++ b/src/lib/study-screen/state.test.ts
@@ -15,6 +15,7 @@ const raw = (overrides: Partial<RawStudyState> = {}): RawStudyState => ({
     reviewerAgreementsAckedAt: null,
     proposalResubmissionNoteDraft: null,
     codeResubmissionNoteDraft: null,
+    proposalRevisionBaseSubmissionId: null,
     piUserId: null,
     datasets: null,
     researchQuestions: null,

--- a/src/lib/study-screen/state.ts
+++ b/src/lib/study-screen/state.ts
@@ -118,6 +118,7 @@ export function projectStudyState(raw: RawStudyState): StudyState {
     return {
         status: raw.status,
         isDraft: raw.status === 'DRAFT',
+        isProposalRevisionDraft: raw.status === 'DRAFT' && raw.proposalRevisionBaseSubmissionId != null,
         hasStep2Progress: draftHasStep2Progress(raw),
         researcherAgreementsAcked: !!raw.researcherAgreementsAckedAt,
         reviewerAgreementsAcked: !!raw.reviewerAgreementsAckedAt,

--- a/src/lib/study-screen/state.types.ts
+++ b/src/lib/study-screen/state.types.ts
@@ -31,6 +31,9 @@ export type RawStudyState = {
     reviewerAgreementsAckedAt: Date | null
     proposalResubmissionNoteDraft: string | null
     codeResubmissionNoteDraft: string | null
+    // OTTER-636: non-null on a revision draft (a change-requested proposal whose first edit flipped it
+    // to DRAFT); points at the immutable snapshot being revised. Null for a fresh draft / submitted study.
+    proposalRevisionBaseSubmissionId: string | null
     jobs: ReadonlyArray<RawJob>
 } & DraftStep2Fields
 
@@ -39,6 +42,10 @@ export type RawStudyState = {
 export type StudyState = {
     status: StudyStatus
     isDraft: boolean
+    // OTTER-636: a revision draft — a change-requested proposal the researcher has begun editing (DRAFT
+    // with a base snapshot). Reviewers see it read-only ("Proposal Draft"); the researcher edits it on
+    // the resubmit flow. Distinct from a fresh draft (isDraft && !isProposalRevisionDraft).
+    isProposalRevisionDraft: boolean
     // A DRAFT that has reached Step 2 of the proposal wizard. Routes a "resume draft" entry to the
     // step the researcher last left off (OTTER-572) instead of always landing on the Step 1 picker.
     hasStep2Progress: boolean

--- a/src/server/actions/resubmit-proposal.test.ts
+++ b/src/server/actions/resubmit-proposal.test.ts
@@ -31,8 +31,26 @@ vi.mock('@/server/aws', async () => {
 
 const NOTE_50_WORDS = buildFeedback(50)
 
+// OTTER-636 (architecture §7): resubmitProposalAction accepts ONLY a revision draft. In production the
+// researcher's first edit flips a change-requested proposal into that state; here we set it up directly:
+// write the immutable submitted snapshot and point the row at it as its revision base.
+const asRevisionDraft = async (studyId: string, submittedByUserId: string) => {
+    await writeProposalSubmissionSnapshot(db, studyId, submittedByUserId)
+    const snap = await db
+        .selectFrom('studyProposalSubmission')
+        .select('id')
+        .where('studyId', '=', studyId)
+        .orderBy('version', 'desc')
+        .executeTakeFirstOrThrow()
+    await db
+        .updateTable('study')
+        .set({ status: 'DRAFT', proposalRevisionBaseSubmissionId: snap.id })
+        .where('id', '=', studyId)
+        .execute()
+}
+
 describe('resubmitProposalAction', () => {
-    it('transitions a CHANGE-REQUESTED study to PENDING-REVIEW and writes a RESUBMISSION-NOTE comment', async () => {
+    it('transitions a revision draft to PENDING-REVIEW and writes a RESUBMISSION-NOTE comment', async () => {
         const { org, user } = await mockSessionWithTestData({ orgSlug: 'lab-resubmit-1', orgType: 'lab' })
         const { study } = await insertTestStudyJobData({
             org,
@@ -40,6 +58,7 @@ describe('resubmitProposalAction', () => {
             studyStatus: 'CHANGE-REQUESTED',
             title: 'Original title',
         })
+        await asRevisionDraft(study.id, user.id)
 
         const beforeResubmit = await db
             .selectFrom('study')
@@ -97,6 +116,7 @@ describe('resubmitProposalAction', () => {
             studyStatus: 'CHANGE-REQUESTED',
             title: 'Original title',
         })
+        await asRevisionDraft(study.id, user.id)
 
         actionResult(
             await resubmitProposalAction({
@@ -123,6 +143,7 @@ describe('resubmitProposalAction', () => {
             researcherId: user.id,
             studyStatus: 'CHANGE-REQUESTED',
         })
+        await asRevisionDraft(study.id, user.id)
 
         await db
             .insertInto('yjsDocument')
@@ -157,6 +178,7 @@ describe('resubmitProposalAction', () => {
             researcherId: user.id,
             studyStatus: 'CHANGE-REQUESTED',
         })
+        await asRevisionDraft(study.id, user.id)
 
         await db
             .insertInto('yjsDocument')
@@ -191,6 +213,7 @@ describe('resubmitProposalAction', () => {
             researcherId: user.id,
             studyStatus: 'CHANGE-REQUESTED',
         })
+        await asRevisionDraft(study.id, user.id)
 
         const result = actionResult(
             await resubmitProposalAction({
@@ -212,7 +235,7 @@ describe('resubmitProposalAction', () => {
         expect(result.orgName).toBe(reviewerOrg.orgName)
     })
 
-    it('rejects resubmission when study is not CHANGE-REQUESTED', async () => {
+    it('rejects resubmission when the study is not a revision draft', async () => {
         const { org, user } = await mockSessionWithTestData({ orgSlug: 'lab-resubmit-2', orgType: 'lab' })
         const { study } = await insertTestStudyJobData({
             org,
@@ -252,6 +275,7 @@ describe('resubmitProposalAction', () => {
             studyStatus: 'CHANGE-REQUESTED',
             title: 'Other lab study',
         })
+        await asRevisionDraft(study.id, ownerA.id)
 
         // a different user from lab B logs in and tries to resubmit it
         await mockSessionWithTestData({ orgSlug: 'lab-B', orgType: 'lab' })
@@ -270,7 +294,8 @@ describe('resubmitProposalAction', () => {
             .where('id', '=', study.id)
             .executeTakeFirstOrThrow()
         expect(unchanged.title).toBe('Other lab study')
-        expect(unchanged.status).toBe('CHANGE-REQUESTED')
+        // The revision draft is untouched by the rejected cross-lab attempt.
+        expect(unchanged.status).toBe('DRAFT')
     })
 
     it('allows any member of the submitting lab to resubmit, not just the original researcher', async () => {
@@ -284,6 +309,7 @@ describe('resubmitProposalAction', () => {
             studyStatus: 'CHANGE-REQUESTED',
             title: 'Original title',
         })
+        await asRevisionDraft(study.id, ownerA.id)
 
         // a second researcher in the same lab takes over the resubmission
         const { user: teammate } = await insertTestUser({ org })
@@ -335,6 +361,7 @@ describe('resubmitProposalAction', () => {
             studyStatus: 'CHANGE-REQUESTED',
             title: 'Original title',
         })
+        await asRevisionDraft(study.id, ownerA.id)
 
         const loginAs = (user: { id: string; clerkId: string; email: string | null }) =>
             mockClerkSession({
@@ -456,7 +483,9 @@ describe('startProposalRevisionAction', () => {
     // A change-requested study with no submitted snapshot (e.g. seeded directly, or a legacy row the
     // backfill missed) cannot become a revision draft — but must not fail the researcher's edit. It
     // stays CHANGE-REQUESTED, from which resubmit works directly.
-    it('is a graceful no-op when the study has no submitted snapshot', async () => {
+    // A submitted study always has a snapshot in production (finalize + backfill), so a missing one is a
+    // data-integrity error the researcher's edit must surface visibly, not swallow (invariant 10).
+    it('fails visibly when the study has no submitted snapshot', async () => {
         const { org, user } = await mockSessionWithTestData({ orgSlug: 'lab-start-rev-nosnap', orgType: 'lab' })
         const { study } = await insertTestStudyJobData({
             org,
@@ -464,7 +493,8 @@ describe('startProposalRevisionAction', () => {
             studyStatus: 'CHANGE-REQUESTED',
         })
 
-        actionResult(await startProposalRevisionAction({ studyId: study.id }))
+        const result = await startProposalRevisionAction({ studyId: study.id })
+        expect('error' in result).toBe(true)
 
         const after = await db
             .selectFrom('study')
@@ -592,6 +622,7 @@ describe('lab co-author edit & resubmit', () => {
             studyStatus: 'CHANGE-REQUESTED',
             title: 'Original',
         })
+        await asRevisionDraft(study.id, originalAuthor.id)
 
         const NOTE_50_WORDS = Array.from({ length: 50 }, (_, i) => `word${i}`).join(' ')
 
@@ -752,8 +783,9 @@ describe('saveProposalResubmissionNoteDraftAction', () => {
             researcherId: user.id,
             studyStatus: 'CHANGE-REQUESTED',
         })
-        // Seed an in-progress draft note
+        // Seed an in-progress draft note, then flip to a revision draft (the note draft is preserved).
         actionResult(await saveProposalResubmissionNoteDraftAction({ studyId: study.id, note: 'will-be-cleared' }))
+        await asRevisionDraft(study.id, user.id)
 
         const NOTE_50_WORDS = Array.from({ length: 50 }, (_, i) => `word${i}`).join(' ')
         actionResult(

--- a/src/server/actions/resubmit-proposal.test.ts
+++ b/src/server/actions/resubmit-proposal.test.ts
@@ -87,6 +87,33 @@ describe('resubmitProposalAction', () => {
         expect(JSON.stringify(comments[0].body)).toContain('word1')
     })
 
+    it('writes an immutable proposal snapshot from the resubmitted fields', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgSlug: 'lab-resubmit-snap', orgType: 'lab' })
+        const { study } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'CHANGE-REQUESTED',
+            title: 'Original title',
+        })
+
+        actionResult(
+            await resubmitProposalAction({
+                studyId: study.id,
+                studyInfo: { title: 'Resubmitted title' },
+                resubmissionNote: NOTE_50_WORDS,
+            }),
+        )
+
+        const snaps = await db
+            .selectFrom('studyProposalSubmission')
+            .select(['version', 'snapshot'])
+            .where('studyId', '=', study.id)
+            .orderBy('version', 'desc')
+            .execute()
+        expect(snaps.length).toBeGreaterThanOrEqual(1)
+        expect((snaps[0].snapshot as { title: string }).title).toBe('Resubmitted title')
+    })
+
     it('deletes stale review-feedback yjs_document rows when resubmitting', async () => {
         const { org, user } = await mockSessionWithTestData({ orgSlug: 'lab-resubmit-yjs', orgType: 'lab' })
         const { study } = await insertTestStudyJobData({

--- a/src/server/actions/resubmit-proposal.test.ts
+++ b/src/server/actions/resubmit-proposal.test.ts
@@ -453,6 +453,28 @@ describe('startProposalRevisionAction', () => {
         expect(second.proposalRevisionBaseSubmissionId).toBe(first.proposalRevisionBaseSubmissionId)
     })
 
+    // A change-requested study with no submitted snapshot (e.g. seeded directly, or a legacy row the
+    // backfill missed) cannot become a revision draft — but must not fail the researcher's edit. It
+    // stays CHANGE-REQUESTED, from which resubmit works directly.
+    it('is a graceful no-op when the study has no submitted snapshot', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgSlug: 'lab-start-rev-nosnap', orgType: 'lab' })
+        const { study } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'CHANGE-REQUESTED',
+        })
+
+        actionResult(await startProposalRevisionAction({ studyId: study.id }))
+
+        const after = await db
+            .selectFrom('study')
+            .select(['status', 'proposalRevisionBaseSubmissionId'])
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+        expect(after.status).toBe('CHANGE-REQUESTED')
+        expect(after.proposalRevisionBaseSubmissionId).toBeNull()
+    })
+
     it('is a no-op for a study that is not CHANGE-REQUESTED', async () => {
         const { org, user } = await mockSessionWithTestData({ orgSlug: 'lab-start-rev-noop', orgType: 'lab' })
         const { study } = await insertTestStudyJobData({

--- a/src/server/actions/resubmit-proposal.test.ts
+++ b/src/server/actions/resubmit-proposal.test.ts
@@ -14,7 +14,9 @@ import {
     onUpdateDraftStudyAction,
     resubmitProposalAction,
     saveProposalResubmissionNoteDraftAction,
+    startProposalRevisionAction,
 } from '@/server/actions/study-request'
+import { writeProposalSubmissionSnapshot } from '@/server/db/proposal-snapshot'
 
 vi.mock('@/server/aws', async () => {
     const actual = await vi.importActual('@/server/aws')
@@ -390,6 +392,138 @@ describe('resubmitProposalAction', () => {
             .where('entryType', '=', 'RESUBMISSION-NOTE')
             .executeTakeFirstOrThrow()
         expect(Number(noteCount.count)).toBe(1)
+    })
+})
+
+// OTTER-636: the first real edit to a change-requested proposal flips it to a literal revision DRAFT
+// that points at the immutable snapshot being revised.
+describe('startProposalRevisionAction', () => {
+    it('flips a CHANGE-REQUESTED study to DRAFT and points at the latest submitted snapshot', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgSlug: 'lab-start-rev-1', orgType: 'lab' })
+        const { study } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'CHANGE-REQUESTED',
+            title: 'Original title',
+        })
+        await writeProposalSubmissionSnapshot(db, study.id, user.id)
+        const snap = await db
+            .selectFrom('studyProposalSubmission')
+            .select('id')
+            .where('studyId', '=', study.id)
+            .orderBy('version', 'desc')
+            .executeTakeFirstOrThrow()
+
+        actionResult(await startProposalRevisionAction({ studyId: study.id }))
+
+        const after = await db
+            .selectFrom('study')
+            .select(['status', 'proposalRevisionBaseSubmissionId'])
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+        expect(after.status).toBe('DRAFT')
+        expect(after.proposalRevisionBaseSubmissionId).toBe(snap.id)
+    })
+
+    it('is idempotent for a study whose revision has already started', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgSlug: 'lab-start-rev-idem', orgType: 'lab' })
+        const { study } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'CHANGE-REQUESTED',
+        })
+        await writeProposalSubmissionSnapshot(db, study.id, user.id)
+
+        actionResult(await startProposalRevisionAction({ studyId: study.id }))
+        const first = await db
+            .selectFrom('study')
+            .select(['status', 'proposalRevisionBaseSubmissionId'])
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+
+        // second call must not throw or change the base
+        actionResult(await startProposalRevisionAction({ studyId: study.id }))
+        const second = await db
+            .selectFrom('study')
+            .select(['status', 'proposalRevisionBaseSubmissionId'])
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+
+        expect(second.status).toBe('DRAFT')
+        expect(second.proposalRevisionBaseSubmissionId).toBe(first.proposalRevisionBaseSubmissionId)
+    })
+
+    it('is a no-op for a study that is not CHANGE-REQUESTED', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgSlug: 'lab-start-rev-noop', orgType: 'lab' })
+        const { study } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'PENDING-REVIEW',
+        })
+
+        actionResult(await startProposalRevisionAction({ studyId: study.id }))
+
+        const after = await db
+            .selectFrom('study')
+            .select(['status', 'proposalRevisionBaseSubmissionId'])
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+        expect(after.status).toBe('PENDING-REVIEW')
+        expect(after.proposalRevisionBaseSubmissionId).toBeNull()
+    })
+
+    it('rejects a caller from a different lab', async () => {
+        const { org: labA, user: ownerA } = await mockSessionWithTestData({
+            orgSlug: 'lab-start-rev-A',
+            orgType: 'lab',
+        })
+        const { study } = await insertTestStudyJobData({
+            org: labA,
+            researcherId: ownerA.id,
+            studyStatus: 'CHANGE-REQUESTED',
+        })
+        await writeProposalSubmissionSnapshot(db, study.id, ownerA.id)
+
+        await mockSessionWithTestData({ orgSlug: 'lab-start-rev-B', orgType: 'lab' })
+        const result = await startProposalRevisionAction({ studyId: study.id })
+        expect('error' in result).toBe(true)
+
+        const unchanged = await db
+            .selectFrom('study')
+            .select('status')
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+        expect(unchanged.status).toBe('CHANGE-REQUESTED')
+    })
+
+    it('lets resubmitProposalAction finalize a revision draft and clear the base', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgSlug: 'lab-start-rev-resub', orgType: 'lab' })
+        const { study } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'CHANGE-REQUESTED',
+            title: 'Original title',
+        })
+        await writeProposalSubmissionSnapshot(db, study.id, user.id)
+
+        actionResult(await startProposalRevisionAction({ studyId: study.id }))
+
+        actionResult(
+            await resubmitProposalAction({
+                studyId: study.id,
+                studyInfo: { title: 'Revised title' },
+                resubmissionNote: NOTE_50_WORDS,
+            }),
+        )
+
+        const after = await db
+            .selectFrom('study')
+            .select(['status', 'title', 'proposalRevisionBaseSubmissionId'])
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+        expect(after.status).toBe('PENDING-REVIEW')
+        expect(after.title).toBe('Revised title')
+        expect(after.proposalRevisionBaseSubmissionId).toBeNull()
     })
 })
 

--- a/src/server/actions/study-request.test.ts
+++ b/src/server/actions/study-request.test.ts
@@ -845,7 +845,10 @@ describe('Request Study Actions', () => {
             expect(await submittedStatusCount(study.id)).toBe(1)
         })
 
-        it('resubmitting after change-requested REUSES the round job (same job, second submission)', async () => {
+        // OTTER-636: a live CODE-CHANGES-REQUESTED is a revision entry state, so the researcher's edit +
+        // resubmit open a FRESH round; the reviewed round-1 job is preserved untouched. Study-wide the
+        // submission count still climbs to 2 and the note records version 2.
+        it('resubmitting after change-requested opens a new round job (fresh code-draft round)', async () => {
             const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
             const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
             const root = await createWorkspaceDir('reuse-resubmit')
@@ -855,7 +858,7 @@ describe('Request Study Actions', () => {
             await submitCode(study.id, root, { 'main.R': 'round1' }, 'main.R')
             // The submit fires a deferred CODE-SCANNED insert; drain it before recording the reviewer's
             // CODE-CHANGES-REQUESTED so the time-ordered v7 ids reflect that real-world order (scan, then
-            // decision). Otherwise the scan can race in afterwards and become the "latest" status.
+            // decision).
             await flushDeferred()
             const round1Job = await db
                 .selectFrom('studyJob')
@@ -868,7 +871,7 @@ describe('Request Study Actions', () => {
                 .execute()
 
             await writeWorkspaceFiles(root, study.id, { 'main.R': 'round2' })
-            actionResult(
+            const result = actionResult(
                 await resubmitStudyCodeAction({
                     studyId: study.id,
                     mainFileName: 'main.R',
@@ -877,29 +880,25 @@ describe('Request Study Actions', () => {
                 }),
             )
 
-            // CR resubmit reuses the existing job — no new job is opened until FILES-APPROVED/REJECTED.
-            // markCodeSubmitted is round-aware: the CODE-CHANGES-REQUESTED opened a new round, so the
-            // resubmit appends a SECOND CODE-SUBMITTED on the same job (count = 2). This is what flips
-            // count-based liveness back to "under review" so the researcher leaves the feedback screen.
-            expect(await jobCount(study.id)).toBe(1)
+            // A new round job now carries round 2; the reviewed round-1 job is left intact.
+            expect(await jobCount(study.id)).toBe(2)
+            expect(result.studyJobId).not.toBe(round1Job.id)
             expect(await submittedStatusCount(study.id)).toBe(2)
 
-            // The note records the round it opened (study-wide submission version) so the reviewer's
-            // feedback panel labels it v2, matching the round-2 decision (OTTER-638).
+            // The note records version 2 and lives on the new round job (OTTER-638).
             const jobAfter = await db
                 .selectFrom('studyJob')
                 .select(['resubmissionNote', 'resubmissionRound'])
-                .where('id', '=', round1Job.id)
+                .where('id', '=', result.studyJobId)
                 .executeTakeFirstOrThrow()
             expect(jobAfter.resubmissionNote).not.toBeNull()
             expect(jobAfter.resubmissionRound).toBe(2)
         })
 
-        // Regression: in the real flow the researcher uploads files on the resubmit page *before*
-        // submitting. Under the new model ensureRoundJobForUpload REUSES the existing job (no new
-        // round job is minted on CR). The resubmit must still succeed and append a second
-        // CODE-SUBMITTED to the same job.
-        it('resubmit succeeds after a file upload reuses the round job (no new job on CR upload)', async () => {
+        // In the real flow the researcher uploads files on the Edit Study Code page before submitting.
+        // That upload opens the fresh code-draft round after change-requested; the resubmit then reuses
+        // it (no third job) and appends the round's CODE-SUBMITTED.
+        it('resubmit reuses the code-draft round opened by a file upload after change-requested', async () => {
             const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
             const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
             const root = await createWorkspaceDir('reuse-resubmit-upload')
@@ -907,9 +906,6 @@ describe('Request Study Actions', () => {
 
             await ensureRoundJobForLaunch(db, study.id)
             await submitCode(study.id, root, { 'main.R': 'round1' }, 'main.R')
-            // The submit fires a deferred CODE-SCANNED insert; drain it before recording the reviewer's
-            // CODE-CHANGES-REQUESTED so the time-ordered v7 ids reflect that real-world order (scan, then
-            // decision). Otherwise the scan can race in afterwards and become the "latest" status.
             await flushDeferred()
             const round1Job = await db
                 .selectFrom('studyJob')
@@ -921,9 +917,9 @@ describe('Request Study Actions', () => {
                 .values({ studyJobId: round1Job.id, status: 'CODE-CHANGES-REQUESTED' })
                 .execute()
 
-            // Researcher uploads a file on the resubmit page → reuses the existing round job (no new job).
+            // Upload on the Edit Study Code page opens the fresh code-draft round.
             await ensureRoundJobForUpload(db, study.id)
-            expect(await jobCount(study.id)).toBe(1)
+            expect(await jobCount(study.id)).toBe(2)
 
             await writeWorkspaceFiles(root, study.id, { 'main.R': 'round2' })
             const result = await resubmitStudyCodeAction({
@@ -934,14 +930,12 @@ describe('Request Study Actions', () => {
             })
 
             expect(result).not.toHaveProperty('error')
-            // Still one job — reused throughout. markCodeSubmitted is round-aware: round 1's
-            // CODE-SUBMITTED + the reviewer's CODE-CHANGES-REQUESTED opened round 2, so the resubmit
-            // appends a second CODE-SUBMITTED on the same job (count = 2).
-            expect(await jobCount(study.id)).toBe(1)
+            // The resubmit reuses the round the upload opened — still two jobs, submission count 2.
+            expect(await jobCount(study.id)).toBe(2)
             expect(await submittedStatusCount(study.id)).toBe(2)
         })
 
-        it('re-submitting again within the SAME change-requested round does not append a third CODE-SUBMITTED', async () => {
+        it('re-submitting again within the SAME code-draft round does not append a third CODE-SUBMITTED', async () => {
             const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
             const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
             const root = await createWorkspaceDir('reuse-resubmit-twice')
@@ -960,13 +954,14 @@ describe('Request Study Actions', () => {
                 .values({ studyJobId: round1Job.id, status: 'CODE-CHANGES-REQUESTED' })
                 .execute()
 
-            // First resubmit of round 2 → appends the second CODE-SUBMITTED.
+            // First resubmit of round 2 → opens the new round and appends its CODE-SUBMITTED (2 study-wide).
             await submitCode(study.id, root, { 'main.R': 'round2a' }, 'main.R')
+            expect(await jobCount(study.id)).toBe(2)
             expect(await submittedStatusCount(study.id)).toBe(2)
 
-            // Resubmit AGAIN before the reviewer decides round 2 → same round, idempotent, still 2.
+            // Re-submit AGAIN before the reviewer decides round 2 → same (round-2) round, idempotent.
             await submitCode(study.id, root, { 'main.R': 'round2b' }, 'main.R')
-            expect(await jobCount(study.id)).toBe(1)
+            expect(await jobCount(study.id)).toBe(2)
             expect(await submittedStatusCount(study.id)).toBe(2)
         })
     })

--- a/src/server/actions/study-request.test.ts
+++ b/src/server/actions/study-request.test.ts
@@ -821,7 +821,11 @@ describe('Request Study Actions', () => {
             expect(await submittedStatusCount(study.id)).toBe(1)
         })
 
-        it('re-submitting before review overwrites files on the same job (no new job, no new version)', async () => {
+        // OTTER-636 (Finding 6): once a round has been submitted (under review), the initial-submit path
+        // is closed — a further change must go through the resubmit-with-note flow. This replaces the old
+        // "re-submit before review overwrites in place" behavior so the initial path can never overwrite
+        // reviewed code or bypass the note. Files and submission count stay at the first submission.
+        it('rejects re-submitting an under-review round via the initial submit path', async () => {
             const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
             const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
             const root = await createWorkspaceDir('reuse-overwrite')
@@ -829,19 +833,20 @@ describe('Request Study Actions', () => {
 
             await ensureRoundJobForLaunch(db, study.id)
             await submitCode(study.id, root, { 'main.R': 'v1', 'helper.R': 'v1' }, 'main.R')
-            vi.mocked(aws.deleteFolderContents).mockClear()
 
-            // second submit drops helper.R, adds extra.R
-            await submitCode(study.id, root, { 'main.R': 'v2', 'extra.R': 'v2' }, 'main.R')
+            await writeWorkspaceFiles(root, study.id, { 'main.R': 'v2', 'extra.R': 'v2' })
+            const second = await submitStudyCodeAction({
+                studyId: study.id,
+                mainFileName: 'main.R',
+                fileNames: ['main.R', 'extra.R'],
+            })
+            expect(second).toHaveProperty('error')
 
             expect(await jobCount(study.id)).toBe(1)
             expect(await codeFilesFor(study.id)).toEqual([
-                { name: 'extra.R', fileType: 'SUPPLEMENTAL-CODE' },
+                { name: 'helper.R', fileType: 'SUPPLEMENTAL-CODE' },
                 { name: 'main.R', fileType: 'MAIN-CODE' },
             ])
-            // old S3 code objects cleared before re-upload
-            expect(aws.deleteFolderContents).toHaveBeenCalledTimes(1)
-            // still a single submission/version
             expect(await submittedStatusCount(study.id)).toBe(1)
         })
 
@@ -935,7 +940,7 @@ describe('Request Study Actions', () => {
             expect(await submittedStatusCount(study.id)).toBe(2)
         })
 
-        it('re-submitting again within the SAME code-draft round does not append a third CODE-SUBMITTED', async () => {
+        it('rejects a second resubmit of the same round until a new decision lands', async () => {
             const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
             const { study } = await insertTestStudyOnly({ org, researcherId: user.id })
             const root = await createWorkspaceDir('reuse-resubmit-twice')
@@ -954,13 +959,31 @@ describe('Request Study Actions', () => {
                 .values({ studyJobId: round1Job.id, status: 'CODE-CHANGES-REQUESTED' })
                 .execute()
 
-            // First resubmit of round 2 → opens the new round and appends its CODE-SUBMITTED (2 study-wide).
-            await submitCode(study.id, root, { 'main.R': 'round2a' }, 'main.R')
+            // Resubmit round 2 → opens the new round and appends its CODE-SUBMITTED (2 study-wide). The
+            // initial submit path is closed after a decision (Finding 6), so resubmission uses the
+            // resubmit-with-note action.
+            await writeWorkspaceFiles(root, study.id, { 'main.R': 'round2a' })
+            actionResult(
+                await resubmitStudyCodeAction({
+                    studyId: study.id,
+                    mainFileName: 'main.R',
+                    fileNames: ['main.R'],
+                    resubmissionNote: 'addressed the feedback and updated the code',
+                }),
+            )
             expect(await jobCount(study.id)).toBe(2)
             expect(await submittedStatusCount(study.id)).toBe(2)
 
-            // Re-submit AGAIN before the reviewer decides round 2 → same (round-2) round, idempotent.
-            await submitCode(study.id, root, { 'main.R': 'round2b' }, 'main.R')
+            // Round 2 is now awaiting review (no new decision), so a second resubmit is rejected — no
+            // third CODE-SUBMITTED, no new round.
+            await writeWorkspaceFiles(root, study.id, { 'main.R': 'round2b' })
+            const second = await resubmitStudyCodeAction({
+                studyId: study.id,
+                mainFileName: 'main.R',
+                fileNames: ['main.R'],
+                resubmissionNote: 'attempting to resubmit again before a decision',
+            })
+            expect(second).toHaveProperty('error')
             expect(await jobCount(study.id)).toBe(2)
             expect(await submittedStatusCount(study.id)).toBe(2)
         })

--- a/src/server/actions/study-request.test.ts
+++ b/src/server/actions/study-request.test.ts
@@ -399,22 +399,47 @@ describe('Request Study Actions', () => {
             expect(study.status).toBe('PENDING-REVIEW')
         })
 
-        it('finalizeStudySubmissionAction transitions CHANGE-REQUESTED → PENDING-REVIEW', async () => {
+        // OTTER-636 (Finding 3): finalize is the FRESH-submit path only. A change-requested proposal must
+        // be revised via the edit-and-resubmit flow (resubmitProposalAction, which requires a note), so
+        // finalize now rejects it rather than submitting it without a note.
+        it('finalizeStudySubmissionAction rejects a CHANGE-REQUESTED study (must resubmit with a note)', async () => {
             const { org } = await mockSessionWithTestData({ orgType: 'lab' })
             const { study } = await insertTestStudyOnly({ org })
-
-            // Force the test study into CHANGE-REQUESTED status (insertTestStudyOnly defaults to APPROVED)
             await setTestStudyStatus(study.id, 'CHANGE-REQUESTED')
 
-            const result = actionResult(await finalizeStudySubmissionAction({ studyId: study.id }))
-            expect(result.studyId).toBe(study.id)
+            const result = await finalizeStudySubmissionAction({ studyId: study.id })
+            expect(result).toHaveProperty('error')
 
             const updated = await db
                 .selectFrom('study')
                 .select(['status'])
                 .where('id', '=', study.id)
                 .executeTakeFirstOrThrow()
-            expect(updated.status).toBe('PENDING-REVIEW')
+            expect(updated.status).toBe('CHANGE-REQUESTED')
+        })
+
+        it('finalizeStudySubmissionAction writes immutable proposal snapshot v1', async () => {
+            const enclave = await insertTestOrg({ type: 'enclave', slug: 'test-snap-v1' })
+            const lab = await insertTestOrg({ slug: `${enclave.slug}-lab`, type: 'lab' })
+            await mockSessionWithTestData({ orgSlug: lab.slug, orgType: 'lab' })
+            const draft = actionResult(
+                await onSaveDraftStudyAction({
+                    orgSlug: enclave.slug,
+                    studyInfo: { title: 'Snapshot Study', piName: 'PI', language: 'R' as const },
+                    submittingOrgSlug: lab.slug,
+                }),
+            )
+
+            actionResult(await finalizeStudySubmissionAction({ studyId: draft.studyId }))
+
+            const snaps = await db
+                .selectFrom('studyProposalSubmission')
+                .select(['version', 'snapshot'])
+                .where('studyId', '=', draft.studyId)
+                .execute()
+            expect(snaps).toHaveLength(1)
+            expect(snaps[0].version).toBe(1)
+            expect((snaps[0].snapshot as { title: string }).title).toBe('Snapshot Study')
         })
 
         it('finalizeStudySubmissionAction rejects callers outside the submitting lab', async () => {

--- a/src/server/actions/study-request.ts
+++ b/src/server/actions/study-request.ts
@@ -17,7 +17,12 @@ import {
 } from '@/server/aws'
 import { CODER_DISABLED, getConfigValue, SIMULATE_CODE_BUILD } from '@/server/config'
 import { getOrCreateCurrentRoundJob, nextVersionForStudyComment } from '@/server/db/mutations'
-import { codeSubmissionVersion, getInfoForStudyId, getOrgIdFromSlug } from '@/server/db/queries'
+import {
+    codeRoundStatusesForStudy,
+    codeSubmissionVersion,
+    getInfoForStudyId,
+    getOrgIdFromSlug,
+} from '@/server/db/queries'
 import { rawStudyStateForStudy } from '@/server/db/study-state-query'
 import { db as database } from '@/database'
 import { deferred, onStudyReviewRequested, onStudyCodeSubmitted, onStudyCreated } from '@/server/events'
@@ -34,7 +39,7 @@ import {
     resubmissionNoteToLexicalJson,
     resubmissionNoteWordCount,
 } from '@/app/[orgSlug]/study/[studyId]/edit-and-resubmit/schema'
-import { canResearcherResubmitCode, projectStudyState } from '@/lib/study-screen'
+import { canResearcherResubmitCode, canSubmitInitialCode, projectStudyState } from '@/lib/study-screen'
 
 const simulateJobScan = deferred(async (studyJobId: string) => {
     await sleep({ 1: 'seconds' })
@@ -64,14 +69,15 @@ function triggerCodeScan(studyJobId: string, orgSlug: string, studyId: string) {
 }
 
 /**
- * Attach the submitted code to the study's current submission round, reusing the job opened at IDE
- * launch / file upload instead of minting a new one (OTTER-601). A new job is created only after a
- * post-run results decision (FILES-APPROVED / FILES-REJECTED) closes the round; change-requested and
- * errored rounds reuse the same job (ROUND_CLOSING_JOB_STATUSES in study-job-status.ts).
+ * Attach the submitted code to the study's current submission round, reusing the job the researcher's
+ * edits already opened at IDE launch / file upload instead of minting a new one (OTTER-601). Round
+ * identity and reuse-vs-new is decided by getOrCreateCurrentRoundJob: once a round has been reviewed
+ * (change-requested, bare errored, or a results decision) the next edit opens a FRESH round, so by
+ * resubmit time this attaches to that new round and reviewed rounds stay immutable (OTTER-636).
  *
- * The MAIN/SUPPLEMENTAL code file set is overwritten each time so a re-submit within an un-reviewed
- * round (or after change-requested) reflects exactly the files now provided, with no leftovers from a
- * prior attempt — in the DB and in S3.
+ * The MAIN/SUPPLEMENTAL code file set is overwritten each time so a re-submit within the same un-reviewed
+ * round reflects exactly the files now provided, with no leftovers from a prior attempt — in the DB and
+ * in S3.
  */
 async function attachCodeToRoundJob(
     db: Kysely<DB>,
@@ -130,10 +136,11 @@ async function attachCodeToRoundJob(
  * CODE-SUBMITTED" — that would swallow the new round's submission and leave the researcher's /view
  * stuck on the feedback screen and the reviewer never re-notified.
  *
- * Round-aware idempotency (order-independent — same counting the liveness/version logic uses): the
- * current round is already submitted iff submitted-count > change-requested-count on this job. A
- * re-submit within the same un-reviewed round (submitted > requested) is a no-op; the first submit
- * of a round (submitted == requested) appends.
+ * Round-aware idempotency (order-independent): the current round is already submitted iff
+ * submitted-count > change-requested-count on this job. A re-submit within the same un-reviewed round
+ * (submitted > requested) is a no-op; the first submit of a round (submitted == requested) appends. Note
+ * that under OTTER-636 a fresh round is opened per review decision, so a resubmit lands on a new job
+ * that appends its own CODE-SUBMITTED.
  */
 async function markCodeSubmitted(db: Kysely<DB>, { studyJobId, userId }: { studyJobId: string; userId: string }) {
     const counts = await db
@@ -523,6 +530,17 @@ export const submitStudyCodeAction = new Action('submitStudyCodeAction', { perfo
 
         if (!fileNames.includes(mainFileName)) {
             throw new Error('Main file not in file list')
+        }
+
+        // OTTER-636 (Finding 6): the initial code-submit path carries no resubmission note, so it is
+        // valid ONLY for a genuine first submission (an open INITIATED round, no prior submitted round).
+        // Once a round has been submitted/reviewed, a further submission must go through
+        // resubmitStudyCodeAction (which requires a note) — a positive gate here stops the initial path
+        // from ever overwriting reviewed code or bypassing the note.
+        if (!canSubmitInitialCode(await codeRoundStatusesForStudy(studyId, db))) {
+            throw new ActionFailure({
+                submission: 'This study must be resubmitted with a note; use the resubmit flow.',
+            })
         }
 
         const userId = session.user.id

--- a/src/server/actions/study-request.ts
+++ b/src/server/actions/study-request.ts
@@ -477,6 +477,7 @@ export const getDraftStudyAction = new Action('getDraftStudyAction')
                 'study.irbDocPath',
                 'study.agreementDocPath',
                 'study.status',
+                'study.proposalRevisionBaseSubmissionId',
                 'study.researcherId',
                 'study.orgId',
                 'study.submittedByOrgId',
@@ -633,6 +634,52 @@ const resubmissionNoteParam = z
 //
 // `performsMutations: true` runs this handler inside db.transaction().
 // Do not drop it: the study updates/inserts must commit or roll back together.
+// OTTER-636: the first real edit to a change-requested proposal transitions it to a literal revision
+// DRAFT that points at the immutable submitted snapshot it is revising. study.status becomes DRAFT so
+// the researcher sees "Proposal draft" and it leaves the reviewer's actionable queue, while reviewers
+// still read the frozen snapshot (Phase 4). Idempotent: an already-started revision draft, or a study
+// not in CHANGE-REQUESTED, is a no-op. Lab-scoped.
+export const startProposalRevisionAction = new Action('startProposalRevisionAction', { performsMutations: true })
+    .params(z.object({ studyId: z.string() }))
+    .middleware(async ({ params: { studyId } }) => await getInfoForStudyId(studyId))
+    .requireAbilityTo('update', 'Study')
+    .handler(async ({ db, params: { studyId }, session }) => {
+        const userLabOrgIds = Object.values(session.orgs)
+            .filter((org) => org.type === 'lab')
+            .map((org) => org.id)
+        const labScope = userLabOrgIds.length > 0 ? userLabOrgIds : ['']
+
+        const current = await db
+            .selectFrom('study')
+            .select(['status', 'proposalRevisionBaseSubmissionId'])
+            .where('id', '=', studyId)
+            .where('submittedByOrgId', 'in', labScope)
+            .executeTakeFirst()
+
+        if (!current) throw new ActionFailure({ submission: 'Study not found or access denied' })
+        // Already a revision draft, or not a change-requested proposal → nothing to do (idempotent).
+        if (current.status !== 'CHANGE-REQUESTED') return { studyId }
+
+        const latest = await db
+            .selectFrom('studyProposalSubmission')
+            .select('id')
+            .where('studyId', '=', studyId)
+            .orderBy('version', 'desc')
+            .limit(1)
+            .executeTakeFirst()
+        if (!latest) throw new ActionFailure({ submission: 'Cannot start a revision: no submitted version exists' })
+
+        await db
+            .updateTable('study')
+            .set({ status: 'DRAFT', proposalRevisionBaseSubmissionId: latest.id, lastUpdatedAt: new Date() })
+            .where('id', '=', studyId)
+            .where('status', '=', 'CHANGE-REQUESTED')
+            .where('submittedByOrgId', 'in', labScope)
+            .execute()
+
+        return { studyId }
+    })
+
 export const resubmitProposalAction = new Action('resubmitProposalAction', { performsMutations: true })
     .params(
         z.object({
@@ -666,7 +713,12 @@ export const resubmitProposalAction = new Action('resubmitProposalAction', { per
         const study = await db
             .selectFrom('study')
             .innerJoin('org', 'org.id', 'study.orgId')
-            .select(['study.id as id', 'study.status as status', 'org.name as orgName'])
+            .select([
+                'study.id as id',
+                'study.status as status',
+                'study.proposalRevisionBaseSubmissionId as revisionBase',
+                'org.name as orgName',
+            ])
             .where('study.id', '=', studyId)
             .where('study.submittedByOrgId', 'in', labScope)
             .executeTakeFirst()
@@ -674,8 +726,11 @@ export const resubmitProposalAction = new Action('resubmitProposalAction', { per
         // User-facing failures (wrong-lab access, wrong-status race) use ActionFailure
         // so the client receives a structured `{ error: { submission } }` it can show,
         // rather than a plain Error bubbling up as a generic unhandled exception.
+        // OTTER-636: resubmit accepts a change-requested proposal OR a revision draft (a study whose
+        // first edit flipped it to DRAFT with a base snapshot). Both carry submitted history and a note.
         if (!study) throw new ActionFailure({ submission: 'Study not found or access denied' })
-        if (study.status !== 'CHANGE-REQUESTED') {
+        const isRevisionDraft = study.status === 'DRAFT' && study.revisionBase != null
+        if (study.status !== 'CHANGE-REQUESTED' && !isRevisionDraft) {
             throw new ActionFailure({ submission: 'This proposal can no longer be resubmitted.' })
         }
 
@@ -698,10 +753,19 @@ export const resubmitProposalAction = new Action('resubmitProposalAction', { per
                 ...updateValues,
                 status: 'PENDING-REVIEW',
                 proposalResubmissionNoteDraft: null,
+                // OTTER-636: the revision is now submitted; clear the base so it is no longer a draft.
+                proposalRevisionBaseSubmissionId: null,
                 lastUpdatedAt: resubmittedAt,
             })
             .where('id', '=', studyId)
-            .where('status', '=', 'CHANGE-REQUESTED')
+            // CHANGE-REQUESTED, or a revision draft (DRAFT with a base snapshot). submittedAt is left
+            // untouched; the studyProposalComment/snapshot carry the resubmission version.
+            .where((eb) =>
+                eb.or([
+                    eb('status', '=', 'CHANGE-REQUESTED'),
+                    eb.and([eb('status', '=', 'DRAFT'), eb('proposalRevisionBaseSubmissionId', 'is not', null)]),
+                ]),
+            )
             .where('submittedByOrgId', 'in', labScope)
             .returning(['id'])
             .executeTakeFirst()
@@ -840,7 +904,14 @@ export const saveProposalResubmissionNoteDraftAction = new Action('saveProposalR
             .updateTable('study')
             .set({ proposalResubmissionNoteDraft: note })
             .where('id', '=', studyId)
-            .where('status', '=', 'CHANGE-REQUESTED')
+            // OTTER-636: the note is editable while the study is CHANGE-REQUESTED and after its first
+            // edit flips it to a revision DRAFT (DRAFT with a base snapshot). A fresh DRAFT has no note.
+            .where((eb) =>
+                eb.or([
+                    eb('status', '=', 'CHANGE-REQUESTED'),
+                    eb.and([eb('status', '=', 'DRAFT'), eb('proposalRevisionBaseSubmissionId', 'is not', null)]),
+                ]),
+            )
             .where('submittedByOrgId', 'in', userLabOrgIds.length > 0 ? userLabOrgIds : [''])
             .returning(['id'])
             .executeTakeFirst()

--- a/src/server/actions/study-request.ts
+++ b/src/server/actions/study-request.ts
@@ -40,7 +40,12 @@ import {
     resubmissionNoteToLexicalJson,
     resubmissionNoteWordCount,
 } from '@/app/[orgSlug]/study/[studyId]/edit-and-resubmit/schema'
-import { canResearcherResubmitCode, canSubmitInitialCode, projectStudyState } from '@/lib/study-screen'
+import {
+    canResearcherResubmitCode,
+    canResubmitProposal,
+    canSubmitInitialCode,
+    projectStudyState,
+} from '@/lib/study-screen'
 
 const simulateJobScan = deferred(async (studyJobId: string) => {
     await sleep({ 1: 'seconds' })
@@ -667,12 +672,11 @@ export const startProposalRevisionAction = new Action('startProposalRevisionActi
             .orderBy('version', 'desc')
             .limit(1)
             .executeTakeFirst()
-        // No snapshot means we cannot set the revision base (the fresh-vs-revision discriminator), so we
-        // cannot flip to a revision DRAFT. This should not happen in production (finalize + the backfill
-        // guarantee a submitted study has a snapshot), but rather than fail the edit, leave the study
-        // CHANGE-REQUESTED — resubmitProposalAction accepts that status directly, so the researcher is
-        // never blocked. The flip is a best-effort display concern, not a prerequisite for resubmitting.
-        if (!latest) return { studyId }
+        // A change-requested proposal was submitted at least once, so finalize + the backfill migration
+        // guarantee it has an immutable snapshot. A missing one is a data-integrity error — surface it
+        // visibly (architecture invariant 10) rather than silently leaving the study un-flipped, which
+        // would let the researcher resubmit without ever becoming a revision draft.
+        if (!latest) throw new ActionFailure({ submission: 'Cannot start a revision: no submitted version exists' })
 
         await db
             .updateTable('study')
@@ -731,11 +735,11 @@ export const resubmitProposalAction = new Action('resubmitProposalAction', { per
         // User-facing failures (wrong-lab access, wrong-status race) use ActionFailure
         // so the client receives a structured `{ error: { submission } }` it can show,
         // rather than a plain Error bubbling up as a generic unhandled exception.
-        // OTTER-636: resubmit accepts a change-requested proposal OR a revision draft (a study whose
-        // first edit flipped it to DRAFT with a base snapshot). Both carry submitted history and a note.
+        // OTTER-636 (architecture §7): resubmit accepts ONLY a revision draft — a DRAFT with a non-null
+        // base snapshot. The researcher's first edit flips a change-requested proposal into that state
+        // (startProposalRevisionAction); resubmit never handles an un-flipped CHANGE-REQUESTED row.
         if (!study) throw new ActionFailure({ submission: 'Study not found or access denied' })
-        const isRevisionDraft = study.status === 'DRAFT' && study.revisionBase != null
-        if (study.status !== 'CHANGE-REQUESTED' && !isRevisionDraft) {
+        if (!canResubmitProposal({ status: study.status, proposalRevisionBaseSubmissionId: study.revisionBase })) {
             throw new ActionFailure({ submission: 'This proposal can no longer be resubmitted.' })
         }
 
@@ -763,14 +767,10 @@ export const resubmitProposalAction = new Action('resubmitProposalAction', { per
                 lastUpdatedAt: resubmittedAt,
             })
             .where('id', '=', studyId)
-            // CHANGE-REQUESTED, or a revision draft (DRAFT with a base snapshot). submittedAt is left
-            // untouched; the studyProposalComment/snapshot carry the resubmission version.
-            .where((eb) =>
-                eb.or([
-                    eb('status', '=', 'CHANGE-REQUESTED'),
-                    eb.and([eb('status', '=', 'DRAFT'), eb('proposalRevisionBaseSubmissionId', 'is not', null)]),
-                ]),
-            )
+            // Revision draft only (DRAFT with a base snapshot). submittedAt is left untouched; the
+            // studyProposalComment/snapshot carry the resubmission version.
+            .where('status', '=', 'DRAFT')
+            .where('proposalRevisionBaseSubmissionId', 'is not', null)
             .where('submittedByOrgId', 'in', labScope)
             .returning(['id'])
             .executeTakeFirst()

--- a/src/server/actions/study-request.ts
+++ b/src/server/actions/study-request.ts
@@ -24,6 +24,7 @@ import {
     getOrgIdFromSlug,
 } from '@/server/db/queries'
 import { rawStudyStateForStudy } from '@/server/db/study-state-query'
+import { writeProposalSubmissionSnapshot } from '@/server/db/proposal-snapshot'
 import { db as database } from '@/database'
 import { deferred, onStudyReviewRequested, onStudyCodeSubmitted, onStudyCreated } from '@/server/events'
 import { purgeProposalYjsDocsBeforeAt } from '@/server/db/yjs-cleanup'
@@ -385,7 +386,11 @@ export const finalizeStudySubmissionAction = new Action('finalizeStudySubmission
             .updateTable('study')
             .set({ ...snapshotFields, status: 'PENDING-REVIEW', submittedAt, lastUpdatedAt: submittedAt })
             .where('id', '=', studyId)
-            .where('status', 'in', ['DRAFT', 'CHANGE-REQUESTED'])
+            // OTTER-636: finalize is the FRESH-submit path only. A revision of a change-requested proposal
+            // goes through resubmitProposalAction (with a note); a revision draft (DRAFT + base snapshot)
+            // is excluded here so it can never be finalized without its note.
+            .where('status', '=', 'DRAFT')
+            .where('proposalRevisionBaseSubmissionId', 'is', null)
             .where('submittedByOrgId', 'in', userLabOrgIds.length > 0 ? userLabOrgIds : [''])
             .returning(['id', 'submittedByOrgId'])
             .executeTakeFirst()
@@ -393,6 +398,10 @@ export const finalizeStudySubmissionAction = new Action('finalizeStudySubmission
         if (!claimed) {
             throw new ActionFailure({ submission: 'Proposal has already been submitted' })
         }
+
+        // OTTER-636: record immutable submission snapshot v1 from the just-persisted proposal columns,
+        // so reviewers read this frozen version rather than the mutable row.
+        await writeProposalSubmissionSnapshot(db, studyId, userId)
 
         // The atomic UPDATE above is the canonical post-submit snapshot. Drop the
         // proposal-* yjs_document rows so a future CHANGE-REQUESTED reopen falls
@@ -700,6 +709,10 @@ export const resubmitProposalAction = new Action('resubmitProposalAction', { per
         if (!claimed) {
             throw new ActionFailure({ submission: 'Proposal has already been submitted' })
         }
+
+        // OTTER-636: record the immutable snapshot for this resubmission (the next version) from the
+        // just-persisted proposal columns, so reviewers read this frozen version, not the mutable row.
+        await writeProposalSubmissionSnapshot(db, studyId, userId)
 
         await db
             .insertInto('studyProposalComment')

--- a/src/server/actions/study-request.ts
+++ b/src/server/actions/study-request.ts
@@ -667,7 +667,12 @@ export const startProposalRevisionAction = new Action('startProposalRevisionActi
             .orderBy('version', 'desc')
             .limit(1)
             .executeTakeFirst()
-        if (!latest) throw new ActionFailure({ submission: 'Cannot start a revision: no submitted version exists' })
+        // No snapshot means we cannot set the revision base (the fresh-vs-revision discriminator), so we
+        // cannot flip to a revision DRAFT. This should not happen in production (finalize + the backfill
+        // guarantee a submitted study has a snapshot), but rather than fail the edit, leave the study
+        // CHANGE-REQUESTED — resubmitProposalAction accepts that status directly, so the researcher is
+        // never blocked. The flip is a best-effort display concern, not a prerequisite for resubmitting.
+        if (!latest) return { studyId }
 
         await db
             .updateTable('study')

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -32,6 +32,7 @@ import {
     submitProposalReviewAction,
 } from './study.actions'
 import { purgeReviewFeedbackYjsDocBeforeAt } from '@/server/db/yjs-cleanup'
+import { writeProposalSubmissionSnapshot } from '@/server/db/proposal-snapshot'
 import { lexicalJson } from '@/lib/lexical'
 
 vi.mock('@/server/mailgun', () => ({
@@ -480,6 +481,46 @@ describe('Study Actions', () => {
             expect(result).toEqual(
                 expect.arrayContaining([expect.objectContaining({ id: studyId, status: 'CHANGE-REQUESTED' })]),
             )
+        })
+
+        // OTTER-636: reviewers (enclave dashboards) see a revision draft (a change-requested proposal
+        // being edited) but never a fresh draft.
+        it('reviewer sees a revision draft but not a fresh draft', async () => {
+            const {
+                enclave,
+                studyId: revisionId,
+                user: revisionAuthor,
+            } = await createTestProposalDraft({
+                enclaveSlug: 'fetch-reviewer-revision-enclave',
+                studyInfo: { title: 'Revision draft' },
+            })
+            await writeProposalSubmissionSnapshot(db, revisionId, revisionAuthor.id)
+            const snap = await db
+                .selectFrom('studyProposalSubmission')
+                .select('id')
+                .where('studyId', '=', revisionId)
+                .executeTakeFirstOrThrow()
+            await db
+                .updateTable('study')
+                .set({ status: 'DRAFT', proposalRevisionBaseSubmissionId: snap.id })
+                .where('id', '=', revisionId)
+                .execute()
+
+            // A fresh draft in the same enclave (no base snapshot).
+            const { studyId: freshId } = await createTestProposalDraft({
+                enclaveSlug: `${enclave.slug}-fresh`,
+                studyInfo: { title: 'Fresh draft' },
+            })
+            await db.updateTable('study').set({ orgId: enclave.id }).where('id', '=', freshId).execute()
+
+            // A reviewer in the enclave loads their dashboard.
+            await mockSessionWithTestData({ orgSlug: enclave.slug, orgType: 'enclave' })
+            const result = await fetchStudiesForOrgAction({ orgSlug: enclave.slug })
+
+            expect(Array.isArray(result)).toBe(true)
+            const ids = (result as Array<{ id: string }>).map((s) => s.id)
+            expect(ids).toContain(revisionId)
+            expect(ids).not.toContain(freshId)
         })
 
         it("outside-lab user does not see another lab's draft", async () => {

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -2516,4 +2516,37 @@ describe('softDeleteStudyAction', () => {
             error: expect.objectContaining({ user: expect.stringMatching(/not found/i) }),
         })
     })
+
+    // OTTER-636: a revision draft (a change-requested proposal being edited) is DRAFT but carries an
+    // immutable submitted snapshot; deleting it would destroy submitted history, so it must be refused.
+    it('rejects deleting a revision draft, preserving its submitted history', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgSlug: 'soft-delete-revision', orgType: 'lab' })
+        const { study } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'CHANGE-REQUESTED',
+        })
+        await writeProposalSubmissionSnapshot(db, study.id, user.id)
+        const snap = await db
+            .selectFrom('studyProposalSubmission')
+            .select('id')
+            .where('studyId', '=', study.id)
+            .executeTakeFirstOrThrow()
+        await db
+            .updateTable('study')
+            .set({ status: 'DRAFT', proposalRevisionBaseSubmissionId: snap.id })
+            .where('id', '=', study.id)
+            .execute()
+
+        await expect(softDeleteStudyAction({ studyId: study.id })).resolves.toMatchObject({
+            error: expect.objectContaining({ study: expect.stringMatching(/being revised/i) }),
+        })
+
+        const row = await db
+            .selectFrom('study')
+            .select('deletedAt')
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+        expect(row.deletedAt).toBeNull()
+    })
 })

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -111,6 +111,7 @@ function fetchStudyQuery(db: DBExecutor) {
             'study.reviewerAgreementsAckedAt',
             'study.codeResubmissionNoteDraft',
             'study.proposalResubmissionNoteDraft',
+            'study.proposalRevisionBaseSubmissionId',
             'researcher.fullName as createdBy',
             'reviewer.fullName as reviewerName',
             'latestStudyJob.jobId as latestStudyJobId',

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -133,8 +133,17 @@ export const fetchStudiesForOrgAction = new Action('fetchStudiesForOrgAction')
     .handler(async ({ db, orgId, orgType }) => {
         let query = fetchStudyQuery(db)
         if (orgType === 'enclave') {
-            // Reviewer dashboards should not see draft studies
-            query = query.where('study.orgId', '=', orgId).where('study.status', '!=', 'DRAFT')
+            // OTTER-636: reviewers see revision drafts (a change-requested proposal being edited) but
+            // not fresh drafts (a brand-new proposal). Exclude only the fresh-draft case: DRAFT with no
+            // base snapshot.
+            query = query
+                .where('study.orgId', '=', orgId)
+                .where((eb) =>
+                    eb.or([
+                        eb('study.status', '!=', 'DRAFT'),
+                        eb('study.proposalRevisionBaseSubmissionId', 'is not', null),
+                    ]),
+                )
         }
         if (orgType === 'lab') {
             // Lab dashboards: show every study submitted by the lab (including drafts and
@@ -170,12 +179,21 @@ export const fetchStudiesForCurrentReviewerAction = new Action('fetchStudiesForC
         if (reviewerOrgIds.length === 0) {
             return []
         }
-        return fetchStudyQuery(db)
-            .where('study.orgId', 'in', reviewerOrgIds)
-            .where('study.status', '!=', 'DRAFT') // Reviewers should not see draft studies
-            .innerJoin('org', 'org.id', 'study.orgId')
-            .select(['org.name as orgName', 'org.slug as orgSlug'])
-            .execute()
+        return (
+            fetchStudyQuery(db)
+                .where('study.orgId', 'in', reviewerOrgIds)
+                // OTTER-636: hide fresh drafts only; a revision draft (DRAFT with a base snapshot) stays
+                // visible so the reviewer can see the change-requested proposal is being revised.
+                .where((eb) =>
+                    eb.or([
+                        eb('study.status', '!=', 'DRAFT'),
+                        eb('study.proposalRevisionBaseSubmissionId', 'is not', null),
+                    ]),
+                )
+                .innerJoin('org', 'org.id', 'study.orgId')
+                .select(['org.name as orgName', 'org.slug as orgSlug'])
+                .execute()
+        )
     })
 
 export const getStudyAction = new Action('getStudyAction')

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -264,7 +264,15 @@ export const softDeleteStudyAction = new Action('softDeleteStudyAction', { perfo
     .middleware(async ({ params: { studyId }, db }) => {
         const study = await db
             .selectFrom('study')
-            .select(['id', 'status', 'title', 'researcherId', 'orgId', 'submittedByOrgId'])
+            .select([
+                'id',
+                'status',
+                'title',
+                'researcherId',
+                'orgId',
+                'submittedByOrgId',
+                'proposalRevisionBaseSubmissionId',
+            ])
             .where('id', '=', studyId)
             .where('deletedAt', 'is', null)
             .executeTakeFirstOrThrow(throwNotFound('study'))
@@ -274,6 +282,12 @@ export const softDeleteStudyAction = new Action('softDeleteStudyAction', { perfo
     .handler(async ({ db, study, params: { studyId }, session }) => {
         if (study.status !== 'DRAFT') {
             throw new ActionFailure({ study: 'only draft studies can be deleted' })
+        }
+        // OTTER-636: a revision draft (a change-requested proposal being edited) is also DRAFT, but it
+        // carries an immutable submitted-proposal snapshot. Deleting it would destroy that submitted
+        // history (the snapshot cascades on study delete), so only a FRESH draft may be deleted.
+        if (study.proposalRevisionBaseSubmissionId !== null) {
+            throw new ActionFailure({ study: 'a proposal being revised cannot be deleted' })
         }
         if (study.researcherId !== session.user.id) {
             throw new ActionFailure({ user: 'only the draft author can delete this proposal' })

--- a/src/server/actions/workspace-files.actions.test.ts
+++ b/src/server/actions/workspace-files.actions.test.ts
@@ -1,0 +1,106 @@
+import { mockSessionWithTestData, actionResult, insertTestStudyJobData, db } from '@/tests/unit.helpers'
+import { describe, expect, test, afterEach, beforeEach, vi } from 'vitest'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+
+// OTTER-636: deleting/replacing an existing code file is a real edit and opens/reuses the current
+// code-draft round; deleting a missing file is idempotent and opens nothing.
+describe('deleteWorkspaceFileAction round behavior (OTTER-636)', () => {
+    const TEST_CODER_FILES = '/tmp/wsfiles-del-' + Math.random().toString(36).slice(2)
+    const originalCoderFiles = process.env.CODER_FILES
+
+    const jobCount = (studyId: string) =>
+        db
+            .selectFrom('studyJob')
+            .select((eb) => eb.fn.countAll<number>().as('n'))
+            .where('studyId', '=', studyId)
+            .executeTakeFirstOrThrow()
+            .then((r) => Number(r.n))
+
+    beforeEach(() => {
+        vi.resetModules()
+        vi.doMock('@/server/config', async (importOriginal) => {
+            const mod = await importOriginal<typeof import('@/server/config')>()
+            return {
+                ...mod,
+                CODER_DISABLED: false,
+                getConfigValue: vi.fn().mockImplementation((key) => process.env[key]),
+            }
+        })
+        process.env.CODER_FILES = TEST_CODER_FILES
+    })
+
+    afterEach(async () => {
+        try {
+            await fs.rm(TEST_CODER_FILES, { recursive: true, force: true })
+        } catch {
+            // ignore
+        }
+        if (originalCoderFiles) process.env.CODER_FILES = originalCoderFiles
+        else delete process.env.CODER_FILES
+    })
+
+    test('deleting an existing file after CODE-CHANGES-REQUESTED opens a fresh code-draft round', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+        const { study, job } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'APPROVED',
+            jobStatus: 'CODE-SUBMITTED',
+        })
+        await db
+            .insertInto('jobStatusChange')
+            .values({ studyJobId: job.id, status: 'CODE-CHANGES-REQUESTED' })
+            .execute()
+
+        const studyDir = path.join(TEST_CODER_FILES, study.id)
+        await fs.mkdir(studyDir, { recursive: true })
+        await fs.writeFile(path.join(studyDir, 'main.r'), 'print(1)')
+
+        const { deleteWorkspaceFileAction } = await import('./workspace-files.actions')
+        actionResult(await deleteWorkspaceFileAction({ studyId: study.id, fileName: 'main.r' }))
+
+        expect(await jobCount(study.id)).toBe(2)
+        await expect(fs.access(path.join(studyDir, 'main.r'))).rejects.toThrow()
+    })
+
+    test('deleting a MISSING file is idempotent and opens no round', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+        const { study, job } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'APPROVED',
+            jobStatus: 'CODE-SUBMITTED',
+        })
+        await db
+            .insertInto('jobStatusChange')
+            .values({ studyJobId: job.id, status: 'CODE-CHANGES-REQUESTED' })
+            .execute()
+
+        const { deleteWorkspaceFileAction } = await import('./workspace-files.actions')
+        const result = actionResult(await deleteWorkspaceFileAction({ studyId: study.id, fileName: 'nope.r' }))
+
+        expect(result).toEqual({ success: true })
+        // No real edit occurred, so no fresh round was opened.
+        expect(await jobCount(study.id)).toBe(1)
+    })
+
+    test('deleting within an open INITIATED round reuses it (no extra round)', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+        const { study } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            studyStatus: 'APPROVED',
+            jobStatus: 'INITIATED',
+        })
+
+        const studyDir = path.join(TEST_CODER_FILES, study.id)
+        await fs.mkdir(studyDir, { recursive: true })
+        await fs.writeFile(path.join(studyDir, 'main.r'), 'print(1)')
+
+        const { deleteWorkspaceFileAction } = await import('./workspace-files.actions')
+        actionResult(await deleteWorkspaceFileAction({ studyId: study.id, fileName: 'main.r' }))
+
+        expect(await jobCount(study.id)).toBe(1)
+    })
+})

--- a/src/server/actions/workspace-files.actions.ts
+++ b/src/server/actions/workspace-files.actions.ts
@@ -50,20 +50,26 @@ export const deleteWorkspaceFileAction = new Action('deleteWorkspaceFileAction',
     .params(z.object({ studyId: z.string(), fileName: z.string() }))
     .middleware(async ({ params: { studyId } }) => await getInfoForStudyId(studyId))
     .requireAbilityTo('load', 'IDE')
-    .handler(async ({ params: { studyId, fileName } }) => {
+    .handler(async ({ db, params: { studyId, fileName } }) => {
         const coderFilesPath = await getStudyFilesPath(studyId)
         const sanitized = sanitizeFileName(fileName)
         const filePath = path.join(coderFilesPath, sanitized)
 
+        // OTTER-636: locate the file first. Deleting a missing file is idempotent success and must NOT
+        // open a draft round (it is not a real edit). Deleting a real file IS a real edit, so open/reuse
+        // the current draft round, then unlink; if the unlink fails the surrounding transaction rolls
+        // back the round insert.
         try {
-            await fs.unlink(filePath)
+            await fs.access(filePath)
         } catch (e) {
             if (e instanceof Error && 'code' in e && e.code === 'ENOENT') {
-                // File already gone, that's fine
-            } else {
-                throw e
+                return { success: true }
             }
+            throw e
         }
+
+        await ensureRoundJobForUpload(db, studyId)
+        await fs.unlink(filePath)
 
         return { success: true }
     })

--- a/src/server/agents/review-agent/runner.ts
+++ b/src/server/agents/review-agent/runner.ts
@@ -7,6 +7,7 @@ import { getConfigValue } from '@/server/config'
 import { fetchFileContents } from '@/server/storage'
 import { generateDataSourcesContextString } from '@/server/utils'
 import { getAgentContextString } from '@/lib/agent-context'
+import { latestProposalSnapshotForStudy } from '@/server/db/proposal-snapshot'
 
 // Written when the API key is missing, before content assembly. This means a
 // no-code-files study with a missing key gets the placeholder too — fine, since
@@ -68,6 +69,7 @@ async function assembleReviewContent(
         .innerJoin('study', 'study.id', 'studyJob.studyId')
         .select([
             'studyJob.id as studyJobId',
+            'study.id as studyId',
             'study.orgId',
             'study.language',
             'study.projectSummary',
@@ -83,11 +85,17 @@ async function assembleReviewContent(
         return null
     }
 
+    // OTTER-636: review the immutable submitted proposal, not the mutable study row (which can hold a
+    // researcher's in-progress revision-draft edits). Fall back to the row only for a study with no
+    // snapshot yet (should not happen for a submitted job, but keeps the agent robust).
+    const latestProposal = await latestProposalSnapshotForStudy(job.studyId)
+    const proposalFields = latestProposal?.snapshot ?? job
+
     const proposalParts = [
-        lexicalFieldToText(job.projectSummary),
-        lexicalFieldToText(job.researchQuestions),
-        lexicalFieldToText(job.impact),
-        lexicalFieldToText(job.additionalNotes),
+        lexicalFieldToText(proposalFields.projectSummary),
+        lexicalFieldToText(proposalFields.researchQuestions),
+        lexicalFieldToText(proposalFields.impact),
+        lexicalFieldToText(proposalFields.additionalNotes),
     ].filter((part) => part.trim().length > 0)
 
     const codeFiles = await fetchCodeFiles(studyJobId)

--- a/src/server/db/mutations.test.ts
+++ b/src/server/db/mutations.test.ts
@@ -55,7 +55,9 @@ describe('getOrCreateCurrentRoundJob (OTTER-601)', () => {
         expect(await jobsForStudy(study.id)).toHaveLength(1)
     })
 
-    it('reuses the job after CODE-CHANGES-REQUESTED (revise in place, no new round)', async () => {
+    // OTTER-636: a live CODE-CHANGES-REQUESTED is a revision entry state, so the next real edit opens a
+    // FRESH INITIATED round (was previously same-job in place), keeping the reviewed round immutable.
+    it('opens a new round after a live CODE-CHANGES-REQUESTED (fresh code-draft round)', async () => {
         const org = await insertTestOrg()
         const { study, job } = await insertTestStudyJobData({
             org,
@@ -67,12 +69,14 @@ describe('getOrCreateCurrentRoundJob (OTTER-601)', () => {
 
         const result = await getOrCreateCurrentRoundJob(db, study.id)
 
-        expect(result.created).toBe(false)
-        expect(result.id).toBe(job.id)
-        expect(await jobsForStudy(study.id)).toHaveLength(1)
+        expect(result.created).toBe(true)
+        expect(result.id).not.toBe(job.id)
+        expect(await jobsForStudy(study.id)).toHaveLength(2)
     })
 
-    it('reuses the job after JOB-ERRORED (awaiting files review, no new round)', async () => {
+    // OTTER-636 (Finding 8): a bare JOB-ERRORED is a revision entry state; the next real edit opens a
+    // fresh round while the errored (reviewer-visible) round is preserved.
+    it('opens a new round after a bare JOB-ERRORED', async () => {
         const org = await insertTestOrg()
         const { study, job } = await insertTestStudyJobData({
             org,
@@ -82,6 +86,42 @@ describe('getOrCreateCurrentRoundJob (OTTER-601)', () => {
         await addFile(job.id)
         await addStatus(job.id, 'CODE-APPROVED')
         await addStatus(job.id, 'JOB-ERRORED')
+
+        const result = await getOrCreateCurrentRoundJob(db, study.id)
+
+        expect(result.created).toBe(true)
+        expect(result.id).not.toBe(job.id)
+        expect(await jobsForStudy(study.id)).toHaveLength(2)
+    })
+
+    it('reuses the fresh INITIATED round once one has been opened after a decision', async () => {
+        const org = await insertTestOrg()
+        const { study, job } = await insertTestStudyJobData({
+            org,
+            studyStatus: 'APPROVED',
+            jobStatus: 'CODE-SUBMITTED',
+        })
+        await addFile(job.id)
+        await addStatus(job.id, 'CODE-CHANGES-REQUESTED')
+
+        const opened = await getOrCreateCurrentRoundJob(db, study.id)
+        const reused = await getOrCreateCurrentRoundJob(db, study.id)
+
+        expect(reused.created).toBe(false)
+        expect(reused.id).toBe(opened.id)
+        expect(await jobsForStudy(study.id)).toHaveLength(2)
+    })
+
+    it('does NOT open a new round for a normal CODE-APPROVED (provisioning/running)', async () => {
+        const org = await insertTestOrg()
+        const { study, job } = await insertTestStudyJobData({
+            org,
+            studyStatus: 'APPROVED',
+            jobStatus: 'CODE-SUBMITTED',
+        })
+        await addFile(job.id)
+        await addStatus(job.id, 'CODE-APPROVED')
+        await addStatus(job.id, 'JOB-RUNNING')
 
         const result = await getOrCreateCurrentRoundJob(db, study.id)
 

--- a/src/server/db/mutations.ts
+++ b/src/server/db/mutations.ts
@@ -1,7 +1,7 @@
 import { Action } from '../actions/action'
-import type { DB } from '@/database/types'
+import type { DB, StudyJobStatus } from '@/database/types'
 import { sql, type Kysely } from 'kysely'
-import { ROUND_CLOSING_JOB_STATUSES } from '@/lib/study-job-status'
+import { isCodeRevisionEntry } from '@/lib/study-screen/code-predicates'
 
 type SiUserOptionalAttrs = {
     firstName?: string | null
@@ -54,14 +54,16 @@ async function createRoundJob(db: Kysely<DB>, studyId: string, createdAt: Date):
 
 /**
  * A study accumulates one studyJob per submission *round*: a round opens when work begins (IDE launch
- * or file upload) and closes only when its job reaches a post-run results decision (FILES-APPROVED /
- * FILES-REJECTED — see ROUND_CLOSING_JOB_STATUSES). Change-requested/errored rounds stay on the same
- * job. The latest job is the "current round" unless it has closed, in which case the next
- * launch/submit starts a new round.
+ * or file upload) and stays the current round until a review decision lands on it. Once the latest
+ * round is one the researcher may revise from — a live CODE-CHANGES-REQUESTED, a bare JOB-ERRORED, or a
+ * results decision (FILES-APPROVED/FILES-REJECTED); see isCodeRevisionEntry — the next real action opens
+ * a FRESH INITIATED round, so reviewed history stays immutable and the study reads "Code draft"
+ * (OTTER-636). An un-reviewed round (INITIATED-only, or CODE-SUBMITTED still awaiting a decision) is
+ * reused. Terminal CODE-REJECTED and a normal CODE-APPROVED (provisioning/running) are not revised.
  *
  * This is the single source of truth for "which job does this study's in-progress work belong to" —
- * shared by IDE launch, file upload, and code submission so they all converge on the same job instead
- * of each minting its own (which is what let an empty IDE-init job mask a real submission, OTTER-601).
+ * shared by IDE launch, file upload, delete, and code submission so they all converge on one job
+ * instead of each minting its own (OTTER-601), and at most one open draft round exists per study.
  *
  * `created` distinguishes a freshly-opened round from a reused one so callers can decide whether to
  * re-anchor the submit-enable timestamp or overwrite a prior submission's files.
@@ -71,52 +73,41 @@ export async function getOrCreateCurrentRoundJob(
     studyId: string,
     { backdateMs = 0 }: { backdateMs?: number } = {},
 ): Promise<RoundJob> {
+    // OTTER-636 (Finding 10): serialize round creation per study so concurrent launch/upload/delete/
+    // submit can't each read "no open round" and mint duplicates that split files/notes/scans across
+    // jobs. Transaction-scoped — the mutating actions that call this run inside a transaction.
+    await sql`select pg_advisory_xact_lock(hashtext(${studyId}))`.execute(db)
+
     const latest = await db
         .selectFrom('studyJob')
         .select(['studyJob.id as id', 'studyJob.createdAt as createdAt'])
-        // Both flags are EXISTENCE checks, not "latest status" lookups, so they're independent of
-        // jobStatusChange ordering. jobStatusChange.createdAt defaults to now() (constant within a
-        // transaction), so two statuses written together tie on createdAt and v7 ids aren't reliably
-        // monotonic within a millisecond — ordering by them to pick "the latest status" is
-        // non-deterministic and could flip the reuse-vs-new-round decision. A round-closing status
-        // (FILES-APPROVED/FILES-REJECTED) is never followed by another status on the same job (the
-        // next round opens a NEW job), so "has any round-closing status" is an order-independent test
-        // for a closed round.
-        .select((eb) =>
-            eb
-                .exists(
-                    eb
-                        .selectFrom('jobStatusChange')
-                        .select('jobStatusChange.id')
-                        .whereRef('jobStatusChange.studyJobId', '=', 'studyJob.id')
-                        .where('jobStatusChange.status', 'in', ROUND_CLOSING_JOB_STATUSES),
-                )
-                .as('roundClosed'),
-        )
-        .select((eb) =>
-            eb
-                .exists(
-                    eb
-                        .selectFrom('jobStatusChange')
-                        .select('jobStatusChange.id')
-                        .whereRef('jobStatusChange.studyJobId', '=', 'studyJob.id')
-                        .where('jobStatusChange.status', '!=', 'INITIATED'),
-                )
-                .as('hasSubmission'),
-        )
         .where('studyJob.studyId', '=', studyId)
-        // Order by id (v7 = insertion order), NOT createdAt: ensureRoundJobForUpload deliberately
-        // backdates a new round job's createdAt (so uploaded files read as newer for submit-enable),
-        // which would otherwise rank it *behind* the prior submission and make us open yet another
-        // round. id is monotonic with insertion, so the most-recently-created job always wins.
+        // Round identity is v7 id order (insertion order), NOT createdAt: ensureRoundJobForUpload
+        // deliberately backdates a new round's createdAt for file-mtime/submit-enable, so createdAt is
+        // presentation metadata only and must not decide which round is current (OTTER-636 Finding 11).
         .orderBy('studyJob.id', 'desc')
         .limit(1)
         .executeTakeFirst()
 
-    if (!latest || latest.roundClosed) {
+    if (!latest) {
         return createRoundJob(db, studyId, new Date(Date.now() - backdateMs))
     }
-    return { id: latest.id, createdAt: latest.createdAt, hasSubmission: Boolean(latest.hasSubmission), created: false }
+
+    // Status SET of the latest round (order-independent). jobStatusChange.createdAt defaults to now()
+    // (constant within a transaction) and v7 ids aren't reliably monotonic within a millisecond, so a
+    // "latest status" lookup would be non-deterministic; the revision-entry test reads the set.
+    const statusRows = await db
+        .selectFrom('jobStatusChange')
+        .select('status')
+        .where('studyJobId', '=', latest.id)
+        .execute()
+    const statuses = statusRows.map((r) => r.status as StudyJobStatus)
+    const hasSubmission = statuses.some((s) => s !== 'INITIATED')
+
+    if (isCodeRevisionEntry(statuses)) {
+        return createRoundJob(db, studyId, new Date(Date.now() - backdateMs))
+    }
+    return { id: latest.id, createdAt: latest.createdAt, hasSubmission, created: false }
 }
 
 // Submit is enabled when any workspace file's mtime > the current round job's createdAt.

--- a/src/server/db/proposal-snapshot.test.ts
+++ b/src/server/db/proposal-snapshot.test.ts
@@ -49,6 +49,23 @@ describe('latestProposalSnapshotForStudy', () => {
         const { study } = await insertTestStudyOnly({ org })
         expect(await latestProposalSnapshotForStudy(study.id)).toBeNull()
     })
+
+    // Regression: datasets can hold non-uuid values (legacy rows, e2e seeds). Resolving org data sources
+    // must not blow up on `orgDataSource.id` (a uuid) — a raw uuid `IN` threw "invalid input syntax for
+    // type uuid" and 500'd every reviewer/submitted page for the study.
+    it('does not throw when datasets contain non-uuid values', async () => {
+        const org = await insertTestOrg()
+        const { study } = await insertTestStudyOnly({ org })
+        await insertSnapshot(study.id, study.researcherId, 1, {
+            ...baseSource,
+            datasets: ['Student Activity Logs', 'Another Label'],
+        })
+
+        const latest = await latestProposalSnapshotForStudy(study.id)
+        expect(latest?.snapshot.datasets).toEqual(['Student Activity Logs', 'Another Label'])
+        // No matching org_data_source rows, but crucially the query resolves instead of throwing.
+        expect(latest?.orgDataSources).toEqual([])
+    })
 })
 
 describe('overlaidWithLatestProposalSnapshot', () => {

--- a/src/server/db/proposal-snapshot.test.ts
+++ b/src/server/db/proposal-snapshot.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { db, insertTestOrg, insertTestStudyOnly } from '@/tests/unit.helpers'
+import type { Json } from '@/database/types'
+import { serializeProposalSnapshot, type ProposalSnapshotSource } from '@/lib/proposal-snapshot'
+import { latestProposalSnapshotForStudy, overlaidWithLatestProposalSnapshot } from './proposal-snapshot'
+
+const baseSource: ProposalSnapshotSource = {
+    title: 'v1 title',
+    piName: 'Dr. PI',
+    piUserId: null,
+    language: 'R',
+    datasets: null,
+    dataSources: [],
+    researchQuestions: { root: 'rq-v1' },
+    projectSummary: null,
+    impact: null,
+    additionalNotes: null,
+    irbProtocols: null,
+    descriptionDocPath: null,
+    irbDocPath: null,
+    agreementDocPath: null,
+}
+
+const insertSnapshot = (studyId: string, userId: string, version: number, source: ProposalSnapshotSource) =>
+    db
+        .insertInto('studyProposalSubmission')
+        .values({
+            studyId,
+            version,
+            submittedByUserId: userId,
+            snapshot: serializeProposalSnapshot(source) as unknown as Json,
+        })
+        .execute()
+
+describe('latestProposalSnapshotForStudy', () => {
+    it('returns the highest-version snapshot', async () => {
+        const org = await insertTestOrg()
+        const { study } = await insertTestStudyOnly({ org })
+        await insertSnapshot(study.id, study.researcherId, 1, baseSource)
+        await insertSnapshot(study.id, study.researcherId, 2, { ...baseSource, title: 'v2 title' })
+
+        const latest = await latestProposalSnapshotForStudy(study.id)
+        expect(latest?.version).toBe(2)
+        expect(latest?.snapshot.title).toBe('v2 title')
+    })
+
+    it('returns null for a study with no snapshot (fresh draft)', async () => {
+        const org = await insertTestOrg()
+        const { study } = await insertTestStudyOnly({ org })
+        expect(await latestProposalSnapshotForStudy(study.id)).toBeNull()
+    })
+})
+
+describe('overlaidWithLatestProposalSnapshot', () => {
+    it('overlays snapshot proposal fields onto the study, leaving non-proposal fields intact', async () => {
+        const org = await insertTestOrg()
+        const { study } = await insertTestStudyOnly({ org })
+        await insertSnapshot(study.id, study.researcherId, 1, { ...baseSource, title: 'snapshot title' })
+
+        // A mutable study object whose title diverges from the snapshot (as during a revision draft).
+        const mutable = { id: study.id, title: 'MUTATED live title', status: 'CHANGE-REQUESTED' } as never
+
+        const overlaid = await overlaidWithLatestProposalSnapshot(study.id, mutable)
+        expect(overlaid.title).toBe('snapshot title')
+        // Non-proposal fields are preserved from the passed study.
+        expect(overlaid.status).toBe('CHANGE-REQUESTED')
+        expect(overlaid.id).toBe(study.id)
+    })
+
+    it('returns the study unchanged when no snapshot exists', async () => {
+        const org = await insertTestOrg()
+        const { study } = await insertTestStudyOnly({ org })
+        const mutable = { id: study.id, title: 'fresh draft title' } as never
+        const overlaid = await overlaidWithLatestProposalSnapshot(study.id, mutable)
+        expect(overlaid.title).toBe('fresh draft title')
+    })
+})

--- a/src/server/db/proposal-snapshot.ts
+++ b/src/server/db/proposal-snapshot.ts
@@ -96,8 +96,14 @@ export async function overlaidWithLatestProposalSnapshot(
 ): Promise<SelectedStudy> {
     const latest = await latestProposalSnapshotForStudy(studyId, db)
     if (!latest) return study
+    // OTTER-636: a revision draft renders as its last submitted version, which was change-requested (the
+    // only decision that produces a revision draft). Present that effective status so read-only feedback
+    // / submitted views treat it as a submitted proposal rather than a fresh draft; the base id is left
+    // on the object so those views can still show a "being revised" notice.
+    const isRevisionDraft = study.status === 'DRAFT' && study.proposalRevisionBaseSubmissionId != null
     return {
         ...study,
+        status: isRevisionDraft ? 'CHANGE-REQUESTED' : study.status,
         title: latest.snapshot.title,
         piName: latest.snapshot.piName,
         piUserId: latest.snapshot.piUserId,

--- a/src/server/db/proposal-snapshot.ts
+++ b/src/server/db/proposal-snapshot.ts
@@ -1,0 +1,67 @@
+import { db as defaultDb, type DBExecutor } from '@/database'
+import { parseProposalSnapshot, type ProposalSnapshot } from '@/lib/proposal-snapshot'
+import type { SelectedStudy } from '@/server/actions/study.actions'
+
+export type LatestProposalSnapshot = {
+    version: number
+    snapshot: ProposalSnapshot
+    // Resolved from the snapshot's frozen dataset ids (not the mutable study row), so a reviewer sees
+    // the datasets as they were submitted even while the researcher revises.
+    orgDataSources: { id: string; name: string }[]
+}
+
+// OTTER-636: the immutable proposal content a reviewer (and the read-only submitted views) must render
+// instead of the mutable `study` row / live Yjs. Returns null for a study that has never been submitted
+// (a fresh draft), whose only source is the mutable row it owns.
+export async function latestProposalSnapshotForStudy(
+    studyId: string,
+    db: DBExecutor = defaultDb,
+): Promise<LatestProposalSnapshot | null> {
+    const row = await db
+        .selectFrom('studyProposalSubmission')
+        .select(['version', 'snapshot'])
+        .where('studyId', '=', studyId)
+        .orderBy('version', 'desc')
+        .limit(1)
+        .executeTakeFirst()
+    if (!row) return null
+
+    const snapshot = parseProposalSnapshot(row.snapshot)
+    const datasets = snapshot.datasets ?? []
+    const orgDataSources = datasets.length
+        ? await db.selectFrom('orgDataSource').select(['id', 'name']).where('id', 'in', datasets).execute()
+        : []
+    return { version: row.version, snapshot, orgDataSources }
+}
+
+// OTTER-636: overlay the latest immutable submitted-proposal snapshot onto a fetched study for any
+// read-only proposal surface (reviewer /review, researcher /view, /submitted). Reviewers and read-only
+// researcher views must show the last submitted proposal, never the mutable study row / live revision
+// draft. A study with no snapshot yet (a fresh, never-submitted draft) is returned unchanged — its own
+// mutable row is the only source and it belongs to the researcher.
+export async function overlaidWithLatestProposalSnapshot(
+    studyId: string,
+    study: SelectedStudy,
+    db: DBExecutor = defaultDb,
+): Promise<SelectedStudy> {
+    const latest = await latestProposalSnapshotForStudy(studyId, db)
+    if (!latest) return study
+    return {
+        ...study,
+        title: latest.snapshot.title,
+        piName: latest.snapshot.piName,
+        piUserId: latest.snapshot.piUserId,
+        language: latest.snapshot.language,
+        datasets: latest.snapshot.datasets,
+        dataSources: latest.snapshot.dataSources,
+        researchQuestions: latest.snapshot.researchQuestions as SelectedStudy['researchQuestions'],
+        projectSummary: latest.snapshot.projectSummary as SelectedStudy['projectSummary'],
+        impact: latest.snapshot.impact as SelectedStudy['impact'],
+        additionalNotes: latest.snapshot.additionalNotes as SelectedStudy['additionalNotes'],
+        irbProtocols: latest.snapshot.irbProtocols,
+        descriptionDocPath: latest.snapshot.descriptionDocPath,
+        irbDocPath: latest.snapshot.irbDocPath,
+        agreementDocPath: latest.snapshot.agreementDocPath,
+        orgDataSources: latest.orgDataSources,
+    }
+}

--- a/src/server/db/proposal-snapshot.ts
+++ b/src/server/db/proposal-snapshot.ts
@@ -1,6 +1,56 @@
 import { db as defaultDb, type DBExecutor } from '@/database'
-import { parseProposalSnapshot, type ProposalSnapshot } from '@/lib/proposal-snapshot'
+import type { Json } from '@/database/types'
+import { parseProposalSnapshot, serializeProposalSnapshot, type ProposalSnapshot } from '@/lib/proposal-snapshot'
 import type { SelectedStudy } from '@/server/actions/study.actions'
+
+// OTTER-636: capture an immutable snapshot of a study's current canonical proposal columns as the next
+// submission version. Called inside the submission transaction by both the fresh-submit (finalize) and
+// resubmit paths, so every submission produces exactly one immutable version and reviewers always have a
+// safe source to read. Version = max(existing) + 1 (so a fresh submit is v1, each resubmit the next).
+export async function writeProposalSubmissionSnapshot(
+    db: DBExecutor,
+    studyId: string,
+    submittedByUserId: string,
+): Promise<number> {
+    const study = await db
+        .selectFrom('study')
+        .select([
+            'title',
+            'piName',
+            'piUserId',
+            'language',
+            'datasets',
+            'dataSources',
+            'researchQuestions',
+            'projectSummary',
+            'impact',
+            'additionalNotes',
+            'irbProtocols',
+            'descriptionDocPath',
+            'irbDocPath',
+            'agreementDocPath',
+        ])
+        .where('id', '=', studyId)
+        .executeTakeFirstOrThrow()
+
+    const maxRow = await db
+        .selectFrom('studyProposalSubmission')
+        .select((eb) => eb.fn.max('version').as('max'))
+        .where('studyId', '=', studyId)
+        .executeTakeFirst()
+    const version = Number(maxRow?.max ?? 0) + 1
+
+    await db
+        .insertInto('studyProposalSubmission')
+        .values({
+            studyId,
+            version,
+            submittedByUserId,
+            snapshot: serializeProposalSnapshot(study) as unknown as Json,
+        })
+        .execute()
+    return version
+}
 
 export type LatestProposalSnapshot = {
     version: number

--- a/src/server/db/proposal-snapshot.ts
+++ b/src/server/db/proposal-snapshot.ts
@@ -1,3 +1,4 @@
+import { sql } from 'kysely'
 import { db as defaultDb, type DBExecutor } from '@/database'
 import type { Json } from '@/database/types'
 import { parseProposalSnapshot, serializeProposalSnapshot, type ProposalSnapshot } from '@/lib/proposal-snapshot'
@@ -78,8 +79,15 @@ export async function latestProposalSnapshotForStudy(
 
     const snapshot = parseProposalSnapshot(row.snapshot)
     const datasets = snapshot.datasets ?? []
+    // Compare on id::text (mirrors fetchStudyQuery), not `id IN (...)`. `orgDataSource.id` is a uuid, and
+    // datasets can hold non-uuid values (legacy rows, e2e seeds); a raw uuid `IN` would make Postgres
+    // throw "invalid input syntax for type uuid" and 500 every reviewer/submitted page for that study.
     const orgDataSources = datasets.length
-        ? await db.selectFrom('orgDataSource').select(['id', 'name']).where('id', 'in', datasets).execute()
+        ? await db
+              .selectFrom('orgDataSource')
+              .select(['id', 'name'])
+              .where(sql<boolean>`"org_data_source"."id"::text = ANY(${datasets})`)
+              .execute()
         : []
     return { version: row.version, snapshot, orgDataSources }
 }

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -10,6 +10,7 @@ import { Action } from '../actions/action'
 import { fetchFileContents } from '@/server/storage'
 import type { PublicKey } from 'si-encryption/job-results/types'
 import type { AnalysisReport } from '@/server/agents/review-agent/types'
+import type { CodeRoundStatuses } from '@/lib/study-screen/code-predicates'
 
 export type SiUser = ClerkUser & {
     id: string
@@ -155,6 +156,51 @@ export const codeSubmissionVersion = async (studyId: string, db: DBExecutor = Ac
         .select((eb) => eb.fn.countAll().as('count'))
         .executeTakeFirst()
     return Number(row?.count ?? 0) + 1
+}
+
+// OTTER-636: the two canonical code-round status sets that drive every positive code gate
+// (see code-predicates.ts). Round identity is v7 id order, never createdAt (which is backdated).
+//  - latestAbsolute: the absolute-latest round (open-draft detection + "Code draft" display)
+//  - latestSubmitted: the latest round that reached a submission (reviewer content + resubmit gate)
+export const codeRoundStatusesForStudy = async (
+    studyId: string,
+    db: DBExecutor = Action.db,
+): Promise<CodeRoundStatuses> => {
+    const latestAbsolute = await db
+        .selectFrom('studyJob')
+        .select('id')
+        .where('studyId', '=', studyId)
+        .orderBy('id', 'desc')
+        .limit(1)
+        .executeTakeFirst()
+    if (!latestAbsolute) return { latestAbsolute: null, latestSubmitted: null }
+
+    const statusesFor = async (jobId: string) =>
+        (await db.selectFrom('jobStatusChange').select('status').where('studyJobId', '=', jobId).execute()).map(
+            (r) => r.status,
+        )
+
+    const submitted = await db
+        .selectFrom('studyJob')
+        .select('studyJob.id')
+        .where('studyJob.studyId', '=', studyId)
+        .where((eb) =>
+            eb.exists(
+                eb
+                    .selectFrom('jobStatusChange')
+                    .select('jobStatusChange.id')
+                    .whereRef('jobStatusChange.studyJobId', '=', 'studyJob.id')
+                    .where('jobStatusChange.status', '!=', 'INITIATED'),
+            ),
+        )
+        .orderBy('studyJob.id', 'desc')
+        .limit(1)
+        .executeTakeFirst()
+
+    return {
+        latestAbsolute: await statusesFor(latestAbsolute.id),
+        latestSubmitted: submitted ? await statusesFor(submitted.id) : null,
+    }
 }
 
 export const jobInfoForJobId = async (jobId: string) => {

--- a/src/server/db/study-state-query.ts
+++ b/src/server/db/study-state-query.ts
@@ -18,6 +18,8 @@ export async function rawStudyStateForStudy(
             'study.reviewerAgreementsAckedAt',
             'study.proposalResubmissionNoteDraft',
             'study.codeResubmissionNoteDraft',
+            // OTTER-636: distinguishes a revision draft from a fresh draft for reviewer routing/pill.
+            'study.proposalRevisionBaseSubmissionId',
             // Step 2 fields → hasStep2Progress (OTTER-572 draft resume).
             'study.piUserId',
             'study.datasets',

--- a/tests/e2e.seed.ts
+++ b/tests/e2e.seed.ts
@@ -16,6 +16,7 @@
 
 import { db, sql } from '@/database'
 import type { Language, StudyJobStatus, StudyStatus } from '@/database/types'
+import { writeProposalSubmissionSnapshot } from '@/server/db/proposal-snapshot'
 
 // openstax is the canonical e2e org pair: the researcher submits from the lab
 // (openstax-lab) and the reviewer reviews in the enclave (openstax). Matches the
@@ -182,6 +183,14 @@ async function insertStudy(overrides: StudyOverrides) {
         })
         .returning(['id', 'orgId', 'submittedByOrgId', 'researcherId'])
         .executeTakeFirstOrThrow()
+
+    // OTTER-636: every submitted proposal has an immutable snapshot in production (finalize writes it;
+    // the backfill covers legacy rows). Mirror that invariant here so seeded non-fresh-draft studies
+    // (PENDING-REVIEW, CHANGE-REQUESTED, APPROVED, REJECTED) carry a snapshot — otherwise the first-edit
+    // revision flip and the reviewer's snapshot reads have no source. A fresh DRAFT correctly has none.
+    if (status !== 'DRAFT') {
+        await writeProposalSubmissionSnapshot(db, study.id, researcherId)
+    }
 
     return { study, enclave, lab, researcherId, reviewerId }
 }

--- a/tests/unit.helpers.tsx
+++ b/tests/unit.helpers.tsx
@@ -1014,6 +1014,7 @@ export const mockStudyRow = (overrides: Partial<StudyRow> = {}): StudyRow => ({
     createdBy: 'Researcher Name',
     jobStatusChanges: [],
     researcherAgreementsAckedAt: null,
+    proposalRevisionBaseSubmissionId: null,
     piUserId: null,
     datasets: null,
     researchQuestions: null,


### PR DESCRIPTION
see [OTTER-636](https://openstax.atlassian.net/browse/OTTER-636)

Full-architecture implementation of the draft concept, replacing the display-only approach in #895 (which will be closed). Immutable submitted-proposal snapshots + an explicit fresh-vs-revision discriminator + an immutable code-round model, so literal proposal `DRAFT` and code Draft are safe without leaking in-progress content to reviewers.

## Core model
- `study.status` is the proposal workflow state; a proposal revision literally uses `DRAFT`.
- Fresh vs revision drafts are distinguished by `study.proposal_revision_base_submission_id`, never by `submittedAt`.
- Reviewers read the latest immutable `study_proposal_submission` snapshot, never the mutable `study` row / live Yjs.
- Code rounds are immutable; absolute-latest round drives Draft display, latest submitted round drives reviewer content; at most one open code-draft round; round identity is UUIDv7 id order.
- Every mutating action uses a positive eligibility predicate.

## Phase checklist
- [x] **Phase 1** migrations (snapshot table, revision-base FK + check + indexes, backfill) + `types.ts` (validated against the real dev DB via `migrate-dev-db`; codegen diff is empty).
- [x] **Phase 3 foundation** snapshot Zod schema/serializer + central proposal/code predicates (+ unit tests).
- [x] **Phase 4** reviewer `/review`, read-only `/view`, `/submitted`, AI review agent read the latest snapshot.
- [x] **Phase 8/9 round model** fresh `INITIATED` round after any revision-entry decision (change-requested, bare `JOB-ERRORED`, FILES-approved/rejected); per-study advisory lock; UUIDv7 identity; delete opens/reuses a round; `codeRoundStatusesForStudy` selector.
- [x] **Phase 8/9 submit gate (Finding 6)** positive `canSubmitInitialCode` gate: the initial-submit path can't overwrite reviewed code or bypass the resubmission note.
- [x] **Phase 2 / 5 (snapshots)** every submission (fresh finalize + resubmit) writes an immutable snapshot version; `finalizeStudySubmissionAction` is fresh-only; `/proposal` redirects change-requested (and revision drafts) to edit-and-resubmit (Finding 3).
- [x] **Phase 6** literal `startProposalRevisionAction` (CHANGE-REQUESTED to DRAFT + base FK, idempotent, lab-scoped); the first *local* user edit flips the study via a shared `useStartProposalRevision` hook wired through `onLocalUserEdit` on the collaborative/single-user editors (Yjs hydration and remote-collaborator updates never trigger it); editor/auth (`services/editor/auth.ts`) accepts a revision DRAFT for proposal fields/text and the resubmission note; `resubmitProposalAction` accepts a revision DRAFT and clears the base on resubmit; Resubmit is blocked while the transition is pending/failed.
- [x] **Phase 10 (reviewer dashboard)** reviewers now see a revision draft (change-requested proposal being edited) as a non-actionable "Proposal Draft" and never a fresh draft; opening it renders the last immutable submitted snapshot + existing feedback read-only (routed to `reviewer-proposal-feedback`), never the mutable draft; the researcher dashboard routes a revision draft straight to edit-and-resubmit with no delete affordance. Threaded `isProposalRevisionDraft` through the study-state projection.
- [x] **Phase 7 (create)** lazy-create a fresh draft the moment a Data Partner is chosen (the first persistable Step-1 edit), not only on "Proceed to Step 2"; subsequent Step-1 edits autosave; the Data Partner selector locks once the draft exists. Duplicate-create is guarded by a synchronous id ref.
- [x] **Phase 10 auth** `load IDE` is scoped to the submitting lab (plus the author) in `src/lib/permissions.ts`, so a member of an unrelated lab can no longer open another lab's workspace. Applied with explicit sign-off; the IDE ability subject gained `submittedByOrgId`.
- [x] **Query invalidation** every transition refetches the dashboards: lazy-create + code submit/resubmit invalidate the researcher study keys, the revision flip invalidates both researcher and reviewer keys, proposal resubmit / reviewer decisions revalidate the dashboard + review paths.

## Verification
Dev stack runs under Docker; migrations applied to the real dev DB and `types.ts` regen produced no diff. Every commit is `pnpm run checks`-green and the full unit suite passes under `./bin/docker-test` (currently 219 files / 2010 tests).

## Review round (addressed)
- **Resubmit is strict (architecture §4/§7):** `resubmitProposalAction` accepts only a revision `DRAFT` (non-null base) via `canResubmitProposal`; `startProposalRevisionAction` fails visibly if a submitted study somehow has no snapshot; Resubmit stays disabled until the first-edit flip commits. The e2e seed now writes an immutable snapshot for every submitted study (mirroring finalize/backfill), which is what lets the flip succeed in tests.
- **Selection is not an edit:** the editor `onLocalUserEdit` fires only on real content mutations (`dirtyElements`/`dirtyLeaves`), never on focus/cursor moves — honoring the Jira non-trigger.
- **Revision drafts protected:** cannot be soft-deleted (submitted history preserved); `/edit` redirects them to the lab-gated `/edit-and-resubmit`.
- **Cache:** the flip invalidates both researcher and reviewer dashboard key families by prefix.
- **Snapshot dataset resolution** uses `id::text = ANY(...)` (uuid `IN` on non-uuid dataset labels 500'd reviewer pages).

## Notes
- Collaborative editor / two-session reviewer flows need manual QA (not unit-testable). In particular: the first-edit DRAFT flip across two collaborators, and a reviewer viewing a revision draft while a researcher edits it.
- The reviewer's read-only view of a revision draft reuses the existing change-requested feedback screen (the snapshot overlay presents its effective status as change-requested), so the standard "clarification requested, you'll be notified once they resubmit" banner already conveys that reviewer action is unavailable.
- Deferred (known-incomplete architecture items, not regressions): code-lifecycle correctness (concurrency claim-inside-lock, positive launch/upload/delete gates, dashboard code-draft representation, bare `JOB-ERRORED` resubmit wiring), server-side rejection of proposal decisions on revision drafts, and single-user proposal-field autosave.

[OTTER-636]: https://openstax.atlassian.net/browse/OTTER-636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
