### PR TITLE
OTTER-527: prevent deleting the last usable code environment 

### DIFF
--- a/src/app/[orgSlug]/admin/settings/code-envs.actions.test.ts
+++ b/src/app/[orgSlug]/admin/settings/code-envs.actions.test.ts
@@ -334,6 +334,89 @@ describe('Code Environment Actions', () => {
         expect(deleted).toBeUndefined()
     })
 
+    it('deleteOrgCodeEnvAction prevents deleting the only scan-passed code environment for a language', async () => {
+        const { org } = await mockSessionWithTestData({ isAdmin: true })
+
+        const passed = await insertTestCodeEnv({
+            orgId: org.id,
+            name: 'Passed R Image',
+            language: 'R',
+            isTesting: false,
+        })
+
+        const failed = await insertTestCodeEnv({
+            orgId: org.id,
+            name: 'Failed R Image',
+            language: 'R',
+            isTesting: false,
+        })
+
+        await db.insertInto('codeScan').values({ codeEnvId: passed.id, status: 'SCAN-COMPLETE' }).execute()
+        await db.insertInto('codeScan').values({ codeEnvId: failed.id, status: 'SCAN-FAILED' }).execute()
+
+        const result = await deleteOrgCodeEnvAction({ orgSlug: org.slug, codeEnvId: passed.id })
+
+        expect(isActionError(result)).toBe(true)
+        if (isActionError(result)) {
+            expect(result.error).toContain('passed scanning')
+        }
+
+        const stillExists = await db.selectFrom('orgCodeEnv').where('id', '=', passed.id).executeTakeFirst()
+        expect(stillExists).toBeDefined()
+    })
+
+    it('deleteOrgCodeEnvAction allows deleting a scan-failed code environment when a passed one remains', async () => {
+        const { org } = await mockSessionWithTestData({ isAdmin: true })
+
+        const passed = await insertTestCodeEnv({
+            orgId: org.id,
+            name: 'Passed R Image',
+            language: 'R',
+            isTesting: false,
+        })
+
+        const failed = await insertTestCodeEnv({
+            orgId: org.id,
+            name: 'Failed R Image',
+            language: 'R',
+            isTesting: false,
+        })
+
+        await db.insertInto('codeScan').values({ codeEnvId: passed.id, status: 'SCAN-COMPLETE' }).execute()
+        await db.insertInto('codeScan').values({ codeEnvId: failed.id, status: 'SCAN-FAILED' }).execute()
+
+        await deleteOrgCodeEnvAction({ orgSlug: org.slug, codeEnvId: failed.id })
+
+        const deleted = await db.selectFrom('orgCodeEnv').where('id', '=', failed.id).executeTakeFirst()
+        expect(deleted).toBeUndefined()
+    })
+
+    it('deleteOrgCodeEnvAction allows deleting a scan-passed code environment when another passed one exists', async () => {
+        const { org } = await mockSessionWithTestData({ isAdmin: true })
+
+        const passed1 = await insertTestCodeEnv({
+            orgId: org.id,
+            name: 'Passed R Image 1',
+            language: 'R',
+            isTesting: false,
+        })
+
+        const passed2 = await insertTestCodeEnv({
+            orgId: org.id,
+            name: 'Passed R Image 2',
+            language: 'R',
+            isTesting: false,
+        })
+
+        await db.insertInto('codeScan').values({ codeEnvId: passed1.id, status: 'SCAN-COMPLETE' }).execute()
+        await db.insertInto('codeScan').values({ codeEnvId: passed2.id, status: 'SCAN-COMPLETE' }).execute()
+
+        await deleteOrgCodeEnvAction({ orgSlug: org.slug, codeEnvId: passed1.id })
+
+        const deleted = await db.selectFrom('orgCodeEnv').where('id', '=', passed1.id).executeTakeFirst()
+        expect(deleted).toBeUndefined()
+    })
+
     it('createOrgCodeEnvAction with athena does not call createAthenaDatabase in test env', async () => {
         const { createAthenaDatabase } = await import('@/server/aws')
         const { org } = await mockSessionWithTestData({ isAdmin: true })

--- a/src/app/[orgSlug]/admin/settings/code-envs.actions.ts
+++ b/src/app/[orgSlug]/admin/settings/code-envs.actions.ts
@@ -383,18 +383,47 @@ export const deleteOrgCodeEnvAction = new Action('deleteOrgCodeEnvAction', { per
     .requireAbilityTo('update', 'Org')
     .handler(async ({ params: { orgSlug }, db, ...codeEnv }) => {
         if (!codeEnv.isTesting) {
-            const nonTestingForLanguage = await db
+            const otherNonTesting = await db
                 .selectFrom('orgCodeEnv')
-                .select(({ fn }) => [fn.count<number>('id').as('count')])
-                .where('orgId', '=', codeEnv.orgId)
-                .where('language', '=', codeEnv.language)
-                .where('isTesting', '=', false)
-                .where('id', '!=', codeEnv.id)
-                .executeTakeFirstOrThrow()
+                .select((eb) => [
+                    'orgCodeEnv.id',
+                    eb
+                        .selectFrom('codeScan')
+                        .select('codeScan.status')
+                        .whereRef('codeScan.codeEnvId', '=', 'orgCodeEnv.id')
+                        .orderBy('codeScan.createdAt', 'desc')
+                        .limit(1)
+                        .as('latestScanStatus'),
+                ])
+                .where('orgCodeEnv.orgId', '=', codeEnv.orgId)
+                .where('orgCodeEnv.language', '=', codeEnv.language)
+                .where('orgCodeEnv.isTesting', '=', false)
+                .where('orgCodeEnv.id', '!=', codeEnv.id)
+                .execute()
 
-            if (Number(nonTestingForLanguage.count) === 0) {
+            if (otherNonTesting.length === 0) {
                 throw new Error(
                     `Cannot delete the last non-testing ${codeEnv.language} code environment. At least one non-testing code environment must exist for each language.`,
+                )
+            }
+
+            // OTTER-527: an env whose latest scan passed must not be deleted unless another
+            // non-testing env for the language also passed, otherwise the language's default
+            // image would fall back to one that failed (or never finished) scanning.
+            const latestScan = await db
+                .selectFrom('codeScan')
+                .select('status')
+                .where('codeEnvId', '=', codeEnv.id)
+                .orderBy('createdAt', 'desc')
+                .limit(1)
+                .executeTakeFirst()
+
+            const deletingPassedEnv = latestScan?.status === 'SCAN-COMPLETE'
+            const anotherPassedEnvExists = otherNonTesting.some((env) => env.latestScanStatus === 'SCAN-COMPLETE')
+
+            if (deletingPassedEnv && !anotherPassedEnvExists) {
+                throw new Error(
+                    `Cannot delete the only ${codeEnv.language} code environment that passed scanning. At least one scan-passed, non-testing code environment must exist for each language.`,
                 )
             }
         }

--- a/src/app/[orgSlug]/admin/settings/code-envs.actions.ts
+++ b/src/app/[orgSlug]/admin/settings/code-envs.actions.ts
@@ -383,7 +383,7 @@ export const deleteOrgCodeEnvAction = new Action('deleteOrgCodeEnvAction', { per
     .requireAbilityTo('update', 'Org')
     .handler(async ({ params: { orgSlug }, db, ...codeEnv }) => {
         if (!codeEnv.isTesting) {
-            const otherNonTesting = await db
+            const nonTesting = await db
                 .selectFrom('orgCodeEnv')
                 .select((eb) => [
                     'orgCodeEnv.id',
@@ -398,10 +398,12 @@ export const deleteOrgCodeEnvAction = new Action('deleteOrgCodeEnvAction', { per
                 .where('orgCodeEnv.orgId', '=', codeEnv.orgId)
                 .where('orgCodeEnv.language', '=', codeEnv.language)
                 .where('orgCodeEnv.isTesting', '=', false)
-                .where('orgCodeEnv.id', '!=', codeEnv.id)
                 .execute()
 
-            if (otherNonTesting.length === 0) {
+            const beingDeleted = nonTesting.find((env) => env.id === codeEnv.id)
+            const others = nonTesting.filter((env) => env.id !== codeEnv.id)
+
+            if (others.length === 0) {
                 throw new Error(
                     `Cannot delete the last non-testing ${codeEnv.language} code environment. At least one non-testing code environment must exist for each language.`,
                 )
@@ -410,16 +412,8 @@ export const deleteOrgCodeEnvAction = new Action('deleteOrgCodeEnvAction', { per
             // OTTER-527: an env whose latest scan passed must not be deleted unless another
             // non-testing env for the language also passed, otherwise the language's default
             // image would fall back to one that failed (or never finished) scanning.
-            const latestScan = await db
-                .selectFrom('codeScan')
-                .select('status')
-                .where('codeEnvId', '=', codeEnv.id)
-                .orderBy('createdAt', 'desc')
-                .limit(1)
-                .executeTakeFirst()
-
-            const deletingPassedEnv = latestScan?.status === 'SCAN-COMPLETE'
-            const anotherPassedEnvExists = otherNonTesting.some((env) => env.latestScanStatus === 'SCAN-COMPLETE')
+            const deletingPassedEnv = beingDeleted?.latestScanStatus === 'SCAN-COMPLETE'
+            const anotherPassedEnvExists = others.some((env) => env.latestScanStatus === 'SCAN-COMPLETE')
 
             if (deletingPassedEnv && !anotherPassedEnvExists) {
                 throw new Error(

--- a/src/app/[orgSlug]/admin/settings/code-envs.test.tsx
+++ b/src/app/[orgSlug]/admin/settings/code-envs.test.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/tests/unit.helpers'
 import { vi } from 'vitest'
 import { Selectable } from 'kysely'
+import { db } from '@/database'
 import { CodeEnvs } from './code-envs'
 import { Org } from '@/database/types'
 import userEvent from '@testing-library/user-event'
@@ -131,35 +132,88 @@ describe('CodeEnvs', async () => {
             expect(screen.getByText('Only Image')).toBeInTheDocument()
         })
 
-        const trashButtons = screen.getAllByRole('button', { name: '' }).filter((btn) => btn.querySelector('svg'))
-        const hasSuretyGuard = trashButtons.some((btn) => btn.closest('[data-variant="filled"]'))
-        expect(hasSuretyGuard).toBe(false)
+        expect(screen.queryByRole('button', { name: 'Delete Only Image' })).not.toBeInTheDocument()
     })
 
-    it('shows delete on all rows when there are multiple code environments', async () => {
+    it('hides delete on the last non-testing environment for a language even when other envs exist', async () => {
         await insertTestCodeEnv({
             orgId: org.id,
-            name: 'R Image',
+            name: 'Prod R',
             language: 'R',
             isTesting: false,
         })
 
         await insertTestCodeEnv({
             orgId: org.id,
-            name: 'Python Image',
-            language: 'PYTHON',
+            name: 'Test R',
+            language: 'R',
             isTesting: true,
         })
 
         renderWithProviders(<CodeEnvs />)
 
         await waitFor(() => {
-            expect(screen.getByText('R Image')).toBeInTheDocument()
-            expect(screen.getByText('Python Image')).toBeInTheDocument()
+            expect(screen.getByText('Prod R')).toBeInTheDocument()
+            expect(screen.getByText('Test R')).toBeInTheDocument()
         })
 
-        const actionIcons = screen.getAllByRole('button', { name: '' })
-        expect(actionIcons.length).toBeGreaterThanOrEqual(4)
+        expect(screen.queryByRole('button', { name: 'Delete Prod R' })).not.toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Delete Test R' })).toBeInTheDocument()
+    })
+
+    it('shows delete when multiple non-testing environments exist for a language', async () => {
+        await insertTestCodeEnv({
+            orgId: org.id,
+            name: 'R Image 1',
+            language: 'R',
+            isTesting: false,
+        })
+
+        await insertTestCodeEnv({
+            orgId: org.id,
+            name: 'R Image 2',
+            language: 'R',
+            isTesting: false,
+        })
+
+        renderWithProviders(<CodeEnvs />)
+
+        await waitFor(() => {
+            expect(screen.getByText('R Image 1')).toBeInTheDocument()
+            expect(screen.getByText('R Image 2')).toBeInTheDocument()
+        })
+
+        expect(screen.getByRole('button', { name: 'Delete R Image 1' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Delete R Image 2' })).toBeInTheDocument()
+    })
+
+    it('hides delete on the only environment that passed scanning', async () => {
+        const passed = await insertTestCodeEnv({
+            orgId: org.id,
+            name: 'Passed R',
+            language: 'R',
+            isTesting: false,
+        })
+
+        const failed = await insertTestCodeEnv({
+            orgId: org.id,
+            name: 'Failed R',
+            language: 'R',
+            isTesting: false,
+        })
+
+        await db.insertInto('codeScan').values({ codeEnvId: passed.id, status: 'SCAN-COMPLETE' }).execute()
+        await db.insertInto('codeScan').values({ codeEnvId: failed.id, status: 'SCAN-FAILED' }).execute()
+
+        renderWithProviders(<CodeEnvs />)
+
+        await waitFor(() => {
+            expect(screen.getByText('Passed R')).toBeInTheDocument()
+            expect(screen.getByText('Failed R')).toBeInTheDocument()
+        })
+
+        expect(screen.queryByRole('button', { name: 'Delete Passed R' })).not.toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Delete Failed R' })).toBeInTheDocument()
     })
 
     it('displays env vars as KEY=VALUE in table', async () => {

--- a/src/app/[orgSlug]/admin/settings/code-envs.tsx
+++ b/src/app/[orgSlug]/admin/settings/code-envs.tsx
@@ -98,11 +98,16 @@ const CodeEnvDetailPanel: React.FC<{
     )
 }
 
-const DeleteCodeEnv: React.FC<{ isVisible: boolean; onConfirmed: () => void }> = ({ isVisible, onConfirmed }) => {
+const DeleteCodeEnv: React.FC<{ isVisible: boolean; label: string; onConfirmed: () => void }> = ({
+    isVisible,
+    label,
+    onConfirmed,
+}) => {
     if (!isVisible) return null
 
     return (
         <SuretyGuard
+            label={label}
             onConfirmed={onConfirmed}
             message="Are you sure you want to delete this code environment? This cannot be undone."
         >
@@ -187,6 +192,7 @@ const CodeEnvRow: React.FC<{
                         </Tooltip>
                         <DeleteCodeEnv
                             isVisible={canDelete}
+                            label={`Delete ${image.name}`}
                             onConfirmed={() => deleteMutation.mutate({ codeEnvId: image.id, orgSlug })}
                         />
                     </>
@@ -236,6 +242,22 @@ function needsRefresh(codeEnvs: CodeEnv[]): boolean {
     return codeEnvs.some((env) => ACTIVE_SCAN_STATUSES.includes(env.latestScanStatus as ScanStatus))
 }
 
+const SCAN_PASSED_STATUS: ScanStatus = 'SCAN-COMPLETE'
+
+const hasPassedScan = (env: CodeEnv) => env.latestScanStatus === SCAN_PASSED_STATUS
+
+// OTTER-527: deleting the last non-testing env for a language — or the only one that
+// passed scanning — would leave the language without a usable default image, so the
+// delete control is hidden for those. The server action enforces the same rules.
+const canDeleteCodeEnv = (env: CodeEnv, allEnvs: CodeEnv[]): boolean => {
+    if (env.isTesting) return true
+    const siblings = allEnvs.filter(
+        (other) => other.id !== env.id && !other.isTesting && other.language === env.language,
+    )
+    if (!siblings.length) return false
+    return !hasPassedScan(env) || siblings.some(hasPassedScan)
+}
+
 const CodeEnvsTable: React.FC<{ images: CodeEnv[] }> = ({ images }) => {
     if (!images.length) {
         return (
@@ -245,7 +267,6 @@ const CodeEnvsTable: React.FC<{ images: CodeEnv[] }> = ({ images }) => {
         )
     }
 
-    const canDelete = images.length > 1
     const defaultEnvIds = new Set(
         ['R', 'PYTHON']
             .map((lang) => images.find((img) => !img.isTesting && img.language === lang)?.id)
@@ -258,7 +279,7 @@ const CodeEnvsTable: React.FC<{ images: CodeEnv[] }> = ({ images }) => {
                 <CodeEnvRow
                     key={image.id}
                     image={image}
-                    canDelete={canDelete}
+                    canDelete={canDeleteCodeEnv(image, images)}
                     isDefault={defaultEnvIds.has(image.id)}
                 />
             ))}

--- a/src/components/surety-guard.tsx
+++ b/src/components/surety-guard.tsx
@@ -6,8 +6,9 @@ import { FC, useState } from 'react'
 export const SuretyGuard: FC<{
     children?: React.ReactNode
     message?: string
+    label?: string
     onConfirmed: () => void | Promise<void>
-}> = ({ message, children, onConfirmed }) => {
+}> = ({ message, children, label, onConfirmed }) => {
     const [opened, { close, open }] = useDisclosure(false)
     const [pending, setPending] = useState(false)
 
@@ -21,7 +22,7 @@ export const SuretyGuard: FC<{
     return (
         <Popover width={300} trapFocus withArrow shadow="md" opened={opened} onChange={close} closeOnClickOutside>
             <Popover.Target>
-                <ActionIcon size="sm" variant="subtle" color="red" onClick={open} disabled={opened}>
+                <ActionIcon size="sm" variant="subtle" color="red" onClick={open} disabled={opened} aria-label={label}>
                     {children || <TrashIcon />}
                 </ActionIcon>
             </Popover.Target>


### PR DESCRIPTION
Fixes [OTTER-527](https://openstax.atlassian.net/browse/OTTER-527)

### Problem

In DO Admin → Settings, the delete icon on a code environment is clickable even when
it's the only usable (non-testing) base image — clicking shows the confirmation popup,
then the server rejects the delete with an error toast.

Root cause: `362e453d` (sample-data-format refactor) collapsed the per-language
`canDelete` guard from `9c109416` into a blanket `images.length > 1` and dropped the
tests that protected it. The server-side guard in `deleteOrgCodeEnvAction` survived,
which is why the delete failed noisily instead of destroying data.

### Change

The delete icon is now hidden, and the server action refuses, when a **non-testing**
env is either:

1. the last non-testing env for its language (restores the pre-regression rule), or
2. the only non-testing env for its language whose latest scan passed
   (`SCAN-COMPLETE`).

Rule 2 is intentionally **new behavior**, not part of the old guard — it implements the
ticket's "successfully passed scans" wording. Without it, an org with one passed and one
failed R image could delete the passed one, leaving the failed image as the language's
default (the [OTTER-525](https://openstax.atlassian.net/browse/OTTER-525) failure mode,
since the default is the newest non-testing env per language).

Unchanged: testing envs are always deletable; a scan-failed env is deletable whenever
another non-testing env for its language exists.

Also: `SuretyGuard` accepts an optional `label` prop rendered as `aria-label` on the
trash `ActionIcon` (used here as `Delete <env name>`); other call sites are unaffected.

### Tests

- Component: delete hidden for the only env, for the last non-testing env per language,
  and for the only scan-passed env; shown when multiple non-testing envs exist.
- Actions: deleting the only scan-passed env errors; deleting a failed env with a
  passed sibling works; deleting a passed env with a passed sibling works.
- `pnpm run checks` and the unit suite pass locally.


[OTTER-527]: https://openstax.atlassian.net/browse/OTTER-527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OTTER-525]: https://openstax.atlassian.net/browse/OTTER-525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ