### PR TITLE
OTTER-661: bring the Mantine theme in line with the design tokens

### DIFF
--- a/.ladle/backgrounds.ts
+++ b/.ladle/backgrounds.ts
@@ -8,7 +8,7 @@
 // the app-canvas grey via `pageBackgroundArgTypes` on their meta, matching the AppShellMain area.
 
 const WHITE = '#ffffff'
-const APP_CANVAS = 'var(--mantine-color-grey-10)'
+const APP_CANVAS = 'var(--si-color-surface-canvas)'
 const NAVY = 'var(--mantine-color-purple-8)'
 
 const control = {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,14 +65,27 @@ pipeline {
                         echo "Not a merge commit"
                     }
                 }
-                sh """
-                    printenv
-                    [ -d ./cicd ] && find ./cicd -maxdepth 1 -name '*.zip' -delete
-                    aws s3 sync s3://si-mgmt-app-build/scripts ./cicd
-                    cd cicd
-                    unzip -o *.zip
-                    ./deploy
-                """
+                // The deploy reports the PR preview and component catalog URLs back to GitHub, which
+                // needs a token in the environment. 'github-app-safeinsights' is the GitHub App the
+                // Branch Source plugin already uses to post build statuses; the plugin exchanges the
+                // app key for a short-lived installation token, exposed here as the password.
+                // Posting needs pull_requests:write and statuses:write on the installation.
+                //
+                // `printenv` was dropped from this step: it predates the credential and would now
+                // echo the token into the build log.
+                withCredentials([usernamePassword(
+                    credentialsId: 'github-app-safeinsights',
+                    usernameVariable: 'GITHUB_APP_USER',
+                    passwordVariable: 'GITHUB_TOKEN'
+                )]) {
+                    sh """
+                        [ -d ./cicd ] && find ./cicd -maxdepth 1 -name '*.zip' -delete
+                        aws s3 sync s3://si-mgmt-app-build/scripts ./cicd
+                        cd cicd
+                        unzip -o *.zip
+                        ./deploy
+                    """
+                }
             }
         }
     }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,6 +25,7 @@ const eslintConfig = [
             '!.ladle',
             '!.ladle/**',
             '.ladle/dist/**',
+            '.ladle/dist-standalone/**',
             'CHANGELOG.md',
             'test-results/**',
             'tests/coverage/**',

--- a/src/components/modals/app-modal.tsx
+++ b/src/components/modals/app-modal.tsx
@@ -37,7 +37,7 @@ export function AppModal({
             styles={{
                 header: {
                     padding: '0px 40px',
-                    backgroundColor: theme.colors.grey[10],
+                    backgroundColor: theme.colors.charcoal[0],
                     ...styles?.header,
                 },
                 body: {

--- a/src/components/ui/components.stories.tsx
+++ b/src/components/ui/components.stories.tsx
@@ -1,0 +1,86 @@
+import type { Story } from '@ladle/react'
+import { Alert, Button, Group, Stack } from '@mantine/core'
+import { Heading, Text } from '@/components/ui'
+
+// Variant matrices mirroring the Figma component pages so they can be compared side by side.
+//   Button 4216:2 · Alert 61:5826
+// Geometry is transcribed from Figma; colors are mapped by role through the semantic tokens,
+// because the Figma component pages are still drawn on a stale palette.
+
+const meta = { title: 'AA Design system / Components' }
+export default meta
+
+const SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] as const
+
+// Figma's variant axis -> the Mantine equivalent. `error` is a color, not a variant, in Mantine.
+const BUTTON_VARIANTS = [
+    { label: 'filled', props: { variant: 'filled' } },
+    { label: 'error (Figma) → color="red"', props: { variant: 'filled', color: 'red' } },
+    { label: 'outline', props: { variant: 'outline' } },
+    { label: 'subtle', props: { variant: 'subtle' } },
+    { label: 'Disable (Figma) → disabled', props: { disabled: true } },
+] as const
+
+const ALERT_COLORS = [
+    { label: 'Red', color: 'red' },
+    { label: 'Green', color: 'green' },
+    { label: 'Purple', color: 'purple' },
+    { label: 'Blue', color: 'blue' },
+    { label: 'Yellow', color: 'yellow' },
+] as const
+
+// Figma spells this axis "Varient" (sic).
+const ALERT_VARIANTS = ['light', 'filled', 'outline'] as const
+
+export const Buttons: Story = () => (
+    <Stack p="xl" gap="xl">
+        <Stack gap="xs">
+            <Heading size="page-sm">Button — sizes</Heading>
+            <Text size="body-sm" c="dimmed">
+                Figma 4216:2. xs h30/pad14/font12 → xl h60/pad32/font20, radius 2 throughout.
+            </Text>
+            <Group align="center">
+                {SIZES.map((size) => (
+                    <Button key={size} size={size}>
+                        Button {size}
+                    </Button>
+                ))}
+            </Group>
+        </Stack>
+
+        <Stack gap="xs">
+            <Heading size="page-sm">Button — variants</Heading>
+            {BUTTON_VARIANTS.map(({ label, props }) => (
+                <Group key={label} align="center">
+                    <Text size="description" c="dimmed" w={220}>
+                        {label}
+                    </Text>
+                    <Button {...props}>Button</Button>
+                </Group>
+            ))}
+        </Stack>
+    </Stack>
+)
+
+export const Alerts: Story = () => (
+    <Stack p="xl" gap="xl">
+        <Stack gap="xs">
+            <Heading size="page-sm">Alert</Heading>
+            <Text size="body-sm" c="dimmed">
+                Figma 61:5826. Pad 12/16, gap 8. Light = shade 0, filled = shade 5, outline = white + shade-5 border.
+            </Text>
+        </Stack>
+        {ALERT_VARIANTS.map((variant) => (
+            <Stack key={variant} gap="xs">
+                <Text size="body-md" fw={700}>
+                    {variant}
+                </Text>
+                {ALERT_COLORS.map(({ label, color }) => (
+                    <Alert key={label} variant={variant} color={color} title={label}>
+                        Alert with paragraph text — the authoritative row in the Figma variant matrix.
+                    </Alert>
+                ))}
+            </Stack>
+        ))}
+    </Stack>
+)

--- a/src/components/ui/foundations.stories.tsx
+++ b/src/components/ui/foundations.stories.tsx
@@ -1,0 +1,189 @@
+import type { Story } from '@ladle/react'
+import { Box, Group, Paper, SimpleGrid, Stack, useMantineTheme } from '@mantine/core'
+import { Heading, Text } from '@/components/ui'
+import { semanticShades, semanticColor, type SemanticToken } from '@/theme/tokens'
+
+// The design-system catalog, from "Interim design tokens - handoff - Jul 2026".
+// Every value is read back out of the live theme, so this page IS the verification surface:
+// if a token is wrong here, it is wrong in the app.
+
+const meta = { title: 'AA Design system / Foundations' }
+export default meta
+
+const RAMPS = ['purple', 'navy', 'turquoise', 'blue', 'green', 'yellow', 'red', 'charcoal', 'grey'] as const
+const SHADES = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] as const
+
+const HEADING_SPECS = [
+    { size: 'display', note: 'Display — 40 / 700 / 120%' },
+    { size: 'page', note: 'Page title — 34 / 700 / 135%' },
+    { size: 'page-sm', note: 'Page title small — 22 / 700 / 135%' },
+    { size: 'card', note: 'Card heading — 20 / 700 / 135%' },
+    { size: 'minor', note: 'Minor heading — 16 / 700 / 135%' },
+] as const
+
+const TEXT_SPECS = [
+    { size: 'body-lg', note: 'Large body — 18 / 400 / 150%' },
+    { size: 'body-md', note: 'Body — 16 / 400 / 150%' },
+    { size: 'body-sm', note: 'Small body — 14 / 400 / 150%' },
+    { size: 'label-md', note: 'Label — 14 / 600 / 120%' },
+    { size: 'label-sm', note: 'Label small — 12 / 600 / 120%' },
+    { size: 'description', note: 'Description — 12 / 400 / 150%' },
+] as const
+
+const SCALE_KEYS = ['xs', 'sm', 'md', 'lg', 'xl'] as const
+const SPACING_KEYS = ['xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl'] as const
+
+const Swatch = ({ color, label, sub }: { color: string; label: string; sub?: string }) => (
+    <Stack gap={4}>
+        <Box style={{ background: color, height: 56, borderRadius: 2, border: '1px solid #0001' }} />
+        <Text size="description" c="dimmed">
+            {label}
+        </Text>
+        {sub ? (
+            <Text size="description" c="dimmed">
+                {sub}
+            </Text>
+        ) : null}
+    </Stack>
+)
+
+export const ColorRamps: Story = () => {
+    const theme = useMantineTheme()
+
+    return (
+        <Stack p="xl" gap="xl">
+            <Heading size="page-sm">Color primitives</Heading>
+            <Text size="body-sm" c="dimmed">
+                Ramps are named 50-900 in the handoff and map onto Mantine index 0-9 in order. Grey and Purple carry an
+                extra 950 step, kept in slot 10.
+            </Text>
+            {RAMPS.map((ramp) => (
+                <Stack key={ramp} gap="xs">
+                    <Text size="body-md" fw={700}>
+                        {ramp}
+                    </Text>
+                    <SimpleGrid cols={10} spacing="xs">
+                        {SHADES.map((shade) => (
+                            <Swatch
+                                key={shade}
+                                color={theme.colors[ramp][shade]}
+                                label={`${shade}`}
+                                sub={theme.colors[ramp][shade]}
+                            />
+                        ))}
+                    </SimpleGrid>
+                </Stack>
+            ))}
+        </Stack>
+    )
+}
+
+const semanticEntries = Object.entries(semanticShades) as [SemanticToken, string][]
+
+export const SemanticTokens: Story = () => (
+    <Stack p="xl" gap="md">
+        <Heading size="page-sm">Semantic tokens</Heading>
+        <Text size="body-sm" c="dimmed">
+            Each token is bound to a primitive exactly as the handoff file states it — these are not inferred. Labels
+            show the binding so a mismatch is visible here rather than in the app.
+        </Text>
+        <SimpleGrid cols={4} spacing="lg">
+            {semanticEntries.map(([token, ref]) => (
+                <Swatch key={token} color={semanticColor(token)} label={token} sub={`→ ${ref}`} />
+            ))}
+        </SimpleGrid>
+    </Stack>
+)
+
+export const Typography: Story = () => (
+    <Stack p="xl" gap="lg">
+        <Heading size="page-sm">Type scale</Heading>
+        <Text size="body-sm" c="dimmed">
+            Open Sans. Names mirror the handoff’s composed type styles. Line heights are the three primitives (1.2 /
+            1.35 / 1.5) the handoff defines.
+        </Text>
+        {HEADING_SPECS.map(({ size, note }) => (
+            <Stack key={size} gap={2}>
+                <Heading size={size}>The quick brown fox ({size})</Heading>
+                <Text size="description" c="dimmed">
+                    {note}
+                </Text>
+            </Stack>
+        ))}
+        {TEXT_SPECS.map(({ size, note }) => (
+            <Stack key={size} gap={2}>
+                <Text size={size}>The quick brown fox jumps over the lazy dog ({size})</Text>
+                <Text size="description" c="dimmed">
+                    {note}
+                </Text>
+            </Stack>
+        ))}
+        <Stack gap={2}>
+            <Text size="body-md" fw={400}>
+                Body 16 Regular (400)
+            </Text>
+            <Text size="body-md" fw={600}>
+                Body 16 Semi-bold (600)
+            </Text>
+            <Text size="body-md" fw={700}>
+                Body 16 Bold (700)
+            </Text>
+        </Stack>
+    </Stack>
+)
+
+export const RadiusAndShadow: Story = () => {
+    const theme = useMantineTheme()
+
+    return (
+        <Stack p="xl" gap="xl">
+            <Stack gap="xs">
+                <Heading size="page-sm">Corner radius</Heading>
+                <Group gap="lg">
+                    {SCALE_KEYS.map((key) => (
+                        <Stack key={key} gap={4} align="center">
+                            <Box
+                                w={80}
+                                h={80}
+                                style={{ background: theme.colors.purple[5], borderRadius: theme.radius[key] }}
+                            />
+                            <Text size="description" c="dimmed">
+                                {key} · {theme.radius[key]}
+                            </Text>
+                        </Stack>
+                    ))}
+                </Group>
+            </Stack>
+
+            <Stack gap="xs">
+                <Heading size="page-sm">Shadows</Heading>
+                <Text size="body-sm" c="dimmed">
+                    The handoff defines shadows as separate blur/spread/offset/opacity parts with no color; these
+                    compose them over black.
+                </Text>
+                <Group gap="xl">
+                    {SCALE_KEYS.map((key) => (
+                        <Stack key={key} gap={4} align="center">
+                            <Paper w={100} h={80} shadow={key} radius="xs" />
+                            <Text size="description" c="dimmed">
+                                {key}
+                            </Text>
+                        </Stack>
+                    ))}
+                </Group>
+            </Stack>
+
+            <Stack gap="xs">
+                <Heading size="page-sm">Spacing</Heading>
+                {SPACING_KEYS.map((key) => (
+                    <Group key={key} gap="sm" align="center">
+                        <Text size="description" c="dimmed" w={80}>
+                            {key} · {theme.spacing[key]}
+                        </Text>
+                        <Box h={16} w={theme.spacing[key]} style={{ background: theme.colors.turquoise[5] }} />
+                    </Group>
+                ))}
+            </Stack>
+        </Stack>
+    )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,3 @@
+export { Heading, Text } from './typography'
+export type { HeadingProps, HeadingSize, TextProps, TextSize } from './typography'
+export { uiThemeComponents } from './theme-components'

--- a/src/components/ui/theme-components.ts
+++ b/src/components/ui/theme-components.ts
@@ -1,0 +1,61 @@
+import { Alert, Button, type MantineThemeComponents } from '@mantine/core'
+import { semanticColor } from '@/theme/tokens'
+
+// Per-component theme overrides. Geometry is transcribed from the Figma component pages
+// (Button 4216:2, Alert 61:5826); colors are NOT taken from those pages — they are still drawn
+// on a stale palette — and are mapped by ROLE through the semantic tokens instead.
+
+/** Button sizes — Figma 4216:2. Height/padding/font-size per size, radius xs on every variant. */
+const BUTTON_SIZES = {
+    xs: { height: 30, padding: 14, fontSize: 12 },
+    sm: { height: 36, padding: 18, fontSize: 14 },
+    md: { height: 42, padding: 22, fontSize: 16 },
+    lg: { height: 50, padding: 26, fontSize: 18 },
+    xl: { height: 60, padding: 32, fontSize: 20 },
+} as const
+
+const buttonSizeVars = (size: string) => {
+    const spec = BUTTON_SIZES[size as keyof typeof BUTTON_SIZES] ?? BUTTON_SIZES.md
+
+    return {
+        '--button-height': `${spec.height}px`,
+        '--button-padding-x': `${spec.padding}px`,
+        '--button-fz': `${spec.fontSize}px`,
+    }
+}
+
+export const uiThemeComponents: MantineThemeComponents = {
+    Button: Button.extend({
+        defaultProps: {
+            radius: 'xs',
+        },
+        vars: (_theme, props) => ({
+            root: buttonSizeVars(props.size ?? 'md'),
+        }),
+        styles: () => ({
+            // Figma label weight is 600 across every size; Mantine has no --button-fw var.
+            label: { fontWeight: 600 },
+        }),
+    }),
+
+    Alert: Alert.extend({
+        defaultProps: {
+            radius: 'xs',
+        },
+        styles: () => ({
+            // Figma: pad 12/16, gap 8 — uniform across all 30 variants.
+            root: { padding: '12px 16px' },
+            wrapper: { gap: 8 },
+            title: { color: 'inherit' },
+        }),
+    }),
+
+    TextInput: {
+        defaultProps: {
+            radius: 'xs',
+        },
+        styles: () => ({
+            input: { '::placeholder': { color: semanticColor('text.placeholder') } },
+        }),
+    },
+}

--- a/src/components/ui/typography.tsx
+++ b/src/components/ui/typography.tsx
@@ -1,0 +1,96 @@
+import {
+    MantineShadow,
+    Text as MantineText,
+    TextProps as MantineTextProps,
+    Title,
+    TitleProps,
+    useMantineTheme,
+} from '@mantine/core'
+import { FC, ReactNode } from 'react'
+import { semanticColor } from '@/theme/tokens'
+
+// Typography — "Interim design tokens - handoff - Jul 2026", Typography-styles group.
+//
+// `size` mirrors the handoff's composed style names exactly (heading display/page/page-sm/card,
+// body lg/md/sm, …) so a reviewer can hold the token file and the catalog side by side with
+// nothing to translate.
+//
+// Mantine's own `size`/`order` props are deliberately omitted: Mantine's `TitleSize` already
+// spells h1-h6 and its `Text` size runs xs-xl, so leaving them exposed would give one prop two
+// meanings. Everything else on Title/Text passes through.
+
+const HEADING_ORDER = {
+    display: 1,
+    page: 1,
+    'page-sm': 2,
+    card: 3,
+    minor: 4,
+} as const satisfies Record<string, TitleProps['order']>
+
+export type HeadingSize = keyof typeof HEADING_ORDER
+export type TextSize = 'body-lg' | 'body-md' | 'body-sm' | 'label-md' | 'label-sm' | 'description'
+
+// Font weight is part of the handoff's composed styles but is not carried by `fz`/`lh`, so it is
+// applied here. Body and description are regular; labels, eyebrows and links are semibold.
+const TEXT_WEIGHT: Partial<Record<TextSize, number>> = {
+    'label-md': 600,
+    'label-sm': 600,
+}
+
+type TypographyExtras = {
+    /** Theme shadow token (`xs`-`xl`) applied as a text-shadow. */
+    shadow?: MantineShadow
+    children?: ReactNode
+}
+
+export type HeadingProps = Omit<TitleProps, 'size' | 'order'> &
+    TypographyExtras & {
+        /** Handoff heading style. @default 'page' */
+        size?: HeadingSize
+    }
+
+export type TextProps = Omit<MantineTextProps, 'size'> &
+    TypographyExtras & {
+        /** Handoff body/label style. @default 'body-md' */
+        size?: TextSize
+    }
+
+const useTextShadow = (shadow?: MantineShadow) => {
+    const theme = useMantineTheme()
+    if (!shadow) return undefined
+    return theme.shadows[shadow as keyof typeof theme.shadows] ?? shadow
+}
+
+export const Heading: FC<HeadingProps> = ({ size = 'page', shadow, style, children, ...props }) => {
+    const textShadow = useTextShadow(shadow)
+
+    return (
+        <Title
+            order={HEADING_ORDER[size]}
+            fz={size}
+            lh={size}
+            c={props.c ?? semanticColor('text.header')}
+            style={{ textShadow, ...style }}
+            {...props}
+        >
+            {children}
+        </Title>
+    )
+}
+
+export const Text: FC<TextProps> = ({ size = 'body-md', shadow, style, children, ...props }) => {
+    const textShadow = useTextShadow(shadow)
+
+    return (
+        <MantineText
+            fz={size}
+            lh={size}
+            fw={props.fw ?? TEXT_WEIGHT[size]}
+            c={props.c ?? semanticColor('text.primary')}
+            style={{ textShadow, ...style }}
+            {...props}
+        >
+            {children}
+        </MantineText>
+    )
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -5,97 +5,147 @@ import {
     DefaultMantineSize,
     MantineColorsTuple,
 } from '@mantine/core'
+import type { HeadingSize, TextSize } from './components/ui/typography'
+import { uiThemeComponents } from './components/ui/theme-components'
+import { semanticCssVariables } from './theme/tokens'
 
+// Generated from "Interim design tokens - handoff - Jul 2026" (W3C DTCG).
+// Ramps map 50..900 onto Mantine index 0..9. Grey/Purple carry an extra 950
+// step, kept in slot 10 and referenced via the semantic tokens below.
+
+const red: MantineColorsTuple = [
+    '#ffe0e0',
+    '#ffcccc',
+    '#ffadad',
+    '#ff8a8a',
+    '#ff6b6b',
+    '#ff4747',
+    '#ff2929',
+    '#ff0505',
+    '#a83028',
+    '#7e241e',
+]
+const navy: MantineColorsTuple = [
+    '#e6e9ef',
+    '#ccd3df',
+    '#99a6bf',
+    '#677a9e',
+    '#344d7e',
+    '#01215e',
+    '#011a4b',
+    '#011438',
+    '#000d26',
+    '#000713',
+]
+const turquoise: MantineColorsTuple = [
+    '#e6fafa',
+    '#ccf6f5',
+    '#99eceb',
+    '#66e3e1',
+    '#33d9d7',
+    '#00d0cd',
+    '#00a6a4',
+    '#007d7b',
+    '#005352',
+    '#002a29',
+]
 const charcoal: MantineColorsTuple = [
-    '#E6E6E6',
-    '#D9D9D9',
-    '#BFBFBF',
-    '#A6A6A6',
-    '#8C8C8C',
+    '#f8f9fa',
+    '#d9d9d9',
+    '#bfbfbf',
+    '#a6a6a6',
+    '#8c8c8c',
     '#737373',
     '#595959',
     '#404040',
     '#262626',
-    '#0D0D0D',
+    '#0d0d0d',
 ]
 const grey: MantineColorsTuple = [
-    '#E6E8EB',
-    '#DADEE1',
-    '#C4C9CF',
-    '#AAB3BB',
-    '#949EA9',
-    '#7A8794',
-    '#64707C',
-    '#525C66',
-    '#3D454C',
-    '#2B3036',
-    '#F1F3F5',
-]
-const red: MantineColorsTuple = [
-    '#FFE0E0',
-    '#FFCCCC',
-    '#FFADAD',
-    '#FF8A8A',
-    '#FF6B6B',
-    '#FF4747',
-    '#FF2929',
-    '#FF0505',
-    '#E60000',
-    '#C70000',
+    '#f1f3f5',
+    '#dadee1',
+    '#c4c9cf',
+    '#aab3bb',
+    '#949ea9',
+    '#7a8794',
+    '#64707c',
+    '#525c66',
+    '#3d454c',
+    '#2b3036',
+    '#212529',
 ]
 const green: MantineColorsTuple = [
-    '#E8F8EB',
-    '#D8F3DD',
-    '#C1ECC9',
-    '#A6E3B2',
-    '#8EDC9E',
-    '#77D58A',
-    '#5CCC72',
-    '#44C55E',
-    '#37AF4F',
-    '#2F9844',
-    '#2B8A3E',
+    '#e8f8eb',
+    '#d8f3dd',
+    '#c1ecc9',
+    '#a6e3b2',
+    '#8edc9e',
+    '#77d58a',
+    '#5ccc72',
+    '#44c55e',
+    '#357642',
+    '#285831',
 ]
 const yellow: MantineColorsTuple = [
-    '#FFF9E5',
-    '#FFF6DB',
-    '#FFF0C2',
-    '#FFE9A8',
-    '#FFE38F',
-    '#FFDD75',
-    '#FFD65C',
-    '#FFD042',
-    '#FFC929',
-    '#FFC30F',
-]
-const purple: MantineColorsTuple = [
-    '#EAE8FC',
-    '#D5D2F9',
-    '#A7A0F3',
-    '#7D73ED',
-    '#4F42E6',
-    '#291BC4',
-    '#2317AB',
-    '#19107A',
-    '#100A4C',
-    '#070524',
+    '#fff9e5',
+    '#fff6db',
+    '#fff0c2',
+    '#ffe9a8',
+    '#ffe38f',
+    '#ffdd75',
+    '#ffd65c',
+    '#ffd042',
+    '#8e6723',
+    '#5e4418',
 ]
 const blue: MantineColorsTuple = [
-    '#D6E9FF',
-    '#BDDCFF',
-    '#94C6FF',
-    '#6BB0FF',
-    '#3D98FF',
-    '#1482FF',
-    '#006DEB',
-    '#0058BD',
+    '#e4f0ff',
+    '#bddcff',
+    '#94c6ff',
+    '#6bb0ff',
+    '#3d98ff',
+    '#1482ff',
+    '#006deb',
+    '#0058bd',
     '#004594',
-    '#00326B',
+    '#00326b',
+]
+const purple: MantineColorsTuple = [
+    '#eae8fc',
+    '#d5d2f9',
+    '#a7a0f3',
+    '#7d73ed',
+    '#4f42e6',
+    '#291bc4',
+    '#2317ab',
+    '#19107a',
+    '#100a4c',
+    '#070524',
+    '#040212',
 ]
 
-type ExtendedCustomColors = 'purple' | 'blue' | 'charcoal' | 'grey' | 'red' | 'green' | 'yellow' | DefaultMantineColor
+// The handoff's alpha primitives (Purple/50 50%, Purple/900 75%) cannot live in a Mantine
+// tuple; they are defined as non-ramp entries in src/theme/tokens.ts instead.
 
-type ExtendedCustomSpacing = 'xxl' | DefaultMantineSize
+type ExtendedCustomColors =
+    | 'purple'
+    | 'blue'
+    | 'charcoal'
+    | 'grey'
+    | 'red'
+    | 'green'
+    | 'yellow'
+    | 'navy'
+    | 'turquoise'
+    | DefaultMantineColor
+
+type ExtendedCustomSpacing = 'xxs' | 'xxl' | DefaultMantineSize
+
+// The handoff's composed type styles, addressable as font-size/line-height keys so the
+// ui/ Heading and Text components can pass their `size` straight through to Mantine's
+// `fz`/`lh`. These sit alongside Mantine's xs-xl scale rather than replacing it, because
+// existing call sites across the app still use size="sm" etc.
+type ExtendedCustomFontSize = HeadingSize | TextSize | DefaultMantineSize
 
 declare module '@mantine/core' {
     export interface MantineThemeColorsOverride {
@@ -104,14 +154,69 @@ declare module '@mantine/core' {
 
     export interface MantineThemeSizesOverride {
         spacing: Record<ExtendedCustomSpacing, string>
+        fontSizes: Record<ExtendedCustomFontSize, string>
+        lineHeights: Record<ExtendedCustomFontSize, string>
     }
 }
 
+const fontFamilySans = '"Open Sans", -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif'
+const fontFamilyMono = 'ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace'
+
 export const theme = createTheme({
-    fontFamily: 'Open Sans',
+    fontFamily: fontFamilySans,
+    fontFamilyMonospace: fontFamilyMono,
     headings: {
-        fontFamily: 'Open Sans',
+        fontFamily: fontFamilySans,
         fontWeight: '700',
+        sizes: {
+            h1: { fontSize: '2.125rem', lineHeight: '1.35' },
+            h2: { fontSize: '1.375rem', lineHeight: '1.35' },
+            h3: { fontSize: '1.25rem', lineHeight: '1.35' },
+            h4: { fontSize: '1rem', lineHeight: '1.35' },
+        },
+    },
+    // Mantine's xs-xl scale (used by existing call sites) plus the handoff's composed
+    // type-style names (used by the ui/ Heading and Text components). Both resolve to the
+    // same font-size primitives from the token file.
+    fontSizes: {
+        xs: '0.625rem',
+        sm: '0.75rem',
+        md: '0.875rem',
+        lg: '1rem',
+        xl: '1.125rem',
+
+        display: '2.5rem',
+        page: '2.125rem',
+        'page-sm': '1.375rem',
+        card: '1.25rem',
+        minor: '1rem',
+        'body-lg': '1.125rem',
+        'body-md': '1rem',
+        'body-sm': '0.875rem',
+        'label-md': '0.875rem',
+        'label-sm': '0.75rem',
+        description: '0.75rem',
+    },
+    // Only three line-height primitives exist in the handoff (1.2 / 1.35 / 1.5); the
+    // composed styles express them as 120% / 135% / 150%, which mean the same thing.
+    lineHeights: {
+        xs: '1.2',
+        sm: '1.2',
+        md: '1.5',
+        lg: '1.5',
+        xl: '1.5',
+
+        display: '1.2',
+        page: '1.35',
+        'page-sm': '1.35',
+        card: '1.35',
+        minor: '1.35',
+        'body-lg': '1.5',
+        'body-md': '1.5',
+        'body-sm': '1.5',
+        'label-md': '1.2',
+        'label-sm': '1.2',
+        description: '1.5',
     },
     colors: {
         charcoal,
@@ -121,17 +226,18 @@ export const theme = createTheme({
         yellow,
         purple,
         blue,
+        navy,
+        turquoise,
     },
     components: {
-        TextInput: {
-            defaultProps: {
-                color: charcoal[9],
-            },
-        },
+        // uiThemeComponents carries the Figma-transcribed Button/Alert/TextInput overrides;
+        // it is spread first so the app-specific entries below win on any shared key.
+        ...uiThemeComponents,
         Table: {
             styles: () => ({
                 th: {
-                    backgroundColor: grey[10],
+                    // surface/Background/table header
+                    backgroundColor: charcoal[0],
                 },
             }),
         },
@@ -139,16 +245,34 @@ export const theme = createTheme({
     primaryShade: 5,
     primaryColor: 'purple',
     spacing: {
+        xxs: '0.25rem',
         xs: '0.5rem',
+        sm: '0.75rem',
+        md: '1rem',
+        lg: '1.5rem',
+        xl: '2rem',
         xxl: '2.5rem',
+    },
+    radius: {
+        xs: '0.125rem',
+        sm: '0.25rem',
+        md: '0.5rem',
+        lg: '1rem',
+        xl: '2rem',
+    },
+    shadows: {
+        xs: '0 1px 3px rgba(0, 0, 0, 0.05)',
+        sm: '0 1px 2px rgba(0, 0, 0, 0.1)',
+        md: '0 4px 6px rgba(0, 0, 0, 0.1)',
+        lg: '0 10px 15px rgba(0, 0, 0, 0.15)',
+        xl: '0 20px 25px rgba(0, 0, 0, 0.2)',
     },
 })
 
 export const cssVariablesResolver: CSSVariablesResolver = (theme) => ({
-    variables: {
-        '--mantine-color-placeholder': theme.colors.grey[7],
-        '--mantine-color-dimmed': theme.colors.gray[7],
-    },
+    // Every --si-color-* variable comes from src/theme/tokens.ts, which is also what the ui/
+    // components read through semanticColor(). One definition, two consumers.
+    variables: semanticCssVariables(theme),
     dark: {},
     light: {},
 })

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -1,0 +1,142 @@
+import type { MantineTheme } from '@mantine/core'
+
+// Semantic color tokens, from the "Interim design tokens - handoff - Jul 2026" DTCG file.
+//
+// Unlike the earlier Figma semantic layer (which was a documentation diagram whose values still
+// pointed at a stale palette), these bindings are NOT inferred: the handoff file states each one
+// explicitly as a reference to a color primitive, e.g. `text/Header -> {color primitive.Navy.500}`.
+// The ramp positions below are those references, mapped onto Mantine's 0-9 indexing (50 = 0).
+//
+// Components reference these tokens, never raw shades, so a retint happens in one place.
+
+type ShadeRef = `${string}.${number}`
+
+/** Semantic token -> ramp position. The single source of truth for what each role means. */
+export const semanticShades = {
+    /** text/Body+ Label */
+    'text.primary': 'charcoal.9',
+    /** text/Sub-labels + Description */
+    'text.secondary': 'charcoal.7',
+    /** text/Header */
+    'text.header': 'navy.5',
+    /** text/Placeholder */
+    'text.placeholder': 'grey.7',
+    /** text/Disabled */
+    'text.disabled': 'charcoal.6',
+
+    /** brand/Default */
+    'brand.default': 'purple.5',
+    /** brand/Hover */
+    'brand.hover': 'purple.7',
+    /** brand/Secondary */
+    'brand.secondary': 'purple.3',
+    /** brand/Light */
+    'brand.light': 'purple.0',
+
+    /** link/Default */
+    'link.default': 'blue.7',
+    /** link/Hover */
+    'link.hover': 'blue.9',
+
+    /** status/error/text-icon */
+    'error.default': 'red.9',
+    /** status/error/border + bg-dark */
+    'error.hover': 'red.8',
+    /** status/success/text-icon */
+    'success.default': 'green.9',
+    /** status/success/border + bg-dark */
+    'success.hover': 'green.8',
+    /** status/warning/text-icon */
+    'warning.default': 'yellow.9',
+    /** status/warning/border */
+    'warning.hover': 'yellow.8',
+    /** status/info/text-icon */
+    'info.default': 'blue.8',
+    /** status/info/border + bg-dark */
+    'info.hover': 'blue.7',
+
+    /** status bg-light — the pale fills those text/border colors sit on. */
+    'error.bg': 'red.0',
+    'success.bg': 'green.0',
+    'warning.bg': 'yellow.0',
+    'info.bg': 'blue.0',
+
+    /** surface/State/Disabled light (input fields) */
+    'state.disabled.light': 'grey.0',
+    /** surface/State/Disabled medium (buttons) */
+    'state.disabled.medium': 'grey.1',
+    /** surface/State/Disabled dark */
+    'state.disabled.dark': 'grey.3',
+    /** surface/State/Selected */
+    'state.selected': 'blue.7',
+
+    /** surface/Background/page — the app canvas. */
+    'surface.canvas': 'grey.0',
+    /** surface/Background/sunken + table header */
+    'surface.sunken': 'charcoal.0',
+    /** surface/Background/sidenav */
+    'surface.sidenav': 'purple.8',
+    /** surface/Background/sidenav dp */
+    'surface.sidenav.dp': 'purple.6',
+    /** surface/Background/Sidenav rl */
+    'surface.sidenav.rl': 'green.8',
+    /** surface/Miscellaneous/Footer */
+    'surface.footer': 'purple.9',
+
+    /** border/Default */
+    'border.default': 'charcoal.1',
+    /** border/Dark */
+    'border.dark': 'grey.4',
+
+    /** icon/light-default */
+    'icon.light': 'charcoal.4',
+    /** icon/light-hover */
+    'icon.light.hover': 'charcoal.5',
+    /** icon/dark-default */
+    'icon.dark': 'charcoal.7',
+    /** icon/dark-hover */
+    'icon.dark.hover': 'charcoal.8',
+} as const satisfies Record<string, ShadeRef>
+
+export type SemanticToken = keyof typeof semanticShades
+
+// Tokens whose values are not a ramp position: the handoff's base colors and its two alpha
+// primitives (`Purple/50 50%`, used by brand/Lighter and surface/Background/selected), which
+// cannot live in a MantineColorsTuple.
+const NON_RAMP = {
+    'text.white': '#ffffff',
+    'text.black': '#000000',
+    'surface.raised': '#ffffff',
+    'surface.popover': '#ffffff',
+    'brand.lighter': '#eae8fc80',
+    'surface.selected': '#eae8fc80',
+} as const
+
+/** CSS custom property name for a token, e.g. `--si-color-text-placeholder`. */
+export const cssVar = (token: SemanticToken | keyof typeof NON_RAMP) => `--si-color-${token.replace(/\./g, '-')}`
+
+/** `var(--si-color-…)` reference for use in styles. */
+export const semanticColor = (token: SemanticToken | keyof typeof NON_RAMP) => `var(${cssVar(token)})`
+
+const resolveShade = (theme: MantineTheme, ref: ShadeRef) => {
+    const [family, shade] = ref.split('.')
+    return theme.colors[family][Number(shade)]
+}
+
+/** Emitted through `cssVariablesResolver` so tokens are reachable from CSS as well as TS. */
+export const semanticCssVariables = (theme: MantineTheme): Record<string, string> => {
+    const vars: Record<string, string> = {}
+
+    for (const [token, ref] of Object.entries(semanticShades)) {
+        vars[cssVar(token as SemanticToken)] = resolveShade(theme, ref)
+    }
+    for (const [token, value] of Object.entries(NON_RAMP)) {
+        vars[cssVar(token as keyof typeof NON_RAMP)] = value
+    }
+
+    // Mantine built-ins that should follow the semantic layer rather than its own defaults.
+    vars['--mantine-color-placeholder'] = resolveShade(theme, semanticShades['text.placeholder'])
+    vars['--mantine-color-dimmed'] = resolveShade(theme, semanticShades['text.secondary'])
+
+    return vars
+}


### PR DESCRIPTION
Brings `src/theme.ts` in line with the design tokens and adds the semantic layer the card asks for. Supersedes #896 (see below).

**Source:** the *Interim design tokens - handoff - Jul 2026* DTCG file, which supersedes the Figma export linked on the card. Its handoff note is explicit that it is hand-corrected and that a fresh Figma export would reintroduce two issues it fixes (line-height units, prototype styles).

## What's in it

- **Palette** — all nine ramps updated; **Navy** and **Turquoise** added. Grey and Purple keep their 950 step in slot 10; the malformed 11th entries on green/yellow are gone.
- **Semantic layer** (`src/theme/tokens.ts`) — each role bound to a ramp position exactly as the handoff states it, emitted as `--si-color-*` via `cssVariablesResolver`. Components reference roles, never shades.
- **Scales the theme never defined** — spacing, radius, shadows, and the composed type styles. These silently used Mantine's defaults before.
- **Components** (`src/components/ui/`) — `Heading`/`Text` plus Button/Alert/TextInput overrides, carried over from #896.
- **Ladle catalog** — Foundations and Components stories that read every value back out of the live theme, so the catalog *is* the verification surface.

## Bug this fixes along the way

Two call sites read `theme.colors.grey[10]` — the old out-of-contract 11th entry — as a **light** surface (`#F1F3F5`). Under the token file slot 10 is Grey 950 `#212529`, so a naive port would have turned modal headers, table headers, and the Ladle canvas near-black. Both are repointed at the semantic surface they actually meant.

## Relationship to #896

#896's *structure* is carried over intact — it referenced semantic tokens rather than raw shades, so it ported by rebinding. Its navy-primary palette is not: the handoff keeps purple as the brand color. One difference worth noting — #896 flagged its bindings as *inferred, needing UX sign-off*; these are stated outright in the handoff file, so that caveat is gone.

## Open questions

1. **Font family.** The card flags Inter @ 500 and says *confirm with design first*. **Not done here** — the July handoff specifies Open Sans, so this keeps Open Sans. Needs a decision on which source wins.
2. **Yellow badge contrast.** `<Badge color="yellow">` resolves to Yellow 500 `#ffdd75` with white text via `primaryShade: 5` — roughly **1.4:1**, illegible. The new `warning.*` tokens are the fix (yellow.9 on yellow.0, AA-compliant), but migrating call sites is out of scope here. Same class of issue for `color="green"`.
3. **Shadow color.** The handoff decomposes shadows into blur/spread/offset/opacity with **no color**; these compose over black. Worth confirming with design. Its `xs` blur (3px) is also larger than `sm` (2px), which looks like an authoring slip on their end.
4. **Catalog sidebar title** is `AA Design system` purely to sort first. Functional but ugly; Ladle supports explicit ordering in `config.mjs` if preferred.
5. **`spacing.lg` shifts 20px → 24px** (Mantine default → token), affecting existing `p="lg"` at ~44 call sites. `radius.md` shifts 10px → 8px at 6 sites. Every other scale key already matched.
6. **Not a migration.** Existing call sites still pass old color names as string props; those degrade quietly. Only the two `theme.colors.X[n]` reads were remapped, because that form throws. The follow-up card covers the rest.

## Verification

`pnpm run checks` and `pnpm run test:unit` (2160 passed) green. Catalog built and loaded in a browser — ramps, semantic tokens, type scale, radius/shadow/spacing all render from the live theme.

Visual spot-check of key app pages is still outstanding; unit tests don't assert on theme values, so green there confirms nothing broke, not that it looks right.

Companion infra PR (publishes this catalog on every PR preview): safeinsights/iac#191