### PR TITLE
OTTER-684: Namespace osenclave calls in the R code samples

### DIFF
--- a/tests/assets/main.r
+++ b/tests/assets/main.r
@@ -3,19 +3,19 @@ library(osenclave)
 ###############################################################################
 # Initialize Research Container
 # DO NOT TOUCH
-initialize()
+osenclave::initialize()
 ###############################################################################
 # Researcher: Insert query code here
 
 # OpenStax Tutor Example: Count unique tasked_id for date range
-results <- query_tutor("
+results <- osenclave::query_tutor("
   SELECT COUNT(DISTINCT tasks_task_id) as unique_tasked_count
   FROM tutor_data
   WHERE created_at >= '2023-02-02' AND created_at <= '2023-02-03'
 ")
 
 # OpenStax Tutor Exercises Example: Count unique question_id
-# exercises_results <- query_tutor_exercises("
+# exercises_results <- osenclave::query_tutor_exercises("
 #   SELECT COUNT(DISTINCT question_uid) as unique_question_count
 #   FROM exercises_data
 # ")
@@ -29,4 +29,4 @@ write.csv(results, "results.csv", row.names = FALSE)
 
 ###############################################################################
 # Researcher: Upload results
-toa_results_upload("results.csv")
+osenclave::toa_results_upload("results.csv")

--- a/tests/assets/simplest-possible-main.r
+++ b/tests/assets/simplest-possible-main.r
@@ -1,5 +1,5 @@
 library(osenclave)
-initialize()
+osenclave::initialize()
 results <- data.frame(col1 = c(1, 2, 3), col2 = c("a", "b", "c"))
 write.csv(results, "results.csv", row.names = FALSE)
-toa_results_upload("results.csv")
+osenclave::toa_results_upload("results.csv")

--- a/tests/fixtures/code-samples/main.r
+++ b/tests/fixtures/code-samples/main.r
@@ -3,19 +3,19 @@ library(osenclave)
 ###############################################################################
 # Initialize Research Container
 # DO NOT TOUCH
-initialize()
+osenclave::initialize()
 ###############################################################################
 # Researcher: Insert query code here
 
 # OpenStax Tutor Example: Count unique tasked_id for date range
-results <- query_tutor("
+results <- osenclave::query_tutor("
   SELECT COUNT(DISTINCT tasks_task_id) as unique_tasked_count
   FROM tutor_data
   WHERE created_at >= '2023-02-02' AND created_at <= '2023-02-03'
 ")
 
 # OpenStax Tutor Exercises Example: Count unique question_id
-# exercises_results <- query_tutor_exercises("
+# exercises_results <- osenclave::query_tutor_exercises("
 #   SELECT COUNT(DISTINCT question_uid) as unique_question_count
 #   FROM exercises_data
 # ")
@@ -29,4 +29,4 @@ write.csv(results, "results.csv", row.names = FALSE)
 
 ###############################################################################
 # Researcher: Upload results
-toa_results_upload("results.csv")
+osenclave::toa_results_upload("results.csv")


### PR DESCRIPTION
Closes [OTTER-684](https://openstax.atlassian.net/browse/OTTER-684).

`initialize()` collides with the S4 generic exported by the `methods` package, which is attached by default. An unqualified call therefore resolves to `methods::initialize()` whenever `osenclave` is missing or stale, failing with a confusing error about a missing `.Object` rather than "could not find function". Qualifying it makes that case fail immediately and clearly.

`query_tutor`, `query_tutor_exercises` and `toa_results_upload` are namespaced alongside it for consistency within the templates.

`library(osenclave)` is deliberately kept: it fails loudly at the top of the script if the package is missing, whereas `::` alone would not fail until first use — potentially after a query has already run.

## Files

- `tests/assets/main.r`
- `tests/assets/simplest-possible-main.r`
- `tests/fixtures/code-samples/main.r`

These are referenced by tests only by filename (uploaded as fixtures, or asserted on as `'main.r'`); nothing asserts on their contents.

## Note

`tests/assets/main.py` has the same shape (`from osenclave.safeinsights_common import initialize`), but Python's failure mode is far more benign — there is no builtin `initialize` to shadow it, so a bad import raises `ImportError` at module load. Left alone here; happy to align it if wanted.

[OTTER-684]: https://openstax.atlassian.net/browse/OTTER-684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ