### PR TITLE
enforce draft privacy from Data Organizations on the backend

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/view/job-results-status-message.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/job-results-status-message.test.tsx
@@ -23,6 +23,7 @@ describe('JobResultsStatusMessage', () => {
         id: 'job-123',
         studyId: 'study-456',
         orgId: 'org-789',
+        status: 'APPROVED',
         language: 'PYTHON',
         statusChanges: statuses.map((status) => ({
             status,

--- a/src/app/dl/study-code/[jobId]/[fileName]/route.test.ts
+++ b/src/app/dl/study-code/[jobId]/[fileName]/route.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest'
+import * as apiHandler from './route'
+import { db } from '@/database'
+import { urlForStudyJobCodeFile } from '@/server/storage'
+import { createTestProposalDraft, mockSessionWithTestData, setTestStudyStatus } from '@/tests/unit.helpers'
+
+// The route only reads the DB row for auth + path; stub the signed-URL helper so the redirect case
+// doesn't need S3.
+vi.mock('@/server/storage', async () => {
+    const actual = await vi.importActual<typeof import('@/server/storage')>('@/server/storage')
+    return { ...actual, urlForStudyJobCodeFile: vi.fn(async () => 'https://signed.example/main.r') }
+})
+
+function request() {
+    return new Request('http://localhost/dl/study-code/x/main.r', { method: 'GET' })
+}
+
+// Attach a code job + MAIN-CODE file to the draft so there is something to download.
+async function seedCodeJob(studyId: string) {
+    const job = await db.insertInto('studyJob').values({ studyId }).returning('id').executeTakeFirstOrThrow()
+    await db
+        .insertInto('studyJobFile')
+        .values({ studyJobId: job.id, name: 'main.r', path: `code/${studyId}/main.r`, fileType: 'MAIN-CODE' })
+        .execute()
+    return job.id
+}
+
+describe('GET /dl/study-code/[jobId]/[fileName] (OTTER-596)', () => {
+    it('returns 401 to a Data Organization member while the study is an unsubmitted draft', async () => {
+        const { enclave, studyId } = await createTestProposalDraft({ enclaveSlug: 'dl-code-draft-enclave' })
+        const jobId = await seedCodeJob(studyId)
+
+        await mockSessionWithTestData({ orgSlug: enclave.slug, orgType: 'enclave' })
+        const resp = await apiHandler.GET(request(), { params: Promise.resolve({ jobId, fileName: 'main.r' }) })
+
+        expect(resp.status).toBe(401)
+    })
+
+    it('redirects a Data Organization member to the signed URL once the study is submitted', async () => {
+        const { enclave, studyId } = await createTestProposalDraft({ enclaveSlug: 'dl-code-submitted-enclave' })
+        const jobId = await seedCodeJob(studyId)
+        await setTestStudyStatus(studyId, 'PENDING-REVIEW')
+
+        await mockSessionWithTestData({ orgSlug: enclave.slug, orgType: 'enclave' })
+        const resp = await apiHandler.GET(request(), { params: Promise.resolve({ jobId, fileName: 'main.r' }) })
+
+        expect(resp.status).toBe(307)
+        expect(resp.headers.get('location')).toBe('https://signed.example/main.r')
+        expect(vi.mocked(urlForStudyJobCodeFile)).toHaveBeenCalled()
+    })
+})

--- a/src/app/dl/study-documents/[studyId]/[fileType]/[fileName]/route.test.ts
+++ b/src/app/dl/study-documents/[studyId]/[fileType]/[fileName]/route.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+import * as apiHandler from './route'
+import { urlForStudyDocumentFile } from '@/server/storage'
+import { createTestProposalDraft, mockSessionWithTestData, setTestStudyStatus } from '@/tests/unit.helpers'
+
+// The route only reads the DB row for auth; stub the signed-URL helper so the redirect case doesn't
+// need S3.
+vi.mock('@/server/storage', async () => {
+    const actual = await vi.importActual<typeof import('@/server/storage')>('@/server/storage')
+    return { ...actual, urlForStudyDocumentFile: vi.fn(async () => 'https://signed.example/description.pdf') }
+})
+
+function request() {
+    return new Request('http://localhost/dl/study-documents/x/DESCRIPTION/description.pdf', { method: 'GET' })
+}
+
+function params(studyId: string) {
+    return { params: Promise.resolve({ studyId, fileType: 'DESCRIPTION', fileName: 'description.pdf' }) }
+}
+
+describe('GET /dl/study-documents/[studyId]/[fileType]/[fileName] (OTTER-596)', () => {
+    it('returns 401 to a Data Organization member while the study is an unsubmitted draft', async () => {
+        const { enclave, studyId } = await createTestProposalDraft({ enclaveSlug: 'dl-docs-draft-enclave' })
+
+        await mockSessionWithTestData({ orgSlug: enclave.slug, orgType: 'enclave' })
+        const resp = await apiHandler.GET(request(), params(studyId))
+
+        expect(resp.status).toBe(401)
+    })
+
+    it('redirects a Data Organization member to the signed URL once the study is submitted', async () => {
+        const { enclave, studyId } = await createTestProposalDraft({ enclaveSlug: 'dl-docs-submitted-enclave' })
+        await setTestStudyStatus(studyId, 'PENDING-REVIEW')
+
+        await mockSessionWithTestData({ orgSlug: enclave.slug, orgType: 'enclave' })
+        const resp = await apiHandler.GET(request(), params(studyId))
+
+        expect(resp.status).toBe(307)
+        expect(resp.headers.get('location')).toBe('https://signed.example/description.pdf')
+        expect(vi.mocked(urlForStudyDocumentFile)).toHaveBeenCalled()
+    })
+})

--- a/src/components/study/job-approval-status.test.tsx
+++ b/src/components/study/job-approval-status.test.tsx
@@ -11,6 +11,7 @@ describe('ApprovalStatus', () => {
         id: 'test-id',
         studyId: 'study-1',
         orgId: 'org-1',
+        status: 'APPROVED',
         language: 'R',
         createdAt: new Date('2024-03-03T00:00:00Z'),
         statusChanges: [],

--- a/src/lib/permission-types.ts
+++ b/src/lib/permission-types.ts
@@ -1,6 +1,7 @@
 import { MongoAbility } from '@casl/ability'
 import { UUID } from './types'
 import { ContextName } from './agent-context'
+import type { StudyStatus } from '@/database/types'
 
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
 type Ability<Kind extends string, Actions extends string, Properties extends Record<string, any>> = [
@@ -43,9 +44,15 @@ type Abilities =
     | Ability<'OrgMembers', 'view', { orgId: UUID }>
     | Ability<'Studies', 'view', object>
     | Ability<'OrgStudies', 'view', { orgType: 'enclave' | 'lab'; orgId?: UUID; submittedByOrgId?: UUID }>
-    | Ability<'Study', 'view' | 'create', { orgId?: UUID; submittedByOrgId?: UUID }>
-    | Ability<'Study', 'review' | 'approve' | 'reject' | 'update' | 'delete', { orgId?: UUID; submittedByOrgId?: UUID }>
-    | Ability<'StudyJob', 'view' | 'create', { orgId?: UUID; submittedByOrgId?: UUID }>
+    | Ability<'Study', 'view' | 'create', { orgId?: UUID; submittedByOrgId?: UUID; status?: StudyStatus }>
+    | Ability<
+          'Study',
+          'review' | 'approve' | 'reject' | 'update' | 'delete',
+          // `status` is unused by these actions but must appear in every 'Study' ability arm so the
+          // CASL MongoQuery/subject union accepts a `status` condition on the view rule.
+          { orgId?: UUID; submittedByOrgId?: UUID; status?: StudyStatus }
+      >
+    | Ability<'StudyJob', 'view' | 'create', { orgId?: UUID; submittedByOrgId?: UUID; status?: StudyStatus }>
     // Renamed from 'ReviewerKey' — every user holds this key now, not just reviewers, so the old
     // name was misleading. Route + UI copy: /user-key (Routes.userKey), "Security key".
     | Ability<'UserKey', 'view' | 'update', object>

--- a/src/lib/permissions.test.ts
+++ b/src/lib/permissions.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from 'vitest'
 
 import type { UserSession, UserOrgRoles } from './types'
+import type { StudyStatus } from '@/database/types'
 import { faker } from '@faker-js/faker'
 import { defineAbilityFor, toRecord } from './permissions'
 
@@ -45,6 +46,41 @@ test('reviewer role', () => {
     // enclave members hold a key to decrypt results for review
     expect(ability.can('view', 'UserKey')).toBe(true)
     expect(ability.can('update', 'UserKey')).toBe(true)
+})
+
+test('reviewer cannot view unsubmitted drafts, but can view submitted studies (OTTER-596)', () => {
+    const { ability, session } = createAbilty({}, 'enclave')
+    const orgId = session.orgs.test.id
+
+    // Data Organization (enclave reviewer) must NOT see an unsubmitted draft, even with the org id
+    const draft: StudyStatus = 'DRAFT'
+    expect(ability.can('view', toRecord('Study', { orgId, status: draft }))).toBe(false)
+    expect(ability.can('view', toRecord('StudyJob', { orgId, status: draft }))).toBe(false)
+
+    // ...but keeps access to every submitted status (incl. CHANGE-REQUESTED resubmissions)
+    const submitted: StudyStatus[] = ['PENDING-REVIEW', 'CHANGE-REQUESTED', 'APPROVED', 'REJECTED', 'ARCHIVED']
+    for (const status of submitted) {
+        expect(ability.can('view', toRecord('Study', { orgId, status }))).toBe(true)
+        expect(ability.can('view', toRecord('StudyJob', { orgId, status }))).toBe(true)
+    }
+
+    // Fail-closed: a subject that omits status is denied rather than silently granted
+    expect(ability.can('view', toRecord('Study', { orgId }))).toBe(false)
+    expect(ability.can('view', toRecord('StudyJob', { orgId }))).toBe(false)
+})
+
+test('lab members can still view their own lab drafts (OTTER-596 regression guard)', () => {
+    const { ability, session } = createAbilty({}, 'lab')
+    const submittedByOrgId = session.orgs.test.id
+    const otherLabId = faker.string.uuid()
+    const draft: StudyStatus = 'DRAFT'
+
+    // The submitting Research Lab retains full draft access via the submittedByOrgId rule
+    expect(ability.can('view', toRecord('Study', { submittedByOrgId, status: draft }))).toBe(true)
+    expect(ability.can('view', toRecord('StudyJob', { submittedByOrgId, status: draft }))).toBe(true)
+
+    // ...but not another lab's draft
+    expect(ability.can('view', toRecord('Study', { submittedByOrgId: otherLabId, status: draft }))).toBe(false)
 })
 
 test('researcher role', () => {

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -11,19 +11,27 @@ import {
 
 export { subject, type AppAbility, type PermissionsActionSubjectMap, type PermissionsSubjectToObjectMap, toRecord }
 
-// Every study status except DRAFT, i.e. "has been submitted at least once". Used to gate what a
-// Data Organization (enclave reviewer) may read: unsubmitted drafts belong to the Research Lab only
-// (OTTER-596). This is a positive allowlist on purpose — the ability subject is assembled from
-// middleware-returned fields, and a mongo `$in` fails CLOSED when `status` is absent (denies),
-// whereas `$ne: 'DRAFT'` would fail OPEN (grant). A new StudyStatus must be added here or DOs will
-// not be able to view studies in that status — the safe direction for a fix about hiding content.
-const SUBMITTED_STUDY_STATUSES: StudyStatus[] = [
-    'APPROVED',
-    'ARCHIVED',
-    'CHANGE-REQUESTED',
-    'PENDING-REVIEW',
-    'REJECTED',
-]
+// Which study statuses a Data Organization (enclave reviewer) may read: every status except DRAFT,
+// i.e. "has been submitted at least once". Unsubmitted drafts belong to the Research Lab only
+// (OTTER-596). Declared as a Record<StudyStatus, …> so adding a new StudyStatus is a TypeScript error
+// until someone makes an explicit visible/hidden decision here — the one constant the whole read
+// boundary hinges on.
+const ENCLAVE_VIEWABLE_STUDY_STATUS: Record<StudyStatus, boolean> = {
+    DRAFT: false,
+    'PENDING-REVIEW': true,
+    'CHANGE-REQUESTED': true,
+    APPROVED: true,
+    REJECTED: true,
+    ARCHIVED: true,
+}
+
+// Derived allowlist used as a positive `$in` condition. Positive on purpose — the ability subject is
+// assembled from middleware-returned fields, and a mongo `$in` fails CLOSED when `status` is absent
+// (denies), whereas `$ne: 'DRAFT'` would fail OPEN (grant): the safe direction for a fix about hiding
+// content.
+const SUBMITTED_STUDY_STATUSES = (Object.keys(ENCLAVE_VIEWABLE_STUDY_STATUS) as StudyStatus[]).filter(
+    (status) => ENCLAVE_VIEWABLE_STUDY_STATUS[status],
+)
 
 export function defineAbilityFor(session: UserSession) {
     const { isSiAdmin } = session.user

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,4 +1,5 @@
 import { type UserSession, isLabOrg, isEnclaveOrg, isOrgAdmin } from './types'
+import type { StudyStatus } from '@/database/types'
 import { AbilityBuilder, createMongoAbility, subject } from '@casl/ability'
 import {
     AppAbility,
@@ -9,6 +10,20 @@ import {
 } from './permission-types'
 
 export { subject, type AppAbility, type PermissionsActionSubjectMap, type PermissionsSubjectToObjectMap, toRecord }
+
+// Every study status except DRAFT, i.e. "has been submitted at least once". Used to gate what a
+// Data Organization (enclave reviewer) may read: unsubmitted drafts belong to the Research Lab only
+// (OTTER-596). This is a positive allowlist on purpose — the ability subject is assembled from
+// middleware-returned fields, and a mongo `$in` fails CLOSED when `status` is absent (denies),
+// whereas `$ne: 'DRAFT'` would fail OPEN (grant). A new StudyStatus must be added here or DOs will
+// not be able to view studies in that status — the safe direction for a fix about hiding content.
+const SUBMITTED_STUDY_STATUSES: StudyStatus[] = [
+    'APPROVED',
+    'ARCHIVED',
+    'CHANGE-REQUESTED',
+    'PENDING-REVIEW',
+    'REJECTED',
+]
 
 export function defineAbilityFor(session: UserSession) {
     const { isSiAdmin } = session.user
@@ -43,8 +58,11 @@ export function defineAbilityFor(session: UserSession) {
     // researchers need to be able to view enclave orgs to create studies
     permit('view', 'Org')
 
-    permit('view', 'Study', { orgId: { $in: usersReviewerOrgIds } })
-    permit('view', 'StudyJob', { orgId: { $in: usersReviewerOrgIds } })
+    // Enclave (Data Organization) reviewers may only view SUBMITTED studies/jobs. Unsubmitted drafts
+    // (proposal content + uploaded code) stay private to the submitting Research Lab, which retains
+    // access via the submittedByOrgId rules below (OTTER-596).
+    permit('view', 'Study', { orgId: { $in: usersReviewerOrgIds }, status: { $in: SUBMITTED_STUDY_STATUSES } })
+    permit('view', 'StudyJob', { orgId: { $in: usersReviewerOrgIds }, status: { $in: SUBMITTED_STUDY_STATUSES } })
 
     permit('view', 'Study', { submittedByOrgId: { $in: usersResearcherOrgIds } })
     permit('view', 'StudyJob', { submittedByOrgId: { $in: usersResearcherOrgIds } })

--- a/src/server/actions/editor.actions.ts
+++ b/src/server/actions/editor.actions.ts
@@ -8,10 +8,10 @@ export const getYjsDocumentUpdatedAtAction = new Action('getYjsDocumentUpdatedAt
     .middleware(async ({ params: { studyId }, db }) => {
         const study = await db
             .selectFrom('study')
-            .select(['id', 'orgId', 'submittedByOrgId'])
+            .select(['id', 'orgId', 'submittedByOrgId', 'status'])
             .where('id', '=', studyId)
             .executeTakeFirstOrThrow(throwNotFound('study'))
-        return { orgId: study.orgId, submittedByOrgId: study.submittedByOrgId }
+        return { orgId: study.orgId, submittedByOrgId: study.submittedByOrgId, status: study.status }
     })
     .requireAbilityTo('view', 'Study')
     .handler(async ({ db, params: { documentName } }) => {
@@ -32,10 +32,10 @@ export const getStudyStatusAction = new Action('getStudyStatusAction')
     .middleware(async ({ params: { studyId }, db }) => {
         const study = await db
             .selectFrom('study')
-            .select(['id', 'orgId', 'submittedByOrgId'])
+            .select(['id', 'orgId', 'submittedByOrgId', 'status'])
             .where('id', '=', studyId)
             .executeTakeFirstOrThrow(throwNotFound('study'))
-        return { orgId: study.orgId, submittedByOrgId: study.submittedByOrgId }
+        return { orgId: study.orgId, submittedByOrgId: study.submittedByOrgId, status: study.status }
     })
     .requireAbilityTo('view', 'Study')
     .handler(async ({ db, params: { studyId } }) => {

--- a/src/server/actions/researcher-profile.actions.ts
+++ b/src/server/actions/researcher-profile.actions.ts
@@ -160,10 +160,10 @@ export const getResearcherProfileByUserIdAction = new Action('getResearcherProfi
     .middleware(async ({ params: { studyId }, db }) => {
         const study = await db
             .selectFrom('study')
-            .select(['orgId', 'submittedByOrgId'])
+            .select(['orgId', 'submittedByOrgId', 'status'])
             .where('id', '=', studyId)
             .executeTakeFirstOrThrow(throwNotFound('Study'))
-        return { orgId: study.orgId, submittedByOrgId: study.submittedByOrgId }
+        return { orgId: study.orgId, submittedByOrgId: study.submittedByOrgId, status: study.status }
     })
     .requireAbilityTo('view', 'Study')
     .handler(async ({ params: { userId }, db }) => {

--- a/src/server/actions/study-job.actions.test.ts
+++ b/src/server/actions/study-job.actions.test.ts
@@ -7,10 +7,13 @@ import {
     insertTestUser,
     mockClerkSession,
     mockSessionWithTestData,
+    createTestProposalDraft,
+    setTestStudyStatus,
 } from '@/tests/unit.helpers'
 import {
     approveStudyJobFilesAction,
     fetchEncryptedJobFilesAction,
+    fetchStudyJobCodeFileAction,
     loadStudyJobAction,
     regenerateStudyReviewAction,
     rejectStudyJobFilesAction,
@@ -21,6 +24,7 @@ import { fetchStudiesForOrgAction } from './study.actions'
 import { dashboardRawStateFromRow } from '@/components/dashboard/studies-table/dashboard-raw-state'
 import type { StudyRow } from '@/components/dashboard/studies-table/types'
 import { projectStudyState, resolvePillStatus } from '@/lib/study-screen'
+import logger from '@/lib/logger'
 
 vi.mock('@/server/storage', () => ({
     fetchCodeManifest: vi.fn(() => ({})),
@@ -312,5 +316,40 @@ describe('Study Job Actions', () => {
                 .executeTakeFirst()
             expect(remaining).toBeDefined()
         })
+    })
+})
+
+describe('draft code files are private to the Research Lab (OTTER-596)', () => {
+    // Attach a code file to the draft's own studyJob so there is something to fetch.
+    const seedCodeFile = async (studyId: string) => {
+        const job = await db.insertInto('studyJob').values({ studyId }).returning('id').executeTakeFirstOrThrow()
+        await db
+            .insertInto('studyJobFile')
+            .values({ studyJobId: job.id, name: 'main.r', path: `code/${studyId}/main.r`, fileType: 'MAIN-CODE' })
+            .execute()
+        return job.id
+    }
+
+    test('data-org member cannot fetch a code file for an unsubmitted draft', async () => {
+        const { enclave, studyId } = await createTestProposalDraft({ enclaveSlug: 'otter596-code-draft-enclave' })
+        const studyJobId = await seedCodeFile(studyId)
+
+        await mockSessionWithTestData({ orgSlug: enclave.slug, orgType: 'enclave' })
+        vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+
+        const result = await fetchStudyJobCodeFileAction({ studyJobId, fileName: 'main.r' })
+        expect(result).toMatchObject({
+            error: expect.objectContaining({ permission_denied: expect.any(String) }),
+        })
+    })
+
+    test('data-org member can fetch a code file once the study is submitted', async () => {
+        const { enclave, studyId } = await createTestProposalDraft({ enclaveSlug: 'otter596-code-submitted-enclave' })
+        const studyJobId = await seedCodeFile(studyId)
+        await setTestStudyStatus(studyId, 'PENDING-REVIEW')
+
+        await mockSessionWithTestData({ orgSlug: enclave.slug, orgType: 'enclave' })
+        const result = actionResult(await fetchStudyJobCodeFileAction({ studyJobId, fileName: 'main.r' }))
+        expect(result).toMatchObject({ fileName: 'main.r' })
     })
 })

--- a/src/server/actions/study-job.actions.ts
+++ b/src/server/actions/study-job.actions.ts
@@ -79,7 +79,7 @@ export const fetchSharedFileIdsAction = new Action('fetchSharedFileIdsAction')
     .params(z.object({ jobId: z.string() }))
     .middleware(async ({ params: { jobId } }) => {
         const studyJob = await getStudyJobInfo(jobId)
-        return { studyJob, orgId: studyJob.orgId }
+        return { studyJob, orgId: studyJob.orgId, status: studyJob.status }
     })
     .requireAbilityTo('view', 'StudyJob')
     .handler(async ({ params: { jobId } }) => {
@@ -121,7 +121,7 @@ export const loadStudyJobAction = new Action('loadStudyJobAction')
     .params(z.object({ studyJobId: z.string() }))
     .middleware(async ({ params: { studyJobId } }) => {
         const studyJob = await getStudyJobInfo(studyJobId)
-        return { studyJob, orgId: studyJob.orgId, submittedByOrgId: studyJob.submittedByOrgId } // orgId is validated in requireAbilityTo below
+        return { studyJob, orgId: studyJob.orgId, submittedByOrgId: studyJob.submittedByOrgId, status: studyJob.status } // orgId + status are validated in requireAbilityTo below
     })
     .requireAbilityTo('view', 'StudyJob')
     .handler(async ({ studyJob }) => {
@@ -134,7 +134,7 @@ export const latestJobForStudyAction = new Action('latestJobForStudyAction')
         if (!session) throw new ActionFailure({ user: 'Unauthorized' })
 
         const studyJob = await latestJobForStudy(studyId)
-        return { studyJob, orgId: studyJob.orgId } // Return the job along with the orgId for validation in requireAbilityTo below
+        return { studyJob, orgId: studyJob.orgId, status: studyJob.status } // Return the job along with the orgId + status for validation in requireAbilityTo below
     })
     .requireAbilityTo('view', 'StudyJob')
     .handler(async ({ studyJob }) => studyJob)
@@ -143,7 +143,7 @@ export const getStudyReviewAction = new Action('getStudyReviewAction')
     .params(z.object({ studyJobId: z.string() }))
     .middleware(async ({ params: { studyJobId } }) => {
         const studyJob = await getStudyJobInfo(studyJobId)
-        return { studyJob, orgId: studyJob.orgId, submittedByOrgId: studyJob.submittedByOrgId }
+        return { studyJob, orgId: studyJob.orgId, submittedByOrgId: studyJob.submittedByOrgId, status: studyJob.status }
     })
     .requireAbilityTo('view', 'StudyJob')
     .handler(async ({ params: { studyJobId } }) => {
@@ -158,7 +158,7 @@ export const regenerateStudyReviewAction = new Action('regenerateStudyReviewActi
     .params(z.object({ studyJobId: z.string() }))
     .middleware(async ({ params: { studyJobId } }) => {
         const studyJob = await getStudyJobInfo(studyJobId)
-        return { studyJob, orgId: studyJob.orgId, submittedByOrgId: studyJob.submittedByOrgId }
+        return { studyJob, orgId: studyJob.orgId, submittedByOrgId: studyJob.submittedByOrgId, status: studyJob.status }
     })
     .requireAbilityTo('view', 'StudyJob')
     .handler(async ({ params: { studyJobId }, db }) => {
@@ -174,7 +174,7 @@ export const fetchApprovedJobFilesAction = new Action('fetchApprovedJobFilesActi
     .params(z.object({ studyJobId: z.string() }))
     .middleware(async ({ params: { studyJobId } }) => {
         const studyJob = await getStudyJobInfo(studyJobId)
-        return { studyJob, orgId: studyJob.orgId, submittedByOrgId: studyJob.submittedByOrgId } // Return the jobInfo along with the orgId for validation in requireAbilityTo below
+        return { studyJob, orgId: studyJob.orgId, submittedByOrgId: studyJob.submittedByOrgId, status: studyJob.status } // Return the jobInfo along with the orgId + status for validation in requireAbilityTo below
     })
     .requireAbilityTo('view', 'StudyJob')
 
@@ -201,7 +201,7 @@ export const fetchStudyJobCodeFileAction = new Action('fetchStudyJobCodeFileActi
     .params(z.object({ studyJobId: z.string(), fileName: z.string() }))
     .middleware(async ({ params: { studyJobId } }) => {
         const studyJob = await getStudyJobInfo(studyJobId)
-        return { studyJob, orgId: studyJob.orgId, submittedByOrgId: studyJob.submittedByOrgId }
+        return { studyJob, orgId: studyJob.orgId, submittedByOrgId: studyJob.submittedByOrgId, status: studyJob.status }
     })
     .requireAbilityTo('view', 'StudyJob')
     .handler(async ({ studyJob, params: { fileName } }) => {
@@ -226,7 +226,7 @@ export const fetchEncryptedJobFilesAction = new Action('fetchEncryptedJobFilesAc
         const studyJob = await getStudyJobInfo(jobId)
         // Include submittedByOrgId so 'view StudyJob' matches lab researchers, not just enclave
         // reviewers — researchers fetch their own re-wrapped result files here.
-        return { studyJob, orgId: studyJob.orgId, submittedByOrgId: studyJob.submittedByOrgId }
+        return { studyJob, orgId: studyJob.orgId, submittedByOrgId: studyJob.submittedByOrgId, status: studyJob.status }
     })
     .requireAbilityTo('view', 'StudyJob')
 

--- a/src/server/actions/study-request.ts
+++ b/src/server/actions/study-request.ts
@@ -476,7 +476,7 @@ export const getDraftStudyAction = new Action('getDraftStudyAction')
             .where('study.id', '=', studyId)
             .where('study.status', 'in', ['DRAFT', 'CHANGE-REQUESTED', 'APPROVED'])
             .executeTakeFirstOrThrow(throwNotFound('Draft study'))
-        return { study, orgId: study.orgId, submittedByOrgId: study.submittedByOrgId }
+        return { study, orgId: study.orgId, submittedByOrgId: study.submittedByOrgId, status: study.status }
     })
     .requireAbilityTo('view', 'Study')
     .handler(async ({ db, study }) => {

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -500,6 +500,45 @@ describe('Study Actions', () => {
         })
     })
 
+    describe('unsubmitted drafts are private to the Research Lab (OTTER-596)', () => {
+        it('data-org (enclave) member cannot getStudyAction an unsubmitted draft by id', async () => {
+            const { enclave, studyId } = await createTestProposalDraft({ enclaveSlug: 'otter596-draft-enclave' })
+
+            // Switch to a member of the reviewing Data Organization (enclave) that owns study.orgId.
+            await mockSessionWithTestData({ orgSlug: enclave.slug, orgType: 'enclave' })
+            vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+
+            const result = await getStudyAction({ studyId })
+            expect(result).toMatchObject({
+                error: expect.objectContaining({ permission_denied: expect.any(String) }),
+            })
+        })
+
+        it('data-org member CAN getStudyAction once the study is submitted', async () => {
+            const { enclave, studyId } = await createTestProposalDraft({ enclaveSlug: 'otter596-submitted-enclave' })
+            await setTestStudyStatus(studyId, 'PENDING-REVIEW')
+
+            await mockSessionWithTestData({ orgSlug: enclave.slug, orgType: 'enclave' })
+            await expect(getStudyAction({ studyId })).resolves.toMatchObject({ id: studyId })
+        })
+
+        it('data-org member CAN getStudyAction a CHANGE-REQUESTED resubmission', async () => {
+            const { enclave, studyId } = await createTestProposalDraft({ enclaveSlug: 'otter596-changereq-enclave' })
+            await setTestStudyStatus(studyId, 'CHANGE-REQUESTED')
+
+            await mockSessionWithTestData({ orgSlug: enclave.slug, orgType: 'enclave' })
+            await expect(getStudyAction({ studyId })).resolves.toMatchObject({ id: studyId })
+        })
+
+        it('lab teammate can still getStudyAction their own unsubmitted draft', async () => {
+            const { lab, studyId } = await createTestProposalDraft({ enclaveSlug: 'otter596-labaccess-enclave' })
+
+            // A different member of the submitting lab.
+            await mockSessionWithTestData({ orgSlug: lab.slug, orgType: 'lab' })
+            await expect(getStudyAction({ studyId })).resolves.toMatchObject({ id: studyId })
+        })
+    })
+
     it('DRAFT studies have lastUpdatedAt defaulting to creation time', async () => {
         const { lab, studyId } = await createTestProposalDraft({
             enclaveSlug: 'last-updated-draft-enclave',

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -31,6 +31,7 @@ import {
     submitCodeReviewDecisionAction,
     submitProposalReviewAction,
 } from './study.actions'
+import { finalizeStudySubmissionAction } from './study-request'
 import { purgeReviewFeedbackYjsDocBeforeAt } from '@/server/db/yjs-cleanup'
 import { lexicalJson } from '@/lib/lexical'
 
@@ -536,6 +537,53 @@ describe('Study Actions', () => {
             // A different member of the submitting lab.
             await mockSessionWithTestData({ orgSlug: lab.slug, orgType: 'lab' })
             await expect(getStudyAction({ studyId })).resolves.toMatchObject({ id: studyId })
+        })
+
+        // Guards the status-flip bypass: without a server-side PENDING-REVIEW check, a DO reviewer
+        // could approve/reject a DRAFT to move it into a viewable status and then read it.
+        it('data-org member cannot approve an unsubmitted draft, and status stays DRAFT', async () => {
+            const { enclave, studyId } = await createTestProposalDraft({ enclaveSlug: 'otter596-approve-draft' })
+
+            await mockSessionWithTestData({ orgSlug: enclave.slug, orgType: 'enclave' })
+            const result = await approveStudyProposalAction({ studyId, orgSlug: enclave.slug })
+
+            expect(result).toMatchObject({ error: expect.objectContaining({ study: expect.any(String) }) })
+            const row = await db
+                .selectFrom('study')
+                .select('status')
+                .where('id', '=', studyId)
+                .executeTakeFirstOrThrow()
+            expect(row.status).toBe('DRAFT')
+        })
+
+        it('data-org member cannot reject an unsubmitted draft, and status stays DRAFT', async () => {
+            const { enclave, studyId } = await createTestProposalDraft({ enclaveSlug: 'otter596-reject-draft' })
+
+            await mockSessionWithTestData({ orgSlug: enclave.slug, orgType: 'enclave' })
+            const result = await rejectStudyProposalAction({ studyId, orgSlug: enclave.slug })
+
+            expect(result).toMatchObject({ error: expect.objectContaining({ study: expect.any(String) }) })
+            const row = await db
+                .selectFrom('study')
+                .select('status')
+                .where('id', '=', studyId)
+                .executeTakeFirstOrThrow()
+            expect(row.status).toBe('DRAFT')
+        })
+
+        // AC3: Research Lab collaboration is unaffected — a lab member can still submit their draft.
+        it('lab member can still submit their own draft (DRAFT to PENDING-REVIEW)', async () => {
+            const { lab, studyId } = await createTestProposalDraft({ enclaveSlug: 'otter596-lab-submit' })
+
+            await mockSessionWithTestData({ orgSlug: lab.slug, orgType: 'lab' })
+            await expect(finalizeStudySubmissionAction({ studyId })).resolves.toMatchObject({ studyId })
+
+            const row = await db
+                .selectFrom('study')
+                .select('status')
+                .where('id', '=', studyId)
+                .executeTakeFirstOrThrow()
+            expect(row.status).toBe('PENDING-REVIEW')
         })
     })
 

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -194,7 +194,7 @@ export const getStudyAction = new Action('getStudyAction')
                 'study.language',
             ])
             .executeTakeFirstOrThrow(throwNotFound('Study'))
-        return { study, orgId: study.orgId, submittedByOrgId: study.submittedByOrgId }
+        return { study, orgId: study.orgId, submittedByOrgId: study.submittedByOrgId, status: study.status }
     })
     .requireAbilityTo('view', 'Study')
     .handler(async ({ study }) => {
@@ -208,10 +208,10 @@ export const ackAgreementsAction = new Action('ackAgreementsAction', { performsM
     .middleware(async ({ params: { studyId }, db }) => {
         const study = await db
             .selectFrom('study')
-            .select(['id', 'orgId', 'submittedByOrgId'])
+            .select(['id', 'orgId', 'submittedByOrgId', 'status'])
             .where('id', '=', studyId)
             .executeTakeFirstOrThrow(throwNotFound('study'))
-        return { study, orgId: study.orgId, submittedByOrgId: study.submittedByOrgId }
+        return { study, orgId: study.orgId, submittedByOrgId: study.submittedByOrgId, status: study.status }
     })
     .requireAbilityTo('view', 'Study')
     .handler(async ({ study, params: { studyId, role }, db, session }) => {
@@ -668,7 +668,7 @@ export const getProposalFeedbackForStudyAction = new Action('getProposalFeedback
     .params(z.object({ studyId: z.string() }))
     .middleware(async ({ params: { studyId } }) => {
         const { study, entries } = await getProposalFeedbackForStudy(studyId)
-        return { study, orgId: study.orgId, submittedByOrgId: study.submittedByOrgId, entries }
+        return { study, orgId: study.orgId, submittedByOrgId: study.submittedByOrgId, status: study.status, entries }
     })
     .requireAbilityTo('view', 'Study')
     .handler(async ({ entries }) => entries)
@@ -861,10 +861,10 @@ export const getCodeReviewFeedbackAction = new Action('getCodeReviewFeedbackActi
     .middleware(async ({ params: { studyId }, db }) => {
         const study = await db
             .selectFrom('study')
-            .select(['orgId', 'submittedByOrgId'])
+            .select(['orgId', 'submittedByOrgId', 'status'])
             .where('id', '=', studyId)
             .executeTakeFirstOrThrow(throwNotFound('study'))
-        return { orgId: study.orgId, submittedByOrgId: study.submittedByOrgId }
+        return { orgId: study.orgId, submittedByOrgId: study.submittedByOrgId, status: study.status }
     })
     .requireAbilityTo('view', 'Study')
     .handler(async ({ params: { studyId }, db }) => {

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -348,13 +348,13 @@ async function performStudyProposalApproval({
     useTestImage?: boolean
     sharedFiles?: SharedFile[]
 }) {
-    // Proposal approval is strictly the first decision; approving a later code
-    // (re)submission is submitCodeReviewDecisionAction's job.
-    if (study.status === 'APPROVED' || study.approvedAt) {
-        throw new ActionFailure({ study: 'has already been decided. Refresh to see the updated status.' })
-    }
-
-    await db
+    // Proposal approval is strictly the first decision from PENDING-REVIEW; approving a later code
+    // (re)submission is submitCodeReviewDecisionAction's job. The PENDING-REVIEW + approvedAt IS NULL
+    // predicate is the server-side gate (mirrors claimInitialProposalReviewStudy): it blocks flipping
+    // a DRAFT (or any non-pending study) into a viewable status, which would otherwise let a DO
+    // reviewer read a draft it was never meant to see (OTTER-596). Atomic so it also settles the
+    // OTTER-471 race where two decisions land at once.
+    const claimed = await db
         .updateTable('study')
         .set({
             status: 'APPROVED',
@@ -364,7 +364,14 @@ async function performStudyProposalApproval({
             lastUpdatedAt: new Date(),
         })
         .where('id', '=', studyId)
-        .execute()
+        .where('status', '=', 'PENDING-REVIEW')
+        .where('approvedAt', 'is', null)
+        .returning('id')
+        .executeTakeFirst()
+
+    if (!claimed) {
+        throw new ActionFailure({ study: 'has already been decided. Refresh to see the updated status.' })
+    }
 
     onStudyApproved({ studyId, userId })
 
@@ -383,7 +390,11 @@ async function performStudyProposalApproval({
 }
 
 async function markStudyRejected({ db, studyId, userId }: { db: DBExecutor; studyId: string; userId: string }) {
-    await db
+    // Same PENDING-REVIEW gate as approval: a proposal can only be rejected while it is under review,
+    // so a DO reviewer can't flip a DRAFT to REJECTED to make it readable (OTTER-596). Atomic for the
+    // OTTER-471 race. Code-stage rejection is a separate path (submitCodeReviewDecisionAction) and does
+    // not go through here.
+    const claimed = await db
         .updateTable('study')
         .set({
             status: 'REJECTED',
@@ -393,7 +404,14 @@ async function markStudyRejected({ db, studyId, userId }: { db: DBExecutor; stud
             lastUpdatedAt: new Date(),
         })
         .where('id', '=', studyId)
-        .execute()
+        .where('status', '=', 'PENDING-REVIEW')
+        .where('approvedAt', 'is', null)
+        .returning('id')
+        .executeTakeFirst()
+
+    if (!claimed) {
+        throw new ActionFailure({ study: 'has already been decided. Refresh to see the updated status.' })
+    }
 }
 
 async function performStudyProposalRejection({

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,22 +1,27 @@
 import { sessionFromClerk } from '@/server/clerk'
 import { toRecord } from '@/lib/permissions'
+import type { StudyStatus } from '@/database/types'
 
-export async function canViewStudyResults(study: { orgId: string; submittedByOrgId: string }) {
+// `status` gates the reviewer (enclave/Data Organization) path only — unsubmitted drafts are private
+// to the submitting Research Lab (OTTER-596). The lab path (submittedByOrgId) is intentionally
+// status-agnostic so a lab keeps access to its own drafts. Guards the direct download routes
+// (study-code, study-documents, results) against a DO fetching a draft by known id.
+export async function canViewStudyResults(study: { orgId: string; submittedByOrgId: string; status: StudyStatus }) {
     const session = await sessionFromClerk()
 
     return (
         session &&
-        (session.can('view', toRecord('Study', { orgId: study.orgId })) ||
+        (session.can('view', toRecord('Study', { orgId: study.orgId, status: study.status })) ||
             session.can('view', toRecord('Study', { submittedByOrgId: study.submittedByOrgId })))
     )
 }
 
-export async function canViewStudyJob(study: { orgId: string; submittedByOrgId: string }) {
+export async function canViewStudyJob(study: { orgId: string; submittedByOrgId: string; status: StudyStatus }) {
     const session = await sessionFromClerk()
 
     return (
         session &&
-        (session.can('view', toRecord('StudyJob', { orgId: study.orgId })) ||
+        (session.can('view', toRecord('StudyJob', { orgId: study.orgId, status: study.status })) ||
             session.can('view', toRecord('StudyJob', { submittedByOrgId: study.submittedByOrgId })))
     )
 }

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -41,6 +41,7 @@ export async function getStudyJobInfo(studyJobId: string) {
             'studyJob.studyId',
             'studyJob.createdAt',
             'study.title as studyTitle',
+            'study.status',
             'org.id as orgId',
             'org.slug as orgSlug',
             'study.submittedByOrgId',
@@ -82,7 +83,7 @@ function latestJobForStudyQuery(studyId: string) {
         .selectFrom('studyJob')
         .selectAll('studyJob')
         .innerJoin('study', 'study.id', 'studyJob.studyId')
-        .select(['study.orgId', 'study.language'])
+        .select(['study.orgId', 'study.language', 'study.status'])
         .select((eb) => [
             jsonArrayFrom(
                 eb
@@ -168,6 +169,7 @@ export const jobInfoForJobId = async (jobId: string) => {
             'org.slug as orgSlug',
             'org.id as orgId',
             'study.submittedByOrgId',
+            'study.status',
         ])
         .where('studyJob.id', '=', jobId)
         .executeTakeFirstOrThrow()
@@ -207,7 +209,7 @@ export const getProposalFeedbackForStudy = async (studyId: string) => {
     const [study, entries] = await Promise.all([
         Action.db
             .selectFrom('study')
-            .select(['orgId', 'submittedByOrgId'])
+            .select(['orgId', 'submittedByOrgId', 'status'])
             .where('id', '=', studyId)
             .executeTakeFirstOrThrow(throwNotFound('study')),
         Action.db
@@ -242,6 +244,7 @@ export const studyInfoForStudyId = async (studyId: string) => {
             'org.slug as orgSlug',
             'study.submittedByOrgId',
             'study.language',
+            'study.status',
         ])
         .where('study.id', '=', studyId)
         .executeTakeFirst()
@@ -333,7 +336,13 @@ export const getInfoForStudyJobId = async (studyJobId: string) => {
         .selectFrom('studyJob')
         .innerJoin('study', 'study.id', 'studyJob.studyId')
         .innerJoin('org', 'org.id', 'study.orgId')
-        .select(['org.id as orgId', 'org.slug as orgSlug', 'study.id as studyId', 'study.submittedByOrgId'])
+        .select([
+            'org.id as orgId',
+            'org.slug as orgSlug',
+            'study.id as studyId',
+            'study.submittedByOrgId',
+            'study.status',
+        ])
         .where('studyJob.id', '=', studyJobId)
         .executeTakeFirstOrThrow()
 }


### PR DESCRIPTION
[Issue:](https://openstax.atlassian.net/browse/OTTER-596) Unsubmitted drafts must not be readable by Data Organizations

### Summary
Unsubmitted study drafts (proposal content and uploaded code) were hidden from Data Organizations (DOs) only in the UI and list actions — the per-record backend paths were not enforcing this. A DO (enclave) member who knew a study or job ID could read draft proposal text, documents, and code directly via server actions **and** the download routes (`/dl/study-code`, `/dl/study-documents`, `/dl/results`).

This PR closes that gap on the server so a draft stays private to its Research Lab until it is submitted. No frontend changes.

### Approach
- Gated the two enclave (reviewer) `view` ability rules in [`src/lib/permissions.ts`](src/lib/permissions.ts) with a positive `SUBMITTED_STUDY_STATUSES` allowlist (`status: { $in: [...] }`).
  - Chose an allowlist over `$ne: 'DRAFT'` deliberately: the CASL subject is assembled from middleware-returned fields, so `$in` **fails closed** when `status` is absent (denies), whereas `$ne` would **fail open** (grant). A security fix should err toward denial.
  - Lab rules (`submittedByOrgId`) are untouched, so Research Labs keep full access to their own drafts. CASL's additive semantics keep dual-role users working.
- Threaded the study `status` into every enclave-reachable read path so the gate has the data it needs: all `view Study` / `view StudyJob` middlewares, the shared queries (`getStudyJobInfo`, `latestJobForStudyQuery`, `getProposalFeedbackForStudy`), the download-route guards in [`src/server/auth.ts`](src/server/auth.ts), and their feeder queries (`jobInfoForJobId`, `studyInfoForStudyId`, `getInfoForStudyJobId`).

### Acceptance criteria
- [x] **Drafts are private to their Research Lab** — a DO cannot access an unsubmitted draft's proposal, documents, or code by known ID.
- [x] **Submitted studies are unaffected** — DOs keep access across the review lifecycle, including `CHANGE-REQUESTED` resubmissions.
- [x] **Research Lab collaboration is unaffected** — lab members still see/edit/submit their lab's drafts (OTTER-497 / OTTER-550 behavior preserved).
- [x] **Other labs stay locked out** — Lab B still cannot see Lab A's drafts.

### Testing
- New unit tests in `permissions.test.ts`, `study.actions.test.ts`, and `study-job.actions.test.ts` cover all four criteria (DO denied on DRAFT for both proposal and code file; DO allowed once submitted and on `CHANGE-REQUESTED`; lab retains draft access; other lab locked out).

