### PR TITLE
Otter 590 update study code section

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.tsx
@@ -2,10 +2,10 @@
 
 import { type FC, type ReactNode } from 'react'
 import type { Route } from 'next'
-import { Anchor, Box, Collapse, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
+import { Box, Collapse, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
 import { ArrowSquareOutIcon, CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
 import { AlertNotFound } from '@/components/errors'
-import { ButtonLink } from '@/components/links'
+import { ButtonLink, LinkWithIcon } from '@/components/links'
 import { PageBreadcrumbs } from '@/components/page-breadcrumbs'
 import { FeedbackAndNotesSection } from '@/components/study/feedback-and-notes'
 import { ProposalStepHeader } from '@/components/study/proposal-step-header'
@@ -220,19 +220,15 @@ const SubmittedCodePanel: FC<SubmittedCodePanelProps> = ({
                 <Stack gap="md">
                     <Group justify="space-between" align="center" wrap="nowrap">
                         <Title order={5}>Submitted code</Title>
-                        <Anchor
+                        <LinkWithIcon
                             href={proposalHref}
                             target="_blank"
                             rel="noopener noreferrer"
-                            size="sm"
-                            fw={700}
-                            display="inline-flex"
-                            style={{ alignItems: 'center', gap: 4, whiteSpace: 'nowrap', flexShrink: 0 }}
+                            icon={<ArrowSquareOutIcon size={14} />}
                             data-testid="view-approved-initial-request"
                         >
                             View approved initial request
-                            <ArrowSquareOutIcon size={14} />
-                        </Anchor>
+                        </LinkWithIcon>
                     </Group>
                     <Divider />
                     <Text>View the code files that you uploaded to run against the dataset.</Text>

--- a/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.tsx
@@ -2,12 +2,12 @@
 
 import { type FC } from 'react'
 import { Alert, Anchor, Collapse, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
-import { CaretRightIcon, CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
+import { ArrowSquareOutIcon, CaretRightIcon, CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
 import dayjs from 'dayjs'
 import type { Route } from 'next'
 import { displayOrgName } from '@/lib/string'
 import { PageBreadcrumbs } from '@/components/page-breadcrumbs'
-import { ButtonLink } from '@/components/links'
+import { ButtonLink, LinkWithIcon } from '@/components/links'
 import { Routes } from '@/lib/routes'
 import { SubmittedCodeTable } from '@/components/study/submitted-code-table'
 import { FeedbackAndNotesSection } from '@/components/study/feedback-and-notes'
@@ -125,9 +125,15 @@ const ExpandedCodePanel: FC<ExpandedCodePanelProps> = ({
                 <Stack gap="md">
                     <Group justify="space-between" align="center">
                         <Title order={5}>Submitted code</Title>
-                        <Anchor href={proposalHref} target="_blank" rel="noopener noreferrer" fw={700} size="sm">
+                        <LinkWithIcon
+                            href={proposalHref}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            icon={<ArrowSquareOutIcon size={14} />}
+                            data-testid="view-approved-initial-request"
+                        >
                             View approved initial request
-                        </Anchor>
+                        </LinkWithIcon>
                     </Group>
                     <Divider />
                     <Text>View the code files that you uploaded to run against the dataset.</Text>

--- a/src/components/links.test.tsx
+++ b/src/components/links.test.tsx
@@ -1,0 +1,52 @@
+import { renderWithProviders, screen } from '@/tests/unit.helpers'
+import { describe, expect, it } from 'vitest'
+import type { Route } from 'next'
+import { LinkWithIcon } from './links'
+
+describe('LinkWithIcon', () => {
+    const icon = <svg data-testid="icon" />
+
+    it('renders the text and href, forwarding target and data-testid', () => {
+        renderWithProviders(
+            <LinkWithIcon
+                href={'/openstax/study/abc/submitted' as Route}
+                target="_blank"
+                icon={icon}
+                data-testid="my-link"
+            >
+                View approved initial request
+            </LinkWithIcon>,
+        )
+
+        const link = screen.getByTestId('my-link')
+        expect(link).toHaveTextContent('View approved initial request')
+        expect(link).toHaveAttribute('href', '/openstax/study/abc/submitted')
+        expect(link).toHaveAttribute('target', '_blank')
+        expect(screen.getByTestId('icon')).toBeInTheDocument()
+    })
+
+    it('renders the icon after the text by default (trailing)', () => {
+        renderWithProviders(
+            <LinkWithIcon href={'/x' as Route} icon={icon} data-testid="link">
+                Label
+            </LinkWithIcon>,
+        )
+
+        const link = screen.getByTestId('link')
+        const iconEl = screen.getByTestId('icon')
+        // Trailing: the icon follows the label text in document order.
+        expect(link.textContent).toBe('Label')
+        expect(link.lastElementChild).toBe(iconEl)
+    })
+
+    it('renders the icon before the text when iconPosition="leading"', () => {
+        renderWithProviders(
+            <LinkWithIcon href={'/x' as Route} icon={icon} iconPosition="leading" data-testid="link">
+                Label
+            </LinkWithIcon>,
+        )
+
+        const link = screen.getByTestId('link')
+        expect(link.firstElementChild).toBe(screen.getByTestId('icon'))
+    })
+})

--- a/src/components/links.test.tsx
+++ b/src/components/links.test.tsx
@@ -52,14 +52,15 @@ describe('LinkWithIcon', () => {
 
     it('merges a caller style over the base layout instead of replacing it', () => {
         renderWithProviders(
-            <LinkWithIcon href={'/x' as Route} icon={icon} data-testid="link" style={{ color: 'red' }}>
+            <LinkWithIcon href={'/x' as Route} icon={icon} data-testid="link" style={{ marginTop: 10, gap: 8 }}>
                 Label
             </LinkWithIcon>,
         )
 
         const link = screen.getByTestId('link')
-        expect(link).toHaveStyle({ color: 'rgb(255, 0, 0)' })
-        // The base flex layout survives the caller's override.
-        expect(link).toHaveStyle({ gap: '4px', whiteSpace: 'nowrap' })
+        // A caller-added key applies, and a caller override of a base key (gap) wins.
+        expect(link).toHaveStyle({ marginTop: '10px', gap: '8px' })
+        // An untouched base layout key survives the merge.
+        expect(link).toHaveStyle({ whiteSpace: 'nowrap' })
     })
 })

--- a/src/components/links.test.tsx
+++ b/src/components/links.test.tsx
@@ -49,4 +49,17 @@ describe('LinkWithIcon', () => {
         const link = screen.getByTestId('link')
         expect(link.firstElementChild).toBe(screen.getByTestId('icon'))
     })
+
+    it('merges a caller style over the base layout instead of replacing it', () => {
+        renderWithProviders(
+            <LinkWithIcon href={'/x' as Route} icon={icon} data-testid="link" style={{ color: 'red' }}>
+                Label
+            </LinkWithIcon>,
+        )
+
+        const link = screen.getByTestId('link')
+        expect(link).toHaveStyle({ color: 'rgb(255, 0, 0)' })
+        // The base flex layout survives the caller's override.
+        expect(link).toHaveStyle({ gap: '4px', whiteSpace: 'nowrap' })
+    })
 })

--- a/src/components/links.tsx
+++ b/src/components/links.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Anchor as MantineAnchor, AnchorProps, Button, ButtonProps } from '@mantine/core'
+import { Anchor as MantineAnchor, AnchorProps, ElementProps, Button, ButtonProps } from '@mantine/core'
 import { FC, ReactNode } from 'react'
 import NextLink from 'next/link'
 import type { Route } from 'next'
@@ -14,6 +14,28 @@ export type LinkProps = AnchorProps & {
 export const Link: FC<LinkProps> = ({ href, target, children, ...anchorProps }) => (
     <MantineAnchor component={NextLink} href={href} target={target} {...anchorProps}>
         {children}
+    </MantineAnchor>
+)
+
+export type LinkWithIconProps = AnchorProps &
+    ElementProps<'a', keyof AnchorProps> & {
+        icon: ReactNode
+        iconPosition?: 'leading' | 'trailing'
+        children: ReactNode
+    }
+
+export const LinkWithIcon: FC<LinkWithIconProps> = ({ icon, iconPosition = 'trailing', children, ...anchorProps }) => (
+    <MantineAnchor
+        c="blue.7"
+        fz="sm"
+        fw={600}
+        display="inline-flex"
+        style={{ alignItems: 'center', gap: 4, whiteSpace: 'nowrap', flexShrink: 0 }}
+        {...anchorProps}
+    >
+        {iconPosition === 'leading' && icon}
+        {children}
+        {iconPosition === 'trailing' && icon}
     </MantineAnchor>
 )
 

--- a/src/components/links.tsx
+++ b/src/components/links.tsx
@@ -24,14 +24,22 @@ export type LinkWithIconProps = AnchorProps &
         children: ReactNode
     }
 
-export const LinkWithIcon: FC<LinkWithIconProps> = ({ icon, iconPosition = 'trailing', children, ...anchorProps }) => (
+export const LinkWithIcon: FC<LinkWithIconProps> = ({
+    icon,
+    iconPosition = 'trailing',
+    children,
+    style,
+    ...anchorProps
+}) => (
     <MantineAnchor
         c="blue.7"
         fz="sm"
         fw={600}
         display="inline-flex"
-        style={{ alignItems: 'center', gap: 4, whiteSpace: 'nowrap', flexShrink: 0 }}
         {...anchorProps}
+        // Merge rather than replace: the icon+text layout depends on these, so a caller
+        // passing `style` overrides individual keys without dropping the flex layout.
+        style={{ alignItems: 'center', gap: 4, whiteSpace: 'nowrap', flexShrink: 0, ...style }}
     >
         {iconPosition === 'leading' && icon}
         {children}

--- a/src/components/study/submitted-code-table-view.tsx
+++ b/src/components/study/submitted-code-table-view.tsx
@@ -18,6 +18,11 @@ const formatUpdatedAt = (date: Date | string) =>
         minute: '2-digit',
     })
 
+// Post-submission the main file is locked in, so the star renders in the disabled
+// grey style (still filled to show it's selected) rather than the active indigo used
+// while the researcher is choosing their main file.
+const STAR_COLOR = 'var(--mantine-color-gray-5)'
+
 const SubmittedCodeRow: FC<{
     file: SubmittedFile
     jobId: string
@@ -25,10 +30,6 @@ const SubmittedCodeRow: FC<{
 }> = ({ file, jobId, onPreview }) => {
     const isMain = file.fileType === 'MAIN-CODE'
     const starWeight = isMain ? 'fill' : 'regular'
-    // Post-submission the main file is locked in, so the star renders in the disabled
-    // grey style (still filled to show it's selected) rather than the active indigo used
-    // while the researcher is choosing their main file.
-    const starColor = 'var(--mantine-color-gray-5)'
     const starLabel = isMain ? 'Main file' : 'Supplemental file'
     const tooltipDisabled = file.name.length <= 48
     const lastUpdated = formatUpdatedAt(file.createdAt)
@@ -36,7 +37,7 @@ const SubmittedCodeRow: FC<{
     return (
         <Table.Tr>
             <Table.Td>
-                <StarIcon size={20} weight={starWeight} color={starColor} aria-label={starLabel} />
+                <StarIcon size={20} weight={starWeight} color={STAR_COLOR} aria-label={starLabel} />
             </Table.Td>
             <Table.Td>
                 <Tooltip label={file.name} disabled={tooltipDisabled}>

--- a/src/components/study/submitted-code-table-view.tsx
+++ b/src/components/study/submitted-code-table-view.tsx
@@ -25,7 +25,10 @@ const SubmittedCodeRow: FC<{
 }> = ({ file, jobId, onPreview }) => {
     const isMain = file.fileType === 'MAIN-CODE'
     const starWeight = isMain ? 'fill' : 'regular'
-    const starColor = isMain ? 'var(--mantine-color-indigo-6)' : 'var(--mantine-color-gray-5)'
+    // Post-submission the main file is locked in, so the star renders in the disabled
+    // grey style (still filled to show it's selected) rather than the active indigo used
+    // while the researcher is choosing their main file.
+    const starColor = 'var(--mantine-color-gray-5)'
     const starLabel = isMain ? 'Main file' : 'Supplemental file'
     const tooltipDisabled = file.name.length <= 48
     const lastUpdated = formatUpdatedAt(file.createdAt)


### PR DESCRIPTION
[Issue](https://openstax.atlassian.net/browse/OTTER-590?focusedCommentId=45203): fix study-code link styling

## Summary

Corrects the styling of the "View approved initial request" link in the study-code
section of the researcher view page, and extracts a reusable `LinkWithIcon`
component so the style lives in one place instead of being re-hardcoded per link.

Previously the link rendered at `fw={700}` in the theme's default link color
(purple). Per design it should be **14px, semi-bold (600), `#0058BD`**.


## What changed

- **New `LinkWithIcon` component** in [links.tsx](src/components/links.tsx),
  alongside the existing `Link`/`ButtonLink`. It renders a text link with an icon
  next to it, with:
  - dynamic text (`children`) and a dynamic `icon` prop
  - `iconPosition` (`'leading' | 'trailing'`, default `trailing`)
  - the standard link style baked in as **overridable** defaults —
    `c="blue.7"` (`#0058BD`), `fz="sm"` (14px), `fw={600}` — using theme tokens
    rather than hardcoded values
  - native anchor attributes (`href`, `target`, `rel`, `data-testid`) forwarded
    via Mantine's `ElementProps`
- **Repointed the two researcher view-page links** to `LinkWithIcon`
  ([code-post-decision-view.tsx](src/app/[orgSlug]/study/[studyId]/view/code-post-decision-view.tsx)
  and [code-post-submission-view.tsx](src/app/[orgSlug]/study/[studyId]/view/code-post-submission-view.tsx)),
  which also fixes the color/weight in both the post-submission and
  change-requested states.

## Why

`#0058BD` already exists in the theme as `blue[7]` and 14px is the `sm` token, so
the values now reference the theme (leaning into the team's theme
standardization). The one value without a theme primitive — weight `600` — is now
defined once, in `LinkWithIcon`, instead of being hardcoded at each call site.
The same icon+text link shape is repeated across the app, so the component is
available for those other links (reviewer side, proposal form, edit-and-resubmit)
in follow-up work.

## Notes / out of scope

- Only the two researcher view-page links are migrated here; the other
  candidate links are left untouched.
- The `LinkWithIcon` default style is overridable, so callers needing a different
  weight/size/color can still pass props.


## Screenshots

| Before | After |
| --- | --- |
| <img width="1814" height="657" alt="Screenshot 2026-07-21 at 5 13 46 PM" src="https://github.com/user-attachments/assets/ecf37d60-ddab-4480-881a-30ffe8b055bf" /> | <img width="1293" height="390" alt="Screenshot 2026-07-21 at 5 16 16 PM" src="https://github.com/user-attachments/assets/bc9f1d6e-4dff-494e-a2c7-d14a174d11a6" /> |


