### PR TITLE
Otter 668 outputs available

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/_screens/registry.ts
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/registry.ts
@@ -13,6 +13,7 @@ import { ReviewerCodeReviewScreen } from './reviewer-code-review-screen'
 import { ReviewerCodeFeedbackScreen } from './reviewer-code-feedback-screen'
 import { ReviewerOutputsPendingScreen } from './reviewer-outputs-pending-screen'
 import { ReviewerOutputsErroredScreen } from './reviewer-outputs-errored-screen'
+import { ReviewerOutputsAvailableScreen } from './reviewer-outputs-available-screen'
 import { ReviewerStudyResultsScreen } from './reviewer-study-results-screen'
 
 // Screens may be async server components (they load their own data). Returned node is awaited
@@ -36,5 +37,6 @@ export const SCREEN_COMPONENTS: Record<ScreenId, ScreenComponent> = {
     'reviewer-code-feedback': ReviewerCodeFeedbackScreen,
     'reviewer-outputs-pending': ReviewerOutputsPendingScreen,
     'reviewer-outputs-errored': ReviewerOutputsErroredScreen,
+    'reviewer-outputs-available': ReviewerOutputsAvailableScreen,
     'reviewer-study-results': ReviewerStudyResultsScreen,
 }

--- a/src/app/[orgSlug]/study/[studyId]/_screens/registry.ts
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/registry.ts
@@ -12,6 +12,7 @@ import { ReviewerAgreementsScreen } from './reviewer-agreements-screen'
 import { ReviewerCodeReviewScreen } from './reviewer-code-review-screen'
 import { ReviewerCodeFeedbackScreen } from './reviewer-code-feedback-screen'
 import { ReviewerOutputsPendingScreen } from './reviewer-outputs-pending-screen'
+import { ReviewerOutputsErroredScreen } from './reviewer-outputs-errored-screen'
 import { ReviewerStudyResultsScreen } from './reviewer-study-results-screen'
 
 // Screens may be async server components (they load their own data). Returned node is awaited
@@ -34,5 +35,6 @@ export const SCREEN_COMPONENTS: Record<ScreenId, ScreenComponent> = {
     'reviewer-code-review': ReviewerCodeReviewScreen,
     'reviewer-code-feedback': ReviewerCodeFeedbackScreen,
     'reviewer-outputs-pending': ReviewerOutputsPendingScreen,
+    'reviewer-outputs-errored': ReviewerOutputsErroredScreen,
     'reviewer-study-results': ReviewerStudyResultsScreen,
 }

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.test.tsx
@@ -1,0 +1,90 @@
+import { vi } from 'vitest'
+import dayjs from 'dayjs'
+import {
+    actionResult,
+    describe,
+    expect,
+    insertTestStudyJobData,
+    it,
+    type Mock,
+    mockSessionWithTestData,
+    renderWithProviders,
+    screen,
+} from '@/tests/unit.helpers'
+import { useParams } from 'next/navigation'
+import type { StudyJobStatus } from '@/database/types'
+import { getStudyAction } from '@/server/actions/study.actions'
+import { setupStudyAction } from '@/tests/db-action.helpers'
+import { ReviewerOutputsAvailableScreen } from './reviewer-outputs-available-screen'
+import type { ScreenComponentProps } from './types'
+
+// The screen embeds SecurityKeyForm, whose file query hits job-file storage; serve no artifacts so
+// the static render under test stays hermetic (same approach as security-key-form.test.tsx).
+vi.mock('@/server/actions/study-job.actions', () => ({
+    fetchEncryptedJobFilesAction: vi.fn(() => []),
+}))
+
+const renderScreen = async (study: ScreenComponentProps['study'], orgSlug: string) =>
+    renderWithProviders(await ReviewerOutputsAvailableScreen({ study, orgSlug }))
+
+const setupWithJobStatus = async (jobStatus: StudyJobStatus) => {
+    const { org, user } = await mockSessionWithTestData({ orgSlug: 'openstax', orgType: 'enclave' })
+    const { study: dbStudy } = await insertTestStudyJobData({ org, researcherId: user.id, jobStatus })
+    const study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+    ;(useParams as Mock).mockReturnValue({ orgSlug: org.slug, studyId: study.id })
+    return { org, study }
+}
+
+describe('ReviewerOutputsAvailableScreen', () => {
+    it('renders the outputs-available banner with the date the run completed', async () => {
+        const { org, study } = await setupWithJobStatus('RUN-COMPLETE')
+        await renderScreen(study, org.slug)
+
+        expect(screen.getByRole('heading', { level: 1, name: 'Secondary analysis study' })).toBeInTheDocument()
+        // The RUN-COMPLETE status row was just inserted, so the surfaced date is today.
+        expect(screen.getByTestId('status-alert')).toHaveTextContent(
+            `Outputs are available for review • ${dayjs().format('MMM DD, YYYY')}`,
+        )
+    })
+
+    it('addresses the banner body to the submitting lab', async () => {
+        const { org, study } = await setupWithJobStatus('RUN-COMPLETE')
+        await renderScreen(study, org.slug)
+
+        expect(screen.getByTestId('status-alert')).toHaveTextContent(
+            `Enter your security key to decrypt the outputs, review them, and then share with ${study.submittingLabName}.`,
+        )
+    })
+
+    it('renders the reused security key form', async () => {
+        const { org, study } = await setupWithJobStatus('RUN-COMPLETE')
+        await renderScreen(study, org.slug)
+
+        expect(screen.getByRole('heading', { name: /security key/i })).toBeInTheDocument()
+        expect(screen.getByRole('textbox')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'View' })).toBeInTheDocument()
+    })
+
+    it('wires Previous step to the read-only code page', async () => {
+        const { org, study } = await setupWithJobStatus('RUN-COMPLETE')
+        await renderScreen(study, org.slug)
+
+        expect(screen.getByRole('link', { name: /previous step/i })).toHaveAttribute(
+            'href',
+            `/${org.slug}/study/${study.id}/review/code`,
+        )
+    })
+
+    it('shows a not-found alert when the study has no submitted job', async () => {
+        const { org, study } = await setupStudyAction({ orgSlug: 'openstax', orgType: 'enclave', createJob: false })
+        ;(useParams as Mock).mockReturnValue({ orgSlug: org.slug, studyId: study.id })
+        await renderScreen(study, org.slug)
+        expect(screen.getByText('No submission found')).toBeInTheDocument()
+    })
+
+    it('shows a not-found alert when the job has not completed a run', async () => {
+        const { org, study } = await setupWithJobStatus('JOB-RUNNING')
+        await renderScreen(study, org.slug)
+        expect(screen.getByText('Outputs not found')).toBeInTheDocument()
+    })
+})

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.tsx
@@ -1,0 +1,75 @@
+import dayjs from 'dayjs'
+import { Box, Group, Stack } from '@mantine/core'
+import { CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
+import { AlertNotFound } from '@/components/errors'
+import { ButtonLink } from '@/components/links'
+import { StudyPageHeader } from '@/components/study/study-page-header'
+import { ProposalStepHeader } from '@/components/study/proposal-step-header'
+import { StatusAlert, STATUS_ALERT_VARIANT } from '@/components/study/status-alert'
+import { SecurityKeyForm } from '@/components/study/security-key-form'
+import { Routes } from '@/lib/routes'
+import { latestSubmittedJobForStudy } from '@/server/db/queries'
+import type { ScreenComponentProps } from './types'
+
+// statusChanges arrive newest-first (see latestJobForStudyQuery ordering), so `find` picks the
+// most recent RUN-COMPLETE — the moment the outputs became available for review.
+function availableTimestamp(
+    statusChanges: ReadonlyArray<{ status: string; createdAt: Date | string }>,
+): Date | string | null {
+    return statusChanges.find((c) => c.status === 'RUN-COMPLETE')?.createdAt ?? null
+}
+
+const AvailableBanner = ({ availableAt, labName }: { availableAt: Date | string; labName: string }) => (
+    <StatusAlert
+        variant={STATUS_ALERT_VARIANT.action}
+        title={`Outputs are available for review \u2022 ${dayjs(availableAt).format('MMM DD, YYYY')}`}
+    >
+        Enter your security key to decrypt the outputs, review them, and then share with {labName}.
+    </StatusAlert>
+)
+
+export async function ReviewerOutputsAvailableScreen({
+    study,
+    orgSlug,
+}: Pick<ScreenComponentProps, 'study' | 'orgSlug'>) {
+    const job = await latestSubmittedJobForStudy(study.id)
+    if (!job) {
+        return <AlertNotFound title="No submission found" message="This study has no submitted code to review." />
+    }
+
+    const availableAt = availableTimestamp(job.statusChanges)
+    if (!availableAt) {
+        return (
+            <AlertNotFound
+                title="Outputs not found"
+                message="This study does not have outputs available for review yet."
+            />
+        )
+    }
+
+    return (
+        <Box bg="grey.10">
+            <Stack px="xl" gap="xxl" py="xl">
+                <StudyPageHeader>Secondary analysis study</StudyPageHeader>
+                <ProposalStepHeader
+                    stepLabel="STEP 3"
+                    heading="Review outputs"
+                    studyTitle={study.title ?? ''}
+                    banner={<AvailableBanner availableAt={availableAt} labName={study.submittingLabName} />}
+                />
+
+                <SecurityKeyForm job={job} />
+
+                <Group>
+                    <ButtonLink
+                        href={Routes.studyReviewCode({ orgSlug, studyId: study.id })}
+                        variant="subtle"
+                        leftSection={<CaretLeftIcon />}
+                    >
+                        Previous step
+                    </ButtonLink>
+                </Group>
+            </Stack>
+        </Box>
+    )
+}

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.tsx
@@ -1,12 +1,12 @@
 import dayjs from 'dayjs'
 import { Box, Group, Stack } from '@mantine/core'
 import { CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
-import { isSubmittedStudy } from '@/schema/study'
 import { AlertNotFound } from '@/components/errors'
 import { ButtonLink } from '@/components/links'
 import { StudyPageHeader } from '@/components/study/study-page-header'
 import { ProposalStepHeader } from '@/components/study/proposal-step-header'
 import { StatusAlert, STATUS_ALERT_VARIANT } from '@/components/study/status-alert'
+import { SecurityKeyForm } from '@/components/study/security-key-form'
 import { Routes } from '@/lib/routes'
 import { latestSubmittedJobForStudy } from '@/server/db/queries'
 import type { ScreenComponentProps } from './types'
@@ -30,10 +30,6 @@ export async function ReviewerOutputsErroredScreen({
     study,
     orgSlug,
 }: Pick<ScreenComponentProps, 'study' | 'orgSlug'>) {
-    if (!isSubmittedStudy(study)) {
-        return <AlertNotFound title="Study was not found" message="No such study exists" />
-    }
-
     const job = await latestSubmittedJobForStudy(study.id)
     if (!job) {
         return <AlertNotFound title="No submission found" message="This study has no submitted code to review." />
@@ -51,9 +47,12 @@ export async function ReviewerOutputsErroredScreen({
                 <ProposalStepHeader
                     stepLabel="STEP 3"
                     heading="Review outputs"
-                    studyTitle={study.title}
+                    studyTitle={study.title ?? ''}
                     banner={<ErroredBanner erroredAt={erroredAt} />}
                 />
+
+                <SecurityKeyForm />
+
                 <Group>
                     <ButtonLink
                         href={Routes.studyReviewCode({ orgSlug, studyId: study.id })}

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.tsx
@@ -1,0 +1,69 @@
+import dayjs from 'dayjs'
+import { Box, Group, Stack } from '@mantine/core'
+import { CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
+import { isSubmittedStudy } from '@/schema/study'
+import { AlertNotFound } from '@/components/errors'
+import { ButtonLink } from '@/components/links'
+import { StudyPageHeader } from '@/components/study/study-page-header'
+import { ProposalStepHeader } from '@/components/study/proposal-step-header'
+import { StatusAlert, STATUS_ALERT_VARIANT } from '@/components/study/status-alert'
+import { Routes } from '@/lib/routes'
+import { latestSubmittedJobForStudy } from '@/server/db/queries'
+import type { ScreenComponentProps } from './types'
+
+function erroredTimestamp(
+    statusChanges: ReadonlyArray<{ status: string; createdAt: Date | string }>,
+): Date | string | null {
+    return statusChanges.find((c) => c.status === 'JOB-ERRORED')?.createdAt ?? null
+}
+
+const ErroredBanner = ({ erroredAt }: { erroredAt: Date | string }) => (
+    <StatusAlert
+        variant={STATUS_ALERT_VARIANT.action}
+        title={`Code errored \u2022 ${dayjs(erroredAt).format('MMM DD, YYYY')}`}
+    >
+        Enter your security key below to access the outputs and see what went wrong.
+    </StatusAlert>
+)
+
+export async function ReviewerOutputsErroredScreen({
+    study,
+    orgSlug,
+}: Pick<ScreenComponentProps, 'study' | 'orgSlug'>) {
+    if (!isSubmittedStudy(study)) {
+        return <AlertNotFound title="Study was not found" message="No such study exists" />
+    }
+
+    const job = await latestSubmittedJobForStudy(study.id)
+    if (!job) {
+        return <AlertNotFound title="No submission found" message="This study has no submitted code to review." />
+    }
+
+    const erroredAt = erroredTimestamp(job.statusChanges)
+    if (!erroredAt) {
+        return <AlertNotFound title="No error found" message="This study has not encountered an error." />
+    }
+
+    return (
+        <Box bg="grey.10">
+            <Stack px="xl" gap="xxl" py="xl">
+                <StudyPageHeader>Secondary analysis study</StudyPageHeader>
+                <ProposalStepHeader
+                    stepLabel="STEP 3"
+                    heading="Review outputs"
+                    studyTitle={study.title}
+                    banner={<ErroredBanner erroredAt={erroredAt} />}
+                />
+                <Group>
+                    <ButtonLink
+                        href={Routes.studyReviewCode({ orgSlug, studyId: study.id })}
+                        variant="subtle"
+                        leftSection={<CaretLeftIcon />}
+                    >
+                        Previous step
+                    </ButtonLink>
+                </Group>
+            </Stack>
+        </Box>
+    )
+}

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.tsx
@@ -51,7 +51,7 @@ export async function ReviewerOutputsErroredScreen({
                     banner={<ErroredBanner erroredAt={erroredAt} />}
                 />
 
-                <SecurityKeyForm />
+                <SecurityKeyForm job={job} />
 
                 <Group>
                     <ButtonLink

--- a/src/app/account/keys/generate-keys.tsx
+++ b/src/app/account/keys/generate-keys.tsx
@@ -53,7 +53,7 @@ export const GenerateKeys: FC<GenerateKeysProps> = ({ isRegenerating = false }) 
 
     return (
         <Paper bg="white" p="xxl" mx="sm" radius="sm" maw={900} my={{ base: '1rem', lg: 0 }}>
-            <Stack gap={24}>
+            <Stack gap="lg">
                 <Title order={3} fz={22}>
                     Security key
                 </Title>

--- a/src/components/study/form-section-header.test.tsx
+++ b/src/components/study/form-section-header.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it, renderWithProviders, screen } from '@/tests/unit.helpers'
+import { FormSectionHeader } from './form-section-header'
+
+describe('FormSectionHeader', () => {
+    it('renders a semantic heading with the title', () => {
+        renderWithProviders(<FormSectionHeader title="Security key" description="Some description" />)
+        expect(screen.getByRole('heading', { name: /security key/i })).toBeInTheDocument()
+    })
+
+    it('renders the description and a divider', () => {
+        renderWithProviders(<FormSectionHeader title="Title" description="Body text here" />)
+        expect(screen.getByText('Body text here')).toBeInTheDocument()
+        expect(screen.getByRole('separator')).toBeInTheDocument()
+    })
+
+    it('shows a required indicator with an accessible label when required', () => {
+        renderWithProviders(<FormSectionHeader title="Title" description="Desc" required />)
+        const indicator = screen.getByLabelText('required')
+        expect(indicator).toHaveTextContent('*')
+    })
+
+    it('omits the required indicator when not required', () => {
+        renderWithProviders(<FormSectionHeader title="Title" description="Desc" />)
+        expect(screen.queryByLabelText('required')).toBeNull()
+    })
+})

--- a/src/components/study/form-section-header.tsx
+++ b/src/components/study/form-section-header.tsx
@@ -1,0 +1,28 @@
+import { Divider, Stack, Text, Title } from '@mantine/core'
+import { FC, ReactNode } from 'react'
+
+interface FormSectionHeaderProps {
+    title: string
+    description: ReactNode
+    required?: boolean
+}
+
+export const FormSectionHeader: FC<FormSectionHeaderProps> = ({ title, description, required }) => (
+    <Stack gap="md">
+        <Title fz="xl" fw={700} c="charcoal.9">
+            {title}
+            {required && (
+                <>
+                    {' '}
+                    <Text component="span" c="red.10" inherit aria-label="required">
+                        *
+                    </Text>
+                </>
+            )}
+        </Title>
+        <Divider color="charcoal.1" />
+        <Text fz="md" c="charcoal.9">
+            {description}
+        </Text>
+    </Stack>
+)

--- a/src/components/study/lost-key-popover.test.tsx
+++ b/src/components/study/lost-key-popover.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it, renderWithProviders, screen } from '@/tests/unit.helpers'
+import { fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { LostKeyPopover } from './lost-key-popover'
+
+describe('LostKeyPopover', () => {
+    it('renders the trigger text and icon', () => {
+        renderWithProviders(<LostKeyPopover />)
+        expect(screen.getByText('Lost your key?')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /lost your key/i })).toBeInTheDocument()
+    })
+
+    it('opens the popover on click and shows the help text', async () => {
+        renderWithProviders(<LostKeyPopover />)
+        await userEvent.click(screen.getByRole('button', { name: /lost your key/i }))
+
+        expect(screen.getByText(/another member of your organization/i)).toBeInTheDocument()
+        expect(screen.getByText(/a key you generate now cannot access/i)).toBeInTheDocument()
+    })
+
+    it('opens the popover with Enter key', async () => {
+        renderWithProviders(<LostKeyPopover />)
+        const trigger = screen.getByRole('button', { name: /lost your key/i })
+        trigger.focus()
+
+        await userEvent.keyboard('{Enter}')
+        expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('opens the popover with Space key', async () => {
+        renderWithProviders(<LostKeyPopover />)
+        const trigger = screen.getByRole('button', { name: /lost your key/i })
+        trigger.focus()
+
+        await userEvent.keyboard(' ')
+        expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('dismisses the popover on Escape and returns focus to trigger', async () => {
+        renderWithProviders(<LostKeyPopover />)
+        const trigger = screen.getByRole('button', { name: /lost your key/i })
+
+        await userEvent.click(trigger)
+        expect(trigger).toHaveAttribute('aria-expanded', 'true')
+
+        await userEvent.keyboard('{Escape}')
+        expect(trigger).toHaveAttribute('aria-expanded', 'false')
+        expect(trigger).toHaveFocus()
+    })
+
+    it('dismisses the popover on outside click', async () => {
+        renderWithProviders(<LostKeyPopover />)
+        const trigger = screen.getByRole('button', { name: /lost your key/i })
+
+        await userEvent.click(trigger)
+        expect(trigger).toHaveAttribute('aria-expanded', 'true')
+
+        fireEvent.mouseDown(document.body)
+        expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    it('includes a link that opens in a new tab with accessible label', async () => {
+        renderWithProviders(<LostKeyPopover />)
+        await userEvent.click(screen.getByRole('button', { name: /lost your key/i }))
+
+        const link = screen.getByRole('link', { name: /manage your security key/i, hidden: true })
+        expect(link).toHaveAttribute('href', '/user-key')
+        expect(link).toHaveAttribute('target', '_blank')
+        expect(link).toHaveAttribute('aria-label', 'Manage your security key (opens in a new tab)')
+    })
+})

--- a/src/components/study/lost-key-popover.tsx
+++ b/src/components/study/lost-key-popover.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { Anchor, Group, Popover, Stack, Text } from '@mantine/core'
+import { useDisclosure } from '@mantine/hooks'
+import { InfoIcon } from '@phosphor-icons/react/dist/ssr'
+import { useRef } from 'react'
+import { Routes } from '@/lib/routes'
+
+export const LostKeyPopover = () => {
+    const [opened, { toggle, close }] = useDisclosure(false)
+    const triggerRef = useRef<SVGSVGElement>(null)
+
+    const closeAndRestoreFocus = () => {
+        close()
+        triggerRef.current?.focus()
+    }
+
+    return (
+        <Group gap={4} align="center">
+            <Text fz={16} c="charcoal.7">
+                Lost your key?
+            </Text>
+            <Popover opened={opened} onChange={close} width={360} position="right" withArrow>
+                <Popover.Target>
+                    <InfoIcon
+                        ref={triggerRef}
+                        size={16}
+                        weight="fill"
+                        color="var(--mantine-color-charcoal-4)"
+                        onClick={toggle}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault()
+                                toggle()
+                            }
+                            if (e.key === 'Escape' && opened) {
+                                e.stopPropagation()
+                                closeAndRestoreFocus()
+                            }
+                        }}
+                        role="button"
+                        tabIndex={0}
+                        style={{ cursor: 'pointer' }}
+                        aria-label="Lost your key? Click for help"
+                    />
+                </Popover.Target>
+                <Popover.Dropdown
+                    onKeyDown={(e) => {
+                        if (e.key === 'Escape') {
+                            e.stopPropagation()
+                            closeAndRestoreFocus()
+                        }
+                    }}
+                >
+                    <Stack gap="sm">
+                        <Text fz={14}>
+                            Another member of your organization can access these outputs with their own valid key. Ask
+                            them to access them.
+                        </Text>
+                        <Text fz={14}>
+                            A key you generate now cannot access these outputs. It applies only to outputs encrypted
+                            after you generate it.
+                        </Text>
+                        <Anchor
+                            href={Routes.userKey}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            fz={14}
+                            aria-label="Manage your security key (opens in a new tab)"
+                            c="blue.7"
+                        >
+                            Manage your security key
+                        </Anchor>
+                    </Stack>
+                </Popover.Dropdown>
+            </Popover>
+        </Group>
+    )
+}

--- a/src/components/study/security-key-form.test.tsx
+++ b/src/components/study/security-key-form.test.tsx
@@ -1,6 +1,4 @@
 import { describe, expect, it, renderWithProviders, screen } from '@/tests/unit.helpers'
-import { fireEvent } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { SecurityKeyForm } from './security-key-form'
 
 describe('SecurityKeyForm', () => {
@@ -30,33 +28,5 @@ describe('SecurityKeyForm', () => {
     it('renders the Lost your key? trigger', () => {
         renderWithProviders(<SecurityKeyForm />)
         expect(screen.getByRole('button', { name: /lost your key/i })).toBeInTheDocument()
-    })
-
-    it('opens the popover on click and shows the help text', async () => {
-        renderWithProviders(<SecurityKeyForm />)
-        await userEvent.click(screen.getByRole('button', { name: /lost your key/i }))
-
-        expect(screen.getByText(/another member of your organization/i)).toBeInTheDocument()
-        expect(screen.getByText(/a key you generate now cannot access/i)).toBeInTheDocument()
-    })
-
-    it('dismisses the popover on outside click', async () => {
-        renderWithProviders(<SecurityKeyForm />)
-        const trigger = screen.getByRole('button', { name: /lost your key/i })
-
-        await userEvent.click(trigger)
-        expect(trigger).toHaveAttribute('aria-expanded', 'true')
-
-        fireEvent.mouseDown(document.body)
-        expect(trigger).toHaveAttribute('aria-expanded', 'false')
-    })
-
-    it('includes a link to the security key management page', async () => {
-        renderWithProviders(<SecurityKeyForm />)
-        await userEvent.click(screen.getByRole('button', { name: /lost your key/i }))
-
-        const link = screen.getByRole('link', { name: /manage your security key/i, hidden: true })
-        expect(link).toHaveAttribute('href', '/user-key')
-        expect(link).toHaveAttribute('target', '_blank')
     })
 })

--- a/src/components/study/security-key-form.test.tsx
+++ b/src/components/study/security-key-form.test.tsx
@@ -105,19 +105,44 @@ describe('SecurityKeyForm', () => {
         expect(screen.getByRole('textbox')).toHaveFocus()
     })
 
-    it('shows the invalid-key error and keeps the input editable for a malformed key', async () => {
+    it('shows the invalid-key error and re-enables both input and button for correction', async () => {
         renderWithProviders(<SecurityKeyForm job={job} />)
 
-        // Wait for the encrypted-files query so submit is not blocked by isLoadingFiles.
         await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
 
         enterKey('not-a-real-key')
         clickView()
 
         expect(await screen.findByText(INVALID_ERROR)).toBeInTheDocument()
-        const textbox = screen.getByRole('textbox')
-        expect(textbox).toBeEnabled()
-        await waitFor(() => expect(textbox).toHaveFocus())
+        expect(screen.getByRole('textbox')).toBeEnabled()
+        expect(screen.getByRole('button', { name: 'View' })).toBeEnabled()
+    })
+
+    it('disables the button and input on submit to prevent double submission', async () => {
+        renderWithProviders(<SecurityKeyForm job={job} />)
+
+        await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
+
+        enterKey('not-a-real-key')
+        clickView()
+
+        expect(screen.getByRole('button', { name: /decrypting/i })).toBeDisabled()
+        expect(screen.getByRole('textbox')).toBeDisabled()
+    })
+
+    it('replaces the empty-field error with the invalid-key error on retry', async () => {
+        renderWithProviders(<SecurityKeyForm job={job} />)
+
+        await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
+
+        clickView()
+        expect(await screen.findByText(EMPTY_ERROR)).toBeInTheDocument()
+
+        enterKey('not-a-real-key')
+        clickView()
+
+        expect(await screen.findByText(INVALID_ERROR)).toBeInTheDocument()
+        expect(screen.queryByText(EMPTY_ERROR)).toBeNull()
     })
 
     it('shows a success message when the key decrypts the outputs', async () => {

--- a/src/components/study/security-key-form.test.tsx
+++ b/src/components/study/security-key-form.test.tsx
@@ -1,32 +1,141 @@
-import { describe, expect, it, renderWithProviders, screen } from '@/tests/unit.helpers'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+    db,
+    fireEvent,
+    insertTestStudyJobData,
+    mockSessionWithTestData,
+    readTestSupportFile,
+    renderWithProviders,
+    screen,
+    waitFor,
+} from '@/tests/unit.helpers'
+import { type Org } from '@/schema/org'
+import { latestJobForStudy, type LatestJobForStudy } from '@/server/db/queries'
+import { fetchEncryptedJobFilesAction } from '@/server/actions/study-job.actions'
+import { type FileType } from '@/database/types'
+import { ResultsWriter } from 'si-encryption/job-results/writer'
+import { fingerprintKeyData, pemToArrayBuffer } from 'si-encryption/util'
 import { SecurityKeyForm } from './security-key-form'
 
+vi.mock('@/server/actions/study-job.actions', () => ({
+    fetchEncryptedJobFilesAction: vi.fn(() => []),
+}))
+
+const toArrayBuffer = (str: string): ArrayBuffer => {
+    const buf = Buffer.from(str, 'utf-8')
+    return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+}
+
+// Encrypt one artifact the way TOA would (whole-zip + embedded manifest) and return the entry the
+// mocked fetchEncryptedJobFilesAction serves. The reviewer is a manifest recipient (empty
+// recipientKeys) — they decrypt with their own key.
+async function seedArtifact(
+    jobId: string,
+    { fileType, files }: { fileType: FileType; files: { name: string; content: string }[] },
+) {
+    const publicKey = pemToArrayBuffer(await readTestSupportFile('public_key.pem'))
+    const fingerprint = await fingerprintKeyData(publicKey)
+    const writer = new ResultsWriter([{ publicKey, fingerprint }])
+    for (const f of files) await writer.addFile(f.name, toArrayBuffer(f.content))
+    const zip = await writer.generate()
+
+    const row = await db
+        .insertInto('studyJobFile')
+        .values({
+            studyJobId: jobId,
+            name: 'encrypted-results.zip',
+            path: `test-org/${jobId}/results/encrypted-logs/encrypted-results.zip`,
+            fileType,
+        })
+        .returning('id')
+        .executeTakeFirstOrThrow()
+
+    return {
+        studyJobFileId: row.id,
+        fileType,
+        name: 'encrypted-results.zip',
+        encryptedBody: await zip.arrayBuffer(),
+        recipientKeys: {} as Record<string, string>,
+    }
+}
+
+const EMPTY_ERROR = 'Enter your security key to decrypt the outputs.'
+const INVALID_ERROR = 'Invalid key. Check that you copied the full key and enter it again.'
+const SUCCESS_MESSAGE = 'Security key accepted.'
+
+const enterKey = (value: string) => {
+    fireEvent.change(screen.getByRole('textbox'), { target: { value } })
+}
+
+const clickView = () => {
+    fireEvent.click(screen.getByRole('button', { name: 'View' }))
+}
+
 describe('SecurityKeyForm', () => {
-    it('renders the header with a required indicator', () => {
-        renderWithProviders(<SecurityKeyForm />)
-        expect(screen.getByRole('heading', { name: /security key/i })).toBeInTheDocument()
-        expect(screen.getByLabelText('required')).toHaveTextContent('*')
+    let org: Org
+    let job: LatestJobForStudy
+
+    beforeEach(async () => {
+        const resp = await mockSessionWithTestData()
+        org = resp.org
+        const { study } = await insertTestStudyJobData({ org, jobStatus: 'JOB-ERRORED' })
+        job = await latestJobForStudy(study.id)
+        vi.mocked(fetchEncryptedJobFilesAction).mockResolvedValue([])
     })
 
-    it('renders the body copy', () => {
-        renderWithProviders(<SecurityKeyForm />)
+    it('renders the key-entry section with a required indicator and body copy', () => {
+        renderWithProviders(<SecurityKeyForm job={job} />)
+
+        expect(screen.getByRole('heading', { name: /security key/i })).toBeInTheDocument()
+        expect(screen.getByLabelText('required')).toHaveTextContent('*')
         expect(
             screen.getByText('This key is required to access the outputs. It was issued to you during sign-up.'),
         ).toBeInTheDocument()
-    })
-
-    it('renders the input with autocomplete off', () => {
-        renderWithProviders(<SecurityKeyForm />)
         expect(screen.getByRole('textbox')).toHaveAttribute('autocomplete', 'off')
-    })
-
-    it('renders the View button', () => {
-        renderWithProviders(<SecurityKeyForm />)
         expect(screen.getByRole('button', { name: 'View' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /lost your key/i })).toBeInTheDocument()
     })
 
-    it('renders the Lost your key? trigger', () => {
-        renderWithProviders(<SecurityKeyForm />)
-        expect(screen.getByRole('button', { name: /lost your key/i })).toBeInTheDocument()
+    it('shows the empty-field error and focuses the input when submitted blank', async () => {
+        renderWithProviders(<SecurityKeyForm job={job} />)
+
+        clickView()
+
+        expect(await screen.findByText(EMPTY_ERROR)).toBeInTheDocument()
+        expect(screen.getByRole('textbox')).toHaveFocus()
+    })
+
+    it('shows the invalid-key error and keeps the input editable for a malformed key', async () => {
+        renderWithProviders(<SecurityKeyForm job={job} />)
+
+        // Wait for the encrypted-files query so submit is not blocked by isLoadingFiles.
+        await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
+
+        enterKey('not-a-real-key')
+        clickView()
+
+        expect(await screen.findByText(INVALID_ERROR)).toBeInTheDocument()
+        const textbox = screen.getByRole('textbox')
+        expect(textbox).toBeEnabled()
+        await waitFor(() => expect(textbox).toHaveFocus())
+    })
+
+    it('shows a success message when the key decrypts the outputs', async () => {
+        const artifact = await seedArtifact(job.id, {
+            fileType: 'ENCRYPTED-CODE-RUN-LOG',
+            files: [{ name: 'run.log', content: 'job started\nsomething went wrong' }],
+        })
+        vi.mocked(fetchEncryptedJobFilesAction).mockResolvedValue([artifact])
+
+        renderWithProviders(<SecurityKeyForm job={job} />)
+
+        await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
+
+        enterKey(await readTestSupportFile('private_key.pem'))
+        clickView()
+
+        expect(await screen.findByText(SUCCESS_MESSAGE)).toBeInTheDocument()
+        expect(screen.queryByText(INVALID_ERROR)).toBeNull()
+        expect(screen.getByRole('button', { name: 'View' })).toBeEnabled()
     })
 })

--- a/src/components/study/security-key-form.test.tsx
+++ b/src/components/study/security-key-form.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it, renderWithProviders, screen } from '@/tests/unit.helpers'
+import { fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SecurityKeyForm } from './security-key-form'
+
+describe('SecurityKeyForm', () => {
+    it('renders the header with a required indicator', () => {
+        renderWithProviders(<SecurityKeyForm />)
+        expect(screen.getByRole('heading', { name: /security key/i })).toBeInTheDocument()
+        expect(screen.getByLabelText('required')).toHaveTextContent('*')
+    })
+
+    it('renders the body copy', () => {
+        renderWithProviders(<SecurityKeyForm />)
+        expect(
+            screen.getByText('This key is required to access the outputs. It was issued to you during sign-up.'),
+        ).toBeInTheDocument()
+    })
+
+    it('renders the input with autocomplete off', () => {
+        renderWithProviders(<SecurityKeyForm />)
+        expect(screen.getByRole('textbox')).toHaveAttribute('autocomplete', 'off')
+    })
+
+    it('renders the View button', () => {
+        renderWithProviders(<SecurityKeyForm />)
+        expect(screen.getByRole('button', { name: 'View' })).toBeInTheDocument()
+    })
+
+    it('renders the Lost your key? trigger', () => {
+        renderWithProviders(<SecurityKeyForm />)
+        expect(screen.getByRole('button', { name: /lost your key/i })).toBeInTheDocument()
+    })
+
+    it('opens the popover on click and shows the help text', async () => {
+        renderWithProviders(<SecurityKeyForm />)
+        await userEvent.click(screen.getByRole('button', { name: /lost your key/i }))
+
+        expect(screen.getByText(/another member of your organization/i)).toBeInTheDocument()
+        expect(screen.getByText(/a key you generate now cannot access/i)).toBeInTheDocument()
+    })
+
+    it('dismisses the popover on outside click', async () => {
+        renderWithProviders(<SecurityKeyForm />)
+        const trigger = screen.getByRole('button', { name: /lost your key/i })
+
+        await userEvent.click(trigger)
+        expect(trigger).toHaveAttribute('aria-expanded', 'true')
+
+        fireEvent.mouseDown(document.body)
+        expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    it('includes a link to the security key management page', async () => {
+        renderWithProviders(<SecurityKeyForm />)
+        await userEvent.click(screen.getByRole('button', { name: /lost your key/i }))
+
+        const link = screen.getByRole('link', { name: /manage your security key/i, hidden: true })
+        expect(link).toHaveAttribute('href', '/user-key')
+        expect(link).toHaveAttribute('target', '_blank')
+    })
+})

--- a/src/components/study/security-key-form.tsx
+++ b/src/components/study/security-key-form.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { Button, Paper, Stack, Textarea } from '@mantine/core'
+import { Button, Paper, Stack } from '@mantine/core'
 import { FormSectionHeader } from '@/components/study/form-section-header'
 import { LostKeyPopover } from '@/components/study/lost-key-popover'
+import { SecurityKeyInput } from '@/components/study/security-key-input'
 
 export function SecurityKeyForm() {
     return (
@@ -13,12 +14,7 @@ export function SecurityKeyForm() {
                     description="This key is required to access the outputs. It was issued to you during sign-up."
                     required
                 />
-                <Textarea
-                    autoComplete="off"
-                    aria-required
-                    styles={{ input: { minHeight: 72, borderColor: 'var(--mantine-color-blue-7)' } }}
-                    maw={800}
-                />
+                <SecurityKeyInput />
                 <div>
                     <Button size="sm">View</Button>
                 </div>

--- a/src/components/study/security-key-form.tsx
+++ b/src/components/study/security-key-form.tsx
@@ -1,10 +1,8 @@
 'use client'
 
-import { Anchor, Button, Group, Paper, Popover, Stack, Text, Textarea } from '@mantine/core'
-import { useDisclosure } from '@mantine/hooks'
-import { InfoIcon } from '@phosphor-icons/react/dist/ssr'
-import { Routes } from '@/lib/routes'
+import { Button, Paper, Stack, Textarea } from '@mantine/core'
 import { FormSectionHeader } from '@/components/study/form-section-header'
+import { LostKeyPopover } from '@/components/study/lost-key-popover'
 
 export function SecurityKeyForm() {
     return (
@@ -27,59 +25,5 @@ export function SecurityKeyForm() {
                 <LostKeyPopover />
             </Stack>
         </Paper>
-    )
-}
-
-const LostKeyPopover = () => {
-    const [opened, { toggle, close }] = useDisclosure(false)
-
-    return (
-        <Group gap={4} align="center">
-            <Text fz={16} c="charcoal.7">
-                Lost your key?
-            </Text>
-            <Popover opened={opened} onChange={close} width={360} position="right" withArrow>
-                <Popover.Target>
-                    <InfoIcon
-                        size={16}
-                        weight="fill"
-                        color="var(--mantine-color-charcoal-4)"
-                        onClick={toggle}
-                        onKeyDown={(e) => {
-                            if (e.key === 'Enter' || e.key === ' ') {
-                                e.preventDefault()
-                                toggle()
-                            }
-                        }}
-                        role="button"
-                        tabIndex={0}
-                        style={{ cursor: 'pointer' }}
-                        aria-label="Lost your key? Click for help"
-                    />
-                </Popover.Target>
-                <Popover.Dropdown>
-                    <Stack gap="sm">
-                        <Text fz={14}>
-                            Another member of your organization can access these outputs with their own valid key. Ask
-                            them to access them.
-                        </Text>
-                        <Text fz={14}>
-                            A key you generate now cannot access these outputs. It applies only to outputs encrypted
-                            after you generate it.
-                        </Text>
-                        <Anchor
-                            href={Routes.userKey}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            fz={14}
-                            aria-label="Manage your security key"
-                            c="blue.7"
-                        >
-                            Manage your security key
-                        </Anchor>
-                    </Stack>
-                </Popover.Dropdown>
-            </Popover>
-        </Group>
     )
 }

--- a/src/components/study/security-key-form.tsx
+++ b/src/components/study/security-key-form.tsx
@@ -1,24 +1,20 @@
 'use client'
 
-import { Anchor, Button, Divider, Group, Paper, Popover, Stack, Text, Textarea, Title } from '@mantine/core'
+import { Anchor, Button, Group, Paper, Popover, Stack, Text, Textarea } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { InfoIcon } from '@phosphor-icons/react/dist/ssr'
 import { Routes } from '@/lib/routes'
+import { FormSectionHeader } from '@/components/study/form-section-header'
 
 export function SecurityKeyForm() {
     return (
         <Paper p="xxl">
             <Stack gap="lg">
-                <Title fz="xl" fw={700} c="charcoal.9">
-                    Security key{' '}
-                    <Text component="span" c="red.10" inherit aria-label="required">
-                        *
-                    </Text>
-                </Title>
-                <Divider color="charcoal.1" />
-                <Text fz="md" c="charcoal.9">
-                    This key is required to access the outputs. It was issued to you during sign-up.
-                </Text>
+                <FormSectionHeader
+                    title="Security key"
+                    description="This key is required to access the outputs. It was issued to you during sign-up."
+                    required
+                />
                 <Textarea
                     autoComplete="off"
                     aria-required

--- a/src/components/study/security-key-form.tsx
+++ b/src/components/study/security-key-form.tsx
@@ -1,11 +1,21 @@
 'use client'
 
-import { Button, Paper, Stack } from '@mantine/core'
+import { Paper, Stack, Text } from '@mantine/core'
+import { FC } from 'react'
 import { FormSectionHeader } from '@/components/study/form-section-header'
 import { LostKeyPopover } from '@/components/study/lost-key-popover'
 import { SecurityKeyInput } from '@/components/study/security-key-input'
+import { SecurityKeyViewButton } from '@/components/study/security-key-view-button'
+import { useSecurityKeyForm } from '@/components/study/use-security-key-form'
+import type { LatestJobForStudy } from '@/server/db/queries'
 
-export function SecurityKeyForm() {
+interface SecurityKeyFormProps {
+    job: LatestJobForStudy
+}
+
+export const SecurityKeyForm: FC<SecurityKeyFormProps> = ({ job }) => {
+    const { value, setValue, error, successMessage, isDecrypting, inputRef, handleSubmit } = useSecurityKeyForm({ job })
+
     return (
         <Paper p="xxl">
             <Stack gap="lg">
@@ -14,12 +24,27 @@ export function SecurityKeyForm() {
                     description="This key is required to access the outputs. It was issued to you during sign-up."
                     required
                 />
-                <SecurityKeyInput />
-                <div>
-                    <Button size="sm">View</Button>
-                </div>
+                <SecurityKeyInput
+                    ref={inputRef}
+                    value={value}
+                    onChange={(event) => setValue(event.currentTarget.value)}
+                    error={error}
+                    disabled={isDecrypting}
+                />
+                <SecurityKeyViewButton isDecrypting={isDecrypting} onClick={handleSubmit} />
+                <SuccessMessage message={successMessage} />
                 <LostKeyPopover />
             </Stack>
         </Paper>
+    )
+}
+
+// TODO: remove this after 675 is implemented. this is temporary for testing.
+const SuccessMessage: FC<{ message?: string }> = ({ message }) => {
+    if (!message) return null
+    return (
+        <Text fz="md" c="green.9">
+            {message}
+        </Text>
     )
 }

--- a/src/components/study/security-key-form.tsx
+++ b/src/components/study/security-key-form.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { Anchor, Button, Divider, Group, Paper, Popover, Stack, Text, Textarea, Title } from '@mantine/core'
+import { useDisclosure } from '@mantine/hooks'
+import { InfoIcon } from '@phosphor-icons/react/dist/ssr'
+import { Routes } from '@/lib/routes'
+
+export function SecurityKeyForm() {
+    return (
+        <Paper p="xxl">
+            <Stack gap="lg">
+                <Title fz="xl" fw={700} c="charcoal.9">
+                    Security key{' '}
+                    <Text component="span" c="red.10" inherit aria-label="required">
+                        *
+                    </Text>
+                </Title>
+                <Divider color="charcoal.1" />
+                <Text fz="md" c="charcoal.9">
+                    This key is required to access the outputs. It was issued to you during sign-up.
+                </Text>
+                <Textarea
+                    autoComplete="off"
+                    aria-required
+                    styles={{ input: { minHeight: 72, borderColor: 'var(--mantine-color-blue-7)' } }}
+                    maw={800}
+                />
+                <div>
+                    <Button size="sm">View</Button>
+                </div>
+                <LostKeyPopover />
+            </Stack>
+        </Paper>
+    )
+}
+
+const LostKeyPopover = () => {
+    const [opened, { toggle, close }] = useDisclosure(false)
+
+    return (
+        <Group gap={4} align="center">
+            <Text fz={16} c="charcoal.7">
+                Lost your key?
+            </Text>
+            <Popover opened={opened} onChange={close} width={360} position="right" withArrow>
+                <Popover.Target>
+                    <InfoIcon
+                        size={16}
+                        weight="fill"
+                        color="var(--mantine-color-charcoal-4)"
+                        onClick={toggle}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault()
+                                toggle()
+                            }
+                        }}
+                        role="button"
+                        tabIndex={0}
+                        style={{ cursor: 'pointer' }}
+                        aria-label="Lost your key? Click for help"
+                    />
+                </Popover.Target>
+                <Popover.Dropdown>
+                    <Stack gap="sm">
+                        <Text fz={14}>
+                            Another member of your organization can access these outputs with their own valid key. Ask
+                            them to access them.
+                        </Text>
+                        <Text fz={14}>
+                            A key you generate now cannot access these outputs. It applies only to outputs encrypted
+                            after you generate it.
+                        </Text>
+                        <Anchor
+                            href={Routes.userKey}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            fz={14}
+                            aria-label="Manage your security key"
+                            c="blue.7"
+                        >
+                            Manage your security key
+                        </Anchor>
+                    </Stack>
+                </Popover.Dropdown>
+            </Popover>
+        </Group>
+    )
+}

--- a/src/components/study/security-key-input.test.tsx
+++ b/src/components/study/security-key-input.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it, renderWithProviders, screen } from '@/tests/unit.helpers'
+import { SecurityKeyInput } from './security-key-input'
+
+describe('SecurityKeyInput', () => {
+    it('renders a textarea with autocomplete off', () => {
+        renderWithProviders(<SecurityKeyInput />)
+        expect(screen.getByRole('textbox')).toHaveAttribute('autocomplete', 'off')
+    })
+
+    it('marks the input as required', () => {
+        renderWithProviders(<SecurityKeyInput />)
+        expect(screen.getByRole('textbox')).toHaveAttribute('aria-required', 'true')
+    })
+
+    it('does not use aria-live', () => {
+        renderWithProviders(<SecurityKeyInput />)
+        expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-live')
+    })
+
+    it('forwards additional props', () => {
+        renderWithProviders(<SecurityKeyInput placeholder="Paste your key" />)
+        expect(screen.getByPlaceholderText('Paste your key')).toBeInTheDocument()
+    })
+})

--- a/src/components/study/security-key-input.test.tsx
+++ b/src/components/study/security-key-input.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it, renderWithProviders, screen } from '@/tests/unit.helpers'
+import { createRef } from 'react'
 import { SecurityKeyInput } from './security-key-input'
 
 describe('SecurityKeyInput', () => {
@@ -20,5 +21,29 @@ describe('SecurityKeyInput', () => {
     it('forwards additional props', () => {
         renderWithProviders(<SecurityKeyInput placeholder="Paste your key" />)
         expect(screen.getByPlaceholderText('Paste your key')).toBeInTheDocument()
+    })
+
+    it('forwards a ref to the underlying textarea', () => {
+        const ref = createRef<HTMLTextAreaElement>()
+        renderWithProviders(<SecurityKeyInput ref={ref} />)
+        expect(ref.current).toBe(screen.getByRole('textbox'))
+    })
+
+    it('associates and announces the error, and marks the field invalid', () => {
+        renderWithProviders(<SecurityKeyInput error="Something went wrong" />)
+        const textbox = screen.getByRole('textbox')
+        expect(textbox).toHaveAttribute('aria-invalid', 'true')
+
+        const alert = screen.getByRole('alert')
+        expect(alert).toHaveTextContent('Something went wrong')
+
+        const describedBy = textbox.getAttribute('aria-describedby')
+        expect(describedBy).toBeTruthy()
+        expect(alert.closest(`#${describedBy}`)).not.toBeNull()
+    })
+
+    it('supports the native disabled attribute', () => {
+        renderWithProviders(<SecurityKeyInput disabled />)
+        expect(screen.getByRole('textbox')).toBeDisabled()
     })
 })

--- a/src/components/study/security-key-input.tsx
+++ b/src/components/study/security-key-input.tsx
@@ -1,13 +1,25 @@
 import { Textarea, type TextareaProps } from '@mantine/core'
+import { forwardRef } from 'react'
 
 type SecurityKeyInputProps = Omit<TextareaProps, 'autoComplete' | 'aria-required'>
 
-export const SecurityKeyInput = (props: SecurityKeyInputProps) => (
-    <Textarea
-        autoComplete="off"
-        aria-required
-        styles={{ input: { minHeight: 72, borderColor: 'var(--mantine-color-blue-7)' } }}
-        maw={800}
-        {...props}
-    />
+export const SecurityKeyInput = forwardRef<HTMLTextAreaElement, SecurityKeyInputProps>(
+    ({ error, disabled, ...props }, ref) => {
+        const borderColor = disabled ? undefined : error ? 'var(--mantine-color-red-7)' : 'var(--mantine-color-blue-7)'
+
+        return (
+            <Textarea
+                ref={ref}
+                autoComplete="off"
+                aria-required
+                disabled={disabled}
+                error={error ? <span role="alert">{error}</span> : undefined}
+                styles={{ input: { minHeight: 72, borderColor } }}
+                maw={800}
+                {...props}
+            />
+        )
+    },
 )
+
+SecurityKeyInput.displayName = 'SecurityKeyInput'

--- a/src/components/study/security-key-input.tsx
+++ b/src/components/study/security-key-input.tsx
@@ -1,0 +1,13 @@
+import { Textarea, type TextareaProps } from '@mantine/core'
+
+type SecurityKeyInputProps = Omit<TextareaProps, 'autoComplete' | 'aria-required'>
+
+export const SecurityKeyInput = (props: SecurityKeyInputProps) => (
+    <Textarea
+        autoComplete="off"
+        aria-required
+        styles={{ input: { minHeight: 72, borderColor: 'var(--mantine-color-blue-7)' } }}
+        maw={800}
+        {...props}
+    />
+)

--- a/src/components/study/security-key-view-button.test.tsx
+++ b/src/components/study/security-key-view-button.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it, renderWithProviders, screen, userEvent, vi } from '@/tests/unit.helpers'
+import { SecurityKeyViewButton } from './security-key-view-button'
+
+describe('SecurityKeyViewButton', () => {
+    it('is enabled and labelled "View" when idle, and fires onClick', async () => {
+        const onClick = vi.fn()
+        renderWithProviders(<SecurityKeyViewButton isDecrypting={false} onClick={onClick} />)
+
+        const button = screen.getByRole('button', { name: 'View' })
+        expect(button).toBeEnabled()
+
+        await userEvent.click(button)
+        expect(onClick).toHaveBeenCalledOnce()
+    })
+
+    it('shows a disabled Decrypting button with a loader and announces it politely', () => {
+        renderWithProviders(<SecurityKeyViewButton isDecrypting onClick={vi.fn()} />)
+
+        expect(screen.getByRole('button', { name: /decrypting/i })).toBeDisabled()
+
+        const status = screen.getByRole('status')
+        expect(status).toHaveAttribute('aria-live', 'polite')
+        expect(status).toHaveTextContent('Decrypting outputs')
+    })
+})

--- a/src/components/study/security-key-view-button.tsx
+++ b/src/components/study/security-key-view-button.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { Button, Loader, VisuallyHidden } from '@mantine/core'
+import { FC } from 'react'
+
+interface SecurityKeyViewButtonProps {
+    isDecrypting: boolean
+    onClick: () => void
+}
+
+export const SecurityKeyViewButton: FC<SecurityKeyViewButtonProps> = ({ isDecrypting, onClick }) => (
+    <div>
+        <Button
+            size="sm"
+            onClick={onClick}
+            disabled={isDecrypting}
+            leftSection={isDecrypting ? <Loader size={14} color="var(--mantine-color-charcoal-6)" /> : undefined}
+            bg={isDecrypting ? 'grey.1' : undefined}
+            c={isDecrypting ? 'charcoal.6' : undefined}
+            styles={isDecrypting ? { root: { opacity: 1 } } : undefined}
+        >
+            {isDecrypting ? 'Decrypting' : 'View'}
+        </Button>
+        <VisuallyHidden role="status" aria-live="polite">
+            {isDecrypting ? 'Decrypting outputs' : ''}
+        </VisuallyHidden>
+    </div>
+)

--- a/src/components/study/status-alert.tsx
+++ b/src/components/study/status-alert.tsx
@@ -19,14 +19,14 @@ const VARIANTS = {
     informative: {
         bg: 'purple.0',
         titleColor: 'purple.5',
-        titleWeight: 600,
+        titleWeight: 700,
         iconColor: 'var(--mantine-color-purple-5)',
         Icon: InfoIcon,
     },
     action: {
         bg: 'yellow.0',
         titleColor: 'yellow.10',
-        titleWeight: 600,
+        titleWeight: 700,
         iconColor: 'var(--mantine-color-yellow-10)',
         Icon: WarningCircleIcon,
     },

--- a/src/components/study/status-alert.tsx
+++ b/src/components/study/status-alert.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 import { Alert, Stack, Text } from '@mantine/core'
-import { InfoIcon, WarningIcon } from '@phosphor-icons/react/dist/ssr'
+import { InfoIcon, WarningCircleIcon } from '@phosphor-icons/react/dist/ssr'
 
 export const STATUS_ALERT_VARIANT = {
     informative: 'informative',
@@ -16,20 +16,27 @@ type StatusAlertProps = {
 }
 
 const VARIANTS = {
-    informative: { bg: 'purple.0', titleColor: 'purple.5', iconColor: 'var(--mantine-color-purple-5)', Icon: InfoIcon },
+    informative: {
+        bg: 'purple.0',
+        titleColor: 'purple.5',
+        titleWeight: 600,
+        iconColor: 'var(--mantine-color-purple-5)',
+        Icon: InfoIcon,
+    },
     action: {
         bg: 'yellow.0',
-        titleColor: 'charcoal.9',
-        iconColor: 'var(--mantine-color-charcoal-9)',
-        Icon: WarningIcon,
+        titleColor: 'yellow.10',
+        titleWeight: 600,
+        iconColor: 'var(--mantine-color-yellow-10)',
+        Icon: WarningCircleIcon,
     },
 } as const satisfies Record<
     StatusAlertVariant,
-    { bg: string; titleColor: string; iconColor: string; Icon: typeof InfoIcon }
+    { bg: string; titleColor: string; titleWeight: number; iconColor: string; Icon: typeof InfoIcon }
 >
 
 export function StatusAlert({ variant, title, children }: StatusAlertProps) {
-    const { bg, titleColor, iconColor, Icon } = VARIANTS[variant]
+    const { bg, titleColor, titleWeight, iconColor, Icon } = VARIANTS[variant]
     return (
         <Alert
             variant="light"
@@ -43,8 +50,8 @@ export function StatusAlert({ variant, title, children }: StatusAlertProps) {
             data-testid="status-alert"
             data-variant={variant}
         >
-            <Stack gap={4}>
-                <Text fz={14} fw={700} c={titleColor}>
+            <Stack gap="xs">
+                <Text fz={14} fw={titleWeight} c={titleColor}>
                     {title}
                 </Text>
                 <Text fz={14} c="charcoal.9">

--- a/src/components/study/use-security-key-form.ts
+++ b/src/components/study/use-security-key-form.ts
@@ -1,0 +1,65 @@
+import { useCallback, useRef, useState } from 'react'
+import { useQuery } from '@/common'
+import { useDecryptFiles } from '@/hooks/use-decrypt-files'
+import { fetchEncryptedJobFilesAction } from '@/server/actions/study-job.actions'
+import type { LatestJobForStudy } from '@/server/db/queries'
+
+const ERRORS = {
+    empty: 'Enter your security key to decrypt the outputs.',
+    invalid: 'Invalid key. Check that you copied the full key and enter it again.',
+} as const
+
+const SUCCESS_MESSAGE = 'Security key accepted.'
+
+export function useSecurityKeyForm({ job }: { job: LatestJobForStudy }) {
+    const [value, setValue] = useState('')
+    const [error, setError] = useState<string>()
+    const [successMessage, setSuccessMessage] = useState<string>()
+    const inputRef = useRef<HTMLTextAreaElement>(null)
+
+    const { data: encryptedFiles, isLoading: isLoadingFiles } = useQuery({
+        queryKey: ['encrypted-files', job.id],
+        queryFn: () => fetchEncryptedJobFilesAction({ jobId: job.id }),
+    })
+
+    const { decrypt, isPending } = useDecryptFiles({
+        encryptedFiles,
+        onSuccess: () => {
+            setError(undefined)
+            setSuccessMessage(SUCCESS_MESSAGE)
+        },
+        onError: () => {
+            setError(ERRORS.invalid)
+            setSuccessMessage(undefined)
+            requestAnimationFrame(() => inputRef.current?.focus())
+        },
+    })
+
+    const handleSubmit = useCallback(() => {
+        if (isPending) return
+
+        const trimmed = value.trim()
+        if (!trimmed) {
+            setError(ERRORS.empty)
+            setSuccessMessage(undefined)
+            inputRef.current?.focus()
+            return
+        }
+
+        if (isLoadingFiles) return
+
+        setError(undefined)
+        setSuccessMessage(undefined)
+        decrypt(trimmed)
+    }, [isPending, isLoadingFiles, value, decrypt])
+
+    return {
+        value,
+        setValue,
+        error,
+        successMessage,
+        isDecrypting: isPending,
+        inputRef,
+        handleSubmit,
+    }
+}

--- a/src/hooks/use-decrypt-files.ts
+++ b/src/hooks/use-decrypt-files.ts
@@ -65,8 +65,9 @@ async function decryptFiles(encryptedFiles: EncryptedJobFile[], privateKey: stri
 export function useDecryptFiles(options: {
     encryptedFiles: EncryptedJobFile[] | undefined
     onSuccess: (files: JobFileInfo[]) => void
+    onError?: (err: Error) => void
 }) {
-    const { encryptedFiles, onSuccess } = options
+    const { encryptedFiles, onSuccess, onError } = options
 
     const form = useForm({
         mode: 'uncontrolled' as const,
@@ -81,7 +82,11 @@ export function useDecryptFiles(options: {
         if (err instanceof KeyParseError || err instanceof DecryptionError) {
             form.setFieldError('privateKey', err.message)
         }
-        reportMutationError('decryption failed')(err)
+        if (onError) {
+            onError(err)
+        } else {
+            reportMutationError('decryption failed')(err)
+        }
     }
 
     const { mutate, isPending } = useMutation({

--- a/src/lib/study-screen/resolve.test.ts
+++ b/src/lib/study-screen/resolve.test.ts
@@ -177,9 +177,18 @@ describe('resolveResearcherCodeScreen (read-only /view/code)', () => {
 })
 
 describe('resolveScreen (reviewer)', () => {
-    it('results present → reviewer-study-results (highest precedence)', () => {
+    it('decided results → reviewer-study-results (highest precedence)', () => {
+        expect(
+            resolveScreen(
+                'reviewer',
+                state({ hasResults: true, resultsApproved: true, codeDecision: 'CODE-APPROVED' }),
+                ctx,
+            ).screen,
+        ).toBe('reviewer-study-results')
+    })
+    it('undecided results → reviewer-outputs-available (decrypt-before-review, OTTER-668)', () => {
         expect(resolveScreen('reviewer', state({ hasResults: true, codeDecision: 'CODE-APPROVED' }), ctx).screen).toBe(
-            'reviewer-study-results',
+            'reviewer-outputs-available',
         )
     })
     it('pending review → reviewer-proposal-review', () => {

--- a/src/lib/study-screen/reviewer-screen-rules.test.ts
+++ b/src/lib/study-screen/reviewer-screen-rules.test.ts
@@ -88,6 +88,35 @@ describe('resolveScreen(reviewer)', () => {
         ).toBe('reviewer-outputs-pending')
     })
 
+    it('job errored, no files decision → reviewer-outputs-errored (not study-results)', () => {
+        expect(
+            screen(
+                st({
+                    status: 'APPROVED',
+                    hasSubmittedCode: true,
+                    codeDecision: 'CODE-APPROVED',
+                    hasResults: true,
+                    resultsErrored: true,
+                }),
+            ),
+        ).toBe('reviewer-outputs-errored')
+    })
+
+    it('job errored then files-rejected → reviewer-study-results (errored no longer intercepted)', () => {
+        expect(
+            screen(
+                st({
+                    status: 'APPROVED',
+                    hasSubmittedCode: true,
+                    codeDecision: 'CODE-APPROVED',
+                    hasResults: true,
+                    resultsErrored: true,
+                    resultsRejected: true,
+                }),
+            ),
+        ).toBe('reviewer-study-results')
+    })
+
     it('results out-rank the executing window → reviewer-study-results (not outputs-pending)', () => {
         expect(
             screen(

--- a/src/lib/study-screen/reviewer-screen-rules.test.ts
+++ b/src/lib/study-screen/reviewer-screen-rules.test.ts
@@ -102,6 +102,62 @@ describe('resolveScreen(reviewer)', () => {
         ).toBe('reviewer-outputs-errored')
     })
 
+    it('run complete, no files decision → reviewer-outputs-available (not study-results)', () => {
+        expect(
+            screen(
+                st({
+                    status: 'APPROVED',
+                    hasSubmittedCode: true,
+                    codeDecision: 'CODE-APPROVED',
+                    hasResults: true,
+                    resultsDisplayStatus: 'RUN-COMPLETE',
+                }),
+            ),
+        ).toBe('reviewer-outputs-available')
+    })
+
+    it('run complete AND errored → reviewer-outputs-errored (errored out-ranks available)', () => {
+        expect(
+            screen(
+                st({
+                    status: 'APPROVED',
+                    hasSubmittedCode: true,
+                    codeDecision: 'CODE-APPROVED',
+                    hasResults: true,
+                    resultsErrored: true,
+                    resultsDisplayStatus: 'JOB-ERRORED',
+                }),
+            ),
+        ).toBe('reviewer-outputs-errored')
+    })
+
+    it('run complete then files decision → reviewer-study-results (available no longer intercepted)', () => {
+        expect(
+            screen(
+                st({
+                    status: 'APPROVED',
+                    hasSubmittedCode: true,
+                    codeDecision: 'CODE-APPROVED',
+                    hasResults: true,
+                    resultsApproved: true,
+                    resultsDisplayStatus: 'FILES-APPROVED',
+                }),
+            ),
+        ).toBe('reviewer-study-results')
+        expect(
+            screen(
+                st({
+                    status: 'APPROVED',
+                    hasSubmittedCode: true,
+                    codeDecision: 'CODE-APPROVED',
+                    hasResults: true,
+                    resultsRejected: true,
+                    resultsDisplayStatus: 'FILES-REJECTED',
+                }),
+            ),
+        ).toBe('reviewer-study-results')
+    })
+
     it('job errored then files-rejected → reviewer-study-results (errored no longer intercepted)', () => {
         expect(
             screen(

--- a/src/lib/study-screen/reviewer-screen-rules.ts
+++ b/src/lib/study-screen/reviewer-screen-rules.ts
@@ -5,9 +5,13 @@ import type { ScreenRuleEntry } from './screen-rules'
 // Transcribes the legacy review/page.tsx cascade with the ?from= cases removed (those are routing,
 // not screen-selection). See docs/plans/2026-06-23-reviewer-screen-state-machine-design.md §4.
 export const REVIEWER_SCREEN_RULES = [
-    // 1. Results exist → results-only Study Details (OTTER-538). Out-ranks the code decision
-    //    (CODE-APPROVED is always present once results land), mirroring legacy
-    //    `decisionMade = hasLiveCodeDecision && !hasResultsStatus`.
+    // 1a. Job errored, no files decision yet → errored outputs view (OTTER-667). The reviewer
+    //     enters their security key to decrypt error logs before making a files decision.
+    ['reviewer-outputs-errored', { when: (s) => s.resultsErrored && !s.resultsApproved && !s.resultsRejected }],
+
+    // 1b. Results exist → results-only Study Details (OTTER-538). Out-ranks the code decision
+    //     (CODE-APPROVED is always present once results land), mirroring legacy
+    //     `decisionMade = hasLiveCodeDecision && !hasResultsStatus`.
     ['reviewer-study-results', { when: (s) => s.hasResults }],
 
     // 2. Code approved and executing in the enclave, no results yet → the "Secondary

--- a/src/lib/study-screen/reviewer-screen-rules.ts
+++ b/src/lib/study-screen/reviewer-screen-rules.ts
@@ -9,7 +9,16 @@ export const REVIEWER_SCREEN_RULES = [
     //     enters their security key to decrypt error logs before making a files decision.
     ['reviewer-outputs-errored', { when: (s) => s.resultsErrored && !s.resultsApproved && !s.resultsRejected }],
 
-    // 1b. Results exist → results-only Study Details (OTTER-538). Out-ranks the code decision
+    // 1b. Run completed, no files decision yet ("results pending review") → outputs-available view
+    //     (OTTER-668). The reviewer enters their security key to decrypt the outputs before making
+    //     a files decision. Sits below 1a so an errored run keeps the errored view even when a
+    //     RUN-COMPLETE also landed.
+    [
+        'reviewer-outputs-available',
+        { when: (s) => s.hasResults && !s.resultsApproved && !s.resultsRejected && !s.resultsErrored },
+    ],
+
+    // 1c. Results exist → results-only Study Details (OTTER-538). Out-ranks the code decision
     //     (CODE-APPROVED is always present once results land), mirroring legacy
     //     `decisionMade = hasLiveCodeDecision && !hasResultsStatus`.
     ['reviewer-study-results', { when: (s) => s.hasResults }],

--- a/src/lib/study-screen/screens.ts
+++ b/src/lib/study-screen/screens.ts
@@ -16,6 +16,7 @@ export type ScreenId =
     | 'reviewer-code-feedback'
     | 'reviewer-outputs-pending'
     | 'reviewer-outputs-errored'
+    | 'reviewer-outputs-available'
     | 'reviewer-study-results'
 
 // The rule table decides WHICH screen a study shows; each leaf view owns its own back/forward

--- a/src/lib/study-screen/screens.ts
+++ b/src/lib/study-screen/screens.ts
@@ -15,6 +15,7 @@ export type ScreenId =
     | 'reviewer-code-review'
     | 'reviewer-code-feedback'
     | 'reviewer-outputs-pending'
+    | 'reviewer-outputs-errored'
     | 'reviewer-study-results'
 
 // The rule table decides WHICH screen a study shows; each leaf view owns its own back/forward

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -142,6 +142,7 @@ export const theme = createTheme({
     primaryColor: 'purple',
     spacing: {
         xs: '0.5rem',
+        lg: '1.5rem',
         xxl: '2.5rem',
     },
 })

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -67,6 +67,7 @@ const yellow: MantineColorsTuple = [
     '#FFD042',
     '#FFC929',
     '#FFC30F',
+    '#5E4418',
 ]
 const purple: MantineColorsTuple = [
     '#EAE8FC',

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -42,6 +42,7 @@ const red: MantineColorsTuple = [
     '#FF0505',
     '#E60000',
     '#C70000',
+    '#7E241E',
 ]
 const green: MantineColorsTuple = [
     '#E8F8EB',

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -329,21 +329,21 @@ async function reviewerDecryptsErrorLogs(page: Page, studyTitle: string): Promis
     await expect(page.getByText('Security key accepted.')).toBeVisible()
 }
 
-async function verifyFailedStatusDisplay(page: Page, studyTitle: string): Promise<void> {
-    await visitAsRole(page, RESEARCHER_DASHBOARD)
-
-    const studyRow = page.getByRole('row').filter({ hasText: studyTitle })
-    await expect(studyRow.getByText(/Errored/i)).toBeVisible()
-
-    await viewStudyDetails(page, studyTitle)
-
-    await expect(page.getByText(/The code errored/i)).toBeVisible()
-    await expect(page.getByText(/Job ID/i)).toBeVisible()
-
-    // Verify logs row exists in the results table (JobResults now renders EncryptedFilesPanel,
-    // which lists the log artifact by its file-type label before decryption).
-    await expect(page.getByText('Code Run Log')).toBeVisible()
-}
+// OTTER-675: restore once the reviewer approve flow is built — the researcher's
+// errored view is gated on file approval (isErroredResultHiddenFromResearcher).
+// async function verifyFailedStatusDisplay(page: Page, studyTitle: string): Promise<void> {
+//     await visitAsRole(page, RESEARCHER_DASHBOARD)
+//
+//     const studyRow = page.getByRole('row').filter({ hasText: studyTitle })
+//     await expect(studyRow.getByText(/Errored/i)).toBeVisible()
+//
+//     await viewStudyDetails(page, studyTitle)
+//
+//     await expect(page.getByText(/The code errored/i)).toBeVisible()
+//     await expect(page.getByText(/Job ID/i)).toBeVisible()
+//
+//     await expect(page.getByText('Code Run Log')).toBeVisible()
+// }
 
 // ============================================================================
 // Tests
@@ -456,8 +456,8 @@ test('Successful results review', async ({ browser, studyFeatures }) => {
     })
 })
 
-// Owns the reviewer error-log decrypt+approve surface and the researcher
-// errored-status view. Seeds a JOB-READY job, uploads an encrypted error log.
+// OTTER-667: reviewer decrypts error logs on the new errored-outputs screen.
+// OTTER-675: uncomment the researcher step once the approve flow is built.
 test('Error log review', async ({ browser, studyFeatures }) => {
     const studyTitle = studyFeatures.uniqueTitle('error-log')
     const { jobId } = await seedCodeApprovedJobReady(studyTitle)
@@ -467,9 +467,9 @@ test('Error log review', async ({ browser, studyFeatures }) => {
         await reviewerDecryptsErrorLogs(page, studyTitle)
     })
 
-    await withRole(browser, 'researcher', async (page) => {
-        await verifyFailedStatusDisplay(page, studyTitle)
-    })
+    // await withRole(browser, 'researcher', async (page) => {
+    //     await verifyFailedStatusDisplay(page, studyTitle)
+    // })
 })
 
 // Owns the reviewer reject-proposal surface + the researcher rejected-proposal view.

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -307,35 +307,26 @@ async function reviewerApprovesResults(page: Page, studyTitle: string): Promise<
     await page.waitForURL('**/dashboard')
 }
 
-async function reviewerApprovesErrorLogs(page: Page, studyTitle: string): Promise<void> {
+// OTTER-667: the errored screen now uses the SecurityKeyForm (decrypt only).
+// The post-decryption approve flow is OTTER-675; until then, verify decrypt succeeds.
+async function reviewerDecryptsErrorLogs(page: Page, studyTitle: string): Promise<void> {
     await visitAsRole(page, REVIEWER_DASHBOARD)
     await expect(page.getByText('Review Studies')).toBeVisible()
     await viewStudyDetails(page, studyTitle)
     await page.waitForURL(/\/review$/)
 
+    await expect(page.getByRole('heading', { name: /security key/i })).toBeVisible()
+
     const privateKey = await readTestSupportFile('private_key.pem')
-    const privateKeyTextarea = page.getByPlaceholder('Enter your Results Key to access encrypted content.')
+    const privateKeyTextarea = page.getByRole('textbox')
     await expect(privateKeyTextarea).toBeVisible()
     await privateKeyTextarea.fill(privateKey)
 
-    const decryptButton = page.getByRole('button', { name: /Decrypt Files/i })
-    await expect(decryptButton).toBeEnabled()
-    await decryptButton.click()
+    const viewButton = page.getByRole('button', { name: 'View' })
+    await expect(viewButton).toBeEnabled()
+    await viewButton.click()
 
-    await expect(page.getByRole('button', { name: 'View' }).first()).toBeVisible()
-
-    // All-or-nothing: approving shares every decrypted artifact (results + logs) with the
-    // researcher — no per-file selection. Approve directly once decrypted.
-    const approveButton = page.getByRole('button', { name: /approve/i }).last()
-    await expect(approveButton).toBeEnabled()
-    await approveButton.click()
-    await page.waitForURL('**/dashboard')
-
-    // Full reload clears the Router Cache so the details re-fetch from the DB.
-    await goto(page, REVIEWER_DASHBOARD)
-    await viewStudyDetails(page, studyTitle)
-    await page.waitForURL(/\/review$/)
-    await expect(page.getByText(/Approved on/).last()).toBeVisible()
+    await expect(page.getByText('Security key accepted.')).toBeVisible()
 }
 
 async function verifyFailedStatusDisplay(page: Page, studyTitle: string): Promise<void> {
@@ -473,7 +464,7 @@ test('Error log review', async ({ browser, studyFeatures }) => {
     uploadErrorLogs(jobId!)
 
     await withRole(browser, 'reviewer', async (page) => {
-        await reviewerApprovesErrorLogs(page, studyTitle)
+        await reviewerDecryptsErrorLogs(page, studyTitle)
     })
 
     await withRole(browser, 'researcher', async (page) => {

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -281,30 +281,28 @@ function uploadResults(jobId: string): void {
     )
 }
 
-// Reviewer results-review (StudyDetailsReviewer) for a successful run: decrypt then
-// approve. Result files auto-select on decrypt, so the job-level Approve enables
-// without ticking a checkbox.
-async function reviewerApprovesResults(page: Page, studyTitle: string): Promise<void> {
+// OTTER-668: a successful run now lands on the outputs-available screen, which uses the
+// SecurityKeyForm (decrypt only). The post-decryption review+approve flow is OTTER-675;
+// until then, verify the banner renders and decrypt succeeds.
+async function reviewerDecryptsAvailableOutputs(page: Page, studyTitle: string): Promise<void> {
     await visitAsRole(page, REVIEWER_DASHBOARD)
     await expect(page.getByText('Review Studies')).toBeVisible()
     await viewStudyDetails(page, studyTitle)
     await page.waitForURL(/\/review$/)
 
+    await expect(page.getByText(/Outputs are available for review/)).toBeVisible()
+    await expect(page.getByRole('heading', { name: /security key/i })).toBeVisible()
+
     const privateKey = await readTestSupportFile('private_key.pem')
-    const privateKeyTextarea = page.getByPlaceholder('Enter your Results Key to access encrypted content.')
+    const privateKeyTextarea = page.getByRole('textbox')
     await expect(privateKeyTextarea).toBeVisible()
     await privateKeyTextarea.fill(privateKey)
 
-    const decryptButton = page.getByRole('button', { name: /Decrypt Files/i })
-    await expect(decryptButton).toBeEnabled()
-    await decryptButton.click()
+    const viewButton = page.getByRole('button', { name: 'View' })
+    await expect(viewButton).toBeEnabled()
+    await viewButton.click()
 
-    await expect(page.getByRole('button', { name: 'View' }).first()).toBeVisible()
-
-    const approveButton = page.getByRole('button', { name: /^Approve$/i }).last()
-    await expect(approveButton).toBeEnabled()
-    await approveButton.click()
-    await page.waitForURL('**/dashboard')
+    await expect(page.getByText('Security key accepted.')).toBeVisible()
 }
 
 // OTTER-667: the errored screen now uses the SecurityKeyForm (decrypt only).
@@ -438,21 +436,17 @@ test('Reviewer approves submitted code', async ({ browser, studyFeatures }) => {
     })
 })
 
-// Owns the reviewer results decrypt+approve surface. Seeds a JOB-READY job, uploads
+// Owns the reviewer outputs-available decrypt surface. Seeds a JOB-READY job, uploads
 // an encrypted result via the debug script (no runner), then drives the UI.
+// OTTER-675: restore the approve step + researcher approved-results check once the
+// post-decryption review flow is built.
 test('Successful results review', async ({ browser, studyFeatures }) => {
     const studyTitle = studyFeatures.uniqueTitle('results')
     const { jobId } = await seedCodeApprovedJobReady(studyTitle)
     uploadResults(jobId!)
 
     await withRole(browser, 'reviewer', async (page) => {
-        await reviewerApprovesResults(page, studyTitle)
-    })
-
-    await withRole(browser, 'researcher', async (page) => {
-        await visitAsRole(page, RESEARCHER_DASHBOARD)
-        await viewStudyDetails(page, studyTitle)
-        await expect(page.getByText(/results of your study have been approved/i)).toBeVisible()
+        await reviewerDecryptsAvailableOutputs(page, studyTitle)
     })
 })
 


### PR DESCRIPTION
Summary

* Adds the "Outputs Available - Before Decryption" screen for Data Partners, shown when the run has completed (`RUN-COMPLETE`) and no files decision exists
* Action alert "Outputs are available for review • {Date}" with body copy naming the submitting lab; reuses the OTTER-667 `SecurityKeyForm` unmodified
* Post-decryption review/approval is OTTER-675 — this screen stops at a successful decrypt, like 667's errored flow

Changes
Routing & screen registration

* `screens.ts` — new `'reviewer-outputs-available'` screen ID
* `reviewer-screen-rules.ts` — new rule between errored and study-results: `hasResults` with no decision and no error
* `registry.ts` — registers `ReviewerOutputsAvailableScreen`

Screen

* `reviewer-outputs-available-screen.tsx` — page header, step header, action alert, `SecurityKeyForm`, "Previous step" → code page; not-found guards for missing job or missing `RUN-COMPLETE`

Tests

* New screen tests (banner, lab name, form, nav, guards) and rule-table cases; stale expectation in `resolve.test.ts` updated
* `study-flow.spec.ts` — results review e2e now drives the decrypt-only screen; approve step deferred to OTTER-675