### PR TITLE
OTTER-674: hide the autosave indicator while a field error is showing

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/proposal/form.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/form.tsx
@@ -135,8 +135,6 @@ export const ProposalForm: FC<ProposalFormProps> = ({
                                 value={form.values.title ?? ''}
                                 {...nativeFieldProps(form.errors.title, { required: true, description: true })}
                             />
-                            {/* Hidden while the field has a validation error: the error renders in the
-                                footer row below and the two must not co-exist (OTTER-674). */}
                             <SaveStatusIndicator status={titleSaveStatus} isVisible={!form.errors.title} />
                         </FormField>
 

--- a/src/app/[orgSlug]/study/[studyId]/proposal/form.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/form.tsx
@@ -135,7 +135,9 @@ export const ProposalForm: FC<ProposalFormProps> = ({
                                 value={form.values.title ?? ''}
                                 {...nativeFieldProps(form.errors.title, { required: true, description: true })}
                             />
-                            <SaveStatusIndicator status={titleSaveStatus} />
+                            {/* Hidden while the field has a validation error: the error renders in the
+                                footer row below and the two must not co-exist (OTTER-674). */}
+                            <SaveStatusIndicator status={titleSaveStatus} isVisible={!form.errors.title} />
                         </FormField>
 
                         <FormField
@@ -175,7 +177,7 @@ export const ProposalForm: FC<ProposalFormProps> = ({
                                     </Group>
                                 </Anchor>
                             </Group>
-                            <SaveStatusIndicator status={datasetsSaveStatus} />
+                            <SaveStatusIndicator status={datasetsSaveStatus} isVisible={!form.errors.datasets} />
                         </FormField>
                     </Stack>
                 </Paper>
@@ -221,7 +223,7 @@ export const ProposalForm: FC<ProposalFormProps> = ({
                                     {...nativeFieldProps(form.errors.piName, { required: true, description: true })}
                                 />
                             </Box>
-                            <SaveStatusIndicator status={piSaveStatus} />
+                            <SaveStatusIndicator status={piSaveStatus} isVisible={!form.errors.piName} />
                         </FormField>
 
                         <Box>

--- a/src/components/editable-text/collaborative-editor.tsx
+++ b/src/components/editable-text/collaborative-editor.tsx
@@ -27,9 +27,9 @@ import { Toolbar } from './toolbar'
 import { EscapeFocusPlugin } from './escape-focus-plugin'
 import { widgetBlurHandler } from '@/components/form-field'
 
-function SaveStatus({ provider }: { provider: HocuspocusProvider | null }) {
+function SaveStatus({ provider, isVisible }: { provider: HocuspocusProvider | null; isVisible: boolean }) {
     const status = useProviderSaveStatus(provider)
-    return <SaveStatusIndicator status={status} />
+    return <SaveStatusIndicator status={status} isVisible={isVisible} />
 }
 
 type ActiveEditor = { userId: string; name: string; color: string; focusing: boolean }
@@ -416,7 +416,9 @@ export function CollaborativeEditor({
                 </Paper>
                 <Stack gap={4} mt={4}>
                     <Group align="center" wrap="nowrap">
-                        <SaveStatus provider={activeProvider} />
+                        {/* The caller renders the error message right below this row; hiding the
+                            indicator keeps the two from co-existing (OTTER-674). */}
+                        <SaveStatus provider={activeProvider} isVisible={!error} />
                         {footerRight && <Box ml="auto">{footerRight}</Box>}
                     </Group>
                     <ActiveEditorsList providerRef={providerRef} currentUserId={userId} />

--- a/src/components/editable-text/collaborative-editor.tsx
+++ b/src/components/editable-text/collaborative-editor.tsx
@@ -184,8 +184,12 @@ export type CollaborativeEditorProps = {
     footerRight?: React.ReactNode
     /** DOM id for the focusable editor surface. Distinct from `id`, which names the Yjs document. */
     inputId?: string
-    /** Presence drives the red border and `aria-invalid`; the message itself is rendered by the caller. */
-    error?: React.ReactNode
+    /**
+     * Presence drives the red border, `aria-invalid`, and hiding the save indicator; the message
+     * itself is rendered by the caller. Typed `string`, not `ReactNode`, so presence stays a plain
+     * truthiness check — a falsy-but-present node (`0`, `''`) can't read as "no error".
+     */
+    error?: string | null
     /** Id(s) of the description/error nodes describing this editor. */
     ariaDescribedBy?: string
     /** Marks the editor required to assistive tech; the label asterisk is visual only. */

--- a/src/components/editable-text/collaborative-editor.tsx
+++ b/src/components/editable-text/collaborative-editor.tsx
@@ -416,8 +416,6 @@ export function CollaborativeEditor({
                 </Paper>
                 <Stack gap={4} mt={4}>
                     <Group align="center" wrap="nowrap">
-                        {/* The caller renders the error message right below this row; hiding the
-                            indicator keeps the two from co-existing (OTTER-674). */}
                         <SaveStatus provider={activeProvider} isVisible={!error} />
                         {footerRight && <Box ml="auto">{footerRight}</Box>}
                     </Group>

--- a/src/components/editable-text/editor.tsx
+++ b/src/components/editable-text/editor.tsx
@@ -41,8 +41,12 @@ export type EditorProps = {
      * primary key, so reusing it as a DOM id couples persistence to markup.
      */
     inputId?: string
-    /** Presence drives the red border and `aria-invalid`; the caller renders the message. */
-    error?: React.ReactNode
+    /**
+     * Presence drives the red border, `aria-invalid`, and hiding the save indicator; the caller
+     * renders the message. Typed `string`, not `ReactNode`, so presence stays a plain truthiness
+     * check — a falsy-but-present node (`0`, `''`) can't read as "no error".
+     */
+    error?: string | null
     /** Id(s) of the nodes describing this editor, e.g. its description and error text. */
     ariaDescribedBy?: string
     /**

--- a/src/components/editable-text/single-user-editor.tsx
+++ b/src/components/editable-text/single-user-editor.tsx
@@ -39,8 +39,12 @@ export type SingleUserEditorProps = {
     footerRight?: React.ReactNode
     /** DOM id for the focusable editor surface. Distinct from `id`, which names the Yjs document. */
     inputId?: string
-    /** Presence drives the red border and `aria-invalid`; the message itself is rendered by the caller. */
-    error?: React.ReactNode
+    /**
+     * Presence drives the red border, `aria-invalid`, and hiding the save indicator; the message
+     * itself is rendered by the caller. Typed `string`, not `ReactNode`, so presence stays a plain
+     * truthiness check — a falsy-but-present node (`0`, `''`) can't read as "no error".
+     */
+    error?: string | null
     /** Id(s) of the description/error nodes describing this editor. */
     ariaDescribedBy?: string
     /** Marks the editor required to assistive tech; the label asterisk is visual only. */

--- a/src/components/save-status.test.tsx
+++ b/src/components/save-status.test.tsx
@@ -29,4 +29,9 @@ describe('SaveStatusIndicator', () => {
         expect(checkmark).toBeInTheDocument()
         expect(checkmark).toHaveAttribute('fill', theme.colors!.green![9])
     })
+
+    it('renders nothing when hidden, even in the saved state (OTTER-674)', () => {
+        renderWithProviders(<SaveStatusIndicator status="saved" isVisible={false} />)
+        expect(screen.queryByTestId('autosave-status')).not.toBeInTheDocument()
+    })
 })

--- a/src/components/save-status.tsx
+++ b/src/components/save-status.tsx
@@ -27,12 +27,19 @@ const SavedLabel: FC = () => {
 
 interface SaveStatusIndicatorProps {
     status: SaveStatusValue
+    /**
+     * Callers pass false while a validation error is showing for the same field:
+     * "All changes saved" beside an empty-field error reads as contradictory, so
+     * the error must win the slot (OTTER-674).
+     */
+    isVisible?: boolean
 }
 
 // Single autosave indicator shared across every surface (collaborative editor,
 // proposal fields, resubmission note). Renders nothing until there is something
 // to report so it can be dropped under any field unconditionally.
-export const SaveStatusIndicator: FC<SaveStatusIndicatorProps> = ({ status }) => {
+export const SaveStatusIndicator: FC<SaveStatusIndicatorProps> = ({ status, isVisible = true }) => {
+    if (!isVisible) return null
     if (status === 'saving') return <SavingLabel />
     if (status === 'saved') return <SavedLabel />
     return null

--- a/src/components/save-status.tsx
+++ b/src/components/save-status.tsx
@@ -27,11 +27,7 @@ const SavedLabel: FC = () => {
 
 interface SaveStatusIndicatorProps {
     status: SaveStatusValue
-    /**
-     * Callers pass false while a validation error is showing for the same field:
-     * "All changes saved" beside an empty-field error reads as contradictory, so
-     * the error must win the slot (OTTER-674).
-     */
+    /** False while the field's validation error is showing — the error takes the slot (OTTER-674). */
     isVisible?: boolean
 }
 

--- a/src/components/study/collaborative-resubmission-note-section.test.tsx
+++ b/src/components/study/collaborative-resubmission-note-section.test.tsx
@@ -49,8 +49,7 @@ function Harness({ initialNote = '', initialError }: { initialNote?: string; ini
 const renderSection = (props: Partial<React.ComponentProps<typeof Harness>> = {}) =>
     renderWithProviders(<Harness {...props} />)
 
-// renderWithProviders hard-codes collaborative mode; single-user mode needs its own tree
-// (same shape as editor.test.tsx).
+// renderWithProviders hard-codes collaborative mode; single-user mode needs its own provider tree.
 const renderSingleUserSection = (props: Partial<React.ComponentProps<typeof Harness>> = {}) =>
     render(
         <MantineProvider theme={theme}>

--- a/src/components/study/collaborative-resubmission-note-section.test.tsx
+++ b/src/components/study/collaborative-resubmission-note-section.test.tsx
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { renderWithProviders, screen } from '@/tests/unit.helpers'
+import { render, renderWithProviders, screen } from '@/tests/unit.helpers'
+import { MantineProvider } from '@mantine/core'
+import { ModalsProvider } from '@mantine/modals'
+import { YjsWebsocketProvider } from '@/lib/realtime/yjs-websocket-context'
+import { theme } from '@/theme'
 import { useForm, zodResolver } from '@/common'
 import {
     initialResubmitNoteValue,
@@ -11,13 +15,15 @@ import { CollaborativeResubmissionNoteSection } from './collaborative-resubmissi
 
 const STUDY_ID = '11111111-1111-4111-8111-111111111111'
 
-function Harness({ initialNote = '' }: { initialNote?: string }) {
+function Harness({ initialNote = '', initialError }: { initialNote?: string; initialError?: string }) {
     const noteForm = useForm<ResubmitNoteValue>({
         validate: zodResolver(resubmitNoteSchema),
         initialValues: {
             ...initialResubmitNoteValue,
             resubmissionNote: resubmissionNoteToLexicalJson(initialNote),
         },
+        // `initialErrors` rather than assigning to `form.errors`, which Mantine exposes as read-only.
+        initialErrors: initialError ? { resubmissionNote: initialError } : {},
         validateInputOnChange: true,
     })
 
@@ -43,6 +49,19 @@ function Harness({ initialNote = '' }: { initialNote?: string }) {
 const renderSection = (props: Partial<React.ComponentProps<typeof Harness>> = {}) =>
     renderWithProviders(<Harness {...props} />)
 
+// renderWithProviders hard-codes collaborative mode; single-user mode needs its own tree
+// (same shape as editor.test.tsx).
+const renderSingleUserSection = (props: Partial<React.ComponentProps<typeof Harness>> = {}) =>
+    render(
+        <MantineProvider theme={theme}>
+            <YjsWebsocketProvider singleUserEditing>
+                <ModalsProvider>
+                    <Harness {...props} />
+                </ModalsProvider>
+            </YjsWebsocketProvider>
+        </MantineProvider>,
+    )
+
 describe('CollaborativeResubmissionNoteSection', () => {
     it('renders the section title with the required indicator', () => {
         renderSection()
@@ -57,6 +76,17 @@ describe('CollaborativeResubmissionNoteSection', () => {
 
     it('does not render the section-level autosave indicator in collaborative mode', () => {
         renderSection()
+        expect(screen.queryByTestId('autosave-status')).not.toBeInTheDocument()
+    })
+
+    it('renders the section-level autosave indicator in single-user mode once a draft has been saved', () => {
+        renderSingleUserSection()
+        expect(screen.getByTestId('autosave-status')).toHaveTextContent('All changes saved')
+    })
+
+    it('hides the autosave indicator while a validation error is showing (OTTER-674)', () => {
+        renderSingleUserSection({ initialError: 'A resubmission note is required.' })
+        expect(screen.getByText('A resubmission note is required.')).toBeInTheDocument()
         expect(screen.queryByTestId('autosave-status')).not.toBeInTheDocument()
     })
 })

--- a/src/components/study/collaborative-resubmission-note-section.tsx
+++ b/src/components/study/collaborative-resubmission-note-section.tsx
@@ -46,8 +46,7 @@ interface CollaborativeResubmissionNoteSectionProps {
 }
 
 // In collaborative mode the editor renders its own provider-driven indicator;
-// showing this one too would double up. It also yields to a validation error —
-// the two must never co-exist (OTTER-674).
+// showing this one too would double up.
 const SingleUserSaveStatus: FC<{ isVisible: boolean; autosaveStatus: ResubmissionNoteAutosaveStatus }> = ({
     isVisible,
     autosaveStatus,

--- a/src/components/study/collaborative-resubmission-note-section.tsx
+++ b/src/components/study/collaborative-resubmission-note-section.tsx
@@ -46,7 +46,8 @@ interface CollaborativeResubmissionNoteSectionProps {
 }
 
 // In collaborative mode the editor renders its own provider-driven indicator;
-// showing this one too would double up.
+// showing this one too would double up. It also yields to a validation error —
+// the two must never co-exist (OTTER-674).
 const SingleUserSaveStatus: FC<{ isVisible: boolean; autosaveStatus: ResubmissionNoteAutosaveStatus }> = ({
     isVisible,
     autosaveStatus,
@@ -108,7 +109,7 @@ export const CollaborativeResubmissionNoteSection: FC<CollaborativeResubmissionN
                         <Box id={fieldErrorId('resubmissionNote')}>
                             <InputError error={error} />
                         </Box>
-                        <SingleUserSaveStatus isVisible={singleUserEditing} autosaveStatus={autosaveStatus} />
+                        <SingleUserSaveStatus isVisible={singleUserEditing && !error} autosaveStatus={autosaveStatus} />
                     </Group>
                 </Box>
             </Stack>

--- a/src/components/study/resubmission-note-section.test.tsx
+++ b/src/components/study/resubmission-note-section.test.tsx
@@ -114,4 +114,17 @@ describe('ResubmissionNoteSection', () => {
         const section = screen.getByTestId('resubmission-note-section')
         expect(section.querySelectorAll('svg')).toHaveLength(1)
     })
+
+    it('replaces "All changes saved" with the error once the note is emptied (OTTER-674)', async () => {
+        const user = userEvent.setup()
+        renderSection({ autosaveStatus: { isSaving: false, lastSavedAt: new Date('2026-05-20T10:15:00Z') } })
+        const textarea = screen.getByRole('textbox', { name: 'Resubmission Note' })
+
+        await user.type(textarea, 'some draft text')
+        expect(screen.getByTestId('autosave-status')).toHaveTextContent('All changes saved')
+
+        await user.clear(textarea)
+        expect(screen.getByText(/resubmission note is required/i)).toBeInTheDocument()
+        expect(screen.queryByTestId('autosave-status')).not.toBeInTheDocument()
+    })
 })

--- a/src/components/study/resubmission-note-section.tsx
+++ b/src/components/study/resubmission-note-section.tsx
@@ -37,9 +37,6 @@ export const ResubmissionNoteSection: FC<ResubmissionNoteSectionProps> = ({ note
     const wordCount = countWords(value)
     const saveStatus = noteSaveStatus(autosaveStatus)
 
-    // The status indicator and validation error share the footer's left slot; only one is relevant at a time.
-    const footerStatus = error ? <InputError error={error} /> : <SaveStatusIndicator status={saveStatus} />
-
     return (
         <Paper p="xxl" data-testid="resubmission-note-section">
             <Stack gap="md">
@@ -69,7 +66,10 @@ export const ResubmissionNoteSection: FC<ResubmissionNoteSectionProps> = ({ note
                         {...nativeFieldProps(error, { required: true })}
                     />
                     <Group justify="space-between" align="center" mt={4}>
-                        <Box id={fieldErrorId('resubmissionNote')}>{footerStatus}</Box>
+                        <Box id={fieldErrorId('resubmissionNote')}>
+                            <InputError error={error} />
+                            <SaveStatusIndicator status={saveStatus} isVisible={!error} />
+                        </Box>
                         <WordCounter wordCount={wordCount} maxWords={RESUBMIT_NOTE_MAX_WORDS} />
                     </Group>
                 </Box>

--- a/src/hooks/use-review-feedback.ts
+++ b/src/hooks/use-review-feedback.ts
@@ -40,7 +40,9 @@ export function useReviewFeedback({ maxWords = FEEDBACK_MAX_WORDS }: UseReviewFe
         value,
         onChange,
         onBlur: field.validate,
-        error: field.error,
+        // Mantine types `field.error` as ReactNode, but this hook's `validate` only ever returns
+        // strings, and the editors' `error` prop is narrowed to `string` (see `EditorProps.error`).
+        error: field.error as string | null,
         wordCount,
         minWords: FEEDBACK_MIN_WORDS,
         maxWords,


### PR DESCRIPTION
## Why

An empty-field error did not dismiss "All changes saved", so both showed at once. The label
also pushed the resubmission note's error message down, away from the input field.

## What changed

`SaveStatusIndicator` gains an `isVisible` prop; every autosave surface passes `!error`, so
the error always wins the slot: the collaborative editor footer (all proposal text fields +
resubmission note), the proposal form's title/datasets/PI indicators, and the single-user
note section. With the label gone the error sits directly under the field — no layout changes
needed. Unit tests cover the ticket's repro (type → clear) and the hidden-indicator states.