### PR TITLE
OTTER-685: Log code environment changes and show them in a history modal

### DIFF
--- a/src/app/[orgSlug]/admin/settings/code-env-history-view.tsx
+++ b/src/app/[orgSlug]/admin/settings/code-env-history-view.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { Badge, Group, Stack, Table, Text } from '@mantine/core'
+import type { AuditEventType } from '@/database/types'
+import type { CodeEnvAuditMetadata } from '@/lib/audit-diff'
+
+// Presentational pieces for the code environment history modal. Data fetching lives in
+// the useCodeEnvHistory hook; these render plain values so they work in isolation.
+
+export type CodeEnvHistoryEntry = {
+    id: string
+    createdAt: Date
+    eventType: AuditEventType
+    userFullName: string | null
+    metadata: CodeEnvAuditMetadata
+}
+
+const EVENT_LABELS: Partial<Record<AuditEventType, { color: string; label: string }>> = {
+    CREATED: { color: 'teal', label: 'Created' },
+    UPDATED: { color: 'blue', label: 'Updated' },
+    DELETED: { color: 'red', label: 'Deleted' },
+}
+
+const FIELD_LABELS: Record<string, string> = {
+    name: 'Name',
+    identifier: 'Identifier',
+    language: 'Language',
+    commandLines: 'Command lines',
+    url: 'Image URL',
+    isTesting: 'Testing environment',
+    settings: 'Environment variables',
+    sampleDataPath: 'Sample data path',
+    dataSourceType: 'Data source type',
+    starterCodeFileNames: 'Starter code files',
+}
+
+const formatValue = (value: unknown): string => {
+    if (value === null || value === undefined) return '—'
+    if (typeof value === 'boolean') return value ? 'Yes' : 'No'
+    if (typeof value === 'string') return value === '' ? '—' : value
+    if (Array.isArray(value)) return value.length ? value.join(', ') : '—'
+    return JSON.stringify(value)
+}
+
+const formatTimestamp = (value: Date) =>
+    new Date(value).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+
+const EventBadge: React.FC<{ eventType: AuditEventType }> = ({ eventType }) => {
+    const config = EVENT_LABELS[eventType]
+    if (!config) return null
+    return (
+        <Badge color={config.color} variant="light" size="sm">
+            {config.label}
+        </Badge>
+    )
+}
+
+const StarterCodeBadge: React.FC<{ isVisible: boolean }> = ({ isVisible }) => {
+    if (!isVisible) return null
+    // "Replaced" rather than "uploaded": the server wiped and rewrote the folder, but the
+    // files themselves are pushed by the browser after the action returns.
+    return (
+        <Badge color="grape" variant="light" size="sm">
+            Starter code replaced
+        </Badge>
+    )
+}
+
+const ChangeList: React.FC<{ changes: CodeEnvAuditMetadata['changes'] }> = ({ changes }) => {
+    if (!changes.length) return <Text c="dimmed">No field changes</Text>
+    return (
+        <Stack gap={4}>
+            {changes.map((change) => (
+                <Text key={change.field} size="sm">
+                    <Text span fw={600}>
+                        {FIELD_LABELS[change.field] ?? change.field}
+                    </Text>
+                    {': '}
+                    <Text span c="dimmed">
+                        {formatValue(change.before)}
+                    </Text>
+                    {' → '}
+                    <Text span>{formatValue(change.after)}</Text>
+                </Text>
+            ))}
+        </Stack>
+    )
+}
+
+const HistoryRow: React.FC<{ entry: CodeEnvHistoryEntry }> = ({ entry }) => (
+    <Table.Tr>
+        <Table.Td valign="top">
+            <Text size="sm">{formatTimestamp(entry.createdAt)}</Text>
+        </Table.Td>
+        <Table.Td valign="top">
+            <Text size="sm">{entry.userFullName ?? 'Unknown user'}</Text>
+        </Table.Td>
+        <Table.Td valign="top">
+            <Group gap={4}>
+                <EventBadge eventType={entry.eventType} />
+                <StarterCodeBadge isVisible={Boolean(entry.metadata.starterCodeReplaced)} />
+            </Group>
+        </Table.Td>
+        <Table.Td>
+            <ChangeList changes={entry.metadata.changes} />
+        </Table.Td>
+    </Table.Tr>
+)
+
+export const CodeEnvHistoryTable: React.FC<{ isVisible: boolean; entries: CodeEnvHistoryEntry[] }> = ({
+    isVisible,
+    entries,
+}) => {
+    if (!isVisible) return null
+
+    return (
+        <Table withRowBorders horizontalSpacing="md" verticalSpacing="sm">
+            <Table.Thead>
+                <Table.Tr>
+                    <Table.Th>When</Table.Th>
+                    <Table.Th>Who</Table.Th>
+                    <Table.Th>Event</Table.Th>
+                    <Table.Th>Changes</Table.Th>
+                </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+                {entries.map((entry) => (
+                    <HistoryRow key={entry.id} entry={entry} />
+                ))}
+            </Table.Tbody>
+        </Table>
+    )
+}
+
+export const CodeEnvHistoryEmpty: React.FC<{ isVisible: boolean }> = ({ isVisible }) => {
+    if (!isVisible) return null
+    return <Text c="dimmed">No changes have been recorded for this code environment yet.</Text>
+}

--- a/src/app/[orgSlug]/admin/settings/code-env-history-view.tsx
+++ b/src/app/[orgSlug]/admin/settings/code-env-history-view.tsx
@@ -136,3 +136,11 @@ export const CodeEnvHistoryEmpty: React.FC<{ isVisible: boolean }> = ({ isVisibl
     if (!isVisible) return null
     return <Text c="dimmed">No changes have been recorded for this code environment yet.</Text>
 }
+
+// Distinct from the empty state on purpose: "nobody changed this" and "we could not tell you
+// who changed this" are opposite answers, and an investigation that trusts the former when
+// the latter is true reaches the wrong conclusion.
+export const CodeEnvHistoryError: React.FC<{ isVisible: boolean }> = ({ isVisible }) => {
+    if (!isVisible) return null
+    return <Text c="red">Could not load the change history for this code environment. Please try again.</Text>
+}

--- a/src/app/[orgSlug]/admin/settings/code-envs.actions.test.ts
+++ b/src/app/[orgSlug]/admin/settings/code-envs.actions.test.ts
@@ -16,7 +16,7 @@ import {
 } from './code-envs.actions'
 import { db } from '@/database'
 import { isActionError } from '@/lib/errors'
-import { codeEnvAuditMetadataSchema } from '@/lib/audit-diff'
+import { REDACTED_ENV_VALUE, codeEnvAuditMetadataSchema } from '@/lib/audit-diff'
 import { insertFakeCodeScan } from '@/server/actions/simulate-scan'
 import { OrgCodeEnvSettings } from '@/database/types'
 
@@ -226,6 +226,113 @@ describe('Code Environment Actions', () => {
         })
 
         expect(isActionError(result)).toBe(true)
+    })
+
+    // A denied ability check stringifies the whole CASL subject — every middleware key —
+    // into the error it returns to the caller. Loading the prior row in middleware put
+    // its plaintext env var values in that message.
+    it('updateOrgCodeEnvAction does not leak env var values to a denied non-admin', async () => {
+        const { org } = await mockSessionWithTestData({ isAdmin: false })
+
+        const codeEnv = await db
+            .insertInto('orgCodeEnv')
+            .values({
+                orgId: org.id,
+                name: 'Holds a secret',
+                identifier: 'secret_holder',
+                commandLines: { r: 'test command' },
+                language: 'R',
+                url: 'test-url',
+                isTesting: false,
+                starterCodeFileNames: ['starter.R'],
+                settings: { environment: [{ name: 'DB_PASSWORD', value: 'super-secret-value' }] },
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        const result = await updateOrgCodeEnvAction({
+            orgSlug: org.slug,
+            codeEnvId: codeEnv.id,
+            name: 'Attempted Update',
+            identifier: 'secret_holder',
+            commandLines: { r: 'test command' },
+            language: 'R',
+            url: 'test-url',
+            isTesting: false,
+            settings: { environment: [] },
+            dataSourceIds: [],
+        })
+
+        expect(isActionError(result)).toBe(true)
+        expect(JSON.stringify(result)).not.toContain('super-secret-value')
+    })
+
+    it('updateOrgCodeEnvAction does not leak another org env var values', async () => {
+        const otherOrg = await insertTestOrg({ slug: 'other-org-env-leak' })
+
+        const otherEnv = await db
+            .insertInto('orgCodeEnv')
+            .values({
+                orgId: otherOrg.id,
+                name: 'Other org secret',
+                identifier: 'other_secret',
+                commandLines: { r: 'test command' },
+                language: 'R',
+                url: 'test-url',
+                isTesting: false,
+                starterCodeFileNames: ['starter.R'],
+                settings: { environment: [{ name: 'DB_PASSWORD', value: 'other-org-secret-value' }] },
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        // An admin of their OWN org: the only thing standing between them and another
+        // org's row is the ability check, since the middleware looks the row up by the
+        // client-supplied orgSlug and codeEnvId.
+        await mockSessionWithTestData({ isAdmin: true })
+
+        const result = await updateOrgCodeEnvAction({
+            orgSlug: otherOrg.slug,
+            codeEnvId: otherEnv.id,
+            name: 'Attempted Update',
+            identifier: 'other_secret',
+            commandLines: { r: 'test command' },
+            language: 'R',
+            url: 'test-url',
+            isTesting: false,
+            settings: { environment: [] },
+            dataSourceIds: [],
+        })
+
+        expect(isActionError(result)).toBe(true)
+        expect(JSON.stringify(result)).not.toContain('other-org-secret-value')
+    })
+
+    it('deleteOrgCodeEnvAction does not leak another org env var values', async () => {
+        const otherOrg = await insertTestOrg({ slug: 'other-org-delete-leak' })
+
+        const otherEnv = await db
+            .insertInto('orgCodeEnv')
+            .values({
+                orgId: otherOrg.id,
+                name: 'Other org secret to delete',
+                identifier: 'other_delete_secret',
+                commandLines: { r: 'test command' },
+                language: 'R',
+                url: 'test-url',
+                isTesting: true,
+                starterCodeFileNames: ['starter.R'],
+                settings: { environment: [{ name: 'API_KEY', value: 'other-org-delete-secret' }] },
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        await mockSessionWithTestData({ isAdmin: true })
+
+        const result = await deleteOrgCodeEnvAction({ orgSlug: otherOrg.slug, codeEnvId: otherEnv.id })
+
+        expect(isActionError(result)).toBe(true)
+        expect(JSON.stringify(result)).not.toContain('other-org-delete-secret')
     })
 
     it('updateOrgCodeEnvAction allows SI admin to update even if not org admin', async () => {
@@ -813,7 +920,16 @@ describe('Code Environment audit logging', () => {
 
         const entries = await getAuditEntriesWithMetadata(codeEnv.id, 'CODE_ENV')
         const metadata = codeEnvAuditMetadataSchema.parse(entries[0].metadata)
-        expect(metadata.changes).toEqual([{ field: 'settings', before: { environment: [] }, after: settings }])
+        expect(metadata.changes).toEqual([
+            {
+                field: 'settings',
+                before: { environment: [] },
+                after: { environment: [{ name: 'API_KEY', value: REDACTED_ENV_VALUE }] },
+            },
+        ])
+        // The audit row is append-only and outlives any rotation, so the value must never
+        // reach it — only the name, which is what identifies the change.
+        expect(JSON.stringify(entries[0].metadata)).not.toContain('secret')
     })
 
     it('records nothing when a save changes nothing', async () => {

--- a/src/app/[orgSlug]/admin/settings/code-envs.actions.test.ts
+++ b/src/app/[orgSlug]/admin/settings/code-envs.actions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
     mockSessionWithTestData,
     actionResult,
+    getAuditEntriesWithMetadata,
     insertTestCodeEnv,
     insertTestDataSource,
     insertTestOrg,
@@ -9,12 +10,20 @@ import {
 import {
     createOrgCodeEnvAction,
     deleteOrgCodeEnvAction,
+    fetchCodeEnvHistoryAction,
     fetchOrgCodeEnvsAction,
     updateOrgCodeEnvAction,
 } from './code-envs.actions'
 import { db } from '@/database'
 import { isActionError } from '@/lib/errors'
+import { codeEnvAuditMetadataSchema } from '@/lib/audit-diff'
+import { insertFakeCodeScan } from '@/server/actions/simulate-scan'
 import { OrgCodeEnvSettings } from '@/database/types'
+
+vi.mock('@/server/actions/simulate-scan', async () => {
+    const actual = await vi.importActual('@/server/actions/simulate-scan')
+    return { ...actual, insertFakeCodeScan: vi.fn(actual.insertFakeCodeScan as never) }
+})
 
 vi.mock('@/server/aws', async () => {
     const actual = await vi.importActual('@/server/aws')
@@ -709,5 +718,239 @@ describe('Code Environment Actions', () => {
         expect(result).toHaveLength(1)
         expect(result[0].dataSources).toHaveLength(1)
         expect(result[0].dataSources[0].name).toEqual('Linked DS')
+    })
+})
+
+// These audit writes are inline rather than deferred, so the rows are committed by the
+// time the action resolves — no waitFor needed, unlike the study/user audit tests.
+describe('Code Environment audit logging', () => {
+    const baseEnv = (orgId: string) => ({
+        orgId,
+        name: 'Audited Env',
+        identifier: 'audited_env',
+        commandLines: { r: 'Rscript main.r' },
+        language: 'R' as const,
+        url: 'repo/img:v1',
+        isTesting: false,
+        starterCodeFileNames: ['main.r'],
+    })
+
+    const updateParams = (orgSlug: string, codeEnvId: string, overrides = {}) => ({
+        orgSlug,
+        codeEnvId,
+        name: 'Audited Env',
+        identifier: 'audited_env',
+        commandLines: { r: 'Rscript main.r' },
+        language: 'R' as const,
+        url: 'repo/img:v1',
+        isTesting: false,
+        settings: { environment: [] },
+        dataSourceIds: [],
+        ...overrides,
+    })
+
+    it('records a CREATED entry with every field and the acting user', async () => {
+        const { org, user } = await mockSessionWithTestData({ isAdmin: true })
+
+        const created = actionResult(
+            await createOrgCodeEnvAction({
+                orgSlug: org.slug,
+                name: 'Audited Env',
+                identifier: 'audited_env',
+                commandLines: { r: 'Rscript main.r' },
+                language: 'R',
+                url: 'repo/img:v1',
+                starterCodeFileNames: ['main.r'],
+                isTesting: false,
+                settings: { environment: [] },
+                dataSourceIds: [],
+            }),
+        )
+
+        const entries = await getAuditEntriesWithMetadata(created.id, 'CODE_ENV')
+        expect(entries).toHaveLength(1)
+        expect(entries[0].eventType).toEqual('CREATED')
+        expect(entries[0].userId).toEqual(user.id)
+
+        const metadata = codeEnvAuditMetadataSchema.parse(entries[0].metadata)
+        expect(metadata.starterCodeReplaced).toBe(true)
+        expect(metadata.name).toEqual('Audited Env')
+        expect(metadata.changes.find((c) => c.field === 'url')).toEqual({
+            field: 'url',
+            before: null,
+            after: 'repo/img:v1',
+        })
+    })
+
+    it('records only the field that changed on update', async () => {
+        const { org } = await mockSessionWithTestData({ isAdmin: true })
+        const codeEnv = await db
+            .insertInto('orgCodeEnv')
+            .values(baseEnv(org.id))
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        await updateOrgCodeEnvAction(updateParams(org.slug, codeEnv.id, { url: 'repo/img:v2' }))
+
+        const entries = await getAuditEntriesWithMetadata(codeEnv.id, 'CODE_ENV')
+        expect(entries).toHaveLength(1)
+        expect(entries[0].eventType).toEqual('UPDATED')
+
+        const metadata = codeEnvAuditMetadataSchema.parse(entries[0].metadata)
+        expect(metadata.changes).toEqual([{ field: 'url', before: 'repo/img:v1', after: 'repo/img:v2' }])
+    })
+
+    it('records changes to environment variables', async () => {
+        const { org } = await mockSessionWithTestData({ isAdmin: true })
+        const codeEnv = await db
+            .insertInto('orgCodeEnv')
+            .values(baseEnv(org.id))
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        const settings = { environment: [{ name: 'API_KEY', value: 'secret' }] }
+        await updateOrgCodeEnvAction(updateParams(org.slug, codeEnv.id, { settings }))
+
+        const entries = await getAuditEntriesWithMetadata(codeEnv.id, 'CODE_ENV')
+        const metadata = codeEnvAuditMetadataSchema.parse(entries[0].metadata)
+        expect(metadata.changes).toEqual([{ field: 'settings', before: { environment: [] }, after: settings }])
+    })
+
+    it('records nothing when a save changes nothing', async () => {
+        const { org } = await mockSessionWithTestData({ isAdmin: true })
+        const codeEnv = await db
+            .insertInto('orgCodeEnv')
+            .values(baseEnv(org.id))
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        await updateOrgCodeEnvAction(updateParams(org.slug, codeEnv.id))
+
+        expect(await getAuditEntriesWithMetadata(codeEnv.id, 'CODE_ENV')).toHaveLength(0)
+    })
+
+    it('flags a starter code replacement even when the file names are unchanged', async () => {
+        const { org } = await mockSessionWithTestData({ isAdmin: true })
+        const codeEnv = await db
+            .insertInto('orgCodeEnv')
+            .values(baseEnv(org.id))
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        await updateOrgCodeEnvAction(
+            updateParams(org.slug, codeEnv.id, {
+                starterCodeFileNames: ['main.r'],
+                starterCodeUploaded: true,
+            }),
+        )
+
+        const entries = await getAuditEntriesWithMetadata(codeEnv.id, 'CODE_ENV')
+        expect(entries).toHaveLength(1)
+
+        const metadata = codeEnvAuditMetadataSchema.parse(entries[0].metadata)
+        expect(metadata.starterCodeReplaced).toBe(true)
+        expect(metadata.changes.some((c) => c.field === 'starterCodeFileNames')).toBe(false)
+    })
+
+    it('records both the flag and the diff when starter code file names change', async () => {
+        const { org } = await mockSessionWithTestData({ isAdmin: true })
+        const codeEnv = await db
+            .insertInto('orgCodeEnv')
+            .values(baseEnv(org.id))
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        await updateOrgCodeEnvAction(
+            updateParams(org.slug, codeEnv.id, {
+                starterCodeFileNames: ['main.r', 'helpers.r'],
+                starterCodeUploaded: true,
+            }),
+        )
+
+        const metadata = codeEnvAuditMetadataSchema.parse(
+            (await getAuditEntriesWithMetadata(codeEnv.id, 'CODE_ENV'))[0].metadata,
+        )
+        expect(metadata.starterCodeReplaced).toBe(true)
+        expect(metadata.changes).toEqual([
+            { field: 'starterCodeFileNames', before: ['main.r'], after: ['main.r', 'helpers.r'] },
+        ])
+    })
+
+    it('records a DELETED entry that outlives the code environment', async () => {
+        const { org } = await mockSessionWithTestData({ isAdmin: true })
+        const codeEnv = await db
+            .insertInto('orgCodeEnv')
+            .values(baseEnv(org.id))
+            .returningAll()
+            .executeTakeFirstOrThrow()
+        // A second env of the same language keeps the "last non-testing env" guard happy.
+        await insertTestCodeEnv({ orgId: org.id, language: 'R' })
+
+        await deleteOrgCodeEnvAction({ orgSlug: org.slug, codeEnvId: codeEnv.id })
+
+        expect(await db.selectFrom('orgCodeEnv').where('id', '=', codeEnv.id).executeTakeFirst()).toBeUndefined()
+
+        const entries = await getAuditEntriesWithMetadata(codeEnv.id, 'CODE_ENV')
+        expect(entries).toHaveLength(1)
+        expect(entries[0].eventType).toEqual('DELETED')
+
+        const metadata = codeEnvAuditMetadataSchema.parse(entries[0].metadata)
+        expect(metadata.name).toEqual('Audited Env')
+        expect(metadata.changes.every((c) => c.after === null)).toBe(true)
+    })
+
+    // The reason these audit writes are inline rather than deferred: a deferred write
+    // would land even though the transaction rolled back, claiming a change that never
+    // happened. deleteFolderContents runs after the update and after the audit write, so
+    // failing it exercises exactly that window.
+    it('writes no audit row when the mutation rolls back', async () => {
+        const { org } = await mockSessionWithTestData({ isAdmin: true })
+        const codeEnv = await db
+            .insertInto('orgCodeEnv')
+            .values(baseEnv(org.id))
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        vi.mocked(insertFakeCodeScan).mockRejectedValueOnce(new Error('simulated post-update failure'))
+
+        const result = await updateOrgCodeEnvAction(updateParams(org.slug, codeEnv.id, { url: 'repo/img:v2' }))
+
+        expect(isActionError(result)).toBe(true)
+        expect(await getAuditEntriesWithMetadata(codeEnv.id, 'CODE_ENV')).toHaveLength(0)
+
+        const unchanged = await db
+            .selectFrom('orgCodeEnv')
+            .select('url')
+            .where('id', '=', codeEnv.id)
+            .executeTakeFirst()
+        expect(unchanged?.url).toEqual('repo/img:v1')
+    })
+
+    it('fetchCodeEnvHistoryAction returns entries newest first with the actor name', async () => {
+        const { org, user } = await mockSessionWithTestData({ isAdmin: true })
+        const codeEnv = await db
+            .insertInto('orgCodeEnv')
+            .values(baseEnv(org.id))
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        await updateOrgCodeEnvAction(updateParams(org.slug, codeEnv.id, { url: 'repo/img:v2' }))
+        await updateOrgCodeEnvAction(updateParams(org.slug, codeEnv.id, { url: 'repo/img:v3', name: 'Renamed' }))
+
+        const history = actionResult(await fetchCodeEnvHistoryAction({ orgSlug: org.slug, codeEnvId: codeEnv.id }))
+        expect(history).toHaveLength(2)
+        expect(history[0].userFullName).toEqual(user.fullName)
+
+        const newest = codeEnvAuditMetadataSchema.parse(history[0].metadata)
+        expect(newest.changes.map((c) => c.field)).toContain('name')
+    })
+
+    it('fetchCodeEnvHistoryAction does not expose another org history', async () => {
+        const otherOrg = await insertTestOrg({ slug: 'other-org-history' })
+        const otherEnv = await insertTestCodeEnv({ orgId: otherOrg.id, language: 'R' })
+        const { org } = await mockSessionWithTestData({ isAdmin: true })
+
+        const result = await fetchCodeEnvHistoryAction({ orgSlug: org.slug, codeEnvId: otherEnv.id })
+        expect(isActionError(result)).toBe(true)
     })
 })

--- a/src/app/[orgSlug]/admin/settings/code-envs.actions.ts
+++ b/src/app/[orgSlug]/admin/settings/code-envs.actions.ts
@@ -36,6 +36,15 @@ import logger from '@/lib/logger'
 import type { DB } from '@/database/types'
 import type { Kysely } from 'kysely'
 import { Routes } from '@/lib/routes'
+import { AUDITED_CODE_ENV_FIELDS, diffFields } from '@/lib/audit-diff'
+import { onCodeEnvCreated, onCodeEnvDeleted, onCodeEnvUpdated } from '@/server/events'
+
+const priorCodeEnvFor = (db: Kysely<DB>, codeEnvId: string) =>
+    db
+        .selectFrom('orgCodeEnv')
+        .select([...AUDITED_CODE_ENV_FIELDS])
+        .where('id', '=', codeEnvId)
+        .executeTakeFirstOrThrow()
 
 const codeEnvFromOrgAndId = async ({
     params: { orgSlug, codeEnvId },
@@ -96,7 +105,7 @@ export const createOrgCodeEnvAction = new Action('createOrgCodeEnvAction', { per
     .params(createOrgCodeEnvSchema)
     .middleware(orgIdFromSlug)
     .requireAbilityTo('update', 'Org')
-    .handler(async ({ params, orgId, db }) => {
+    .handler(async ({ params, orgId, db, session }) => {
         const { orgSlug, starterCodeFileNames, sampleDataPath, sampleDataUploaded, dataSourceIds, ...fieldValues } =
             params
 
@@ -127,6 +136,15 @@ export const createOrgCodeEnvAction = new Action('createOrgCodeEnvAction', { per
             })
             .returningAll()
             .executeTakeFirstOrThrow()
+
+        await onCodeEnvCreated({
+            db,
+            codeEnvId: newCodeEnv.id,
+            userId: session.user.id,
+            changes: diffFields({}, newCodeEnv, AUDITED_CODE_ENV_FIELDS),
+            starterCodeReplaced: true,
+            name: newCodeEnv.name,
+        })
 
         if (dataSourceIds.length > 0) {
             await db
@@ -181,7 +199,10 @@ export const updateOrgCodeEnvAction = new Action('updateOrgCodeEnvAction', { per
     .params(updateOrgCodeEnvSchema)
     .middleware(async (args) => {
         const { codeEnv, orgId } = await codeEnvFromOrgAndId(args)
-        return { ...codeEnv, orgId }
+        // Namespaced rather than flattened: the handler already destructures several of
+        // these columns as prev*, and every middleware key is fed into the CASL subject.
+        const priorCodeEnv = await priorCodeEnvFor(args.db, codeEnv.id)
+        return { ...codeEnv, orgId, priorCodeEnv }
     })
     .requireAbilityTo('update', 'Org')
     // other parms comes from the DB query in middleware (codeEnvFromOrgAndId), not from client params
@@ -195,7 +216,9 @@ export const updateOrgCodeEnvAction = new Action('updateOrgCodeEnvAction', { per
             identifier: prevIdentifier,
             orgSlug: prevOrgSlug,
             orgId,
+            priorCodeEnv,
             db,
+            session,
         }) => {
             const {
                 orgSlug,
@@ -254,6 +277,19 @@ export const updateOrgCodeEnvAction = new Action('updateOrgCodeEnvAction', { per
                 .where('id', '=', codeEnvId)
                 .returningAll()
                 .executeTakeFirstOrThrow()
+
+            await onCodeEnvUpdated({
+                db,
+                codeEnvId,
+                userId: session.user.id,
+                changes: diffFields(priorCodeEnv, updatedCodeEnv, AUDITED_CODE_ENV_FIELDS),
+                // Mirrors the condition that gated the S3 wipe above, so this records what
+                // the server actually did rather than what the client merely claimed. The
+                // files themselves are uploaded after this action returns, so a replacement
+                // is not proof that the new objects landed in S3.
+                starterCodeReplaced: Boolean(starterCodeUploaded && starterCodeFileNames?.length),
+                name: updatedCodeEnv.name,
+            })
 
             await db.deleteFrom('orgDataSourceCodeEnv').where('codeEnvId', '=', codeEnvId).execute()
             if (dataSourceIds.length > 0) {
@@ -378,10 +414,13 @@ export const deleteOrgCodeEnvAction = new Action('deleteOrgCodeEnvAction', { per
             .where('orgCodeEnv.id', '=', codeEnvId)
             .executeTakeFirstOrThrow()
 
-        return codeEnv
+        // Captured before the row is destroyed so the audit entry records its final state.
+        const priorCodeEnv = await priorCodeEnvFor(db, codeEnv.id)
+
+        return { ...codeEnv, priorCodeEnv }
     })
     .requireAbilityTo('update', 'Org')
-    .handler(async ({ params: { orgSlug }, db, ...codeEnv }) => {
+    .handler(async ({ params: { orgSlug }, db, priorCodeEnv, session, ...codeEnv }) => {
         if (!codeEnv.isTesting) {
             const nonTesting = await db
                 .selectFrom('orgCodeEnv')
@@ -453,7 +492,51 @@ export const deleteOrgCodeEnvAction = new Action('deleteOrgCodeEnvAction', { per
             .where('orgCodeEnv.id', '=', codeEnv.id)
             .executeTakeFirstOrThrow(throwNotFound(`Failed to delete code environment with id ${codeEnv.id}`))
 
+        // The audit row deliberately outlives the record (audit.recordId has no FK), so
+        // the name is denormalized into metadata to keep the entry readable.
+        await onCodeEnvDeleted({
+            db,
+            codeEnvId: codeEnv.id,
+            userId: session.user.id,
+            changes: diffFields(priorCodeEnv, {}, AUDITED_CODE_ENV_FIELDS),
+            name: priorCodeEnv.name,
+        })
+
         revalidatePath(Routes.adminSettings({ orgSlug }))
+    })
+
+const fetchCodeEnvHistorySchema = z.object({
+    orgSlug: z.string(),
+    codeEnvId: z.string(),
+})
+
+export const fetchCodeEnvHistoryAction = new Action('fetchCodeEnvHistoryAction')
+    .params(fetchCodeEnvHistorySchema)
+    .middleware(codeEnvFromOrgAndId)
+    .requireAbilityTo('update', 'Org')
+    .handler(async ({ codeEnv, db }) => {
+        return await db
+            .selectFrom('audit')
+            // audit.userId has no FK because entries outlive deleted users; an inner join
+            // would silently drop exactly the history an audit trail exists to preserve.
+            .leftJoin('user', 'user.id', 'audit.userId')
+            .select([
+                'audit.id',
+                'audit.createdAt',
+                'audit.eventType',
+                'audit.userId',
+                'audit.metadata',
+                'user.fullName as userFullName',
+            ])
+            .where('audit.recordType', '=', 'CODE_ENV')
+            // Scoped to the middleware-resolved id, never the raw param: audit has no org
+            // column, so trusting params.codeEnvId here would expose other orgs' history.
+            .where('audit.recordId', '=', codeEnv.id)
+            .orderBy('audit.createdAt', 'desc')
+            // v7 ids are time-ordered, so they break ties between rows written inside the
+            // same clock tick — createdAt alone leaves those in an arbitrary order.
+            .orderBy('audit.id', 'desc')
+            .execute()
     })
 
 const fetchStarterCodeSchema = z.object({

--- a/src/app/[orgSlug]/admin/settings/code-envs.actions.ts
+++ b/src/app/[orgSlug]/admin/settings/code-envs.actions.ts
@@ -199,10 +199,7 @@ export const updateOrgCodeEnvAction = new Action('updateOrgCodeEnvAction', { per
     .params(updateOrgCodeEnvSchema)
     .middleware(async (args) => {
         const { codeEnv, orgId } = await codeEnvFromOrgAndId(args)
-        // Namespaced rather than flattened: the handler already destructures several of
-        // these columns as prev*, and every middleware key is fed into the CASL subject.
-        const priorCodeEnv = await priorCodeEnvFor(args.db, codeEnv.id)
-        return { ...codeEnv, orgId, priorCodeEnv }
+        return { ...codeEnv, orgId }
     })
     .requireAbilityTo('update', 'Org')
     // other parms comes from the DB query in middleware (codeEnvFromOrgAndId), not from client params
@@ -216,7 +213,6 @@ export const updateOrgCodeEnvAction = new Action('updateOrgCodeEnvAction', { per
             identifier: prevIdentifier,
             orgSlug: prevOrgSlug,
             orgId,
-            priorCodeEnv,
             db,
             session,
         }) => {
@@ -230,6 +226,12 @@ export const updateOrgCodeEnvAction = new Action('updateOrgCodeEnvAction', { per
                 dataSourceIds,
                 ...fieldValues
             } = params
+
+            // Loaded here rather than in middleware: every middleware key is fed into the
+            // CASL subject, and a failed ability check returns that subject to the caller
+            // JSON-stringified. In middleware this row's `settings.environment` — plaintext
+            // env var values — would leak to anyone the check then denies.
+            const priorCodeEnv = await priorCodeEnvFor(db, codeEnvId)
 
             if (dataSourceIds.length > 0) {
                 const matched = await db
@@ -414,13 +416,15 @@ export const deleteOrgCodeEnvAction = new Action('deleteOrgCodeEnvAction', { per
             .where('orgCodeEnv.id', '=', codeEnvId)
             .executeTakeFirstOrThrow()
 
-        // Captured before the row is destroyed so the audit entry records its final state.
-        const priorCodeEnv = await priorCodeEnvFor(db, codeEnv.id)
-
-        return { ...codeEnv, priorCodeEnv }
+        return { ...codeEnv }
     })
     .requireAbilityTo('update', 'Org')
-    .handler(async ({ params: { orgSlug }, db, priorCodeEnv, session, ...codeEnv }) => {
+    .handler(async ({ params: { orgSlug }, db, session, ...codeEnv }) => {
+        // Captured before the row is destroyed so the audit entry records its final state.
+        // Loaded here rather than in middleware for the same reason as the update action:
+        // middleware keys reach the caller in a denied ability check's error message.
+        const priorCodeEnv = await priorCodeEnvFor(db, codeEnv.id)
+
         if (!codeEnv.isTesting) {
             const nonTesting = await db
                 .selectFrom('orgCodeEnv')

--- a/src/app/[orgSlug]/admin/settings/code-envs.test.tsx
+++ b/src/app/[orgSlug]/admin/settings/code-envs.test.tsx
@@ -242,4 +242,44 @@ describe('CodeEnvs', async () => {
         expect(screen.getByText('VAR1=value1')).toBeInTheDocument()
         expect(screen.getAllByText('-').length).toBeGreaterThanOrEqual(1)
     })
+
+    describe('change history', () => {
+        it('shows recorded changes when the history icon is clicked', async () => {
+            const codeEnv = await insertTestCodeEnv({ orgId: org.id, name: 'Audited Env', language: 'R' })
+            const { user } = await mockSessionWithTestData({ isAdmin: true, orgSlug: org.slug })
+
+            await db
+                .insertInto('audit')
+                .values({
+                    userId: user.id,
+                    eventType: 'UPDATED',
+                    recordType: 'CODE_ENV',
+                    recordId: codeEnv.id,
+                    metadata: { changes: [{ field: 'url', before: 'repo/img:v1', after: 'repo/img:v2' }] },
+                })
+                .execute()
+
+            renderWithProviders(<CodeEnvs />)
+            await waitFor(() => expect(screen.getByText('Audited Env')).toBeInTheDocument())
+
+            fireEvent.click(screen.getByRole('button', { name: /history for audited env/i }))
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument()
+            })
+            expect(await screen.findByText(/repo\/img:v1/)).toBeInTheDocument()
+            expect(screen.getByText(/repo\/img:v2/)).toBeInTheDocument()
+        })
+
+        it('shows an empty state when nothing has been recorded', async () => {
+            await insertTestCodeEnv({ orgId: org.id, name: 'Untouched Env', language: 'R' })
+
+            renderWithProviders(<CodeEnvs />)
+            await waitFor(() => expect(screen.getByText('Untouched Env')).toBeInTheDocument())
+
+            fireEvent.click(screen.getByRole('button', { name: /history for untouched env/i }))
+
+            expect(await screen.findByText(/no changes have been recorded/i)).toBeInTheDocument()
+        })
+    })
 })

--- a/src/app/[orgSlug]/admin/settings/code-envs.tsx
+++ b/src/app/[orgSlug]/admin/settings/code-envs.tsx
@@ -14,7 +14,7 @@ import {
     ClockCounterClockwiseIcon,
 } from '@phosphor-icons/react/dist/ssr'
 import { deleteOrgCodeEnvAction, fetchOrgCodeEnvsAction, fetchStarterCodeAction } from './code-envs.actions'
-import { CodeEnvHistoryEmpty, CodeEnvHistoryTable } from './code-env-history-view'
+import { CodeEnvHistoryEmpty, CodeEnvHistoryError, CodeEnvHistoryTable } from './code-env-history-view'
 import { useCodeEnvHistory } from './use-code-env-history'
 import { SuretyGuard } from '@/components/surety-guard'
 import { reportMutationError, reportError } from '@/components/errors'
@@ -151,7 +151,11 @@ const CodeEnvRow: React.FC<{
 
     // Deferred until the modal opens so listing the environments does not also fetch
     // every row's history.
-    const { entries: history, isLoading: isLoadingHistory } = useCodeEnvHistory(orgSlug, image.id, historyOpened)
+    const {
+        entries: history,
+        isLoading: isLoadingHistory,
+        isError: isHistoryError,
+    } = useCodeEnvHistory(orgSlug, image.id, historyOpened)
 
     const handleEditComplete = () => {
         closeEditModal()
@@ -264,7 +268,8 @@ const CodeEnvRow: React.FC<{
             </AppModal>
             <AppModal isOpen={historyOpened} onClose={closeHistory} title={`History: ${image.name}`} size="xl">
                 <LoadingMessage message="Loading history..." isVisible={isLoadingHistory} />
-                <CodeEnvHistoryEmpty isVisible={!isLoadingHistory && history.length === 0} />
+                <CodeEnvHistoryError isVisible={!isLoadingHistory && isHistoryError} />
+                <CodeEnvHistoryEmpty isVisible={!isLoadingHistory && !isHistoryError && history.length === 0} />
                 <CodeEnvHistoryTable isVisible={!isLoadingHistory && history.length > 0} entries={history} />
             </AppModal>
         </>

--- a/src/app/[orgSlug]/admin/settings/code-envs.tsx
+++ b/src/app/[orgSlug]/admin/settings/code-envs.tsx
@@ -7,8 +7,15 @@ import { useDisclosure } from '@mantine/hooks'
 import { AppModal } from '@/components/modals/app-modal'
 import { CodeEnvForm } from './code-env-form'
 import { CodeEnvRowView, CodeEnvsView } from './code-envs-view'
-import { TrashIcon, PencilIcon, FileMagnifyingGlassIcon } from '@phosphor-icons/react/dist/ssr'
+import {
+    TrashIcon,
+    PencilIcon,
+    FileMagnifyingGlassIcon,
+    ClockCounterClockwiseIcon,
+} from '@phosphor-icons/react/dist/ssr'
 import { deleteOrgCodeEnvAction, fetchOrgCodeEnvsAction, fetchStarterCodeAction } from './code-envs.actions'
+import { CodeEnvHistoryEmpty, CodeEnvHistoryTable } from './code-env-history-view'
+import { useCodeEnvHistory } from './use-code-env-history'
 import { SuretyGuard } from '@/components/surety-guard'
 import { reportMutationError, reportError } from '@/components/errors'
 import { reportSuccess } from '@/components/notices'
@@ -126,6 +133,7 @@ const CodeEnvRow: React.FC<{
     const [editModalOpened, { open: openEditModal, close: closeEditModal }] = useDisclosure(false)
     const [codeViewerOpened, { open: openCodeViewer, close: closeCodeViewer }] = useDisclosure(false)
     const [scanResultsOpened, { open: openScanResults, close: closeScanResults }] = useDisclosure(false)
+    const [historyOpened, { open: openHistory, close: closeHistory }] = useDisclosure(false)
     const [detailOpened, { toggle: toggleDetail }] = useDisclosure(false)
     const [starterCode, setStarterCode] = useState<{ content: string; fileName: string } | null>(null)
     const [isLoadingCode, setIsLoadingCode] = useState(false)
@@ -141,9 +149,14 @@ const CodeEnvRow: React.FC<{
         onError: reportMutationError('Failed to delete code environment'),
     })
 
+    // Deferred until the modal opens so listing the environments does not also fetch
+    // every row's history.
+    const { entries: history, isLoading: isLoadingHistory } = useCodeEnvHistory(orgSlug, image.id, historyOpened)
+
     const handleEditComplete = () => {
         closeEditModal()
         queryClient.invalidateQueries({ queryKey: ['orgCodeEnvs', orgSlug] })
+        queryClient.invalidateQueries({ queryKey: ['codeEnvHistory', orgSlug, image.id] })
     }
 
     const handleViewCode = async (fileName?: string) => {
@@ -186,8 +199,25 @@ const CodeEnvRow: React.FC<{
                 actions={
                     <>
                         <Tooltip label="Edit" withArrow>
-                            <ActionIcon size="sm" variant="subtle" color="green" onClick={openEditModal}>
+                            <ActionIcon
+                                size="sm"
+                                variant="subtle"
+                                color="green"
+                                onClick={openEditModal}
+                                aria-label={`Edit ${image.name}`}
+                            >
                                 <PencilIcon />
+                            </ActionIcon>
+                        </Tooltip>
+                        <Tooltip label="History" withArrow>
+                            <ActionIcon
+                                size="sm"
+                                variant="subtle"
+                                color="blue"
+                                onClick={openHistory}
+                                aria-label={`History for ${image.name}`}
+                            >
+                                <ClockCounterClockwiseIcon />
                             </ActionIcon>
                         </Tooltip>
                         <DeleteCodeEnv
@@ -231,6 +261,11 @@ const CodeEnvRow: React.FC<{
                 styles={{ body: { padding: 0 } }}
             >
                 <FileViewer path="scan-results.txt" text={image.latestScanResults || 'No results available.'} />
+            </AppModal>
+            <AppModal isOpen={historyOpened} onClose={closeHistory} title={`History: ${image.name}`} size="xl">
+                <LoadingMessage message="Loading history..." isVisible={isLoadingHistory} />
+                <CodeEnvHistoryEmpty isVisible={!isLoadingHistory && history.length === 0} />
+                <CodeEnvHistoryTable isVisible={!isLoadingHistory && history.length > 0} entries={history} />
             </AppModal>
         </>
     )

--- a/src/app/[orgSlug]/admin/settings/use-code-env-history.ts
+++ b/src/app/[orgSlug]/admin/settings/use-code-env-history.ts
@@ -2,26 +2,49 @@
 
 import { useQuery } from '@/common'
 import { codeEnvAuditMetadataSchema } from '@/lib/audit-diff'
+import { isActionError } from '@/lib/errors'
 import { fetchCodeEnvHistoryAction } from './code-envs.actions'
 import type { CodeEnvHistoryEntry } from './code-env-history-view'
 
-// metadata is jsonb, so it arrives typed as Json. Parsing it through the schema here
-// keeps that shape defined in one place rather than cast at each render site; entries
-// written before a field was added still parse, since every key is optional or defaulted.
-export const useCodeEnvHistory = (orgSlug: string, codeEnvId: string, enabled: boolean) => {
-    const query = useQuery({
-        queryKey: ['codeEnvHistory', orgSlug, codeEnvId],
-        enabled,
-        queryFn: async () => await fetchCodeEnvHistoryAction({ orgSlug, codeEnvId }),
-    })
+// metadata is jsonb, so it arrives typed as Json. Parsing it through the schema keeps that
+// shape defined in one place rather than cast at each render site.
+//
+// safeParse rather than parse, inside queryFn rather than during render: audit rows outlive
+// the code that wrote them, so a future shape change would otherwise throw out of the hook
+// body, where TanStack cannot catch it — taking down the whole settings page instead of
+// leaving one row unreadable. A row that fails the schema degrades to "no field changes"
+// and keeps the rest of the history visible.
+const toEntry = (entry: {
+    id: string
+    createdAt: Date
+    eventType: CodeEnvHistoryEntry['eventType']
+    userFullName: string | null
+    metadata: unknown
+}): CodeEnvHistoryEntry => {
+    const parsed = codeEnvAuditMetadataSchema.safeParse(entry.metadata ?? {})
 
-    const entries: CodeEnvHistoryEntry[] = (query.data ?? []).map((entry) => ({
+    return {
         id: entry.id,
         createdAt: entry.createdAt,
         eventType: entry.eventType,
         userFullName: entry.userFullName,
-        metadata: codeEnvAuditMetadataSchema.parse(entry.metadata ?? {}),
-    }))
+        metadata: parsed.success ? parsed.data : { changes: [] },
+    }
+}
 
-    return { entries, isLoading: query.isLoading }
+export const useCodeEnvHistory = (orgSlug: string, codeEnvId: string, enabled: boolean) => {
+    const query = useQuery({
+        queryKey: ['codeEnvHistory', orgSlug, codeEnvId],
+        enabled,
+        // Thrown rather than filtered out: a denied or failed fetch has to reach query.isError,
+        // otherwise it arrives as an empty list and renders as "no changes recorded" — the
+        // opposite of what happened.
+        queryFn: async () => {
+            const result = await fetchCodeEnvHistoryAction({ orgSlug, codeEnvId })
+            if (isActionError(result)) throw new Error('Failed to load code environment history')
+            return result.map(toEntry)
+        },
+    })
+
+    return { entries: query.data ?? [], isLoading: query.isLoading, isError: query.isError }
 }

--- a/src/app/[orgSlug]/admin/settings/use-code-env-history.ts
+++ b/src/app/[orgSlug]/admin/settings/use-code-env-history.ts
@@ -1,0 +1,27 @@
+'use client'
+
+import { useQuery } from '@/common'
+import { codeEnvAuditMetadataSchema } from '@/lib/audit-diff'
+import { fetchCodeEnvHistoryAction } from './code-envs.actions'
+import type { CodeEnvHistoryEntry } from './code-env-history-view'
+
+// metadata is jsonb, so it arrives typed as Json. Parsing it through the schema here
+// keeps that shape defined in one place rather than cast at each render site; entries
+// written before a field was added still parse, since every key is optional or defaulted.
+export const useCodeEnvHistory = (orgSlug: string, codeEnvId: string, enabled: boolean) => {
+    const query = useQuery({
+        queryKey: ['codeEnvHistory', orgSlug, codeEnvId],
+        enabled,
+        queryFn: async () => await fetchCodeEnvHistoryAction({ orgSlug, codeEnvId }),
+    })
+
+    const entries: CodeEnvHistoryEntry[] = (query.data ?? []).map((entry) => ({
+        id: entry.id,
+        createdAt: entry.createdAt,
+        eventType: entry.eventType,
+        userFullName: entry.userFullName,
+        metadata: codeEnvAuditMetadataSchema.parse(entry.metadata ?? {}),
+    }))
+
+    return { entries, isLoading: query.isLoading }
+}

--- a/src/app/api/qa/users/[userId]/route.test.ts
+++ b/src/app/api/qa/users/[userId]/route.test.ts
@@ -38,6 +38,9 @@ const auditRowsFor = async (recordId: string) =>
         .select(['eventType', 'recordType', 'recordId', 'userId', 'metadata'])
         .where('recordId', '=', recordId)
         .orderBy('createdAt')
+        // Both rows are written inside the same clock tick, so createdAt alone leaves
+        // their order undefined; v7 ids are time-ordered and break the tie.
+        .orderBy('id')
         .execute()
 
 const auditRowFor = async (recordId: string, outcome = 'succeeded') => {

--- a/src/database/migrations/1780400000000_add_code_env_audit_record_type.ts
+++ b/src/database/migrations/1780400000000_add_code_env_audit_record_type.ts
@@ -1,0 +1,10 @@
+import { type Kysely, sql } from 'kysely'
+
+// Must be the only statement in this migration: Postgres forbids using a newly added
+// enum value in the same transaction that adds it, and each migration runs in one.
+export async function up(db: Kysely<unknown>): Promise<void> {
+    await sql`ALTER TYPE audit_record_type ADD VALUE 'CODE_ENV'`.execute(db)
+}
+
+// Postgres does not support removing enum values, so down is a no-op.
+export async function down(_db: Kysely<unknown>): Promise<void> {}

--- a/src/database/migrations/1780400000001_add_audit_record_lookup_index.ts
+++ b/src/database/migrations/1780400000001_add_audit_record_lookup_index.ts
@@ -1,0 +1,15 @@
+import { type Kysely, sql } from 'kysely'
+
+// audit is append-only and grows with every login, so the per-record history query
+// (filter on record_type + record_id, newest first) needs to stay off a seq scan.
+// created_at is part of the index so the ordering is satisfied without a sort.
+export async function up(db: Kysely<unknown>): Promise<void> {
+    await sql`
+        CREATE INDEX audit_record_type_record_id_created_at_idx
+        ON audit (record_type, record_id, created_at DESC)
+    `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+    await sql`DROP INDEX IF EXISTS audit_record_type_record_id_created_at_idx`.execute(db)
+}

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -18,7 +18,7 @@ export type AuditEventType =
     | 'RESET_PASSWORD'
     | 'UPDATED'
 
-export type AuditRecordType = 'STUDY' | 'USER'
+export type AuditRecordType = 'CODE_ENV' | 'STUDY' | 'USER'
 
 export type Generated<T> =
     T extends ColumnType<infer S, infer I, infer U> ? ColumnType<S, I | undefined, U> : ColumnType<T, T | undefined, T>

--- a/src/lib/audit-diff.test.ts
+++ b/src/lib/audit-diff.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import { codeEnvAuditMetadataSchema, diffFields } from './audit-diff'
+
+// Mirrors the shape of the audited orgCodeEnv columns. Declared explicitly so the
+// generic infers the full key set rather than narrowing to whichever keys a given
+// fixture happens to set.
+type Row = {
+    name: string
+    url: string
+    settings: { environment: { name: string; value: string }[] }
+    commandLines: Record<string, string>
+    starterCodeFileNames: string[]
+    sampleDataPath: string | null
+}
+
+const FIELDS = ['name', 'url', 'settings', 'commandLines', 'starterCodeFileNames', 'sampleDataPath'] as const
+
+describe('diffFields', () => {
+    it('omits fields that did not change', () => {
+        const row = { name: 'env', url: 'repo/img:v1' }
+        expect(diffFields<Row>(row, row, FIELDS)).toEqual([])
+    })
+
+    it('reports primitive changes with before and after', () => {
+        const changes = diffFields<Row>({ url: 'repo/img:v1' }, { url: 'repo/img:v2' }, FIELDS)
+        expect(changes).toEqual([{ field: 'url', before: 'repo/img:v1', after: 'repo/img:v2' }])
+    })
+
+    it('treats undefined and null as equal', () => {
+        expect(diffFields<Row>({ sampleDataPath: undefined }, { sampleDataPath: null }, FIELDS)).toEqual([])
+    })
+
+    it('does not report jsonb objects that are deeply equal but not identical', () => {
+        const before = { settings: { environment: [{ name: 'KEY', value: 'a' }] } }
+        const after = { settings: { environment: [{ name: 'KEY', value: 'a' }] } }
+        expect(diffFields<Row>(before, after, FIELDS)).toEqual([])
+    })
+
+    it('detects a changed value inside settings.environment', () => {
+        const before = { settings: { environment: [{ name: 'KEY', value: 'a' }] } }
+        const after = { settings: { environment: [{ name: 'KEY', value: 'b' }] } }
+        expect(diffFields<Row>(before, after, FIELDS)).toEqual([
+            { field: 'settings', before: before.settings, after: after.settings },
+        ])
+    })
+
+    // Postgres reorders jsonb object keys on storage, so a stringify-based comparison
+    // would report a change here on every save.
+    it('ignores key order differences in commandLines', () => {
+        const before = { commandLines: { r: 'Rscript main.r', py: 'python main.py' } }
+        const after = { commandLines: { py: 'python main.py', r: 'Rscript main.r' } }
+        expect(diffFields<Row>(before, after, FIELDS)).toEqual([])
+    })
+
+    it('detects reordering of starterCodeFileNames', () => {
+        const before = { starterCodeFileNames: ['main.r', 'helpers.r'] }
+        const after = { starterCodeFileNames: ['helpers.r', 'main.r'] }
+        expect(diffFields<Row>(before, after, FIELDS)).toHaveLength(1)
+    })
+
+    it('returns changes in the order given by fields', () => {
+        const before = { url: 'a', name: 'x', sampleDataPath: 'p1' }
+        const after = { url: 'b', name: 'y', sampleDataPath: 'p2' }
+        expect(diffFields<Row>(before, after, FIELDS).map((c) => c.field)).toEqual(['name', 'url', 'sampleDataPath'])
+    })
+
+    it('reports every field as created when before is empty', () => {
+        const changes = diffFields<Row>({}, { name: 'env', url: 'repo/img:v1' }, FIELDS)
+        expect(changes).toEqual([
+            { field: 'name', before: null, after: 'env' },
+            { field: 'url', before: null, after: 'repo/img:v1' },
+        ])
+    })
+
+    it('reports every field as removed when after is empty', () => {
+        const changes = diffFields<Row>({ name: 'env' }, {}, FIELDS)
+        expect(changes).toEqual([{ field: 'name', before: 'env', after: null }])
+    })
+})
+
+describe('codeEnvAuditMetadataSchema', () => {
+    it('parses metadata with changes and flags', () => {
+        const parsed = codeEnvAuditMetadataSchema.parse({
+            changes: [{ field: 'url', before: 'a', after: 'b' }],
+            starterCodeReplaced: true,
+            name: 'env',
+        })
+        expect(parsed.changes).toHaveLength(1)
+        expect(parsed.starterCodeReplaced).toBe(true)
+    })
+
+    it('defaults changes to an empty array', () => {
+        expect(codeEnvAuditMetadataSchema.parse({}).changes).toEqual([])
+    })
+
+    it('accepts nested json values for before and after', () => {
+        const parsed = codeEnvAuditMetadataSchema.parse({
+            changes: [{ field: 'settings', before: null, after: { environment: [{ name: 'K', value: 'v' }] } }],
+        })
+        expect(parsed.changes[0].after).toEqual({ environment: [{ name: 'K', value: 'v' }] })
+    })
+})

--- a/src/lib/audit-diff.test.ts
+++ b/src/lib/audit-diff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { codeEnvAuditMetadataSchema, diffFields } from './audit-diff'
+import { REDACTED_ENV_VALUE, codeEnvAuditMetadataSchema, diffFields } from './audit-diff'
 
 // Mirrors the shape of the audited orgCodeEnv columns. Declared explicitly so the
 // generic infers the full key set rather than narrowing to whichever keys a given
@@ -36,11 +36,35 @@ describe('diffFields', () => {
         expect(diffFields<Row>(before, after, FIELDS)).toEqual([])
     })
 
+    // The change is still detected even though neither value is recorded: comparison runs on
+    // the real values, redaction applies only to what gets written.
     it('detects a changed value inside settings.environment', () => {
         const before = { settings: { environment: [{ name: 'KEY', value: 'a' }] } }
         const after = { settings: { environment: [{ name: 'KEY', value: 'b' }] } }
         expect(diffFields<Row>(before, after, FIELDS)).toEqual([
-            { field: 'settings', before: before.settings, after: after.settings },
+            {
+                field: 'settings',
+                before: { environment: [{ name: 'KEY', value: REDACTED_ENV_VALUE }] },
+                after: { environment: [{ name: 'KEY', value: REDACTED_ENV_VALUE }] },
+            },
+        ])
+    })
+
+    it('keeps env var names but never records their values', () => {
+        const before = { settings: { environment: [] } }
+        const after = { settings: { environment: [{ name: 'DB_PASSWORD', value: 'hunter2' }] } }
+
+        const changes = diffFields<Row>(before, after, FIELDS)
+
+        expect(JSON.stringify(changes)).not.toContain('hunter2')
+        expect(JSON.stringify(changes)).toContain('DB_PASSWORD')
+    })
+
+    it('leaves non-settings fields untouched', () => {
+        const before = { commandLines: { r: 'old' } }
+        const after = { commandLines: { r: 'new' } }
+        expect(diffFields<Row>(before, after, FIELDS)).toEqual([
+            { field: 'commandLines', before: { r: 'old' }, after: { r: 'new' } },
         ])
     })
 

--- a/src/lib/audit-diff.ts
+++ b/src/lib/audit-diff.ts
@@ -1,0 +1,84 @@
+import type { Json } from '@/database/types'
+import { isDeepEqual } from 'remeda'
+import { z } from 'zod'
+
+export type AuditFieldChange = {
+    field: string
+    before: Json
+    after: Json
+}
+
+// Single source for the audited orgCodeEnv columns so the "before" select, the diff, and
+// the audit metadata cannot drift apart as columns are added. Lives here rather than
+// beside the actions because that is a server module, where every export must be an
+// action.
+export const AUDITED_CODE_ENV_FIELDS = [
+    'name',
+    'identifier',
+    'language',
+    'commandLines',
+    'url',
+    'isTesting',
+    'settings',
+    'sampleDataPath',
+    'dataSourceType',
+    'starterCodeFileNames',
+] as const
+
+const jsonSchema: z.ZodType<Json> = z.lazy(() =>
+    z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(jsonSchema), z.record(z.string(), jsonSchema)]),
+)
+
+export const auditFieldChangeSchema = z.object({
+    field: z.string(),
+    before: jsonSchema,
+    after: jsonSchema,
+})
+
+export const codeEnvAuditMetadataSchema = z.object({
+    changes: z.array(auditFieldChangeSchema).default([]),
+    starterCodeReplaced: z.boolean().optional(),
+    name: z.string().optional(),
+})
+
+export type CodeEnvAuditMetadata = z.infer<typeof codeEnvAuditMetadataSchema>
+
+/**
+ * `undefined` is not representable in JSON and would be dropped during jsonb
+ * serialization, leaving an entry with a missing before/after key that the history
+ * table cannot render. Collapsing it to `null` also makes "key absent from params"
+ * compare equal to "column is null in the database" — without this, every save of a
+ * record with an optional-but-null column reports a spurious change.
+ */
+const normalize = (value: unknown): Json => {
+    if (value === undefined || value === null) return null
+    if (value instanceof Date) return value.toISOString()
+    return value as Json
+}
+
+/**
+ * Compares two records and returns one entry per field whose value changed.
+ *
+ * Values are compared structurally so jsonb and array columns diff by content:
+ * Kysely parses a fresh object for every jsonb read, so reference equality would
+ * report those fields as changed on every save. Structural comparison is also
+ * immune to Postgres reordering jsonb object keys on storage, which makes a
+ * stringify-based comparison report false positives.
+ */
+export function diffFields<T extends Record<string, unknown>>(
+    before: Partial<T>,
+    after: Partial<T>,
+    fields: readonly (keyof T & string)[],
+): AuditFieldChange[] {
+    const changes: AuditFieldChange[] = []
+
+    for (const field of fields) {
+        const prev = normalize(before[field])
+        const next = normalize(after[field])
+        if (!isDeepEqual(prev, next)) {
+            changes.push({ field, before: prev, after: next })
+        }
+    }
+
+    return changes
+}

--- a/src/lib/audit-diff.ts
+++ b/src/lib/audit-diff.ts
@@ -56,6 +56,37 @@ const normalize = (value: unknown): Json => {
     return value as Json
 }
 
+export const REDACTED_ENV_VALUE = '••••••'
+
+/**
+ * Replaces environment variable values with a placeholder before they are recorded.
+ *
+ * `orgCodeEnv.settings` holds env var values in plaintext, but the audit trail is
+ * append-only and outlives any later rotation — a credential written here would stay
+ * readable by every org admin forever, even after the real one was changed. Names are
+ * kept, since "which variable changed" is the part an admin needs during an incident.
+ *
+ * Applied only when recording: comparison still runs on the real values, so a change to
+ * a value alone is still detected as a change.
+ */
+const redactSettings = (value: Json): Json => {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) return value
+
+    const environment = (value as Record<string, Json>).environment
+    if (!Array.isArray(environment)) return value
+
+    return {
+        ...(value as Record<string, Json>),
+        environment: environment.map((entry) =>
+            entry !== null && typeof entry === 'object' && !Array.isArray(entry) && 'value' in entry
+                ? { ...(entry as Record<string, Json>), value: REDACTED_ENV_VALUE }
+                : entry,
+        ),
+    }
+}
+
+const forRecording = (field: string, value: Json): Json => (field === 'settings' ? redactSettings(value) : value)
+
 /**
  * Compares two records and returns one entry per field whose value changed.
  *
@@ -76,7 +107,7 @@ export function diffFields<T extends Record<string, unknown>>(
         const prev = normalize(before[field])
         const next = normalize(after[field])
         if (!isDeepEqual(prev, next)) {
-            changes.push({ field, before: prev, after: next })
+            changes.push({ field, before: forRecording(field, prev), after: forRecording(field, next) })
         }
     }
 

--- a/src/server/events.ts
+++ b/src/server/events.ts
@@ -1,5 +1,6 @@
-import { db } from '@/database'
+import { db, type DBExecutor } from '@/database'
 import { AuditEventType, AuditRecordType, Json } from '@/database/types'
+import type { AuditFieldChange } from '@/lib/audit-diff'
 import logger from '@/lib/logger'
 import { UserOrgRoles } from '@/lib/types'
 import * as Sentry from '@sentry/nextjs'
@@ -41,10 +42,59 @@ type AuditEntry = {
     metadata?: Json
 }
 
-export const audit = async (entry: AuditEntry): Promise<void> => {
+// Defaults to the module-level connection so existing callers are unaffected; pass an
+// executor to enlist the audit row in the caller's transaction (see auditCodeEnv below).
+export const audit = async (entry: AuditEntry, executor: DBExecutor = db): Promise<void> => {
     logger.info(`${entry.eventType}: ${entry.recordType}/${entry.recordId}`)
-    await db.insertInto('audit').values(entry).execute()
+    await executor.insertInto('audit').values(entry).execute()
 }
+
+type CodeEnvAuditArgs = {
+    db: DBExecutor
+    codeEnvId: string
+    userId: string
+    changes: AuditFieldChange[]
+    starterCodeReplaced?: boolean
+    name?: string
+}
+
+/**
+ * Unlike every other handler in this file these are NOT wrapped in deferred(): a
+ * deferred callback runs after the response, by which point the action's transaction
+ * has already committed *or rolled back*, and after() does not unschedule on error. A
+ * mutation that failed partway (an AWS call after the update, say) would still emit an
+ * audit row claiming the change succeeded. Writing inline on the caller's executor
+ * makes the audit row commit and roll back atomically with the change it describes.
+ */
+const auditCodeEnv = async (
+    eventType: Extract<AuditEventType, 'CREATED' | 'UPDATED' | 'DELETED'>,
+    { db: executor, codeEnvId, userId, changes, starterCodeReplaced, name }: CodeEnvAuditArgs,
+): Promise<void> => {
+    await audit(
+        {
+            userId,
+            eventType,
+            recordType: 'CODE_ENV',
+            recordId: codeEnvId,
+            metadata: {
+                changes,
+                ...(starterCodeReplaced ? { starterCodeReplaced: true } : {}),
+                ...(name ? { name } : {}),
+            },
+        },
+        executor,
+    )
+}
+
+export const onCodeEnvCreated = (args: CodeEnvAuditArgs) => auditCodeEnv('CREATED', args)
+
+export const onCodeEnvUpdated = async (args: CodeEnvAuditArgs) => {
+    // A save that changed nothing and replaced nothing is not history worth keeping.
+    if (args.changes.length === 0 && !args.starterCodeReplaced) return
+    await auditCodeEnv('UPDATED', args)
+}
+
+export const onCodeEnvDeleted = (args: CodeEnvAuditArgs) => auditCodeEnv('DELETED', args)
 
 type StudyEvent = { studyId: string; userId: string }
 

--- a/tests/unit.helpers.tsx
+++ b/tests/unit.helpers.tsx
@@ -55,6 +55,18 @@ export const getAuditEntries = (recordId: string, recordType: AuditRecordType) =
         .where('recordType', '=', recordType)
         .execute()
 
+// Separate from getAuditEntries because that one is used with toContainEqual, whose
+// exact-object matching would break on an extra metadata key.
+export const getAuditEntriesWithMetadata = (recordId: string, recordType: AuditRecordType) =>
+    db
+        .selectFrom('audit')
+        .select(['eventType', 'recordType', 'recordId', 'userId', 'metadata', 'createdAt'])
+        .where('recordId', '=', recordId)
+        .where('recordType', '=', recordType)
+        .orderBy('createdAt', 'desc')
+        .orderBy('id', 'desc')
+        .execute()
+
 export const readTestSupportFile = (file: string) => {
     return fs.promises.readFile(path.join(__dirname, 'support', file), 'utf8')
 }


### PR DESCRIPTION
Closes [OTTER-685](https://openstax.atlassian.net/browse/OTTER-685).

Edits to code environments can break studies later, but nothing recorded who changed what — `orgCodeEnv` has no `updated_at` and the actions wrote no audit events. This records a per-field before/after diff on create, update and delete, and surfaces it behind a history icon beside the pencil in org settings.

## Notable decisions

**Audit writes are inline, not `deferred()`.** Every other handler in `events.ts` defers via `after()`, which runs post-response — after the transaction has committed *or rolled back* — and `after()` does not unschedule on error. A mutation that failed partway would still emit a row claiming it succeeded. These write on the caller's transactional executor instead, so the audit row commits and rolls back with the change. A test forces that rollback and asserts no row is written.

**The update middleware only loaded 6 of the 10 editable columns**, so there was no "before" value for `name`, `language`, `commandLines`, `isTesting` or `settings`. It now takes a namespaced snapshot of the full prior row rather than widening the shared loader, which `fetchStarterCodeAction` also uses and which feeds every key into the CASL subject.

**Field comparison is structural.** Kysely parses a fresh object per jsonb read and Postgres reorders jsonb keys on storage, so both reference equality and `JSON.stringify` comparison report false positives on every save.

**The history query filters on the middleware-resolved code env id, never the client-supplied param** — `audit` has no org column to scope by, so trusting the param would expose other orgs' history. Covered by a cross-org test.

## Scope notes

- The starter-code flag records that the server wiped and rewrote the S3 prefix, not that the new files landed — the browser uploads them after the action returns. If that upload fails the row claims files that aren't in S3, which is a plausible cause of the failures this is meant to diagnose; fixing it needs a separate post-upload confirmation step.
- Deletes are logged with full final state but have no UI, since the row is gone from the listing.
- Two migrations: `CODE_ENV` added to the `audit_record_type` enum (alone in its file — Postgres forbids using a new enum value in the transaction that adds it) and an index on `audit (record_type, record_id, created_at DESC)`.

## Testing

`pnpm run checks` and the full unit suite pass — 2008 tests, 0 failures. New coverage includes the no-op save (logs nothing), starter-code replacement with unchanged filenames, rollback safety and cross-org denial.

Not yet exercised end-to-end in a running app.


[OTTER-685]: https://openstax.atlassian.net/browse/OTTER-685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ