### PR TITLE
OTTER-675: review decrypted outputs and submit a sharing decision

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
         "@types/jsonwebtoken": "^9.0.10",
         "@types/papaparse": "^5.5.2",
         "@types/pg": "^8.15.6",
+        "@zip.js/zip.js": "^2.8.26",
         "aws-iam-policy-types": "^1.0.2",
         "child_process": "^1.0.2",
         "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       '@types/pg':
         specifier: ^8.15.6
         version: 8.15.6
+      '@zip.js/zip.js':
+        specifier: ^2.8.26
+        version: 2.8.26
       aws-iam-policy-types:
         specifier: ^1.0.2
         version: 1.0.2

--- a/services/editor/auth.test.ts
+++ b/services/editor/auth.test.ts
@@ -820,10 +820,18 @@ describe('shouldPersistDocument', () => {
         expect(query).not.toHaveBeenCalled()
     })
 
-    it('always allows outputs-review-feedback persistence without touching the DB', async () => {
-        const query = vi.fn()
-        const db: DbQuery = { query: query as unknown as DbQuery['query'] }
-        await expect(shouldPersistDocument({ kind: 'outputs-review-feedback', jobId: JOB_ID }, db)).resolves.toBe(true)
-        expect(query).not.toHaveBeenCalled()
+    // Deleting the draft on submit is only half the guard: without this gate an already-connected
+    // tab would persist the document again a moment later and resurrect feedback for a decision
+    // that is final.
+    it('allows outputs-review-feedback persistence while the job has no files decision', async () => {
+        await expect(
+            shouldPersistDocument({ kind: 'outputs-review-feedback', jobId: JOB_ID }, fakeDb([])),
+        ).resolves.toBe(true)
+    })
+
+    it('blocks outputs-review-feedback persistence once a files decision is recorded', async () => {
+        await expect(
+            shouldPersistDocument({ kind: 'outputs-review-feedback', jobId: JOB_ID }, fakeDb([{ status: 'x' }])),
+        ).resolves.toBe(false)
     })
 })

--- a/services/editor/auth.test.ts
+++ b/services/editor/auth.test.ts
@@ -34,6 +34,13 @@ describe('parseDocumentName', () => {
         })
     })
 
+    it('parses outputs-review-feedback documents', () => {
+        expect(parseDocumentName(`outputs-review-feedback-${JOB_ID}`)).toEqual({
+            kind: 'outputs-review-feedback',
+            jobId: JOB_ID,
+        })
+    })
+
     it('parses proposal-fields documents', () => {
         expect(parseDocumentName(`proposal-${STUDY_ID}-fields`)).toEqual({
             kind: 'proposal-fields',
@@ -75,6 +82,7 @@ describe('parseDocumentName', () => {
         `review-feedback-${STUDY_ID}-v-1`,
         `review-feedback-${STUDY_ID}-v`,
         `code-review-feedback-not-a-uuid`,
+        `outputs-review-feedback-not-a-uuid`,
         `proposal-${STUDY_ID}-resubmission-note`,
         `proposal-${STUDY_ID}-resubmission-note-v0`,
         `proposal-${STUDY_ID}-resubmission-note-v01`,
@@ -96,6 +104,10 @@ describe('requiredOrgIdForDocument', () => {
 
     it('returns DO org for code-review-feedback', () => {
         expect(requiredOrgIdForDocument({ kind: 'code-review-feedback', jobId: JOB_ID }, study)).toBe('do-org')
+    })
+
+    it('returns DO org for outputs-review-feedback', () => {
+        expect(requiredOrgIdForDocument({ kind: 'outputs-review-feedback', jobId: JOB_ID }, study)).toBe('do-org')
     })
 
     it('returns lab org for proposal-fields', () => {
@@ -457,6 +469,22 @@ describe('authenticate', () => {
         ).resolves.toEqual({ user: { id: 'do-user', clerkId: 'clerk-user-1' }, studyId: STUDY_ID })
     })
 
+    it('resolves the studyId through study_job for an outputs-review-feedback document', async () => {
+        const db = dbFromScripts(async (text) => {
+            if (text.includes('FROM "user"')) return { rows: [{ id: 'do-user' }], rowCount: 1 }
+            if (text.includes('FROM study_job')) return { rows: [{ study_id: STUDY_ID }], rowCount: 1 }
+            if (text.includes('FROM study'))
+                return {
+                    rows: [{ org_id: 'do-org', submitted_by_org_id: 'lab-org', status: 'APPROVED' }],
+                    rowCount: 1,
+                }
+            return { rows: [{}], rowCount: 1 }
+        })
+        await expect(
+            authenticate({ token: 'tok', documentName: `outputs-review-feedback-${JOB_ID}` }, baseDeps({ db })),
+        ).resolves.toEqual({ user: { id: 'do-user', clerkId: 'clerk-user-1' }, studyId: STUDY_ID })
+    })
+
     it('rejects a code-review-feedback connection when the study_job row does not exist', async () => {
         const db = dbFromScripts(async (text) => {
             if (text.includes('FROM "user"')) return { rows: [{ id: 'do-user' }], rowCount: 1 }
@@ -584,6 +612,14 @@ describe('isDocumentEditable', () => {
     it('always allows code-review-feedback regardless of study status (editor is not the enforcer)', () => {
         for (const status of ['DRAFT', 'PENDING-REVIEW', 'APPROVED', 'CHANGE-REQUESTED', 'REJECTED'] as const) {
             expect(isDocumentEditable({ kind: 'code-review-feedback', jobId: JOB_ID }, { status })).toBe(true)
+        }
+    })
+
+    // Same exemption, same reason: the one-decision-per-round guard for outputs feedback is the
+    // study_review_comment unique constraint, not this gate.
+    it('always allows outputs-review-feedback regardless of study status', () => {
+        for (const status of ['DRAFT', 'PENDING-REVIEW', 'APPROVED', 'CHANGE-REQUESTED', 'REJECTED'] as const) {
+            expect(isDocumentEditable({ kind: 'outputs-review-feedback', jobId: JOB_ID }, { status })).toBe(true)
         }
     })
 })
@@ -781,6 +817,13 @@ describe('shouldPersistDocument', () => {
         const query = vi.fn()
         const db: DbQuery = { query: query as unknown as DbQuery['query'] }
         await expect(shouldPersistDocument({ kind: 'code-review-feedback', jobId: JOB_ID }, db)).resolves.toBe(true)
+        expect(query).not.toHaveBeenCalled()
+    })
+
+    it('always allows outputs-review-feedback persistence without touching the DB', async () => {
+        const query = vi.fn()
+        const db: DbQuery = { query: query as unknown as DbQuery['query'] }
+        await expect(shouldPersistDocument({ kind: 'outputs-review-feedback', jobId: JOB_ID }, db)).resolves.toBe(true)
         expect(query).not.toHaveBeenCalled()
     })
 })

--- a/services/editor/auth.ts
+++ b/services/editor/auth.ts
@@ -128,9 +128,9 @@ export type StudyEditabilitySnapshot = {
 // is the single enforcer of code-review versioning (see
 // claimInitialCodeReviewJob in study.actions.ts), and per-document room
 // isolation in Hocuspocus prevents stale-round writes from polluting a
-// different round's persisted state. Outputs-review feedback takes the same
-// exemption for the same reason — its one-decision-per-round guard is the
-// study_review_comment unique constraint, not this gate.
+// different round's persisted state. Outputs-review feedback is exempt here too, but for a
+// narrower reason: what bounds it is the job's files decision, not the STUDY status this snapshot
+// carries, so the check lives in shouldPersistDocument where the job id is available.
 export function isDocumentEditable(parsed: ParsedDocumentName, snap: StudyEditabilitySnapshot): boolean {
     switch (parsed.kind) {
         case 'review-feedback':
@@ -152,9 +152,23 @@ export function isDocumentEditable(parsed: ParsedDocumentName, snap: StudyEditab
 // covers new and reconnecting clients, but already-connected clients keep
 // streaming Yjs updates between a status flip and their own kick-out. This
 // gate is the second line of defense so post-flip writes never land in
-// yjs_document. Job-keyed review docs are not gated here; see isDocumentEditable.
+// yjs_document.
+//
+// Code-review docs are exempt (see isDocumentEditable). Outputs-review docs are NOT: the decision
+// action deletes the draft on submit, and without a gate here an already-connected tab would
+// simply persist it again a moment later, resurrecting feedback for a decision that is final.
 export async function shouldPersistDocument(parsed: ParsedDocumentName, db: Pick<DbQuery, 'query'>): Promise<boolean> {
-    if (isJobKeyed(parsed)) return true
+    if (parsed.kind === 'code-review-feedback') return true
+
+    if (parsed.kind === 'outputs-review-feedback') {
+        const decided = await db.query<{ exists: boolean }>(
+            `SELECT 1 FROM job_status_change
+              WHERE study_job_id = $1 AND status::text IN ('FILES-APPROVED', 'FILES-REJECTED')
+              LIMIT 1`,
+            [parsed.jobId],
+        )
+        return decided.rowCount === 0
+    }
 
     const row = await db.query<{ status: StudyStatus }>('SELECT status FROM study WHERE id = $1', [parsed.studyId])
     const status = row.rows[0]?.status

--- a/services/editor/auth.ts
+++ b/services/editor/auth.ts
@@ -5,6 +5,7 @@
 
 import {
     CODE_REVIEW_FEEDBACK_PREFIX,
+    OUTPUTS_REVIEW_FEEDBACK_PREFIX,
     PROPOSAL_PREFIX,
     PROPOSAL_TEXT_SLUGS,
     RESUBMISSION_NOTE_SUFFIX_RE,
@@ -47,13 +48,27 @@ const SUBMITTED_REVIEW_STATUSES: readonly StudyStatus[] = ['APPROVED', 'CHANGE-R
 export type ParsedDocumentName =
     | { kind: 'review-feedback'; studyId: string; version: number }
     | { kind: 'code-review-feedback'; jobId: string }
+    | { kind: 'outputs-review-feedback'; jobId: string }
     | { kind: 'proposal-fields'; studyId: string }
     | { kind: 'proposal-text'; studyId: string; slug: ProposalTextSlug }
     | { kind: 'proposal-resubmission-note'; studyId: string; version: number }
 
 const VERSION_SUFFIX_RE = /^-v([1-9]\d*)$/
 
+// Job-keyed feedback documents: the doc name carries a study_job.id, not a study.id.
+const JOB_KEYED_KINDS: ReadonlyArray<ParsedDocumentName['kind']> = ['code-review-feedback', 'outputs-review-feedback']
+
+const isJobKeyed = (
+    parsed: ParsedDocumentName,
+): parsed is { kind: 'code-review-feedback' | 'outputs-review-feedback'; jobId: string } =>
+    JOB_KEYED_KINDS.includes(parsed.kind)
+
 export function parseDocumentName(name: string): ParsedDocumentName | null {
+    if (name.startsWith(OUTPUTS_REVIEW_FEEDBACK_PREFIX)) {
+        const jobId = name.slice(OUTPUTS_REVIEW_FEEDBACK_PREFIX.length)
+        return UUID_RE.test(jobId) ? { kind: 'outputs-review-feedback', jobId } : null
+    }
+
     // Longer prefix first; otherwise REVIEW_FEEDBACK_PREFIX would mis-match a
     // code-review-feedback doc name.
     if (name.startsWith(CODE_REVIEW_FEEDBACK_PREFIX)) {
@@ -92,13 +107,13 @@ export function parseDocumentName(name: string): ParsedDocumentName | null {
     return null
 }
 
-// review-feedback-* and code-review-feedback-* documents are owned by the
-// reviewing org (DO). proposal-* documents are owned by the submitting lab.
+// review-feedback-*, code-review-feedback-* and outputs-review-feedback-* documents are owned
+// by the reviewing org (DO). proposal-* documents are owned by the submitting lab.
 export function requiredOrgIdForDocument(
     parsed: ParsedDocumentName,
     study: { org_id: string; submitted_by_org_id: string },
 ): string {
-    if (parsed.kind === 'review-feedback' || parsed.kind === 'code-review-feedback') return study.org_id
+    if (parsed.kind === 'review-feedback' || isJobKeyed(parsed)) return study.org_id
     return study.submitted_by_org_id
 }
 
@@ -109,11 +124,13 @@ export type StudyEditabilitySnapshot = {
 // Whether the canonical Yjs state for `parsed` may still be mutated given the
 // current study status. Authentication and the persist-time gate both consult
 // this so stale clients cannot keep streaming updates after a status flip.
-// Code-review docs are not status-gated here: the management-app action layer
+// Job-keyed review docs are not status-gated here: the management-app action layer
 // is the single enforcer of code-review versioning (see
 // claimInitialCodeReviewJob in study.actions.ts), and per-document room
 // isolation in Hocuspocus prevents stale-round writes from polluting a
-// different round's persisted state.
+// different round's persisted state. Outputs-review feedback takes the same
+// exemption for the same reason — its one-decision-per-round guard is the
+// study_review_comment unique constraint, not this gate.
 export function isDocumentEditable(parsed: ParsedDocumentName, snap: StudyEditabilitySnapshot): boolean {
     switch (parsed.kind) {
         case 'review-feedback':
@@ -125,6 +142,7 @@ export function isDocumentEditable(parsed: ParsedDocumentName, snap: StudyEditab
         case 'proposal-resubmission-note':
             return snap.status === 'CHANGE-REQUESTED'
         case 'code-review-feedback':
+        case 'outputs-review-feedback':
             return true
     }
 }
@@ -134,9 +152,9 @@ export function isDocumentEditable(parsed: ParsedDocumentName, snap: StudyEditab
 // covers new and reconnecting clients, but already-connected clients keep
 // streaming Yjs updates between a status flip and their own kick-out. This
 // gate is the second line of defense so post-flip writes never land in
-// yjs_document. Code-review docs are not gated here; see isDocumentEditable.
+// yjs_document. Job-keyed review docs are not gated here; see isDocumentEditable.
 export async function shouldPersistDocument(parsed: ParsedDocumentName, db: Pick<DbQuery, 'query'>): Promise<boolean> {
-    if (parsed.kind === 'code-review-feedback') return true
+    if (isJobKeyed(parsed)) return true
 
     const row = await db.query<{ status: StudyStatus }>('SELECT status FROM study WHERE id = $1', [parsed.studyId])
     const status = row.rows[0]?.status
@@ -261,11 +279,11 @@ export interface AuthenticatedContext {
     studyId: string
 }
 
-// Resolves the authoritative studyId for the document. For non-code-review
-// docs this is just parsed.studyId. For code-review-feedback docs the doc name
+// Resolves the authoritative studyId for the document. For study-keyed docs this is just
+// parsed.studyId. For job-keyed docs (code-review / outputs-review feedback) the doc name
 // carries a study_job.id, so we resolve through one single-table SELECT.
 export async function studyIdForDocument(parsed: ParsedDocumentName, db: Pick<DbQuery, 'query'>): Promise<string> {
-    if (parsed.kind !== 'code-review-feedback') return parsed.studyId
+    if (!isJobKeyed(parsed)) return parsed.studyId
     const row = await db.query<{ study_id: string }>('SELECT study_id FROM study_job WHERE id = $1', [parsed.jobId])
     const studyId = row.rows[0]?.study_id
     if (!studyId) throw new AuthFailureError('STUDY_NOT_FOUND', 'study_job not found')

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.test.tsx
@@ -225,7 +225,9 @@ describe('ReviewerOutputsErroredScreen after decryption', () => {
 
         expect(screen.getByRole('button', { name: 'run.log' })).toBeInTheDocument()
         expect(screen.getByRole('button', { name: 'results.csv' })).toBeInTheDocument()
-        expect(screen.getAllByText('No activity yet')).toHaveLength(2)
+        // Waits for the activity query: the cell stays blank until the answer is in, so it never
+        // claims "No activity yet" on the strength of an unresolved request.
+        await waitFor(() => expect(screen.getAllByText('No activity yet')).toHaveLength(2))
     })
 
     it('offers Download all once two files are present', async () => {

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.test.tsx
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import { useParams } from 'next/navigation'
+import { ResultsWriter } from 'si-encryption/job-results/writer'
+import { fingerprintKeyData, pemToArrayBuffer } from 'si-encryption/util'
+import {
+    actionResult,
+    db,
+    fireEvent,
+    insertTestStudyJobData,
+    mockSessionWithTestData,
+    readTestSupportFile,
+    renderWithProviders,
+    screen,
+    waitFor,
+} from '@/tests/unit.helpers'
+import type { FileType, StudyJobStatus } from '@/database/types'
+import { getStudyAction } from '@/server/actions/study.actions'
+import { fetchEncryptedJobFilesAction } from '@/server/actions/study-job.actions'
+import { latestJobForStudy } from '@/server/db/queries'
+import { ReviewerOutputsErroredScreen } from './reviewer-outputs-errored-screen'
+import type { ScreenComponentProps } from './types'
+
+vi.mock('@/server/actions/study-job.actions', async () => {
+    const actual = await vi.importActual<typeof import('@/server/actions/study-job.actions')>(
+        '@/server/actions/study-job.actions',
+    )
+    return { ...actual, fetchEncryptedJobFilesAction: vi.fn(async () => []) }
+})
+
+const toArrayBuffer = (str: string): ArrayBuffer => {
+    const buf = Buffer.from(str, 'utf-8')
+    return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+}
+
+// Encrypt an artifact the way the enclave would (whole-zip + embedded manifest) so the reviewer's
+// real key decrypts it — the phase flip is driven by genuine decryption, not a stubbed callback.
+async function seedArtifact(jobId: string, files: { name: string; content: string }[], fileType: FileType) {
+    const publicKey = pemToArrayBuffer(await readTestSupportFile('public_key.pem'))
+    const fingerprint = await fingerprintKeyData(publicKey)
+    const writer = new ResultsWriter([{ publicKey, fingerprint }])
+    for (const file of files) await writer.addFile(file.name, toArrayBuffer(file.content))
+    const zip = await writer.generate()
+
+    const row = await db
+        .insertInto('studyJobFile')
+        .values({
+            studyJobId: jobId,
+            name: 'encrypted-logs.zip',
+            path: `test-org/${jobId}/results/encrypted-logs.zip`,
+            fileType,
+        })
+        .returning('id')
+        .executeTakeFirstOrThrow()
+
+    return {
+        studyJobFileId: row.id,
+        fileType,
+        name: 'encrypted-logs.zip',
+        encryptedBody: await zip.arrayBuffer(),
+        recipientKeys: {} as Record<string, string>,
+    }
+}
+
+const setupErrored = async (jobStatus: StudyJobStatus = 'JOB-ERRORED') => {
+    const { org, user } = await mockSessionWithTestData({ orgSlug: 'openstax', orgType: 'enclave' })
+    const { study: dbStudy } = await insertTestStudyJobData({ org, researcherId: user.id, jobStatus })
+    const study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+    const job = await latestJobForStudy(dbStudy.id)
+    ;(useParams as Mock).mockReturnValue({ orgSlug: org.slug, studyId: study.id })
+    return { org, study, job }
+}
+
+const renderScreen = async (study: ScreenComponentProps['study'], orgSlug: string) =>
+    renderWithProviders(await ReviewerOutputsErroredScreen({ study, orgSlug }))
+
+const unlock = async () => {
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: await readTestSupportFile('private_key.pem') } })
+    fireEvent.click(screen.getByRole('button', { name: 'View' }))
+}
+
+describe('ReviewerOutputsErroredScreen before decryption', () => {
+    beforeEach(() => {
+        vi.mocked(fetchEncryptedJobFilesAction).mockResolvedValue([])
+    })
+
+    it('renders the shared page and section headers', async () => {
+        const { org, study } = await setupErrored()
+        await renderScreen(study, org.slug)
+
+        expect(screen.getByRole('heading', { level: 1, name: 'Secondary analysis study' })).toBeInTheDocument()
+        expect(screen.getByTestId('proposal-section-header')).toHaveTextContent('STEP 3')
+        expect(screen.getByTestId('proposal-section-header')).toHaveTextContent('Review outputs')
+    })
+
+    it('asks for the security key rather than showing the review view', async () => {
+        const { org, study } = await setupErrored()
+        await renderScreen(study, org.slug)
+
+        expect(screen.getByRole('heading', { name: /security key/i })).toBeInTheDocument()
+        expect(screen.getByTestId('status-alert')).toHaveTextContent('Code errored')
+    })
+
+    // The two-part gate: JOB-ERRORED alone must not surface the outputs. Only a validated key
+    // does, which is why this screen is a client phase flip and not a route.
+    it('hides the outputs table, decision section and submit until a key validates', async () => {
+        const { org, study } = await setupErrored()
+        await renderScreen(study, org.slug)
+
+        expect(screen.queryByTestId('outputs-files-section')).toBeNull()
+        expect(screen.queryByTestId('outputs-decision-section')).toBeNull()
+        expect(screen.queryByTestId('outputs-submit-decision')).toBeNull()
+    })
+
+    it('keeps the outputs hidden when the key is wrong', async () => {
+        const { org, study, job } = await setupErrored()
+        vi.mocked(fetchEncryptedJobFilesAction).mockResolvedValue([
+            await seedArtifact(job.id, [{ name: 'run.log', content: 'boom' }], 'ENCRYPTED-CODE-RUN-LOG'),
+        ])
+        await renderScreen(study, org.slug)
+        await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
+
+        fireEvent.change(screen.getByRole('textbox'), { target: { value: 'not-a-real-key' } })
+        fireEvent.click(screen.getByRole('button', { name: 'View' }))
+
+        expect(
+            await screen.findByText('Invalid key. Check that you copied the full key and enter it again.'),
+        ).toBeInTheDocument()
+        expect(screen.queryByTestId('outputs-files-section')).toBeNull()
+    })
+
+    it('links Previous step to the read-only code page for this study', async () => {
+        const { org, study } = await setupErrored()
+        await renderScreen(study, org.slug)
+
+        expect(screen.getByRole('link', { name: /previous step/i })).toHaveAttribute(
+            'href',
+            `/${org.slug}/study/${study.id}/review/code`,
+        )
+    })
+
+    it('reports a missing error status rather than rendering the screen', async () => {
+        const { org, study } = await setupErrored('JOB-RUNNING')
+        await renderScreen(study, org.slug)
+
+        expect(screen.getByText('No error found')).toBeInTheDocument()
+    })
+})
+
+describe('ReviewerOutputsErroredScreen after decryption', () => {
+    beforeEach(() => {
+        vi.mocked(fetchEncryptedJobFilesAction).mockResolvedValue([])
+    })
+
+    const setupDecrypted = async (files: { name: string; content: string }[]) => {
+        const { org, study, job } = await setupErrored()
+        vi.mocked(fetchEncryptedJobFilesAction).mockResolvedValue([
+            await seedArtifact(job.id, files, 'ENCRYPTED-CODE-RUN-LOG'),
+        ])
+        await renderScreen(study, org.slug)
+        await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
+        await unlock()
+        await waitFor(() => expect(screen.getByTestId('outputs-files-section')).toBeInTheDocument())
+        return { org, study, job }
+    }
+
+    it('swaps the key form for the outputs table and decision section', async () => {
+        await setupDecrypted([{ name: 'run.log', content: 'boom' }])
+
+        expect(screen.queryByRole('heading', { name: /security key/i })).toBeNull()
+        expect(screen.getByTestId('outputs-files-section')).toBeInTheDocument()
+        expect(screen.getByTestId('outputs-decision-section')).toBeInTheDocument()
+        expect(screen.getByTestId('outputs-submit-decision')).toBeInTheDocument()
+    })
+
+    it('replaces the errored banner with the review-before-sharing warning', async () => {
+        const { study } = await setupDecrypted([{ name: 'run.log', content: 'boom' }])
+        const labName = study.submittingLabName ?? study.submittedByOrgSlug
+
+        const alert = screen.getByTestId('status-alert')
+        expect(alert).toHaveTextContent('Review the outputs before sharing')
+        expect(alert).toHaveTextContent(
+            `As the reviewer, you are responsible for checking the outputs for sensitive or restricted information* before they are shared with ${labName}.`,
+        )
+        expect(alert).toHaveTextContent(
+            '*Sensitive data could cause harm if disclosed, such as personally identifiable information (PII). Restricted data is limited by a data use agreement or policy.',
+        )
+        expect(alert).toHaveAttribute('data-variant', 'action')
+    })
+
+    // The asterisk's meaning has to reach AT programmatically; visual proximity to the footnote
+    // conveys nothing to a screen reader.
+    it('associates the footnote with the asterisked sentence via aria-describedby', async () => {
+        await setupDecrypted([{ name: 'run.log', content: 'boom' }])
+
+        const described = screen
+            .getByTestId('status-alert')
+            .querySelector('[aria-describedby="outputs-sensitive-data-footnote"]')
+        expect(described).not.toBeNull()
+        expect(document.getElementById('outputs-sensitive-data-footnote')).toHaveTextContent(
+            /Sensitive data could cause harm if disclosed/,
+        )
+    })
+
+    it('lists every decrypted file with an empty activity state', async () => {
+        await setupDecrypted([
+            { name: 'run.log', content: 'boom' },
+            { name: 'results.csv', content: 'a,b\n1,2' },
+        ])
+
+        expect(screen.getByRole('button', { name: 'run.log' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'results.csv' })).toBeInTheDocument()
+        expect(screen.getAllByText('No activity yet')).toHaveLength(2)
+    })
+
+    it('offers Download all once two files are present', async () => {
+        await setupDecrypted([
+            { name: 'run.log', content: 'boom' },
+            { name: 'results.csv', content: 'a,b\n1,2' },
+        ])
+
+        expect(screen.getByRole('button', { name: 'Download all' })).toBeInTheDocument()
+    })
+
+    it('omits Download all for a single file', async () => {
+        await setupDecrypted([{ name: 'run.log', content: 'boom' }])
+
+        expect(screen.queryByRole('button', { name: 'Download all' })).toBeNull()
+    })
+
+    it('keeps Submit decision enabled on arrival', async () => {
+        await setupDecrypted([{ name: 'run.log', content: 'boom' }])
+
+        expect(screen.getByTestId('outputs-submit-decision')).toBeEnabled()
+    })
+
+    it('flags both empty fields and opens no modal on a blank submit', async () => {
+        const { study } = await setupDecrypted([{ name: 'run.log', content: 'boom' }])
+        const labName = study.submittingLabName ?? study.submittedByOrgSlug
+
+        fireEvent.click(screen.getByTestId('outputs-submit-decision'))
+
+        expect(await screen.findByText(`Enter your feedback for ${labName} before submitting.`)).toBeInTheDocument()
+        expect(screen.getByText('Select an option before submitting')).toBeInTheDocument()
+        expect(screen.queryByText('Submit your decision?')).toBeNull()
+    })
+
+    it('records a view against the file when its name is clicked', async () => {
+        const { job } = await setupDecrypted([{ name: 'run.log', content: 'boom' }])
+
+        fireEvent.click(screen.getByRole('button', { name: 'run.log' }))
+
+        await waitFor(async () => {
+            const rows = await db
+                .selectFrom('studyJobFileActivity')
+                .innerJoin('studyJobFile', 'studyJobFile.id', 'studyJobFileActivity.studyJobFileId')
+                .where('studyJobFile.studyJobId', '=', job.id)
+                .selectAll('studyJobFileActivity')
+                .execute()
+            expect(rows).toHaveLength(1)
+            expect(rows[0].action).toBe('VIEWED')
+            expect(rows[0].filePath).toBe('run.log')
+        })
+    })
+})

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.test.tsx
@@ -128,6 +128,22 @@ describe('ReviewerOutputsErroredScreen before decryption', () => {
         expect(screen.queryByTestId('outputs-files-section')).toBeNull()
     })
 
+    // The default mock serves no artifacts, which is a legitimate state (no registered reviewer
+    // key, or a failed fetch). A well-formed key must not unlock the review view against nothing.
+    it('does not unlock the review view when there are no artifacts to decrypt', async () => {
+        const { org, study } = await setupErrored()
+        await renderScreen(study, org.slug)
+        await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
+
+        await unlock()
+
+        expect(
+            await screen.findByText('These outputs are not available to decrypt. Contact your organization admin.'),
+        ).toBeInTheDocument()
+        expect(screen.queryByTestId('outputs-files-section')).toBeNull()
+        expect(screen.queryByTestId('outputs-decision-section')).toBeNull()
+    })
+
     it('links Previous step to the read-only code page for this study', async () => {
         const { org, study } = await setupErrored()
         await renderScreen(study, org.slug)

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.test.tsx
@@ -33,7 +33,7 @@ const toArrayBuffer = (str: string): ArrayBuffer => {
 }
 
 // Encrypt an artifact the way the enclave would (whole-zip + embedded manifest) so the reviewer's
-// real key decrypts it — the phase flip is driven by genuine decryption, not a stubbed callback.
+// real key decrypts it, so the phase flip is driven by genuine decryption rather than a stub.
 async function seedArtifact(jobId: string, files: { name: string; content: string }[], fileType: FileType) {
     const publicKey = pemToArrayBuffer(await readTestSupportFile('public_key.pem'))
     const fingerprint = await fingerprintKeyData(publicKey)

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.tsx
@@ -1,12 +1,8 @@
 import dayjs from 'dayjs'
-import { Box, Group, Stack } from '@mantine/core'
-import { CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
 import { AlertNotFound } from '@/components/errors'
-import { ButtonLink } from '@/components/links'
-import { StudyPageHeader } from '@/components/study/study-page-header'
-import { ProposalStepHeader } from '@/components/study/proposal-step-header'
+import { OutputsReviewPanel } from '@/components/study/outputs-review-panel'
 import { StatusAlert, STATUS_ALERT_VARIANT } from '@/components/study/status-alert'
-import { SecurityKeyForm } from '@/components/study/security-key-form'
+import { ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS } from '@/lib/outputs-review'
 import { Routes } from '@/lib/routes'
 import { latestSubmittedJobForStudy } from '@/server/db/queries'
 import type { ScreenComponentProps } from './types'
@@ -20,9 +16,27 @@ function erroredTimestamp(
 const ErroredBanner = ({ erroredAt }: { erroredAt: Date | string }) => (
     <StatusAlert
         variant={STATUS_ALERT_VARIANT.action}
-        title={`Code errored \u2022 ${dayjs(erroredAt).format('MMM DD, YYYY')}`}
+        title={`Code errored • ${dayjs(erroredAt).format('MMM DD, YYYY')}`}
     >
         Enter your security key below to access the outputs and see what went wrong.
+    </StatusAlert>
+)
+
+// OTTER-675: once the key decrypts, the banner stops asking for a key and starts warning about
+// what the reviewer is about to share. The footnote is a real element referenced by
+// aria-describedby, so the asterisk's meaning reaches AT instead of being implied by position.
+const FOOTNOTE_ID = 'outputs-sensitive-data-footnote'
+
+const ReviewBeforeSharingBanner = ({ labName }: { labName: string }) => (
+    <StatusAlert variant={STATUS_ALERT_VARIANT.action} title="Review the outputs before sharing">
+        <span aria-describedby={FOOTNOTE_ID}>
+            As the reviewer, you are responsible for checking the outputs for sensitive or restricted information*
+            before they are shared with {labName}.
+        </span>
+        <span id={FOOTNOTE_ID} style={{ display: 'block', fontSize: 12, marginTop: 8 }}>
+            *Sensitive data could cause harm if disclosed, such as personally identifiable information (PII). Restricted
+            data is limited by a data use agreement or policy.
+        </span>
     </StatusAlert>
 )
 
@@ -40,29 +54,19 @@ export async function ReviewerOutputsErroredScreen({
         return <AlertNotFound title="No error found" message="This study has not encountered an error." />
     }
 
+    const labName = study.submittingLabName ?? study.submittedByOrgSlug
+
     return (
-        <Box bg="grey.10">
-            <Stack px="xl" gap="xxl" py="xl">
-                <StudyPageHeader>Secondary analysis study</StudyPageHeader>
-                <ProposalStepHeader
-                    stepLabel="STEP 3"
-                    heading="Review outputs"
-                    studyTitle={study.title ?? ''}
-                    banner={<ErroredBanner erroredAt={erroredAt} />}
-                />
-
-                <SecurityKeyForm job={job} />
-
-                <Group>
-                    <ButtonLink
-                        href={Routes.studyReviewCode({ orgSlug, studyId: study.id })}
-                        variant="subtle"
-                        leftSection={<CaretLeftIcon />}
-                    >
-                        Previous step
-                    </ButtonLink>
-                </Group>
-            </Stack>
-        </Box>
+        <OutputsReviewPanel
+            orgSlug={orgSlug}
+            studyId={study.id}
+            studyTitle={study.title ?? ''}
+            job={job}
+            labName={labName}
+            maxWords={ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS}
+            lockedBanner={<ErroredBanner erroredAt={erroredAt} />}
+            unlockedBanner={<ReviewBeforeSharingBanner labName={labName} />}
+            previousHref={Routes.studyReviewCode({ orgSlug, studyId: study.id })}
+        />
     )
 }

--- a/src/app/[orgSlug]/study/[studyId]/review/job-review-buttons.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/job-review-buttons.tsx
@@ -5,7 +5,7 @@ import { useMutation, useQueryClient } from '@/common'
 import { reportMutationError } from '@/components/errors'
 import { StudyJobStatus } from '@/database/types'
 import { Routes } from '@/lib/routes'
-import { JobFileInfo, MinimalJobInfo } from '@/lib/types'
+import { JobFileInfo } from '@/lib/types'
 import { approveStudyJobFilesAction, rejectStudyJobFilesAction } from '@/server/actions/study-job.actions'
 import type { LatestJobForStudy } from '@/server/db/queries'
 import { buildSharedFiles } from '@/lib/re-wrap-results'
@@ -36,21 +36,15 @@ export const JobReviewButtons = ({
         mutationFn: async ({ status }: { status: StudyJobStatus }) => {
             if (!decryptedResults?.length) return
 
-            const jobInfo: MinimalJobInfo = {
-                studyId: job.studyId,
-                studyJobId: job.id,
-                orgSlug: orgSlug,
-            }
-
             if (status === 'FILES-APPROVED') {
                 // Re-wrap each approved file's AES key for the lab researchers, client-side.
                 // Only the wrapped keys are sent — never the raw key or plaintext.
                 const sharedFiles = await buildSharedFiles(job.studyId, decryptedResults)
-                await approveStudyJobFilesAction({ orgSlug, jobInfo, sharedFiles })
+                await approveStudyJobFilesAction({ orgSlug, studyJobId: job.id, sharedFiles })
             }
 
             if (status === 'FILES-REJECTED') {
-                await rejectStudyJobFilesAction(jobInfo)
+                await rejectStudyJobFilesAction({ orgSlug, studyJobId: job.id })
             }
         },
         onError: reportMutationError('Failed to update study job status'),

--- a/src/components/modals/file-or-image-preview-modal.tsx
+++ b/src/components/modals/file-or-image-preview-modal.tsx
@@ -23,7 +23,16 @@ export function FileOrImagePreviewModal({
 
     const mime = imageMimeType(file.name)
     if (mime && file.contents) {
-        return <ImagePreviewModal isVisible name={file.name} contents={file.contents} mime={mime} onClose={onClose} />
+        return (
+            <ImagePreviewModal
+                isVisible
+                name={file.name}
+                contents={file.contents}
+                mime={mime}
+                onClose={onClose}
+                onDownload={onDownload}
+            />
+        )
     }
 
     const textFile = { name: file.name, contents: file.contents === null ? null : decodeFileContents(file.contents) }

--- a/src/components/modals/file-or-image-preview-modal.tsx
+++ b/src/components/modals/file-or-image-preview-modal.tsx
@@ -9,7 +9,16 @@ type PreviewFile = {
 
 // Callers hand over raw bytes so binary files like png plots survive the trip intact;
 // decoding to utf-8 happens here and only for non-image files (OTTER-516).
-export function FileOrImagePreviewModal({ file, onClose }: { file: PreviewFile | null; onClose: () => void }) {
+export function FileOrImagePreviewModal({
+    file,
+    onClose,
+    onDownload,
+}: {
+    file: PreviewFile | null
+    onClose: () => void
+    /** Notified when the preview's own download link is used (OTTER-675 activity logging). */
+    onDownload?: () => void
+}) {
     if (!file) return null
 
     const mime = imageMimeType(file.name)
@@ -18,5 +27,5 @@ export function FileOrImagePreviewModal({ file, onClose }: { file: PreviewFile |
     }
 
     const textFile = { name: file.name, contents: file.contents === null ? null : decodeFileContents(file.contents) }
-    return <FilePreviewModal file={textFile} onClose={onClose} />
+    return <FilePreviewModal file={textFile} onClose={onClose} onDownload={onDownload} />
 }

--- a/src/components/modals/file-preview-modal.tsx
+++ b/src/components/modals/file-preview-modal.tsx
@@ -6,9 +6,12 @@ import { FileViewer } from '@/components/file-viewers'
 export function FilePreviewModal({
     file,
     onClose,
+    onDownload,
 }: {
     file: { name: string; contents: string | null } | null
     onClose: () => void
+    /** Notified when the in-modal download link is used, so callers can log the download. */
+    onDownload?: () => void
 }) {
     if (!file) return null
     const isLoading = file.contents === null
@@ -16,7 +19,13 @@ export function FilePreviewModal({
         <Group gap="md" align="baseline">
             <span>{file.name}</span>
             {!isLoading && (
-                <DownloadBlobLink filename={file.name} fileContent={file.contents ?? ''} size="sm" fw={400} />
+                <DownloadBlobLink
+                    filename={file.name}
+                    fileContent={file.contents ?? ''}
+                    size="sm"
+                    fw={400}
+                    onClick={onDownload}
+                />
             )}
         </Group>
     )

--- a/src/components/modals/image-preview-modal.tsx
+++ b/src/components/modals/image-preview-modal.tsx
@@ -9,15 +9,17 @@ type ImagePreviewModalProps = {
     contents: ArrayBuffer
     mime: string | null
     onClose: () => void
+    /** Notified when this modal's own download link is used, so callers can log the download. */
+    onDownload?: () => void
 }
 
-export function ImagePreviewModal({ isVisible, name, contents, mime, onClose }: ImagePreviewModalProps) {
+export function ImagePreviewModal({ isVisible, name, contents, mime, onClose, onDownload }: ImagePreviewModalProps) {
     if (!isVisible || !mime) return null
 
     const title = (
         <Group gap="md" align="baseline">
             <span>{name}</span>
-            <DownloadBlobLink filename={name} fileContent={contents} size="sm" fw={400} />
+            <DownloadBlobLink filename={name} fileContent={contents} size="sm" fw={400} onClick={onDownload} />
         </Group>
     )
 

--- a/src/components/modals/submit-confirmation-modal.tsx
+++ b/src/components/modals/submit-confirmation-modal.tsx
@@ -21,7 +21,18 @@ export const SubmitConfirmationModal: FC<SubmitConfirmationModalProps> = ({
     body,
     confirmLabel,
 }) => (
-    <AppModal isOpen={isOpen} onClose={onClose} title={title} closeButtonProps={{ 'aria-label': 'Close' }}>
+    // Every dismissal route closes with Cancel, not just the button: leaving the X, Escape and
+    // outside-click live while Cancel is disabled lets the user dismiss a submission that is still
+    // running, with no way to tell whether dismissing cancelled it (it does not).
+    <AppModal
+        isOpen={isOpen}
+        onClose={onClose}
+        title={title}
+        closeButtonProps={{ 'aria-label': 'Close' }}
+        withCloseButton={!isSubmitting}
+        closeOnEscape={!isSubmitting}
+        closeOnClickOutside={!isSubmitting}
+    >
         <Stack gap="xl">
             <Text size="md">{body}</Text>
             <Group>

--- a/src/components/study/outputs-decision-section.test.tsx
+++ b/src/components/study/outputs-decision-section.test.tsx
@@ -1,0 +1,228 @@
+import { MantineProvider } from '@mantine/core'
+import { ModalsProvider } from '@mantine/modals'
+import { describe, expect, faker, it, render, screen, userEvent, vi, within } from '@/tests/unit.helpers'
+import { YjsWebsocketProvider } from '@/lib/realtime/yjs-websocket-context'
+import { fieldDescriptionId, fieldErrorId } from '@/components/form-field'
+import { theme } from '@/theme'
+import { ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS } from '@/lib/outputs-review'
+import { FEEDBACK_INPUT_ID, OutputsDecisionSection } from './outputs-decision-section'
+
+const LAB = 'Rice Lab'
+
+// singleUserEditing renders the standalone Lexical surface, so the editor is interactive here
+// instead of held behind the collaborative skeleton (which needs a live websocket).
+const renderSection = (overrides: Record<string, unknown> = {}) => {
+    const props = {
+        jobId: faker.string.uuid(),
+        studyId: faker.string.uuid(),
+        labName: LAB,
+        maxWords: ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS,
+        wordCount: 0,
+        feedbackError: undefined,
+        saveStatus: 'idle' as const,
+        onFeedbackChange: vi.fn(),
+        onFeedbackBlur: vi.fn(),
+        onProviderReady: vi.fn(),
+        selected: null,
+        onSelect: vi.fn(),
+        onDecisionBlur: vi.fn(),
+        decisionError: undefined,
+        ...overrides,
+    }
+
+    render(
+        <MantineProvider theme={theme}>
+            <YjsWebsocketProvider singleUserEditing>
+                <ModalsProvider>
+                    <OutputsDecisionSection {...props} />
+                </ModalsProvider>
+            </YjsWebsocketProvider>
+        </MantineProvider>,
+    )
+    return props
+}
+
+describe('OutputsDecisionSection header', () => {
+    it('renders the Decision heading with a required marker carrying an accessible name', () => {
+        renderSection()
+
+        expect(screen.getByText('Decision')).toBeInTheDocument()
+        expect(screen.getByLabelText('required')).toHaveTextContent('*')
+    })
+
+    it('renders the guidance copy with the lab name interpolated', () => {
+        renderSection()
+
+        const section = screen.getByTestId('outputs-decision-section')
+        expect(section).toHaveTextContent('Based on your review:')
+        expect(section).toHaveTextContent(
+            `If the outputs contain sensitive or restricted information, do not share them. Describe the issue in your feedback so ${LAB} can revise the code.`,
+        )
+        expect(section).toHaveTextContent('If they do not, share the outputs along with your feedback.')
+    })
+})
+
+describe('OutputsDecisionSection feedback field', () => {
+    it('marks the editor required for assistive tech', async () => {
+        renderSection()
+
+        expect(await screen.findByLabelText('Decision feedback')).toHaveAttribute('aria-required', 'true')
+    })
+
+    it('renders the word counter against the errored-run cap of 300', () => {
+        renderSection({ wordCount: 12 })
+
+        expect(screen.getByText('12/300')).toBeInTheDocument()
+    })
+
+    it('associates the counter with the editor via aria-describedby', async () => {
+        renderSection({ wordCount: 12 })
+
+        const editor = await screen.findByLabelText('Decision feedback')
+        expect(editor.getAttribute('aria-describedby')).toContain(fieldDescriptionId(FEEDBACK_INPUT_ID))
+        expect(document.getElementById(fieldDescriptionId(FEEDBACK_INPUT_ID))).toHaveTextContent('12/300')
+    })
+
+    it('marks the editor invalid and describes the error when over the limit', async () => {
+        renderSection({
+            wordCount: 301,
+            feedbackError: 'Feedback exceeds the 300 word limit. Shorten it to continue.',
+        })
+
+        const editor = await screen.findByLabelText('Decision feedback')
+        expect(editor).toHaveAttribute('aria-invalid', 'true')
+        expect(editor.getAttribute('aria-describedby')).toContain(fieldErrorId(FEEDBACK_INPUT_ID))
+        expect(screen.getByText('Feedback exceeds the 300 word limit. Shorten it to continue.')).toBeInTheDocument()
+    })
+
+    // Polite, not assertive: the over-limit message can fire on every keystroke past the cap, and
+    // an assertive region would interrupt the user mid-sentence.
+    it('announces field messages politely', () => {
+        renderSection({ feedbackError: 'Feedback exceeds the 300 word limit. Shorten it to continue.' })
+
+        const region = document.getElementById(fieldErrorId(FEEDBACK_INPUT_ID))!
+        expect(region).toHaveAttribute('aria-live', 'polite')
+        expect(region).not.toHaveAttribute('aria-live', 'assertive')
+    })
+
+    it('shows the autosave indicator when there is no error', () => {
+        renderSection({ saveStatus: 'saved' })
+
+        expect(screen.getByTestId('autosave-status')).toHaveTextContent('All changes saved')
+    })
+
+    // An unresolved error outranks "All changes saved", which would otherwise read as
+    // "this is fine to submit".
+    it('replaces the autosave indicator with the error while one is showing', () => {
+        renderSection({ saveStatus: 'saved', feedbackError: 'Enter your feedback for Rice Lab before submitting.' })
+
+        expect(screen.queryByTestId('autosave-status')).toBeNull()
+        expect(screen.getByText('Enter your feedback for Rice Lab before submitting.')).toBeInTheDocument()
+    })
+
+    // Guards against an accidental keyboard trap: an unresolved error must not pin the caret in
+    // the editor. Tabs until the radio is reached rather than assuming a fixed count, because the
+    // editor's formatting toolbar sits between the two and its size is not this test's business.
+    it('does not trap focus while an error is active', async () => {
+        renderSection({ feedbackError: 'Enter your feedback for Rice Lab before submitting.' })
+
+        const editor = await screen.findByLabelText('Decision feedback')
+        editor.focus()
+        expect(editor).toHaveFocus()
+
+        const firstRadio = screen.getByTestId('outputs-decision-share-outputs')
+        for (let i = 0; i < 12 && !firstRadio.matches(':focus'); i++) {
+            await userEvent.tab()
+        }
+
+        expect(firstRadio).toHaveFocus()
+    })
+})
+
+describe('OutputsDecisionSection radio buttons', () => {
+    it('renders exactly two options with their titles and descriptions', () => {
+        renderSection()
+
+        const radios = screen.getAllByRole('radio')
+        expect(radios).toHaveLength(2)
+
+        expect(screen.getByText('Share outputs and feedback')).toBeInTheDocument()
+        expect(screen.getByText(`Share the output files and your feedback with ${LAB}.`)).toBeInTheDocument()
+        expect(screen.getByText('Share feedback only')).toBeInTheDocument()
+        expect(
+            screen.getByText(
+                'Share your feedback without sharing the output files. Choose this if the outputs contain sensitive or restricted information.',
+            ),
+        ).toBeInTheDocument()
+    })
+
+    it('starts with neither option selected', () => {
+        renderSection()
+
+        for (const radio of screen.getAllByRole('radio')) {
+            expect(radio).not.toBeChecked()
+        }
+    })
+
+    // Native inputs sharing one `name`, not two JS-coordinated buttons: that is what gives the
+    // group real AT semantics and arrow-key navigation for free.
+    it('uses native radio inputs that share a name', () => {
+        renderSection()
+
+        for (const radio of screen.getAllByRole('radio')) {
+            expect(radio.tagName).toBe('INPUT')
+            expect(radio).toHaveAttribute('type', 'radio')
+            expect(radio).toHaveAttribute('name', 'outputs-decision')
+        }
+    })
+
+    it('groups the options with an accessible group name', () => {
+        renderSection()
+
+        const group = screen.getByRole('radiogroup')
+        expect(group).toBeInTheDocument()
+        expect(within(group).getAllByRole('radio')).toHaveLength(2)
+        expect(screen.getByText('Sharing decision')).toBeInTheDocument()
+    })
+
+    it('describes each option with its body text', () => {
+        renderSection()
+
+        const [shareOutputs, feedbackOnly] = screen.getAllByRole('radio')
+        expect(shareOutputs).toHaveAccessibleDescription(`Share the output files and your feedback with ${LAB}.`)
+        expect(feedbackOnly).toHaveAccessibleDescription(
+            'Share your feedback without sharing the output files. Choose this if the outputs contain sensitive or restricted information.',
+        )
+    })
+
+    it('reports the chosen option', async () => {
+        const props = renderSection()
+
+        await userEvent.click(screen.getByTestId('outputs-decision-share-feedback-only'))
+
+        expect(props.onSelect).toHaveBeenCalledWith('share-feedback-only')
+    })
+
+    it('checks only the selected option', () => {
+        renderSection({ selected: 'share-outputs' })
+
+        const [shareOutputs, feedbackOnly] = screen.getAllByRole('radio')
+        expect(shareOutputs).toBeChecked()
+        expect(feedbackOnly).not.toBeChecked()
+    })
+
+    it('moves the selection with arrow keys', async () => {
+        const props = renderSection()
+
+        await userEvent.click(screen.getByTestId('outputs-decision-share-outputs'))
+        await userEvent.keyboard('{ArrowDown}')
+
+        expect(props.onSelect).toHaveBeenLastCalledWith('share-feedback-only')
+    })
+
+    it('shows the unselected error on the group', () => {
+        renderSection({ decisionError: 'Select an option before submitting' })
+
+        expect(screen.getByText('Select an option before submitting')).toBeInTheDocument()
+    })
+})

--- a/src/components/study/outputs-decision-section.test.tsx
+++ b/src/components/study/outputs-decision-section.test.tsx
@@ -103,13 +103,22 @@ describe('OutputsDecisionSection feedback field', () => {
         expect(region).not.toHaveAttribute('aria-live', 'assertive')
     })
 
-    // The editor draws its own autosave indicator next to this counter; rendering a second one
-    // here would show the reviewer two "All changes saved" messages in collaborative mode.
-    it('renders exactly one autosave indicator, owned by the editor', async () => {
-        renderSection()
+    // The editor owns the autosave indicator (it renders one next to this counter in
+    // collaborative mode), so this section must not draw a second. Asserting on the counter's own
+    // slot rather than a global count, because a global "at most one" also passes when there are
+    // none and would prove nothing.
+    it('puts the counter in the editor footer and adds no autosave indicator of its own', async () => {
+        renderSection({ wordCount: 7 })
 
         await screen.findByLabelText('Decision feedback')
-        expect(screen.queryAllByTestId('autosave-status').length).toBeLessThanOrEqual(1)
+        const counter = document.getElementById(fieldDescriptionId(FEEDBACK_INPUT_ID))!
+        expect(counter).toHaveTextContent('7/300')
+        expect(counter.querySelector('[data-testid="autosave-status"]')).toBeNull()
+
+        const section = screen.getByTestId('outputs-decision-section')
+        const errorSlot = document.getElementById(fieldErrorId(FEEDBACK_INPUT_ID))!
+        expect(errorSlot.querySelector('[data-testid="autosave-status"]')).toBeNull()
+        expect(section.contains(counter)).toBe(true)
     })
 
     it('shows the validation error beneath the field', () => {

--- a/src/components/study/outputs-decision-section.test.tsx
+++ b/src/components/study/outputs-decision-section.test.tsx
@@ -5,7 +5,7 @@ import { YjsWebsocketProvider } from '@/lib/realtime/yjs-websocket-context'
 import { fieldDescriptionId, fieldErrorId } from '@/components/form-field'
 import { theme } from '@/theme'
 import { ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS } from '@/lib/outputs-review'
-import { FEEDBACK_INPUT_ID, OutputsDecisionSection } from './outputs-decision-section'
+import { DECISION_GROUP_ID, FEEDBACK_INPUT_ID, OutputsDecisionSection } from './outputs-decision-section'
 
 const LAB = 'Rice Lab'
 
@@ -67,10 +67,12 @@ describe('OutputsDecisionSection feedback field', () => {
         expect(await screen.findByLabelText('Decision feedback')).toHaveAttribute('aria-required', 'true')
     })
 
-    it('renders the word counter against the errored-run cap of 300', () => {
+    // Figma renders the unit alongside the count ("0/300 words"), which is also the evidence the
+    // cap is counted in words rather than characters.
+    it('renders the word counter with its unit against the errored-run cap of 300', () => {
         renderSection({ wordCount: 12 })
 
-        expect(screen.getByText('12/300')).toBeInTheDocument()
+        expect(screen.getByText('12/300 words')).toBeInTheDocument()
     })
 
     it('associates the counter with the editor via aria-describedby', async () => {
@@ -78,7 +80,7 @@ describe('OutputsDecisionSection feedback field', () => {
 
         const editor = await screen.findByLabelText('Decision feedback')
         expect(editor.getAttribute('aria-describedby')).toContain(fieldDescriptionId(FEEDBACK_INPUT_ID))
-        expect(document.getElementById(fieldDescriptionId(FEEDBACK_INPUT_ID))).toHaveTextContent('12/300')
+        expect(document.getElementById(fieldDescriptionId(FEEDBACK_INPUT_ID))).toHaveTextContent('12/300 words')
     })
 
     it('marks the editor invalid and describes the error when over the limit', async () => {
@@ -112,7 +114,7 @@ describe('OutputsDecisionSection feedback field', () => {
 
         await screen.findByLabelText('Decision feedback')
         const counter = document.getElementById(fieldDescriptionId(FEEDBACK_INPUT_ID))!
-        expect(counter).toHaveTextContent('7/300')
+        expect(counter).toHaveTextContent('7/300 words')
         expect(counter.querySelector('[data-testid="autosave-status"]')).toBeNull()
 
         const section = screen.getByTestId('outputs-decision-section')
@@ -198,7 +200,18 @@ describe('OutputsDecisionSection radio buttons', () => {
         const group = screen.getByRole('radiogroup')
         expect(group).toBeInTheDocument()
         expect(within(group).getAllByRole('radio')).toHaveLength(2)
-        expect(screen.getByText('Sharing decision')).toBeInTheDocument()
+        expect(group).toHaveAccessibleName('Sharing decision')
+    })
+
+    // The submit-time focus jump resolves this id with document.getElementById, so it has to be on
+    // a real element that actually contains the radios. Mantine's Radio.Group swallows an `id` prop
+    // without rendering it, which made the jump a silent no-op until the id moved to a wrapper.
+    it('exposes a resolvable anchor element containing the radios', () => {
+        renderSection()
+
+        const anchor = document.getElementById(DECISION_GROUP_ID)
+        expect(anchor).not.toBeNull()
+        expect(anchor!.querySelector('input[type="radio"]')).not.toBeNull()
     })
 
     it('describes each option with its body text', () => {

--- a/src/components/study/outputs-decision-section.test.tsx
+++ b/src/components/study/outputs-decision-section.test.tsx
@@ -19,10 +19,8 @@ const renderSection = (overrides: Record<string, unknown> = {}) => {
         maxWords: ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS,
         wordCount: 0,
         feedbackError: undefined,
-        saveStatus: 'idle' as const,
         onFeedbackChange: vi.fn(),
         onFeedbackBlur: vi.fn(),
-        onProviderReady: vi.fn(),
         selected: null,
         onSelect: vi.fn(),
         onDecisionBlur: vi.fn(),
@@ -105,19 +103,28 @@ describe('OutputsDecisionSection feedback field', () => {
         expect(region).not.toHaveAttribute('aria-live', 'assertive')
     })
 
-    it('shows the autosave indicator when there is no error', () => {
-        renderSection({ saveStatus: 'saved' })
+    // The editor draws its own autosave indicator next to this counter; rendering a second one
+    // here would show the reviewer two "All changes saved" messages in collaborative mode.
+    it('renders exactly one autosave indicator, owned by the editor', async () => {
+        renderSection()
 
-        expect(screen.getByTestId('autosave-status')).toHaveTextContent('All changes saved')
+        await screen.findByLabelText('Decision feedback')
+        expect(screen.queryAllByTestId('autosave-status').length).toBeLessThanOrEqual(1)
     })
 
-    // An unresolved error outranks "All changes saved", which would otherwise read as
-    // "this is fine to submit".
-    it('replaces the autosave indicator with the error while one is showing', () => {
-        renderSection({ saveStatus: 'saved', feedbackError: 'Enter your feedback for Rice Lab before submitting.' })
+    it('shows the validation error beneath the field', () => {
+        renderSection({ feedbackError: 'Enter your feedback for Rice Lab before submitting.' })
 
-        expect(screen.queryByTestId('autosave-status')).toBeNull()
         expect(screen.getByText('Enter your feedback for Rice Lab before submitting.')).toBeInTheDocument()
+    })
+
+    // A real list, so a screen reader announces two items rather than one run-on sentence.
+    it('renders the guidance clauses as a list', () => {
+        renderSection()
+
+        const items = screen.getAllByRole('listitem')
+        expect(items).toHaveLength(2)
+        expect(items[1]).toHaveTextContent('If they do not, share the outputs along with your feedback.')
     })
 
     // Guards against an accidental keyboard trap: an unresolved error must not pin the caret in

--- a/src/components/study/outputs-decision-section.tsx
+++ b/src/components/study/outputs-decision-section.tsx
@@ -119,7 +119,7 @@ const DecisionRadioGroup: FC<DecisionRadioGroupProps> = ({ value, onChange, onBl
 }
 
 // Carries the description id so the count reaches the editor's aria-describedby. Rendered through
-// the Editor's own `footerRight` slot, beside the save indicator the editor already draws — a
+// the Editor's own `footerRight` slot, beside the save indicator the editor already draws. A
 // second SaveStatusIndicator here would show the user two "All changes saved" messages in
 // collaborative mode, and could contradict the error below when validation fails.
 const FeedbackCounter: FC<{ wordCount: number; maxWords: number }> = ({ wordCount, maxWords }) => (

--- a/src/components/study/outputs-decision-section.tsx
+++ b/src/components/study/outputs-decision-section.tsx
@@ -1,0 +1,208 @@
+'use client'
+
+import { FC, type ReactNode } from 'react'
+import { Box, Divider, Group, Paper, Radio, Stack, Text } from '@mantine/core'
+import type { HocuspocusProvider } from '@hocuspocus/provider'
+import { InputError } from '@/components/errors'
+import { Editor } from '@/components/editable-text/editor'
+import { RequiredIndicator } from '@/components/required-indicator'
+import { SaveStatusIndicator, type SaveStatusValue } from '@/components/save-status'
+import { WordCounter } from '@/components/word-counter'
+import { fieldDescribedBy, fieldDescriptionId, fieldErrorId, widgetBlurHandler } from '@/components/form-field'
+import { useYjsWebsocket } from '@/lib/realtime/yjs-websocket-context'
+import { outputsReviewFeedbackDocName } from '@/lib/collaboration-documents'
+import type { OutputsDecision } from '@/lib/outputs-review'
+
+export const FEEDBACK_INPUT_ID = 'outputs-decision-feedback'
+export const DECISION_GROUP_ID = 'outputs-decision-options'
+
+const EDITOR_SKELETON_HEIGHT = 260
+
+const contentStyle = {
+    minHeight: 260,
+    padding: '8px 16px',
+    outline: 'none',
+    fontSize: '14px',
+    lineHeight: 1.6,
+} as const
+
+const DecisionIntro: FC<{ labName: string }> = ({ labName }) => (
+    <Text fz={16} c="charcoal.9">
+        Based on your review:
+        <br />• If the outputs contain sensitive or restricted information, do not share them. Describe the issue in
+        your feedback so {labName} can revise the code.
+        <br />• If they do not, share the outputs along with your feedback.
+    </Text>
+)
+
+type DecisionOption = { value: OutputsDecision; title: string; description: string }
+
+const buildDecisionOptions = (labName: string): DecisionOption[] => [
+    {
+        value: 'share-outputs',
+        title: 'Share outputs and feedback',
+        description: `Share the output files and your feedback with ${labName}.`,
+    },
+    {
+        value: 'share-feedback-only',
+        title: 'Share feedback only',
+        description:
+            'Share your feedback without sharing the output files. Choose this if the outputs contain sensitive or restricted information.',
+    },
+]
+
+const RADIO_STYLES = { label: { fontWeight: 600, fontSize: 16 }, description: { fontSize: 14 } }
+
+type DecisionRadioGroupProps = {
+    value: OutputsDecision | null
+    onChange: (next: OutputsDecision) => void
+    onBlur: () => void
+    error: ReactNode
+    labName: string
+}
+
+const descriptionId = (value: OutputsDecision) => `outputs-decision-${value}-description`
+
+const DecisionRadioGroup: FC<DecisionRadioGroupProps> = ({ value, onChange, onBlur, error, labName }) => {
+    // Mantine's Radio renders a native <input type="radio">; Radio.Group gives them a shared
+    // `name`, so mutual exclusivity and arrow-key navigation are the browser's, not simulated.
+    //
+    // The description is wrapped in an element we own so it can be referenced by
+    // `aria-describedby`: Mantine renders `description` for sighted users but never associates it
+    // with the input, so without this a screen reader announces only the title and the user never
+    // hears which option withholds the files.
+    const options = buildDecisionOptions(labName).map((option) => (
+        <Radio
+            key={option.value}
+            value={option.value}
+            label={option.title}
+            description={<span id={descriptionId(option.value)}>{option.description}</span>}
+            aria-describedby={descriptionId(option.value)}
+            styles={RADIO_STYLES}
+            data-testid={`outputs-decision-${option.value}`}
+        />
+    ))
+
+    return (
+        // Blur is a bubbled focusout, so moving between the two radios would validate a
+        // still-empty group; widgetBlurHandler waits for focus to leave it (OTTER-647).
+        <Radio.Group
+            id={DECISION_GROUP_ID}
+            value={value ?? ''}
+            onChange={(next) => onChange(next as OutputsDecision)}
+            onBlur={widgetBlurHandler(onBlur)}
+            name="outputs-decision"
+            label="Sharing decision"
+            labelProps={{ fw: 600 }}
+            error={error}
+        >
+            <Stack gap="md">{options}</Stack>
+        </Radio.Group>
+    )
+}
+
+type FeedbackFooterProps = {
+    saveStatus: SaveStatusValue
+    error: ReactNode
+    wordCount: number
+    maxWords: number
+}
+
+// The autosave indicator and the validation error share the footer's left slot; an unresolved
+// error outranks "All changes saved", which would otherwise read as "this is fine to submit".
+//
+// Both halves are polite live regions: the over-limit error can fire on every keystroke past the
+// cap, and an assertive announcement there would interrupt the user mid-sentence.
+const FeedbackFooter: FC<FeedbackFooterProps> = ({ saveStatus, error, wordCount, maxWords }) => (
+    <Group justify="space-between" align="center">
+        <Box id={fieldErrorId(FEEDBACK_INPUT_ID)} aria-live="polite">
+            {error ? <InputError error={error} /> : <SaveStatusIndicator status={saveStatus} />}
+        </Box>
+        {/* Carries the description id so the count reaches the editor's aria-describedby. */}
+        <Box id={fieldDescriptionId(FEEDBACK_INPUT_ID)}>
+            <WordCounter wordCount={wordCount} maxWords={maxWords} />
+        </Box>
+    </Group>
+)
+
+export type OutputsDecisionSectionProps = {
+    jobId: string
+    studyId: string
+    labName: string
+    maxWords: number
+    wordCount: number
+    feedbackError: ReactNode
+    saveStatus: SaveStatusValue
+    onFeedbackChange: (json: string) => void
+    onFeedbackBlur: () => void
+    onProviderReady: (provider: HocuspocusProvider | null) => void
+    selected: OutputsDecision | null
+    onSelect: (next: OutputsDecision) => void
+    onDecisionBlur: () => void
+    decisionError: ReactNode
+}
+
+export const OutputsDecisionSection: FC<OutputsDecisionSectionProps> = ({
+    jobId,
+    studyId,
+    labName,
+    maxWords,
+    wordCount,
+    feedbackError,
+    saveStatus,
+    onFeedbackChange,
+    onFeedbackBlur,
+    onProviderReady,
+    selected,
+    onSelect,
+    onDecisionBlur,
+    decisionError,
+}) => {
+    const websocketProvider = useYjsWebsocket()
+
+    return (
+        <Paper p="xxl" data-testid="outputs-decision-section">
+            <Stack gap="lg">
+                <Group gap={0} align="center">
+                    <Text fz={20} fw={700} c="charcoal.9">
+                        Decision
+                    </Text>
+                    <RequiredIndicator fz={20} fw={700} />
+                </Group>
+                <Divider color="charcoal.1" />
+                <DecisionIntro labName={labName} />
+                <Editor
+                    id={outputsReviewFeedbackDocName(jobId)}
+                    inputId={FEEDBACK_INPUT_ID}
+                    studyId={studyId}
+                    websocketProvider={websocketProvider}
+                    contentStyle={contentStyle}
+                    onChange={onFeedbackChange}
+                    onBlur={onFeedbackBlur}
+                    error={feedbackError}
+                    ariaLabel="Decision feedback"
+                    ariaRequired
+                    ariaDescribedBy={fieldDescribedBy(FEEDBACK_INPUT_ID, {
+                        hasError: !!feedbackError,
+                        hasDescription: true,
+                    })}
+                    onProviderReady={onProviderReady}
+                    skeletonHeight={EDITOR_SKELETON_HEIGHT}
+                />
+                <FeedbackFooter
+                    saveStatus={saveStatus}
+                    error={feedbackError}
+                    wordCount={wordCount}
+                    maxWords={maxWords}
+                />
+                <DecisionRadioGroup
+                    value={selected}
+                    onChange={onSelect}
+                    onBlur={onDecisionBlur}
+                    error={decisionError}
+                    labName={labName}
+                />
+            </Stack>
+        </Paper>
+    )
+}

--- a/src/components/study/outputs-decision-section.tsx
+++ b/src/components/study/outputs-decision-section.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { FC, type ReactNode } from 'react'
-import { Box, Divider, Group, List, Paper, Radio, Stack, Text } from '@mantine/core'
+import { Box, Divider, Group, List, Paper, Radio, Stack, Text, VisuallyHidden } from '@mantine/core'
 import { InputError } from '@/components/errors'
 import { Editor } from '@/components/editable-text/editor'
 import { RequiredIndicator } from '@/components/required-indicator'
@@ -87,21 +87,34 @@ const DecisionRadioGroup: FC<DecisionRadioGroupProps> = ({ value, onChange, onBl
         />
     ))
 
+    // Guarded rather than passed unconditionally: InputError renders null for a falsy error, but
+    // the element itself is truthy, and Mantine treats any error node as "this field is invalid".
+    const errorNode = error ? <InputError error={error} /> : undefined
+
     return (
-        // Blur is a bubbled focusout, so moving between the two radios would validate a
-        // still-empty group; widgetBlurHandler waits for focus to leave it (OTTER-647).
-        <Radio.Group
-            id={DECISION_GROUP_ID}
-            value={value ?? ''}
-            onChange={(next) => onChange(next as OutputsDecision)}
-            onBlur={widgetBlurHandler(onBlur)}
-            name="outputs-decision"
-            label="Sharing decision"
-            labelProps={{ fw: 600 }}
-            error={error}
-        >
-            <Stack gap="md">{options}</Stack>
-        </Radio.Group>
+        // The id lives on this wrapper, not on Radio.Group: Mantine consumes an `id` prop to derive
+        // its internal label/error ids and never renders it on an element, so
+        // document.getElementById would find nothing and the submit-time focus jump would silently
+        // do nothing (see focusFirstInvalid).
+        <Box id={DECISION_GROUP_ID}>
+            {/* Blur is a bubbled focusout, so moving between the two radios would validate a
+                still-empty group; widgetBlurHandler waits for focus to leave it (OTTER-647).
+                The group's name is required by AT but is not drawn in the design, so the label is
+                visually hidden rather than dropped.
+                inputWrapperOrder moves the message above the options, where the design puts it;
+                Mantine's default order would render it under the last description. */}
+            <Radio.Group
+                value={value ?? ''}
+                onChange={(next) => onChange(next as OutputsDecision)}
+                onBlur={widgetBlurHandler(onBlur)}
+                name="outputs-decision"
+                label={<VisuallyHidden>Sharing decision</VisuallyHidden>}
+                error={errorNode}
+                inputWrapperOrder={['label', 'description', 'error', 'input']}
+            >
+                <Stack gap="md">{options}</Stack>
+            </Radio.Group>
+        </Box>
     )
 }
 
@@ -111,7 +124,7 @@ const DecisionRadioGroup: FC<DecisionRadioGroupProps> = ({ value, onChange, onBl
 // collaborative mode, and could contradict the error below when validation fails.
 const FeedbackCounter: FC<{ wordCount: number; maxWords: number }> = ({ wordCount, maxWords }) => (
     <Box id={fieldDescriptionId(FEEDBACK_INPUT_ID)}>
-        <WordCounter wordCount={wordCount} maxWords={maxWords} />
+        <WordCounter wordCount={wordCount} maxWords={maxWords} unit="words" />
     </Box>
 )
 

--- a/src/components/study/outputs-decision-section.tsx
+++ b/src/components/study/outputs-decision-section.tsx
@@ -1,12 +1,10 @@
 'use client'
 
 import { FC, type ReactNode } from 'react'
-import { Box, Divider, Group, Paper, Radio, Stack, Text } from '@mantine/core'
-import type { HocuspocusProvider } from '@hocuspocus/provider'
+import { Box, Divider, Group, List, Paper, Radio, Stack, Text } from '@mantine/core'
 import { InputError } from '@/components/errors'
 import { Editor } from '@/components/editable-text/editor'
 import { RequiredIndicator } from '@/components/required-indicator'
-import { SaveStatusIndicator, type SaveStatusValue } from '@/components/save-status'
 import { WordCounter } from '@/components/word-counter'
 import { fieldDescribedBy, fieldDescriptionId, fieldErrorId, widgetBlurHandler } from '@/components/form-field'
 import { useYjsWebsocket } from '@/lib/realtime/yjs-websocket-context'
@@ -26,12 +24,18 @@ const contentStyle = {
     lineHeight: 1.6,
 } as const
 
+// A real <ul>, not "<br />•": the two clauses are a list, and a screen reader should announce them
+// as one ("list, 2 items") rather than as a single run-on sentence with stray bullet characters.
 const DecisionIntro: FC<{ labName: string }> = ({ labName }) => (
-    <Text fz={16} c="charcoal.9">
+    <Text component="div" fz={16} c="charcoal.9">
         Based on your review:
-        <br />• If the outputs contain sensitive or restricted information, do not share them. Describe the issue in
-        your feedback so {labName} can revise the code.
-        <br />• If they do not, share the outputs along with your feedback.
+        <List spacing={4} size="md" pt={4}>
+            <List.Item>
+                If the outputs contain sensitive or restricted information, do not share them. Describe the issue in
+                your feedback so {labName} can revise the code.
+            </List.Item>
+            <List.Item>If they do not, share the outputs along with your feedback.</List.Item>
+        </List>
     </Text>
 )
 
@@ -101,28 +105,22 @@ const DecisionRadioGroup: FC<DecisionRadioGroupProps> = ({ value, onChange, onBl
     )
 }
 
-type FeedbackFooterProps = {
-    saveStatus: SaveStatusValue
-    error: ReactNode
-    wordCount: number
-    maxWords: number
-}
+// Carries the description id so the count reaches the editor's aria-describedby. Rendered through
+// the Editor's own `footerRight` slot, beside the save indicator the editor already draws — a
+// second SaveStatusIndicator here would show the user two "All changes saved" messages in
+// collaborative mode, and could contradict the error below when validation fails.
+const FeedbackCounter: FC<{ wordCount: number; maxWords: number }> = ({ wordCount, maxWords }) => (
+    <Box id={fieldDescriptionId(FEEDBACK_INPUT_ID)}>
+        <WordCounter wordCount={wordCount} maxWords={maxWords} />
+    </Box>
+)
 
-// The autosave indicator and the validation error share the footer's left slot; an unresolved
-// error outranks "All changes saved", which would otherwise read as "this is fine to submit".
-//
-// Both halves are polite live regions: the over-limit error can fire on every keystroke past the
-// cap, and an assertive announcement there would interrupt the user mid-sentence.
-const FeedbackFooter: FC<FeedbackFooterProps> = ({ saveStatus, error, wordCount, maxWords }) => (
-    <Group justify="space-between" align="center">
-        <Box id={fieldErrorId(FEEDBACK_INPUT_ID)} aria-live="polite">
-            {error ? <InputError error={error} /> : <SaveStatusIndicator status={saveStatus} />}
-        </Box>
-        {/* Carries the description id so the count reaches the editor's aria-describedby. */}
-        <Box id={fieldDescriptionId(FEEDBACK_INPUT_ID)}>
-            <WordCounter wordCount={wordCount} maxWords={maxWords} />
-        </Box>
-    </Group>
+// Polite, not assertive: the over-limit message can fire on every keystroke past the cap, and an
+// assertive region would interrupt the user mid-sentence.
+const FeedbackError: FC<{ error: ReactNode }> = ({ error }) => (
+    <Box id={fieldErrorId(FEEDBACK_INPUT_ID)} aria-live="polite">
+        <InputError error={error} />
+    </Box>
 )
 
 export type OutputsDecisionSectionProps = {
@@ -132,10 +130,8 @@ export type OutputsDecisionSectionProps = {
     maxWords: number
     wordCount: number
     feedbackError: ReactNode
-    saveStatus: SaveStatusValue
     onFeedbackChange: (json: string) => void
     onFeedbackBlur: () => void
-    onProviderReady: (provider: HocuspocusProvider | null) => void
     selected: OutputsDecision | null
     onSelect: (next: OutputsDecision) => void
     onDecisionBlur: () => void
@@ -149,10 +145,8 @@ export const OutputsDecisionSection: FC<OutputsDecisionSectionProps> = ({
     maxWords,
     wordCount,
     feedbackError,
-    saveStatus,
     onFeedbackChange,
     onFeedbackBlur,
-    onProviderReady,
     selected,
     onSelect,
     onDecisionBlur,
@@ -186,15 +180,10 @@ export const OutputsDecisionSection: FC<OutputsDecisionSectionProps> = ({
                         hasError: !!feedbackError,
                         hasDescription: true,
                     })}
-                    onProviderReady={onProviderReady}
                     skeletonHeight={EDITOR_SKELETON_HEIGHT}
+                    footerRight={<FeedbackCounter wordCount={wordCount} maxWords={maxWords} />}
                 />
-                <FeedbackFooter
-                    saveStatus={saveStatus}
-                    error={feedbackError}
-                    wordCount={wordCount}
-                    maxWords={maxWords}
-                />
+                <FeedbackError error={feedbackError} />
                 <DecisionRadioGroup
                     value={selected}
                     onChange={onSelect}

--- a/src/components/study/outputs-file-row.module.css
+++ b/src/components/study/outputs-file-row.module.css
@@ -1,0 +1,22 @@
+/* The row highlight and the file-name underline must appear on keyboard focus as well as
+   hover, so the two states are always declared together (OTTER-675 accessibility criteria). */
+
+.row:hover,
+.row:focus-within {
+    background-color: var(--mantine-color-grey-10);
+}
+
+.fileName {
+    cursor: pointer;
+    font-size: 14px;
+}
+
+.fileName:hover,
+.fileName:focus-visible {
+    text-decoration: underline;
+}
+
+.fileName:focus-visible {
+    outline: 2px solid var(--mantine-color-blue-7);
+    outline-offset: 2px;
+}

--- a/src/components/study/outputs-file-row.test.tsx
+++ b/src/components/study/outputs-file-row.test.tsx
@@ -9,6 +9,7 @@ const buildRow = (overrides: Partial<OutputFileRowData> = {}): OutputFileRowData
     filePath: 'run.log',
     name: 'run.log',
     contents: new ArrayBuffer(4),
+    isActivityKnown: true,
     activity: null,
     ...overrides,
 })

--- a/src/components/study/outputs-file-row.test.tsx
+++ b/src/components/study/outputs-file-row.test.tsx
@@ -1,0 +1,165 @@
+import { Table } from '@mantine/core'
+import { describe, expect, it, renderWithProviders, screen, userEvent, vi } from '@/tests/unit.helpers'
+import type { JobFileActivity } from '@/server/db/queries'
+import { OutputsFileRow, formatActivityDate, truncateFileName, type OutputFileRowData } from './outputs-file-row'
+
+const buildRow = (overrides: Partial<OutputFileRowData> = {}): OutputFileRowData => ({
+    key: 'row-1',
+    studyJobFileId: 'archive-1',
+    filePath: 'run.log',
+    name: 'run.log',
+    contents: new ArrayBuffer(4),
+    activity: null,
+    ...overrides,
+})
+
+const buildActivity = (overrides: Partial<JobFileActivity> = {}): JobFileActivity => ({
+    studyJobFileId: 'archive-1',
+    filePath: 'run.log',
+    action: 'VIEWED',
+    createdAt: new Date('2026-04-22T12:38:00Z'),
+    actorName: 'Jessica Walters',
+    ...overrides,
+})
+
+const renderRow = (row: OutputFileRowData) => {
+    const onView = vi.fn()
+    const onDownload = vi.fn()
+    renderWithProviders(
+        <Table>
+            <Table.Tbody>
+                <OutputsFileRow row={row} onView={onView} onDownload={onDownload} />
+            </Table.Tbody>
+        </Table>,
+    )
+    return { onView, onDownload }
+}
+
+const NAME_51 = 'a'.repeat(51)
+const NAME_50 = 'a'.repeat(50)
+
+describe('truncateFileName', () => {
+    it('leaves names at or under 50 characters untouched', () => {
+        expect(truncateFileName('run.log')).toBe('run.log')
+        expect(truncateFileName(NAME_50)).toBe(NAME_50)
+    })
+
+    it('truncates at exactly 50 characters with an ellipsis', () => {
+        expect(truncateFileName(NAME_51)).toBe(`${'a'.repeat(50)}…`)
+    })
+})
+
+describe('OutputsFileRow file name', () => {
+    it('renders the name as a real button, reachable by Tab and activatable by keyboard', async () => {
+        const { onView } = renderRow(buildRow())
+
+        const button = screen.getByRole('button', { name: 'run.log' })
+        await userEvent.tab()
+        expect(button).toHaveFocus()
+
+        await userEvent.keyboard('{Enter}')
+        expect(onView).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls onView when clicked', async () => {
+        const { onView } = renderRow(buildRow())
+
+        await userEvent.click(screen.getByRole('button', { name: 'run.log' }))
+
+        expect(onView).toHaveBeenCalledWith(expect.objectContaining({ name: 'run.log' }))
+    })
+
+    // The visual tooltip is not exposed to every AT, so a truncated name also carries the full
+    // value as its accessible name.
+    it('exposes the untruncated name to assistive tech when truncated', () => {
+        renderRow(buildRow({ name: NAME_51 }))
+
+        expect(screen.getByRole('button', { name: NAME_51 })).toBeInTheDocument()
+        expect(screen.getByText(`${'a'.repeat(50)}…`)).toBeInTheDocument()
+    })
+
+    it('shows the full name in a tooltip on hover', async () => {
+        renderRow(buildRow({ name: NAME_51 }))
+
+        await userEvent.hover(screen.getByTestId('outputs-file-name-row-1'))
+
+        expect(await screen.findByRole('tooltip')).toHaveTextContent(NAME_51)
+    })
+
+    // Keyboard users never hover, so a hover-only tooltip would hide the full name from them.
+    it('shows the tooltip on keyboard focus too', async () => {
+        renderRow(buildRow({ name: NAME_51 }))
+
+        await userEvent.tab()
+
+        expect(await screen.findByRole('tooltip')).toHaveTextContent(NAME_51)
+    })
+})
+
+describe('OutputsFileRow last activity', () => {
+    it('renders real text when nothing has happened yet', () => {
+        renderRow(buildRow())
+        expect(screen.getByText('No activity yet')).toBeInTheDocument()
+    })
+
+    it('renders actor, action and timestamp for a view', () => {
+        renderRow(buildRow({ activity: buildActivity() }))
+
+        const cell = screen.getByText(/Jessica Walters/).closest('p')!
+        expect(cell).toHaveTextContent('Jessica Walters')
+        expect(cell).toHaveTextContent('Viewed')
+        expect(cell).toHaveTextContent(formatActivityDate(new Date('2026-04-22T12:38:00Z')))
+    })
+
+    it('labels a download action "Downloaded"', () => {
+        renderRow(buildRow({ activity: buildActivity({ action: 'DOWNLOADED', actorName: 'David Burns' }) }))
+
+        expect(screen.getByText(/David Burns/).closest('p')).toHaveTextContent('Downloaded')
+    })
+
+    it('formats the timestamp as "MMM DD, YYYY, hh:mm a"', () => {
+        expect(formatActivityDate(new Date('2026-04-21T13:12:00'))).toBe('Apr 21, 2026, 01:12 pm')
+    })
+
+    // Read straight through, "Name · Viewed · Apr 22" announces as one run-on phrase; the dots
+    // are hidden and replaced with connective text so the three parts stay distinguishable.
+    it('hides the middle dots from assistive tech and supplies spoken separators', () => {
+        renderRow(buildRow({ activity: buildActivity() }))
+
+        const cell = screen.getByText(/Jessica Walters/).closest('p')!
+        const hiddenDots = cell.querySelectorAll('[aria-hidden="true"]')
+        expect(hiddenDots).toHaveLength(2)
+        for (const dot of hiddenDots) {
+            expect(dot.textContent?.trim()).toBe('·')
+        }
+        expect(cell.textContent).toContain(' on ')
+    })
+})
+
+describe('OutputsFileRow actions', () => {
+    it('downloads that file when the icon is clicked', async () => {
+        const { onDownload } = renderRow(buildRow())
+
+        await userEvent.click(screen.getByRole('button', { name: 'Download run.log' }))
+
+        expect(onDownload).toHaveBeenCalledWith(expect.objectContaining({ name: 'run.log' }))
+    })
+
+    // Inverse of the header's Download all icon: this icon is the only control in the cell, so
+    // hiding it would leave the button with no accessible name at all.
+    it('names the icon after the file rather than hiding it', () => {
+        renderRow(buildRow({ name: 'results.csv' }))
+
+        const button = screen.getByRole('button', { name: 'Download results.csv' })
+        expect(button).not.toHaveAttribute('aria-hidden')
+        expect(button.querySelector('svg')).not.toHaveAttribute('aria-hidden', 'true')
+    })
+
+    it('shows a Download tooltip on hover', async () => {
+        renderRow(buildRow())
+
+        await userEvent.hover(screen.getByTestId('outputs-file-download-row-1'))
+
+        expect(await screen.findByRole('tooltip')).toHaveTextContent('Download')
+    })
+})

--- a/src/components/study/outputs-file-row.tsx
+++ b/src/components/study/outputs-file-row.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { FC } from 'react'
+import { ActionIcon, Table, Text, Tooltip, UnstyledButton, VisuallyHidden } from '@mantine/core'
+import { DownloadSimpleIcon } from '@phosphor-icons/react/dist/ssr'
+import dayjs from 'dayjs'
+import type { JobFileActivity } from '@/server/db/queries'
+import { OUTPUTS_FILE_NAME_MAX_LENGTH } from '@/lib/outputs-review'
+import classes from './outputs-file-row.module.css'
+
+export type OutputFileRowData = {
+    /** Stable row key: the archive row plus the inner path uniquely identifies a decrypted file. */
+    key: string
+    studyJobFileId: string
+    filePath: string
+    name: string
+    contents: ArrayBuffer
+    activity: JobFileActivity | null
+}
+
+export const truncateFileName = (name: string): string =>
+    name.length <= OUTPUTS_FILE_NAME_MAX_LENGTH ? name : `${name.slice(0, OUTPUTS_FILE_NAME_MAX_LENGTH)}…`
+
+const ACTION_LABEL = { VIEWED: 'Viewed', DOWNLOADED: 'Downloaded' } as const
+
+export const formatActivityDate = (date: Date | string): string => dayjs(date).format('MMM DD, YYYY, hh:mm a')
+
+// The middle dots are decorative. Read straight through, "Jessica Walters · Viewed · Apr 22"
+// announces as one run-on phrase, so each dot is paired with hidden connective text and hidden
+// from AT itself.
+const LastActivityCell: FC<{ activity: JobFileActivity | null }> = ({ activity }) => {
+    if (!activity) {
+        return (
+            <Text fz={14} c="charcoal.9">
+                No activity yet
+            </Text>
+        )
+    }
+
+    return (
+        <Text fz={14} c="charcoal.9">
+            {activity.actorName}
+            <VisuallyHidden>, </VisuallyHidden>
+            <span aria-hidden="true"> · </span>
+            {ACTION_LABEL[activity.action]}
+            <VisuallyHidden> on </VisuallyHidden>
+            <span aria-hidden="true"> · </span>
+            {formatActivityDate(activity.createdAt)}
+        </Text>
+    )
+}
+
+type OutputsFileRowProps = {
+    row: OutputFileRowData
+    onView: (row: OutputFileRowData) => void
+    onDownload: (row: OutputFileRowData) => void
+}
+
+export const OutputsFileRow: FC<OutputsFileRowProps> = ({ row, onView, onDownload }) => {
+    // Only a truncated name needs an explicit accessible name; when the text is shown in full the
+    // button's own content already is it, and an aria-label would just duplicate it.
+    const isTruncated = row.name.length > OUTPUTS_FILE_NAME_MAX_LENGTH
+    const fileNameLabel = isTruncated ? row.name : undefined
+
+    return (
+        <Table.Tr className={classes.row}>
+            <Table.Td>
+                {/* Tooltip on a focusable button so the full name reaches keyboard users too, not
+                    just on hover. `events` adds focus; Mantine omits it by default. */}
+                <Tooltip label={row.name} events={{ hover: true, focus: true, touch: true }}>
+                    <UnstyledButton
+                        className={classes.fileName}
+                        onClick={() => onView(row)}
+                        aria-label={fileNameLabel}
+                        data-testid={`outputs-file-name-${row.key}`}
+                    >
+                        <Text component="span" fz={14} c="charcoal.9" inherit>
+                            {truncateFileName(row.name)}
+                        </Text>
+                    </UnstyledButton>
+                </Tooltip>
+            </Table.Td>
+            <Table.Td>
+                <LastActivityCell activity={row.activity} />
+            </Table.Td>
+            <Table.Td ta="right">
+                {/* The sole control for this row's download, so the icon carries the accessible
+                    name (naming the file) rather than being hidden as decorative. */}
+                <Tooltip label="Download" events={{ hover: true, focus: true, touch: true }}>
+                    <ActionIcon
+                        variant="subtle"
+                        color="gray"
+                        aria-label={`Download ${row.name}`}
+                        onClick={() => onDownload(row)}
+                        data-testid={`outputs-file-download-${row.key}`}
+                    >
+                        <DownloadSimpleIcon size={20} />
+                    </ActionIcon>
+                </Tooltip>
+            </Table.Td>
+        </Table.Tr>
+    )
+}

--- a/src/components/study/outputs-file-row.tsx
+++ b/src/components/study/outputs-file-row.tsx
@@ -15,6 +15,8 @@ export type OutputFileRowData = {
     filePath: string
     name: string
     contents: ArrayBuffer
+    /** False while the activity query is still in flight or has failed; see LastActivityCell. */
+    isActivityKnown: boolean
     activity: JobFileActivity | null
 }
 
@@ -28,7 +30,11 @@ export const formatActivityDate = (date: Date | string): string => dayjs(date).f
 // The middle dots are decorative. Read straight through, "Jessica Walters · Viewed · Apr 22"
 // announces as one run-on phrase, so each dot is paired with hidden connective text and hidden
 // from AT itself.
-const LastActivityCell: FC<{ activity: JobFileActivity | null }> = ({ activity }) => {
+const LastActivityCell: FC<{ activity: JobFileActivity | null; isKnown: boolean }> = ({ activity, isKnown }) => {
+    // "No activity yet" is a claim about who has accessed the file, so it waits until the answer is
+    // actually in. An unresolved or failed query leaves the cell blank instead of asserting it.
+    if (!isKnown) return null
+
     if (!activity) {
         return (
             <Text fz={14} c="charcoal.9">
@@ -81,7 +87,7 @@ export const OutputsFileRow: FC<OutputsFileRowProps> = ({ row, onView, onDownloa
                 </Tooltip>
             </Table.Td>
             <Table.Td>
-                <LastActivityCell activity={row.activity} />
+                <LastActivityCell activity={row.activity} isKnown={row.isActivityKnown} />
             </Table.Td>
             <Table.Td ta="right">
                 {/* The sole control for this row's download, so the icon carries the accessible

--- a/src/components/study/outputs-files-section.test.tsx
+++ b/src/components/study/outputs-files-section.test.tsx
@@ -1,0 +1,112 @@
+import { describe, expect, it, renderWithProviders, screen, userEvent, vi, within } from '@/tests/unit.helpers'
+import { OutputsFilesSection } from './outputs-files-section'
+import type { OutputFileRowData } from './outputs-file-row'
+
+const buildRow = (name: string, overrides: Partial<OutputFileRowData> = {}): OutputFileRowData => ({
+    key: `file-${name}`,
+    studyJobFileId: 'archive-1',
+    filePath: name,
+    name,
+    contents: new ArrayBuffer(4),
+    activity: null,
+    ...overrides,
+})
+
+const renderSection = (rows: OutputFileRowData[], overrides: Record<string, unknown> = {}) => {
+    const props = {
+        rows,
+        isPreparingZip: false,
+        onView: vi.fn(),
+        onDownload: vi.fn(),
+        onDownloadAll: vi.fn(),
+        ...overrides,
+    }
+    renderWithProviders(<OutputsFilesSection {...props} />)
+    return props
+}
+
+describe('OutputsFilesSection', () => {
+    it('renders the section header and the three columns', () => {
+        renderSection([buildRow('run.log')])
+
+        expect(screen.getByText('Output files')).toBeInTheDocument()
+        expect(screen.getByRole('columnheader', { name: 'File name' })).toBeInTheDocument()
+        expect(screen.getByRole('columnheader', { name: 'Last activity' })).toBeInTheDocument()
+        expect(screen.getByRole('columnheader', { name: 'Actions' })).toBeInTheDocument()
+    })
+
+    // Semantic table markup, not a div grid: screen readers navigate by row/column and announce
+    // the header with each cell only when the real roles are present.
+    it('uses real table semantics with column-scoped headers', () => {
+        renderSection([buildRow('run.log')])
+
+        expect(screen.getByRole('table')).toBeInTheDocument()
+        for (const header of screen.getAllByRole('columnheader')) {
+            expect(header).toHaveAttribute('scope', 'col')
+        }
+    })
+
+    it('renders one row per file', () => {
+        renderSection([buildRow('run.log'), buildRow('results.csv')])
+
+        const body = screen.getByRole('table').querySelector('tbody')!
+        expect(within(body).getAllByRole('row')).toHaveLength(2)
+    })
+
+    describe('Download all', () => {
+        it('renders once two or more files are present', () => {
+            renderSection([buildRow('run.log'), buildRow('results.csv')])
+            expect(screen.getByRole('button', { name: 'Download all' })).toBeInTheDocument()
+        })
+
+        // Removed from the DOM, not merely hidden: a CSS-hidden control still takes tab focus and
+        // leaves a keyboard user on an invisible element.
+        it('is absent from the DOM for a single file', () => {
+            renderSection([buildRow('run.log')])
+            expect(screen.queryByRole('button', { name: 'Download all' })).toBeNull()
+            expect(screen.queryByTestId('outputs-download-all')).toBeNull()
+        })
+
+        it('is absent from the DOM when there are no files', () => {
+            renderSection([])
+            expect(screen.queryByTestId('outputs-download-all')).toBeNull()
+        })
+
+        it('appears in the tab order only when rendered', async () => {
+            const { unmount } = renderWithProviders(
+                <OutputsFilesSection
+                    rows={[buildRow('run.log')]}
+                    isPreparingZip={false}
+                    onView={vi.fn()}
+                    onDownload={vi.fn()}
+                    onDownloadAll={vi.fn()}
+                />,
+            )
+            // One file: tabbing lands on the file name, never on a hidden Download all.
+            await userEvent.tab()
+            expect(screen.getByTestId('outputs-file-name-file-run.log')).toHaveFocus()
+            unmount()
+
+            renderSection([buildRow('a.log'), buildRow('b.log')])
+            await userEvent.tab()
+            expect(screen.getByTestId('outputs-download-all')).toHaveFocus()
+        })
+
+        it('calls onDownloadAll when clicked', async () => {
+            const props = renderSection([buildRow('a.log'), buildRow('b.log')])
+
+            await userEvent.click(screen.getByRole('button', { name: 'Download all' }))
+
+            expect(props.onDownloadAll).toHaveBeenCalledTimes(1)
+        })
+
+        // Decorative here, unlike the per-row icon: the button already carries a visible text
+        // label, so announcing the icon too would double up.
+        it('marks its icon decorative', () => {
+            renderSection([buildRow('a.log'), buildRow('b.log')])
+
+            const icon = screen.getByTestId('outputs-download-all').querySelector('svg')
+            expect(icon).toHaveAttribute('aria-hidden', 'true')
+        })
+    })
+})

--- a/src/components/study/outputs-files-section.test.tsx
+++ b/src/components/study/outputs-files-section.test.tsx
@@ -8,6 +8,7 @@ const buildRow = (name: string, overrides: Partial<OutputFileRowData> = {}): Out
     filePath: name,
     name,
     contents: new ArrayBuffer(4),
+    isActivityKnown: true,
     activity: null,
     ...overrides,
 })

--- a/src/components/study/outputs-files-section.tsx
+++ b/src/components/study/outputs-files-section.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { FC } from 'react'
+import { Button, Divider, Group, Paper, Stack, Table, Text } from '@mantine/core'
+import { DownloadSimpleIcon } from '@phosphor-icons/react/dist/ssr'
+import { OutputsFileRow, type OutputFileRowData } from './outputs-file-row'
+
+// Two files is the threshold: with one file the row's own download icon already does the job, so
+// a "Download all" would be a second control for the same action.
+const DOWNLOAD_ALL_MIN_FILES = 2
+
+type DownloadAllButtonProps = {
+    isVisible: boolean
+    isPreparing: boolean
+    onClick: () => void
+}
+
+const DownloadAllButton: FC<DownloadAllButtonProps> = ({ isVisible, isPreparing, onClick }) => {
+    // Returns null rather than hiding with CSS so the button leaves the tab order entirely when
+    // there are fewer than two files.
+    if (!isVisible) return null
+
+    return (
+        <Button
+            variant="outline"
+            onClick={onClick}
+            loading={isPreparing}
+            // Decorative here: the button already has a visible text label, so announcing the
+            // icon too would double up. Contrast with the per-row icon, which is the only control.
+            rightSection={<DownloadSimpleIcon size={16} aria-hidden="true" />}
+            data-testid="outputs-download-all"
+        >
+            Download all
+        </Button>
+    )
+}
+
+type OutputsFilesSectionProps = {
+    rows: OutputFileRowData[]
+    isPreparingZip: boolean
+    onView: (row: OutputFileRowData) => void
+    onDownload: (row: OutputFileRowData) => void
+    onDownloadAll: () => void
+}
+
+export const OutputsFilesSection: FC<OutputsFilesSectionProps> = ({
+    rows,
+    isPreparingZip,
+    onView,
+    onDownload,
+    onDownloadAll,
+}) => {
+    const fileRows = rows.map((row) => (
+        <OutputsFileRow key={row.key} row={row} onView={onView} onDownload={onDownload} />
+    ))
+
+    return (
+        <Paper p="xxl" data-testid="outputs-files-section">
+            <Stack gap="lg">
+                <Group justify="space-between" align="center">
+                    <Text fz={20} fw={700} c="charcoal.9">
+                        Output files
+                    </Text>
+                    <DownloadAllButton
+                        isVisible={rows.length >= DOWNLOAD_ALL_MIN_FILES}
+                        isPreparing={isPreparingZip}
+                        onClick={onDownloadAll}
+                    />
+                </Group>
+                <Divider color="charcoal.1" />
+                <Table verticalSpacing="md" data-testid="outputs-files-table">
+                    <Table.Thead bg="grey.10">
+                        <Table.Tr>
+                            <Table.Th scope="col">File name</Table.Th>
+                            <Table.Th scope="col">Last activity</Table.Th>
+                            <Table.Th scope="col" ta="right">
+                                Actions
+                            </Table.Th>
+                        </Table.Tr>
+                    </Table.Thead>
+                    <Table.Tbody>{fileRows}</Table.Tbody>
+                </Table>
+            </Stack>
+        </Paper>
+    )
+}

--- a/src/components/study/outputs-files-section.tsx
+++ b/src/components/study/outputs-files-section.tsx
@@ -68,18 +68,22 @@ export const OutputsFilesSection: FC<OutputsFilesSectionProps> = ({
                     />
                 </Group>
                 <Divider color="charcoal.1" />
-                <Table verticalSpacing="md" data-testid="outputs-files-table">
-                    <Table.Thead bg="grey.10">
-                        <Table.Tr>
-                            <Table.Th scope="col">File name</Table.Th>
-                            <Table.Th scope="col">Last activity</Table.Th>
-                            <Table.Th scope="col" ta="right">
-                                Actions
-                            </Table.Th>
-                        </Table.Tr>
-                    </Table.Thead>
-                    <Table.Tbody>{fileRows}</Table.Tbody>
-                </Table>
+                {/* File names, actor names and timestamps are all unbounded; without this the
+                    Actions column is the first thing pushed off a narrow viewport. */}
+                <Table.ScrollContainer minWidth={520}>
+                    <Table verticalSpacing="md" data-testid="outputs-files-table">
+                        <Table.Thead bg="grey.10">
+                            <Table.Tr>
+                                <Table.Th scope="col">File name</Table.Th>
+                                <Table.Th scope="col">Last activity</Table.Th>
+                                <Table.Th scope="col" ta="right">
+                                    Actions
+                                </Table.Th>
+                            </Table.Tr>
+                        </Table.Thead>
+                        <Table.Tbody>{fileRows}</Table.Tbody>
+                    </Table>
+                </Table.ScrollContainer>
             </Stack>
         </Paper>
     )

--- a/src/components/study/outputs-review-panel.tsx
+++ b/src/components/study/outputs-review-panel.tsx
@@ -179,10 +179,8 @@ const ReviewBody: FC<ReviewBodyProps> = ({
                 maxWords={maxWords}
                 wordCount={decision.wordCount}
                 feedbackError={decision.feedbackError}
-                saveStatus={decision.saveStatus}
                 onFeedbackChange={decision.onFeedbackChange}
                 onFeedbackBlur={decision.onFeedbackBlur}
-                onProviderReady={decision.onProviderReady}
                 selected={decision.selected}
                 onSelect={decision.onSelect}
                 onDecisionBlur={decision.onDecisionBlur}
@@ -208,7 +206,11 @@ const ReviewBody: FC<ReviewBodyProps> = ({
                 onClose={decision.closeModal}
                 onConfirm={decision.confirmSubmit}
             />
-            <FileOrImagePreviewModal file={previewFile} onClose={files.closeViewer} />
+            <FileOrImagePreviewModal
+                file={previewFile}
+                onClose={files.closeViewer}
+                onDownload={files.onViewerDownload}
+            />
         </>
     )
 }

--- a/src/components/study/outputs-review-panel.tsx
+++ b/src/components/study/outputs-review-panel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FC, ReactNode, useCallback, useRef, useState } from 'react'
+import { FC, ReactNode, useState } from 'react'
 import type { Route } from 'next'
 import { Box, Button, Group, Stack } from '@mantine/core'
 import { CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
@@ -162,16 +162,6 @@ const ReviewBody: FC<ReviewBodyProps> = ({
     const files = useOutputsFiles({ jobId: job.id, decryptedFiles })
     const decision = useOutputsDecision({ orgSlug, studyId, jobId: job.id, labName, maxWords, decryptedFiles })
     const previewFile = files.viewing ? { name: files.viewing.name, contents: files.viewing.contents } : null
-    const submitRef = useRef<HTMLButtonElement>(null)
-
-    // SubmitOutputsDecisionModal unmounts on close (to keep its body text fresh), which pre-empts
-    // Mantine's own focus-return effect and would otherwise drop focus onto <body>. Restoring it
-    // here covers all three dismissals: X, Cancel and Escape. rAF waits for the unmount, since the
-    // button cannot take focus while the modal still has it trapped.
-    const closeAndRestoreFocus = useCallback(() => {
-        decision.closeModal()
-        requestAnimationFrame(() => submitRef.current?.focus())
-    }, [decision])
 
     return (
         <>
@@ -201,7 +191,6 @@ const ReviewBody: FC<ReviewBodyProps> = ({
                 {/* Enabled from the start by design: pressing it is how the user learns what is
                     still missing, rather than being left with a dead button and no explanation. */}
                 <Button
-                    ref={submitRef}
                     onClick={decision.attemptSubmit}
                     disabled={decision.isSubmitting}
                     data-testid="outputs-submit-decision"
@@ -213,7 +202,7 @@ const ReviewBody: FC<ReviewBodyProps> = ({
                 decision={decision.confirming}
                 labName={labName}
                 isSubmitting={decision.isSubmitting}
-                onClose={closeAndRestoreFocus}
+                onClose={decision.closeModal}
                 onConfirm={decision.confirmSubmit}
             />
             <FileOrImagePreviewModal

--- a/src/components/study/outputs-review-panel.tsx
+++ b/src/components/study/outputs-review-panel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FC, ReactNode, useState } from 'react'
+import { FC, ReactNode, useCallback, useRef, useState } from 'react'
 import type { Route } from 'next'
 import { Box, Button, Group, Stack } from '@mantine/core'
 import { CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
@@ -162,6 +162,16 @@ const ReviewBody: FC<ReviewBodyProps> = ({
     const files = useOutputsFiles({ jobId: job.id, decryptedFiles })
     const decision = useOutputsDecision({ orgSlug, studyId, jobId: job.id, labName, maxWords, decryptedFiles })
     const previewFile = files.viewing ? { name: files.viewing.name, contents: files.viewing.contents } : null
+    const submitRef = useRef<HTMLButtonElement>(null)
+
+    // SubmitOutputsDecisionModal unmounts on close (to keep its body text fresh), which pre-empts
+    // Mantine's own focus-return effect and would otherwise drop focus onto <body>. Restoring it
+    // here covers all three dismissals: X, Cancel and Escape. rAF waits for the unmount, since the
+    // button cannot take focus while the modal still has it trapped.
+    const closeAndRestoreFocus = useCallback(() => {
+        decision.closeModal()
+        requestAnimationFrame(() => submitRef.current?.focus())
+    }, [decision])
 
     return (
         <>
@@ -191,6 +201,7 @@ const ReviewBody: FC<ReviewBodyProps> = ({
                 {/* Enabled from the start by design: pressing it is how the user learns what is
                     still missing, rather than being left with a dead button and no explanation. */}
                 <Button
+                    ref={submitRef}
                     onClick={decision.attemptSubmit}
                     disabled={decision.isSubmitting}
                     data-testid="outputs-submit-decision"
@@ -199,11 +210,10 @@ const ReviewBody: FC<ReviewBodyProps> = ({
                 </Button>
             </Group>
             <SubmitOutputsDecisionModal
-                decision={decision.selected}
+                decision={decision.confirming}
                 labName={labName}
-                isOpen={decision.isModalOpen}
                 isSubmitting={decision.isSubmitting}
-                onClose={decision.closeModal}
+                onClose={closeAndRestoreFocus}
                 onConfirm={decision.confirmSubmit}
             />
             <FileOrImagePreviewModal

--- a/src/components/study/outputs-review-panel.tsx
+++ b/src/components/study/outputs-review-panel.tsx
@@ -123,7 +123,7 @@ type UnlockedPhaseProps = {
     previousHref: Route
 }
 
-// Split from the panel so the hooks below run only once decryption has happened — mounting the
+// Split from the panel so the hooks below run only once decryption has happened: mounting the
 // collaborative editor (and its websocket) behind a still-locked key would be wasted work.
 const UnlockedPhase: FC<UnlockedPhaseProps> = ({
     decryptedFiles,

--- a/src/components/study/outputs-review-panel.tsx
+++ b/src/components/study/outputs-review-panel.tsx
@@ -1,0 +1,214 @@
+'use client'
+
+import { FC, ReactNode, useState } from 'react'
+import type { Route } from 'next'
+import { Box, Button, Group, Stack } from '@mantine/core'
+import { CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
+import { ButtonLink } from '@/components/links'
+import { FileOrImagePreviewModal } from '@/components/modals/file-or-image-preview-modal'
+import { OutputsDecisionSection } from '@/components/study/outputs-decision-section'
+import { OutputsFilesSection } from '@/components/study/outputs-files-section'
+import { ProposalStepHeader } from '@/components/study/proposal-step-header'
+import { SecurityKeyForm } from '@/components/study/security-key-form'
+import { StudyPageHeader } from '@/components/study/study-page-header'
+import { SubmitOutputsDecisionModal } from '@/components/study/submit-outputs-decision-modal'
+import { useOutputsDecision } from '@/hooks/use-outputs-decision'
+import { useOutputsFiles } from '@/hooks/use-outputs-files'
+import type { JobFileInfo } from '@/lib/types'
+import type { LatestJobForStudy } from '@/server/db/queries'
+
+type OutputsReviewPanelProps = {
+    orgSlug: string
+    studyId: string
+    studyTitle: string
+    job: NonNullable<LatestJobForStudy>
+    labName: string
+    maxWords: number
+    /** Shown while the outputs are still encrypted (OTTER-667 / OTTER-668 copy). */
+    lockedBanner: ReactNode
+    /** Replaces it once the key decrypts, warning the reviewer to check before sharing. */
+    unlockedBanner: ReactNode
+    previousHref: Route
+}
+
+/**
+ * The reviewer's outputs step, in its two phases.
+ *
+ * Decryption happens in the browser and changes no server state, so "advancing" to the review
+ * view is a local phase flip, not a route change or a new screen: the study is still
+ * JOB-ERRORED / RUN-COMPLETE either side of it. Holding both phases in one component is what
+ * lets the decrypted plaintext stay in memory and never travel back to the server.
+ *
+ * The page and section headers are identical across both phases; only the banner below the
+ * divider and the body beneath it change.
+ */
+export const OutputsReviewPanel: FC<OutputsReviewPanelProps> = ({
+    orgSlug,
+    studyId,
+    studyTitle,
+    job,
+    labName,
+    maxWords,
+    lockedBanner,
+    unlockedBanner,
+    previousHref,
+}) => {
+    const [decryptedFiles, setDecryptedFiles] = useState<JobFileInfo[] | null>(null)
+    const isLocked = decryptedFiles === null
+    const banner = isLocked ? lockedBanner : unlockedBanner
+
+    return (
+        <Box bg="grey.10">
+            <Stack px="xl" gap="xxl" py="xl">
+                <StudyPageHeader>Secondary analysis study</StudyPageHeader>
+                <ProposalStepHeader
+                    stepLabel="STEP 3"
+                    heading="Review outputs"
+                    studyTitle={studyTitle}
+                    banner={banner}
+                />
+                <LockedPhase
+                    isVisible={isLocked}
+                    job={job}
+                    previousHref={previousHref}
+                    onDecrypted={setDecryptedFiles}
+                />
+                <UnlockedPhase
+                    decryptedFiles={decryptedFiles}
+                    orgSlug={orgSlug}
+                    studyId={studyId}
+                    job={job}
+                    labName={labName}
+                    maxWords={maxWords}
+                    previousHref={previousHref}
+                />
+            </Stack>
+        </Box>
+    )
+}
+
+type LockedPhaseProps = {
+    isVisible: boolean
+    job: NonNullable<LatestJobForStudy>
+    previousHref: Route
+    onDecrypted: (files: JobFileInfo[]) => void
+}
+
+const LockedPhase: FC<LockedPhaseProps> = ({ isVisible, job, previousHref, onDecrypted }) => {
+    if (!isVisible) return null
+    return (
+        <>
+            <SecurityKeyForm job={job} onDecrypted={onDecrypted} />
+            <Group>
+                <PreviousStepLink previousHref={previousHref} />
+            </Group>
+        </>
+    )
+}
+
+const PreviousStepLink: FC<{ previousHref: Route }> = ({ previousHref }) => (
+    <ButtonLink href={previousHref} variant="subtle" leftSection={<CaretLeftIcon />}>
+        Previous step
+    </ButtonLink>
+)
+
+type UnlockedPhaseProps = {
+    /** null until a key has successfully decrypted; the whole review view is gated on it. */
+    decryptedFiles: JobFileInfo[] | null
+    orgSlug: string
+    studyId: string
+    job: NonNullable<LatestJobForStudy>
+    labName: string
+    maxWords: number
+    previousHref: Route
+}
+
+// Split from the panel so the hooks below run only once decryption has happened — mounting the
+// collaborative editor (and its websocket) behind a still-locked key would be wasted work.
+const UnlockedPhase: FC<UnlockedPhaseProps> = ({
+    decryptedFiles,
+    orgSlug,
+    studyId,
+    job,
+    labName,
+    maxWords,
+    previousHref,
+}) => {
+    if (decryptedFiles === null) return null
+    return (
+        <ReviewBody
+            decryptedFiles={decryptedFiles}
+            orgSlug={orgSlug}
+            studyId={studyId}
+            job={job}
+            labName={labName}
+            maxWords={maxWords}
+            previousHref={previousHref}
+        />
+    )
+}
+
+type ReviewBodyProps = Omit<UnlockedPhaseProps, 'decryptedFiles'> & { decryptedFiles: JobFileInfo[] }
+
+const ReviewBody: FC<ReviewBodyProps> = ({
+    decryptedFiles,
+    orgSlug,
+    studyId,
+    job,
+    labName,
+    maxWords,
+    previousHref,
+}) => {
+    const files = useOutputsFiles({ jobId: job.id, decryptedFiles })
+    const decision = useOutputsDecision({ orgSlug, studyId, jobId: job.id, labName, maxWords, decryptedFiles })
+    const previewFile = files.viewing ? { name: files.viewing.name, contents: files.viewing.contents } : null
+
+    return (
+        <>
+            <OutputsFilesSection
+                rows={files.rows}
+                isPreparingZip={files.isPreparingZip}
+                onView={files.onView}
+                onDownload={files.onDownload}
+                onDownloadAll={files.onDownloadAll}
+            />
+            <OutputsDecisionSection
+                jobId={job.id}
+                studyId={studyId}
+                labName={labName}
+                maxWords={maxWords}
+                wordCount={decision.wordCount}
+                feedbackError={decision.feedbackError}
+                saveStatus={decision.saveStatus}
+                onFeedbackChange={decision.onFeedbackChange}
+                onFeedbackBlur={decision.onFeedbackBlur}
+                onProviderReady={decision.onProviderReady}
+                selected={decision.selected}
+                onSelect={decision.onSelect}
+                onDecisionBlur={decision.onDecisionBlur}
+                decisionError={decision.decisionError}
+            />
+            <Group justify="space-between">
+                <PreviousStepLink previousHref={previousHref} />
+                {/* Enabled from the start by design: pressing it is how the user learns what is
+                    still missing, rather than being left with a dead button and no explanation. */}
+                <Button
+                    onClick={decision.attemptSubmit}
+                    disabled={decision.isSubmitting}
+                    data-testid="outputs-submit-decision"
+                >
+                    Submit decision
+                </Button>
+            </Group>
+            <SubmitOutputsDecisionModal
+                decision={decision.selected}
+                labName={labName}
+                isOpen={decision.isModalOpen}
+                isSubmitting={decision.isSubmitting}
+                onClose={decision.closeModal}
+                onConfirm={decision.confirmSubmit}
+            />
+            <FileOrImagePreviewModal file={previewFile} onClose={files.closeViewer} />
+        </>
+    )
+}

--- a/src/components/study/security-key-form.test.tsx
+++ b/src/components/study/security-key-form.test.tsx
@@ -61,6 +61,7 @@ async function seedArtifact(
 
 const EMPTY_ERROR = 'Enter your security key to decrypt the outputs.'
 const INVALID_ERROR = 'Invalid key. Check that you copied the full key and enter it again.'
+const UNAVAILABLE_ERROR = 'These outputs are not available to decrypt. Contact your organization admin.'
 
 const enterKey = (value: string) => {
     fireEvent.change(screen.getByRole('textbox'), { target: { value } })
@@ -74,6 +75,16 @@ describe('SecurityKeyForm', () => {
     let org: Org
     let job: LatestJobForStudy
     let onDecrypted: Mock
+
+    // Most error paths need real ciphertext present: without it the form now stops at
+    // "nothing to decrypt" before a key is ever tested.
+    const seedDecryptableArtifact = async () => {
+        const artifact = await seedArtifact(job.id, {
+            fileType: 'ENCRYPTED-CODE-RUN-LOG',
+            files: [{ name: 'run.log', content: 'job started' }],
+        })
+        vi.mocked(fetchEncryptedJobFilesAction).mockResolvedValue([artifact])
+    }
 
     beforeEach(async () => {
         const resp = await mockSessionWithTestData()
@@ -107,6 +118,7 @@ describe('SecurityKeyForm', () => {
     })
 
     it('shows the invalid-key error and re-enables both input and button for correction', async () => {
+        await seedDecryptableArtifact()
         renderWithProviders(<SecurityKeyForm job={job} onDecrypted={onDecrypted} />)
 
         await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
@@ -120,6 +132,7 @@ describe('SecurityKeyForm', () => {
     })
 
     it('disables the button and input on submit to prevent double submission', async () => {
+        await seedDecryptableArtifact()
         renderWithProviders(<SecurityKeyForm job={job} onDecrypted={onDecrypted} />)
 
         await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
@@ -132,6 +145,7 @@ describe('SecurityKeyForm', () => {
     })
 
     it('replaces the empty-field error with the invalid-key error on retry', async () => {
+        await seedDecryptableArtifact()
         renderWithProviders(<SecurityKeyForm job={job} onDecrypted={onDecrypted} />)
 
         await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
@@ -144,6 +158,33 @@ describe('SecurityKeyForm', () => {
 
         expect(await screen.findByText(INVALID_ERROR)).toBeInTheDocument()
         expect(screen.queryByText(EMPTY_ERROR)).toBeNull()
+    })
+
+    // A key is only proven by ciphertext it actually opened. With nothing to decrypt, the parse
+    // step accepts any syntactically valid PEM, so reporting success here would unlock the review
+    // view for any well-formed key and show an empty table as a reviewed state.
+    it('refuses to unlock when there are no artifacts to decrypt', async () => {
+        renderWithProviders(<SecurityKeyForm job={job} onDecrypted={onDecrypted} />)
+
+        await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
+
+        enterKey(await readTestSupportFile('private_key.pem'))
+        clickView()
+
+        expect(await screen.findByText(UNAVAILABLE_ERROR)).toBeInTheDocument()
+        expect(onDecrypted).not.toHaveBeenCalled()
+    })
+
+    it('separates "nothing to decrypt" from a bad key', async () => {
+        renderWithProviders(<SecurityKeyForm job={job} onDecrypted={onDecrypted} />)
+
+        await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
+
+        enterKey('not-a-real-key')
+        clickView()
+
+        expect(await screen.findByText(UNAVAILABLE_ERROR)).toBeInTheDocument()
+        expect(screen.queryByText(INVALID_ERROR)).toBeNull()
     })
 
     it('hands the decrypted files to the caller when the key is valid', async () => {

--- a/src/components/study/security-key-form.test.tsx
+++ b/src/components/study/security-key-form.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
 import {
     db,
     fireEvent,
@@ -61,7 +61,6 @@ async function seedArtifact(
 
 const EMPTY_ERROR = 'Enter your security key to decrypt the outputs.'
 const INVALID_ERROR = 'Invalid key. Check that you copied the full key and enter it again.'
-const SUCCESS_MESSAGE = 'Security key accepted.'
 
 const enterKey = (value: string) => {
     fireEvent.change(screen.getByRole('textbox'), { target: { value } })
@@ -74,17 +73,19 @@ const clickView = () => {
 describe('SecurityKeyForm', () => {
     let org: Org
     let job: LatestJobForStudy
+    let onDecrypted: Mock
 
     beforeEach(async () => {
         const resp = await mockSessionWithTestData()
         org = resp.org
         const { study } = await insertTestStudyJobData({ org, jobStatus: 'JOB-ERRORED' })
         job = await latestJobForStudy(study.id)
+        onDecrypted = vi.fn()
         vi.mocked(fetchEncryptedJobFilesAction).mockResolvedValue([])
     })
 
     it('renders the key-entry section with a required indicator and body copy', () => {
-        renderWithProviders(<SecurityKeyForm job={job} />)
+        renderWithProviders(<SecurityKeyForm job={job} onDecrypted={onDecrypted} />)
 
         expect(screen.getByRole('heading', { name: /security key/i })).toBeInTheDocument()
         expect(screen.getByLabelText('required')).toHaveTextContent('*')
@@ -97,7 +98,7 @@ describe('SecurityKeyForm', () => {
     })
 
     it('shows the empty-field error and focuses the input when submitted blank', async () => {
-        renderWithProviders(<SecurityKeyForm job={job} />)
+        renderWithProviders(<SecurityKeyForm job={job} onDecrypted={onDecrypted} />)
 
         clickView()
 
@@ -106,7 +107,7 @@ describe('SecurityKeyForm', () => {
     })
 
     it('shows the invalid-key error and re-enables both input and button for correction', async () => {
-        renderWithProviders(<SecurityKeyForm job={job} />)
+        renderWithProviders(<SecurityKeyForm job={job} onDecrypted={onDecrypted} />)
 
         await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
 
@@ -119,7 +120,7 @@ describe('SecurityKeyForm', () => {
     })
 
     it('disables the button and input on submit to prevent double submission', async () => {
-        renderWithProviders(<SecurityKeyForm job={job} />)
+        renderWithProviders(<SecurityKeyForm job={job} onDecrypted={onDecrypted} />)
 
         await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
 
@@ -131,7 +132,7 @@ describe('SecurityKeyForm', () => {
     })
 
     it('replaces the empty-field error with the invalid-key error on retry', async () => {
-        renderWithProviders(<SecurityKeyForm job={job} />)
+        renderWithProviders(<SecurityKeyForm job={job} onDecrypted={onDecrypted} />)
 
         await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
 
@@ -145,21 +146,24 @@ describe('SecurityKeyForm', () => {
         expect(screen.queryByText(EMPTY_ERROR)).toBeNull()
     })
 
-    it('shows a success message when the key decrypts the outputs', async () => {
+    it('hands the decrypted files to the caller when the key is valid', async () => {
         const artifact = await seedArtifact(job.id, {
             fileType: 'ENCRYPTED-CODE-RUN-LOG',
             files: [{ name: 'run.log', content: 'job started\nsomething went wrong' }],
         })
         vi.mocked(fetchEncryptedJobFilesAction).mockResolvedValue([artifact])
 
-        renderWithProviders(<SecurityKeyForm job={job} />)
+        renderWithProviders(<SecurityKeyForm job={job} onDecrypted={onDecrypted} />)
 
         await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
 
         enterKey(await readTestSupportFile('private_key.pem'))
         clickView()
 
-        expect(await screen.findByText(SUCCESS_MESSAGE)).toBeInTheDocument()
+        await waitFor(() => expect(onDecrypted).toHaveBeenCalled())
+        const files = onDecrypted.mock.calls[0][0]
+        expect(files).toHaveLength(1)
+        expect(files[0].path).toBe('run.log')
         expect(screen.queryByText(INVALID_ERROR)).toBeNull()
         expect(screen.getByRole('button', { name: 'View' })).toBeEnabled()
     })

--- a/src/components/study/security-key-form.tsx
+++ b/src/components/study/security-key-form.tsx
@@ -1,20 +1,23 @@
 'use client'
 
-import { Paper, Stack, Text } from '@mantine/core'
+import { Paper, Stack } from '@mantine/core'
 import { FC } from 'react'
 import { FormSectionHeader } from '@/components/study/form-section-header'
 import { LostKeyPopover } from '@/components/study/lost-key-popover'
 import { SecurityKeyInput } from '@/components/study/security-key-input'
 import { SecurityKeyViewButton } from '@/components/study/security-key-view-button'
 import { useSecurityKeyForm } from '@/components/study/use-security-key-form'
+import type { JobFileInfo } from '@/lib/types'
 import type { LatestJobForStudy } from '@/server/db/queries'
 
 interface SecurityKeyFormProps {
     job: LatestJobForStudy
+    /** Fires once the key decrypts the job's artifacts; the caller swaps in the review view. */
+    onDecrypted: (files: JobFileInfo[]) => void
 }
 
-export const SecurityKeyForm: FC<SecurityKeyFormProps> = ({ job }) => {
-    const { value, setValue, error, successMessage, isDecrypting, inputRef, handleSubmit } = useSecurityKeyForm({ job })
+export const SecurityKeyForm: FC<SecurityKeyFormProps> = ({ job, onDecrypted }) => {
+    const { value, setValue, error, isDecrypting, inputRef, handleSubmit } = useSecurityKeyForm({ job, onDecrypted })
 
     return (
         <Paper p="xxl">
@@ -32,19 +35,8 @@ export const SecurityKeyForm: FC<SecurityKeyFormProps> = ({ job }) => {
                     disabled={isDecrypting}
                 />
                 <SecurityKeyViewButton isDecrypting={isDecrypting} onClick={handleSubmit} />
-                <SuccessMessage message={successMessage} />
                 <LostKeyPopover />
             </Stack>
         </Paper>
-    )
-}
-
-// TODO: remove this after 675 is implemented. this is temporary for testing.
-const SuccessMessage: FC<{ message?: string }> = ({ message }) => {
-    if (!message) return null
-    return (
-        <Text fz="md" c="green.9">
-            {message}
-        </Text>
     )
 }

--- a/src/components/study/submit-outputs-decision-modal.test.tsx
+++ b/src/components/study/submit-outputs-decision-modal.test.tsx
@@ -14,7 +14,6 @@ const renderModal = (decision: OutputsDecision | null, overrides: Record<string,
     const props = {
         decision,
         labName: LAB,
-        isOpen: true,
         isSubmitting: false,
         onClose: vi.fn(),
         onConfirm: vi.fn(),
@@ -49,13 +48,9 @@ describe('SubmitOutputsDecisionModal', () => {
         expect(confirmationBody('share-feedback-only', 'Acme Lab')).toContain('Acme Lab')
     })
 
+    // A null decision IS the closed state: there is no separate open flag to disagree with it.
     it('stays closed until a decision has been picked', () => {
         renderModal(null)
-        expect(screen.queryByText('Submit your decision?')).toBeNull()
-    })
-
-    it('stays closed when isOpen is false', () => {
-        renderModal('share-outputs', { isOpen: false })
         expect(screen.queryByText('Submit your decision?')).toBeNull()
     })
 
@@ -65,25 +60,16 @@ describe('SubmitOutputsDecisionModal', () => {
     // survive precisely that sequence.
     it('shows the updated body after the decision changes between opens', async () => {
         const Harness = () => {
-            const [decision, setDecision] = useState<OutputsDecision>('share-outputs')
-            const [isOpen, setIsOpen] = useState(true)
+            const [confirming, setConfirming] = useState<OutputsDecision | null>('share-outputs')
             return (
                 <>
-                    <button onClick={() => setIsOpen(false)}>close it</button>
-                    <button
-                        onClick={() => {
-                            setDecision('share-feedback-only')
-                            setIsOpen(true)
-                        }}
-                    >
-                        reopen with feedback only
-                    </button>
+                    <button onClick={() => setConfirming(null)}>close it</button>
+                    <button onClick={() => setConfirming('share-feedback-only')}>reopen with feedback only</button>
                     <SubmitOutputsDecisionModal
-                        decision={decision}
+                        decision={confirming}
                         labName={LAB}
-                        isOpen={isOpen}
                         isSubmitting={false}
-                        onClose={() => setIsOpen(false)}
+                        onClose={() => setConfirming(null)}
                         onConfirm={vi.fn()}
                     />
                 </>
@@ -100,6 +86,9 @@ describe('SubmitOutputsDecisionModal', () => {
         expect(screen.queryByText(SHARE_OUTPUTS_BODY)).toBeNull()
     })
 
+    // Focus restoration on close is the trigger owner's job (the modal unmounts itself, which
+    // pre-empts Mantine's focus-return effect), so it is asserted in
+    // reviewer-outputs-errored-screen.test.tsx where the real Submit decision button exists.
     it('closes without submitting from Cancel', async () => {
         const { onClose, onConfirm } = renderModal('share-outputs')
 

--- a/src/components/study/submit-outputs-decision-modal.test.tsx
+++ b/src/components/study/submit-outputs-decision-modal.test.tsx
@@ -1,0 +1,150 @@
+import { useState } from 'react'
+import { describe, expect, it, renderWithProviders, screen, userEvent, vi } from '@/tests/unit.helpers'
+import { SubmitOutputsDecisionModal, confirmationBody } from './submit-outputs-decision-modal'
+import type { OutputsDecision } from '@/lib/outputs-review'
+
+const LAB = 'Rice Lab'
+
+const SHARE_OUTPUTS_BODY =
+    'You are sharing the output files and your feedback with Rice Lab. You will not be able to make changes after submitting.'
+const FEEDBACK_ONLY_BODY =
+    'You are sharing your feedback only. The output files will not be shared with Rice Lab. You will not be able to make changes after submitting.'
+
+const renderModal = (decision: OutputsDecision | null, overrides: Record<string, unknown> = {}) => {
+    const props = {
+        decision,
+        labName: LAB,
+        isOpen: true,
+        isSubmitting: false,
+        onClose: vi.fn(),
+        onConfirm: vi.fn(),
+        ...overrides,
+    }
+    renderWithProviders(<SubmitOutputsDecisionModal {...props} />)
+    return props
+}
+
+describe('SubmitOutputsDecisionModal', () => {
+    it('renders the title and all three controls', () => {
+        renderModal('share-outputs')
+
+        expect(screen.getByText('Submit your decision?')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Submit decision' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
+    })
+
+    it('states that the files and feedback are being shared for the share-outputs path', () => {
+        renderModal('share-outputs')
+        expect(screen.getByText(SHARE_OUTPUTS_BODY)).toBeInTheDocument()
+    })
+
+    it('states that the files are withheld for the feedback-only path', () => {
+        renderModal('share-feedback-only')
+        expect(screen.getByText(FEEDBACK_ONLY_BODY)).toBeInTheDocument()
+    })
+
+    it('interpolates the lab name into both bodies', () => {
+        expect(confirmationBody('share-outputs', 'Acme Lab')).toContain('Acme Lab')
+        expect(confirmationBody('share-feedback-only', 'Acme Lab')).toContain('Acme Lab')
+    })
+
+    it('stays closed until a decision has been picked', () => {
+        renderModal(null)
+        expect(screen.queryByText('Submit your decision?')).toBeNull()
+    })
+
+    it('stays closed when isOpen is false', () => {
+        renderModal('share-outputs', { isOpen: false })
+        expect(screen.queryByText('Submit your decision?')).toBeNull()
+    })
+
+    // Mantine keeps modal children mounted, so a cached body from the previously chosen option is
+    // exactly what a screen reader would re-announce on the next open. Driven through a real
+    // close → change → reopen cycle rather than a prop rerender, because a stale body would
+    // survive precisely that sequence.
+    it('shows the updated body after the decision changes between opens', async () => {
+        const Harness = () => {
+            const [decision, setDecision] = useState<OutputsDecision>('share-outputs')
+            const [isOpen, setIsOpen] = useState(true)
+            return (
+                <>
+                    <button onClick={() => setIsOpen(false)}>close it</button>
+                    <button
+                        onClick={() => {
+                            setDecision('share-feedback-only')
+                            setIsOpen(true)
+                        }}
+                    >
+                        reopen with feedback only
+                    </button>
+                    <SubmitOutputsDecisionModal
+                        decision={decision}
+                        labName={LAB}
+                        isOpen={isOpen}
+                        isSubmitting={false}
+                        onClose={() => setIsOpen(false)}
+                        onConfirm={vi.fn()}
+                    />
+                </>
+            )
+        }
+
+        renderWithProviders(<Harness />)
+        expect(screen.getByText(SHARE_OUTPUTS_BODY)).toBeInTheDocument()
+
+        await userEvent.click(screen.getByRole('button', { name: 'close it' }))
+        await userEvent.click(screen.getByRole('button', { name: 'reopen with feedback only' }))
+
+        expect(screen.getByText(FEEDBACK_ONLY_BODY)).toBeInTheDocument()
+        expect(screen.queryByText(SHARE_OUTPUTS_BODY)).toBeNull()
+    })
+
+    it('closes without submitting from Cancel', async () => {
+        const { onClose, onConfirm } = renderModal('share-outputs')
+
+        await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+        expect(onClose).toHaveBeenCalledTimes(1)
+        expect(onConfirm).not.toHaveBeenCalled()
+    })
+
+    it('closes without submitting from the X', async () => {
+        const { onClose, onConfirm } = renderModal('share-outputs')
+
+        await userEvent.click(screen.getByRole('button', { name: 'Close' }))
+
+        expect(onClose).toHaveBeenCalledTimes(1)
+        expect(onConfirm).not.toHaveBeenCalled()
+    })
+
+    it('closes on Escape', async () => {
+        const { onClose } = renderModal('share-outputs')
+
+        await userEvent.keyboard('{Escape}')
+
+        expect(onClose).toHaveBeenCalled()
+    })
+
+    it('submits from the confirm button', async () => {
+        const { onConfirm } = renderModal('share-outputs')
+
+        await userEvent.click(screen.getByRole('button', { name: 'Submit decision' }))
+
+        expect(onConfirm).toHaveBeenCalledTimes(1)
+    })
+
+    it('exposes itself as a modal dialog labelled by its title', () => {
+        renderModal('share-outputs')
+
+        const dialog = screen.getByRole('dialog')
+        expect(dialog).toHaveAttribute('aria-modal', 'true')
+        expect(dialog).toHaveAccessibleName('Submit your decision?')
+    })
+
+    it('disables Cancel while the submission is in flight', () => {
+        renderModal('share-outputs', { isSubmitting: true })
+
+        expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
+    })
+})

--- a/src/components/study/submit-outputs-decision-modal.test.tsx
+++ b/src/components/study/submit-outputs-decision-modal.test.tsx
@@ -49,8 +49,11 @@ describe('SubmitOutputsDecisionModal', () => {
     })
 
     // A null decision IS the closed state: there is no separate open flag to disagree with it.
-    it('stays closed until a decision has been picked', () => {
+    // The component stays mounted while closed (that is what keeps Mantine's focus return alive),
+    // so "closed" means no dialog is rendered, not that nothing is.
+    it('shows no dialog until a decision has been picked', () => {
         renderModal(null)
+        expect(screen.queryByRole('dialog')).toBeNull()
         expect(screen.queryByText('Submit your decision?')).toBeNull()
     })
 
@@ -86,9 +89,8 @@ describe('SubmitOutputsDecisionModal', () => {
         expect(screen.queryByText(SHARE_OUTPUTS_BODY)).toBeNull()
     })
 
-    // Focus restoration on close is the trigger owner's job (the modal unmounts itself, which
-    // pre-empts Mantine's focus-return effect), so it is asserted in
-    // reviewer-outputs-errored-screen.test.tsx where the real Submit decision button exists.
+    // Focus restoration is Mantine's own returnFocus, which works because this component stays
+    // mounted across close; the e2e covers it end to end against a real trigger.
     it('closes without submitting from Cancel', async () => {
         const { onClose, onConfirm } = renderModal('share-outputs')
 

--- a/src/components/study/submit-outputs-decision-modal.tsx
+++ b/src/components/study/submit-outputs-decision-modal.tsx
@@ -10,10 +10,13 @@ export const confirmationBody = (decision: OutputsDecision, labName: string): st
         : `You are sharing your feedback only. The output files will not be shared with ${labName}. You will not be able to make changes after submitting.`
 
 type SubmitOutputsDecisionModalProps = {
-    /** null keeps the modal closed; submit only opens it once an option is picked. */
+    /**
+     * The decision being confirmed, or null when the modal is closed. A single nullable value
+     * rather than an `isOpen` flag beside it: "open with no decision" is not a legal state, and
+     * spelling it that way is what stops it needing a guard.
+     */
     decision: OutputsDecision | null
     labName: string
-    isOpen: boolean
     isSubmitting: boolean
     onClose: () => void
     onConfirm: () => void
@@ -22,7 +25,6 @@ type SubmitOutputsDecisionModalProps = {
 export const SubmitOutputsDecisionModal: FC<SubmitOutputsDecisionModalProps> = ({
     decision,
     labName,
-    isOpen,
     isSubmitting,
     onClose,
     onConfirm,
@@ -30,7 +32,10 @@ export const SubmitOutputsDecisionModal: FC<SubmitOutputsDecisionModalProps> = (
     // Unmounting while closed is what keeps the body text honest: Mantine's Modal keeps its
     // children mounted, so a cached body from the previously chosen option would be what a
     // screen reader re-announces on the next open.
-    if (!isOpen || !decision) return null
+    //
+    // The unmount also pre-empts Mantine's own focus-return effect, so the caller has to restore
+    // focus to the trigger itself; see closeAndRestoreFocus in outputs-review-panel.
+    if (!decision) return null
 
     return (
         <SubmitConfirmationModal

--- a/src/components/study/submit-outputs-decision-modal.tsx
+++ b/src/components/study/submit-outputs-decision-modal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FC } from 'react'
+import { FC, useState } from 'react'
 import { SubmitConfirmationModal } from '@/components/modals/submit-confirmation-modal'
 import type { OutputsDecision } from '@/lib/outputs-review'
 
@@ -13,7 +13,7 @@ type SubmitOutputsDecisionModalProps = {
     /**
      * The decision being confirmed, or null when the modal is closed. A single nullable value
      * rather than an `isOpen` flag beside it: "open with no decision" is not a legal state, and
-     * spelling it that way is what stops it needing a guard.
+     * spelling it this way is what stops it needing a guard.
      */
     decision: OutputsDecision | null
     labName: string
@@ -22,6 +22,18 @@ type SubmitOutputsDecisionModalProps = {
     onConfirm: () => void
 }
 
+/**
+ * Stays mounted across open and close, and lets Mantine own both behaviours the AC asks for.
+ *
+ * Mantine renders modal content inside its exit Transition and unmounts it once the transition
+ * finishes (`keepMounted` defaults to false), so each open already mounts fresh copy: the body text
+ * cannot be a stale cached announcement. Returning null while closed would achieve the same thing,
+ * but it also unmounts ModalBase, and `useFocusReturn` lives in there, so focus would never return
+ * to the trigger on Escape, Cancel or X.
+ *
+ * The last non-null decision is retained only so the body does not blank out mid-animation while
+ * the modal fades away.
+ */
 export const SubmitOutputsDecisionModal: FC<SubmitOutputsDecisionModalProps> = ({
     decision,
     labName,
@@ -29,22 +41,20 @@ export const SubmitOutputsDecisionModal: FC<SubmitOutputsDecisionModalProps> = (
     onClose,
     onConfirm,
 }) => {
-    // Unmounting while closed is what keeps the body text honest: Mantine's Modal keeps its
-    // children mounted, so a cached body from the previously chosen option would be what a
-    // screen reader re-announces on the next open.
-    //
-    // The unmount also pre-empts Mantine's own focus-return effect, so the caller has to restore
-    // focus to the trigger itself; see closeAndRestoreFocus in outputs-review-panel.
-    if (!decision) return null
+    // Adjusted during render rather than in an effect (React's documented pattern for deriving
+    // state from a prop): it re-renders immediately with the new copy, before the browser paints,
+    // so the modal never shows the previous decision's text for a frame.
+    const [shown, setShown] = useState<OutputsDecision>(decision ?? 'share-outputs')
+    if (decision && decision !== shown) setShown(decision)
 
     return (
         <SubmitConfirmationModal
-            isOpen
+            isOpen={decision !== null}
             onClose={onClose}
             onConfirm={onConfirm}
             isSubmitting={isSubmitting}
             title="Submit your decision?"
-            body={confirmationBody(decision, labName)}
+            body={confirmationBody(shown, labName)}
             confirmLabel="Submit decision"
         />
     )

--- a/src/components/study/submit-outputs-decision-modal.tsx
+++ b/src/components/study/submit-outputs-decision-modal.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { FC } from 'react'
+import { SubmitConfirmationModal } from '@/components/modals/submit-confirmation-modal'
+import type { OutputsDecision } from '@/lib/outputs-review'
+
+export const confirmationBody = (decision: OutputsDecision, labName: string): string =>
+    decision === 'share-outputs'
+        ? `You are sharing the output files and your feedback with ${labName}. You will not be able to make changes after submitting.`
+        : `You are sharing your feedback only. The output files will not be shared with ${labName}. You will not be able to make changes after submitting.`
+
+type SubmitOutputsDecisionModalProps = {
+    /** null keeps the modal closed; submit only opens it once an option is picked. */
+    decision: OutputsDecision | null
+    labName: string
+    isOpen: boolean
+    isSubmitting: boolean
+    onClose: () => void
+    onConfirm: () => void
+}
+
+export const SubmitOutputsDecisionModal: FC<SubmitOutputsDecisionModalProps> = ({
+    decision,
+    labName,
+    isOpen,
+    isSubmitting,
+    onClose,
+    onConfirm,
+}) => {
+    // Unmounting while closed is what keeps the body text honest: Mantine's Modal keeps its
+    // children mounted, so a cached body from the previously chosen option would be what a
+    // screen reader re-announces on the next open.
+    if (!isOpen || !decision) return null
+
+    return (
+        <SubmitConfirmationModal
+            isOpen
+            onClose={onClose}
+            onConfirm={onConfirm}
+            isSubmitting={isSubmitting}
+            title="Submit your decision?"
+            body={confirmationBody(decision, labName)}
+            confirmLabel="Submit decision"
+        />
+    )
+}

--- a/src/components/study/use-security-key-form.ts
+++ b/src/components/study/use-security-key-form.ts
@@ -15,7 +15,7 @@ const ERRORS = {
 type UseSecurityKeyFormOptions = {
     job: LatestJobForStudy
     /**
-     * Handed the decrypted plaintext on a successful key. The caller owns it from here — the
+     * Handed the decrypted plaintext on a successful key. The caller owns it from here: the
      * files carry raw AES keys (see JobFileInfo) and must stay in memory, never persisted.
      */
     onDecrypted: (files: JobFileInfo[]) => void

--- a/src/components/study/use-security-key-form.ts
+++ b/src/components/study/use-security-key-form.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useQuery } from '@/common'
 import { useDecryptFiles } from '@/hooks/use-decrypt-files'
 import type { JobFileInfo } from '@/lib/types'
@@ -24,6 +24,8 @@ export function useSecurityKeyForm({ job, onDecrypted }: UseSecurityKeyFormOptio
     const [value, setValue] = useState('')
     const [error, setError] = useState<string>()
     const inputRef = useRef<HTMLTextAreaElement>(null)
+    // A key submitted while the artifact fetch was still in flight, replayed once it settles.
+    const pendingKeyRef = useRef<string | null>(null)
 
     const { data: encryptedFiles, isLoading: isLoadingFiles } = useQuery({
         queryKey: ['encrypted-files', job.id],
@@ -52,6 +54,23 @@ export function useSecurityKeyForm({ job, onDecrypted }: UseSecurityKeyFormOptio
         onError: failInvalid,
     })
 
+    const submit = useCallback(
+        (rawKey: string) => {
+            // No artifacts to test the key against: either the query failed, this reviewer has no
+            // registered public key, or the job has no encrypted output. None of those is a bad
+            // key, so say so rather than reporting the key as invalid.
+            if (!encryptedFiles?.length) {
+                setError(ERRORS.unavailable)
+                inputRef.current?.focus()
+                return
+            }
+
+            setError(undefined)
+            decrypt(rawKey)
+        },
+        [encryptedFiles, decrypt],
+    )
+
     const handleSubmit = useCallback(() => {
         if (isPending) return
 
@@ -62,20 +81,24 @@ export function useSecurityKeyForm({ job, onDecrypted }: UseSecurityKeyFormOptio
             return
         }
 
-        if (isLoadingFiles) return
-
-        // No artifacts to test the key against: either the query failed, this reviewer has no
-        // registered public key, or the job has no encrypted output. None of those is a bad key,
-        // so say so rather than reporting the key as invalid.
-        if (!encryptedFiles?.length) {
-            setError(ERRORS.unavailable)
-            inputRef.current?.focus()
+        // The artifact fetch starts on mount and normally finishes long before a PEM key has been
+        // pasted, but a click that lands first must not be dropped: remember it and let the effect
+        // below run it once the fetch settles. The button stays enabled either way (OTTER-667).
+        if (isLoadingFiles) {
+            pendingKeyRef.current = trimmed
             return
         }
 
-        setError(undefined)
-        decrypt(trimmed)
-    }, [isPending, isLoadingFiles, encryptedFiles, value, decrypt])
+        submit(trimmed)
+    }, [isPending, isLoadingFiles, value, submit])
+
+    useEffect(() => {
+        if (isLoadingFiles) return
+        const queued = pendingKeyRef.current
+        if (!queued) return
+        pendingKeyRef.current = null
+        submit(queued)
+    }, [isLoadingFiles, submit])
 
     return {
         value,

--- a/src/components/study/use-security-key-form.ts
+++ b/src/components/study/use-security-key-form.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from 'react'
 import { useQuery } from '@/common'
 import { useDecryptFiles } from '@/hooks/use-decrypt-files'
+import type { JobFileInfo } from '@/lib/types'
 import { fetchEncryptedJobFilesAction } from '@/server/actions/study-job.actions'
 import type { LatestJobForStudy } from '@/server/db/queries'
 
@@ -9,12 +10,18 @@ const ERRORS = {
     invalid: 'Invalid key. Check that you copied the full key and enter it again.',
 } as const
 
-const SUCCESS_MESSAGE = 'Security key accepted.'
+type UseSecurityKeyFormOptions = {
+    job: LatestJobForStudy
+    /**
+     * Handed the decrypted plaintext on a successful key. The caller owns it from here — the
+     * files carry raw AES keys (see JobFileInfo) and must stay in memory, never persisted.
+     */
+    onDecrypted: (files: JobFileInfo[]) => void
+}
 
-export function useSecurityKeyForm({ job }: { job: LatestJobForStudy }) {
+export function useSecurityKeyForm({ job, onDecrypted }: UseSecurityKeyFormOptions) {
     const [value, setValue] = useState('')
     const [error, setError] = useState<string>()
-    const [successMessage, setSuccessMessage] = useState<string>()
     const inputRef = useRef<HTMLTextAreaElement>(null)
 
     const { data: encryptedFiles, isLoading: isLoadingFiles } = useQuery({
@@ -24,13 +31,12 @@ export function useSecurityKeyForm({ job }: { job: LatestJobForStudy }) {
 
     const { decrypt, isPending } = useDecryptFiles({
         encryptedFiles,
-        onSuccess: () => {
+        onSuccess: (files) => {
             setError(undefined)
-            setSuccessMessage(SUCCESS_MESSAGE)
+            onDecrypted(files)
         },
         onError: () => {
             setError(ERRORS.invalid)
-            setSuccessMessage(undefined)
             requestAnimationFrame(() => inputRef.current?.focus())
         },
     })
@@ -41,7 +47,6 @@ export function useSecurityKeyForm({ job }: { job: LatestJobForStudy }) {
         const trimmed = value.trim()
         if (!trimmed) {
             setError(ERRORS.empty)
-            setSuccessMessage(undefined)
             inputRef.current?.focus()
             return
         }
@@ -49,7 +54,6 @@ export function useSecurityKeyForm({ job }: { job: LatestJobForStudy }) {
         if (isLoadingFiles) return
 
         setError(undefined)
-        setSuccessMessage(undefined)
         decrypt(trimmed)
     }, [isPending, isLoadingFiles, value, decrypt])
 
@@ -57,7 +61,6 @@ export function useSecurityKeyForm({ job }: { job: LatestJobForStudy }) {
         value,
         setValue,
         error,
-        successMessage,
         isDecrypting: isPending,
         inputRef,
         handleSubmit,

--- a/src/components/study/use-security-key-form.ts
+++ b/src/components/study/use-security-key-form.ts
@@ -8,6 +8,7 @@ import type { LatestJobForStudy } from '@/server/db/queries'
 const ERRORS = {
     empty: 'Enter your security key to decrypt the outputs.',
     invalid: 'Invalid key. Check that you copied the full key and enter it again.',
+    unavailable: 'These outputs are not available to decrypt. Contact your organization admin.',
 } as const
 
 type UseSecurityKeyFormOptions = {
@@ -29,16 +30,26 @@ export function useSecurityKeyForm({ job, onDecrypted }: UseSecurityKeyFormOptio
         queryFn: () => fetchEncryptedJobFilesAction({ jobId: job.id }),
     })
 
+    const failInvalid = useCallback(() => {
+        setError(ERRORS.invalid)
+        requestAnimationFrame(() => inputRef.current?.focus())
+    }, [])
+
     const { decrypt, isPending } = useDecryptFiles({
         encryptedFiles,
         onSuccess: (files) => {
+            // A key is only proven by ciphertext it actually opened. useDecryptFiles resolves with
+            // [] when there is nothing to decrypt, and its parse step accepts any syntactically
+            // valid PEM, so treating that as success would unlock the review view for any
+            // well-formed key and present an empty table as a reviewed state.
+            if (!files.length) {
+                failInvalid()
+                return
+            }
             setError(undefined)
             onDecrypted(files)
         },
-        onError: () => {
-            setError(ERRORS.invalid)
-            requestAnimationFrame(() => inputRef.current?.focus())
-        },
+        onError: failInvalid,
     })
 
     const handleSubmit = useCallback(() => {
@@ -53,9 +64,18 @@ export function useSecurityKeyForm({ job, onDecrypted }: UseSecurityKeyFormOptio
 
         if (isLoadingFiles) return
 
+        // No artifacts to test the key against: either the query failed, this reviewer has no
+        // registered public key, or the job has no encrypted output. None of those is a bad key,
+        // so say so rather than reporting the key as invalid.
+        if (!encryptedFiles?.length) {
+            setError(ERRORS.unavailable)
+            inputRef.current?.focus()
+            return
+        }
+
         setError(undefined)
         decrypt(trimmed)
-    }, [isPending, isLoadingFiles, value, decrypt])
+    }, [isPending, isLoadingFiles, encryptedFiles, value, decrypt])
 
     return {
         value,

--- a/src/components/word-counter.tsx
+++ b/src/components/word-counter.tsx
@@ -8,14 +8,17 @@ interface WordCounterProps {
     wordCount: number
     /** Maximum number of words allowed */
     maxWords: number
+    /** Appended after the count, e.g. "words". Omitted by default so existing call sites are unchanged. */
+    unit?: string
 }
 
-export const WordCounter: FC<WordCounterProps> = ({ wordCount, maxWords }) => {
+export const WordCounter: FC<WordCounterProps> = ({ wordCount, maxWords, unit }) => {
     const isOverLimit = wordCount > maxWords
 
     return (
         <Text size="xs" c={isOverLimit ? 'red' : 'dimmed'}>
             {wordCount}/{maxWords}
+            {unit ? ` ${unit}` : ''}
         </Text>
     )
 }

--- a/src/database/migrations/1780500000000_study_job_file_activity.ts
+++ b/src/database/migrations/1780500000000_study_job_file_activity.ts
@@ -1,0 +1,41 @@
+import { type Kysely, sql } from 'kysely'
+
+// OTTER-675: the reviewer's "Last activity" column on the outputs table. One row per
+// view/download of one decrypted output file, so the column can render
+// "{Reviewer} · {action} · {date}" for the most recent action on each file.
+//
+// Addressed by (study_job_file_id, file_path), following study_job_file_recipient_key: a
+// study_job_file row is the encrypted *archive*, and what the reviewer views or downloads is one
+// inner file within it. Keying on the archive alone would smear one file's activity across every
+// sibling extracted from the same zip.
+//
+// Rows are the audit of who looked at what, not a cache: "Download all" writes one row per
+// file rather than a single aggregate row, because the column reports per-file activity.
+export async function up(db: Kysely<unknown>): Promise<void> {
+    await db.schema.createType('study_job_file_action').asEnum(['VIEWED', 'DOWNLOADED']).execute()
+
+    await db.schema
+        .createTable('study_job_file_activity')
+        .addColumn('id', 'uuid', (col) => col.primaryKey().defaultTo(sql`v7uuid()`))
+        .addColumn('study_job_file_id', 'uuid', (col) =>
+            col.notNull().references('study_job_file.id').onDelete('cascade'),
+        )
+        .addColumn('file_path', 'text', (col) => col.notNull())
+        .addColumn('user_id', 'uuid', (col) => col.notNull().references('user.id').onDelete('cascade'))
+        .addColumn('action', sql`study_job_file_action`, (col) => col.notNull())
+        .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+        .execute()
+
+    // The read is always "latest activity for these files", so lead with the file identity and
+    // order the timestamp descending to let the planner walk the index backwards.
+    await db.schema
+        .createIndex('study_job_file_activity_file_created_idx')
+        .on('study_job_file_activity')
+        .columns(['study_job_file_id', 'file_path', 'created_at desc'])
+        .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+    await db.schema.dropTable('study_job_file_activity').ifExists().execute()
+    await db.schema.dropType('study_job_file_action').ifExists().execute()
+}

--- a/src/database/migrations/1780500000001_study_review_comment_results_kind.ts
+++ b/src/database/migrations/1780500000001_study_review_comment_results_kind.ts
@@ -1,0 +1,54 @@
+import { type Kysely, sql } from 'kysely'
+
+// OTTER-675: the Data Partner's decision on a job's OUTPUTS (share the files + feedback, or
+// share feedback only) is a third kind of review, alongside PROPOSAL and CODE. It carries the
+// same shape as a CODE decision — a job, a round, a decision, a Lexical body — so it reuses
+// study_review_comment rather than growing a parallel table. The existing
+// (study_job_id, review_kind, round) unique constraint then gives outputs decisions the same
+// one-per-round race guard code review relies on (OTTER-471).
+export async function up(db: Kysely<unknown>): Promise<void> {
+    await sql`alter type study_review_comment_kind add value 'RESULTS'`.execute(db)
+
+    // Mirrors study_review_comment_code_requires_job: an outputs decision is always about one
+    // job's files, so a NULL job id would silently escape the uniqueness constraint above.
+    // review_kind is cast to text because the value was added in this same transaction and
+    // Postgres rejects comparing it as the enum ("unsafe use of new value of enum type").
+    await sql`
+        ALTER TABLE study_review_comment
+            ADD CONSTRAINT study_review_comment_results_requires_job
+            CHECK (review_kind::text <> 'RESULTS' OR study_job_id IS NOT NULL)
+    `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+    await sql`
+        ALTER TABLE study_review_comment
+            DROP CONSTRAINT IF EXISTS study_review_comment_results_requires_job
+    `.execute(db)
+
+    // study_review_comment_code_requires_job compares review_kind against the enum literal
+    // 'CODE'. Retyping the column to text below would leave that check comparing text to the
+    // enum type ("operator does not exist"), so it comes off first and goes back on at the end.
+    await sql`
+        ALTER TABLE study_review_comment
+            DROP CONSTRAINT IF EXISTS study_review_comment_code_requires_job
+    `.execute(db)
+
+    await sql`DELETE FROM study_review_comment WHERE review_kind::text = 'RESULTS'`.execute(db)
+
+    // Postgres cannot drop a single enum value, so the type is rebuilt without it.
+    await sql`ALTER TABLE study_review_comment ALTER COLUMN review_kind TYPE text`.execute(db)
+    await sql`DROP TYPE study_review_comment_kind`.execute(db)
+    await sql`CREATE TYPE study_review_comment_kind AS ENUM ('PROPOSAL', 'CODE')`.execute(db)
+    await sql`
+        ALTER TABLE study_review_comment
+            ALTER COLUMN review_kind TYPE study_review_comment_kind
+            USING review_kind::study_review_comment_kind
+    `.execute(db)
+
+    await sql`
+        ALTER TABLE study_review_comment
+            ADD CONSTRAINT study_review_comment_code_requires_job
+            CHECK (review_kind <> 'CODE' OR study_job_id IS NOT NULL)
+    `.execute(db)
+}

--- a/src/database/migrations/1780500000001_study_review_comment_results_kind.ts
+++ b/src/database/migrations/1780500000001_study_review_comment_results_kind.ts
@@ -2,7 +2,7 @@ import { type Kysely, sql } from 'kysely'
 
 // OTTER-675: the Data Partner's decision on a job's OUTPUTS (share the files + feedback, or
 // share feedback only) is a third kind of review, alongside PROPOSAL and CODE. It carries the
-// same shape as a CODE decision — a job, a round, a decision, a Lexical body — so it reuses
+// same shape as a CODE decision (a job, a round, a decision, a Lexical body), so it reuses
 // study_review_comment rather than growing a parallel table. The existing
 // (study_job_id, review_kind, round) unique constraint then gives outputs decisions the same
 // one-per-round race guard code review relies on (OTTER-471).

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -43,6 +43,8 @@ export type ReviewDecision = 'APPROVE' | 'NEEDS-CLARIFICATION' | 'REJECT'
 
 export type ScanStatus = 'SCAN-COMPLETE' | 'SCAN-FAILED' | 'SCAN-PENDING' | 'SCAN-RUNNING'
 
+export type StudyJobFileAction = 'DOWNLOADED' | 'VIEWED'
+
 export type StudyJobFileType =
     | 'APPROVED-CODE-RUN-LOG'
     | 'APPROVED-PACKAGING-ERROR-LOG'
@@ -79,7 +81,7 @@ export type StudyProposalCommentEntryType = 'RESUBMISSION-NOTE' | 'REVIEWER-FEED
 
 export type StudyReviewCommentEntryType = 'DECISION' | 'NOTE'
 
-export type StudyReviewCommentKind = 'CODE' | 'PROPOSAL'
+export type StudyReviewCommentKind = 'CODE' | 'PROPOSAL' | 'RESULTS'
 
 export type StudyStatus = 'APPROVED' | 'ARCHIVED' | 'CHANGE-REQUESTED' | 'DRAFT' | 'PENDING-REVIEW' | 'REJECTED'
 
@@ -265,6 +267,15 @@ export interface StudyJobFile {
     studyJobId: string
 }
 
+export interface StudyJobFileActivity {
+    action: StudyJobFileAction
+    createdAt: Generated<Timestamp>
+    filePath: string
+    id: Generated<string>
+    studyJobFileId: string
+    userId: string
+}
+
 export interface StudyJobFileRecipientKey {
     createdAt: Generated<Timestamp>
     crypt: string
@@ -352,6 +363,7 @@ export interface DB {
     study: Study
     studyJob: StudyJob
     studyJobFile: StudyJobFile
+    studyJobFileActivity: StudyJobFileActivity
     studyJobFileRecipientKey: StudyJobFileRecipientKey
     studyProposalComment: StudyProposalComment
     studyReview: StudyReview

--- a/src/hooks/use-outputs-decision.ts
+++ b/src/hooks/use-outputs-decision.ts
@@ -1,0 +1,142 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import type { HocuspocusProvider } from '@hocuspocus/provider'
+import { useMutation, useQueryClient } from '@/common'
+import { reportMutationError } from '@/components/errors'
+import { DECISION_GROUP_ID, FEEDBACK_INPUT_ID } from '@/components/study/outputs-decision-section'
+import { useProviderSaveStatus } from '@/lib/realtime/use-provider-save-status'
+import { countWordsFromLexical } from '@/lib/lexical'
+import { focusFirstInvalid } from '@/lib/focus-first-invalid'
+import { buildSharedFiles } from '@/lib/re-wrap-results'
+import { Routes } from '@/lib/routes'
+import { actionResult } from '@/lib/utils'
+import { OUTPUTS_DECISION_ERRORS, OUTPUTS_FEEDBACK_MIN_WORDS, type OutputsDecision } from '@/lib/outputs-review'
+import type { JobFileInfo } from '@/lib/types'
+import { submitOutputsDecisionAction } from '@/server/actions/study-job.actions'
+
+type UseOutputsDecisionOptions = {
+    orgSlug: string
+    studyId: string
+    jobId: string
+    labName: string
+    maxWords: number
+    decryptedFiles: JobFileInfo[]
+}
+
+// Fields in visual/DOM order. The order IS the promise made to the user ("scroll to the first
+// flagged field, reading top to bottom"), so it lives next to the validation that consumes it.
+const FIELD_ORDER = [FEEDBACK_INPUT_ID, DECISION_GROUP_ID]
+
+export function useOutputsDecision({
+    orgSlug,
+    studyId,
+    jobId,
+    labName,
+    maxWords,
+    decryptedFiles,
+}: UseOutputsDecisionOptions) {
+    const router = useRouter()
+    const queryClient = useQueryClient()
+
+    const [feedback, setFeedback] = useState('')
+    const [selected, setSelected] = useState<OutputsDecision | null>(null)
+    const [provider, setProvider] = useState<HocuspocusProvider | null>(null)
+    // Errors surface only after the user has left a field or pressed Submit; a pristine form
+    // must not open with everything flagged red.
+    const [showFeedbackError, setShowFeedbackError] = useState(false)
+    const [showDecisionError, setShowDecisionError] = useState(false)
+    const [isOpen, setIsOpen] = useState(false)
+
+    const saveStatus = useProviderSaveStatus(provider)
+    const wordCount = countWordsFromLexical(feedback)
+    const isEmpty = wordCount < OUTPUTS_FEEDBACK_MIN_WORDS
+    const isOverLimit = wordCount > maxWords
+
+    // Over-limit is reported the moment it happens (the counter is already live, so a silent
+    // field would contradict it); emptiness waits for blur or a submit attempt.
+    const resolveFeedbackError = () => {
+        if (isOverLimit) return OUTPUTS_DECISION_ERRORS.feedbackTooLong(maxWords)
+        if (showFeedbackError && isEmpty) return OUTPUTS_DECISION_ERRORS.feedbackEmpty(labName)
+        return undefined
+    }
+
+    const feedbackError = resolveFeedbackError()
+    const decisionError = showDecisionError && selected === null ? OUTPUTS_DECISION_ERRORS.decisionMissing : undefined
+
+    const { mutate: submit, isPending } = useMutation({
+        mutationFn: async (decision: OutputsDecision) => {
+            // Only the sharing branch re-wraps: withholding the files means there is nothing to
+            // grant the lab access to, and buildSharedFiles would throw on a missing AES key.
+            const sharedFiles = decision === 'share-outputs' ? await buildSharedFiles(studyId, decryptedFiles) : []
+
+            return actionResult(
+                await submitOutputsDecisionAction({
+                    orgSlug,
+                    jobInfo: { studyId, studyJobId: jobId, orgSlug },
+                    decision,
+                    feedback,
+                    maxWords,
+                    sharedFiles,
+                }),
+            )
+        },
+        onError: reportMutationError('Failed to submit your decision'),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['org-studies', orgSlug] })
+            setIsOpen(false)
+            // The decision is recorded, so bare /review re-resolves through the reviewer state
+            // machine to the post-decision screen.
+            router.push(Routes.studyReview({ orgSlug, studyId }))
+        },
+    })
+
+    // Flags every problem at once rather than stopping at the first: the user should see the
+    // full set on one click, even though focus can only land on one of them.
+    const attemptSubmit = useCallback(() => {
+        setShowFeedbackError(true)
+        setShowDecisionError(true)
+
+        const invalid: Record<string, boolean> = {
+            [FEEDBACK_INPUT_ID]: isEmpty || isOverLimit,
+            [DECISION_GROUP_ID]: selected === null,
+        }
+
+        if (FIELD_ORDER.some((fieldId) => invalid[fieldId])) {
+            focusFirstInvalid(FIELD_ORDER, (fieldId) => invalid[fieldId])
+            return
+        }
+
+        setIsOpen(true)
+    }, [isEmpty, isOverLimit, selected])
+
+    const onSelect = useCallback((next: OutputsDecision) => {
+        setSelected(next)
+        setShowDecisionError(false)
+    }, [])
+
+    const confirmSubmit = useCallback(() => {
+        if (selected === null) return
+        submit(selected)
+    }, [selected, submit])
+
+    return {
+        feedback,
+        onFeedbackChange: setFeedback,
+        onFeedbackBlur: () => setShowFeedbackError(true),
+        onProviderReady: setProvider,
+        feedbackError,
+        wordCount,
+        saveStatus,
+        selected,
+        onSelect,
+        onDecisionBlur: () => setShowDecisionError(true),
+        decisionError,
+        isModalOpen: isOpen,
+        closeModal: () => setIsOpen(false),
+        attemptSubmit,
+        confirmSubmit,
+        isSubmitting: isPending,
+    }
+}

--- a/src/hooks/use-outputs-decision.ts
+++ b/src/hooks/use-outputs-decision.ts
@@ -44,7 +44,10 @@ export function useOutputsDecision({
     // must not open with everything flagged red.
     const [showFeedbackError, setShowFeedbackError] = useState(false)
     const [showDecisionError, setShowDecisionError] = useState(false)
-    const [isOpen, setIsOpen] = useState(false)
+    // The decision the confirmation modal is confirming; null means closed. One nullable value
+    // rather than an open flag beside the selection, so "open with nothing chosen" cannot be
+    // represented and needs no guard.
+    const [confirming, setConfirming] = useState<OutputsDecision | null>(null)
 
     const wordCount = countWordsFromLexical(feedback)
     const isEmpty = wordCount < OUTPUTS_FEEDBACK_MIN_WORDS
@@ -80,7 +83,7 @@ export function useOutputsDecision({
         onError: reportMutationError('Failed to submit your decision'),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['org-studies', orgSlug] })
-            setIsOpen(false)
+            setConfirming(null)
             // push() alone would be a no-op here: /review is already the current URL, so the
             // decrypted review form would stay mounted with plaintext on screen even though the
             // decision is final. refresh() is what re-runs the server components and lets the
@@ -91,7 +94,8 @@ export function useOutputsDecision({
     })
 
     // Flags every problem at once rather than stopping at the first: the user should see the
-    // full set on one click, even though focus can only land on one of them.
+    // full set on one click, even though focus can only land on one of them. focusFirstInvalid
+    // returns the field it moved to, so its own scan doubles as the "is anything invalid" test.
     const attemptSubmit = useCallback(() => {
         setShowFeedbackError(true)
         setShowDecisionError(true)
@@ -101,12 +105,9 @@ export function useOutputsDecision({
             [DECISION_GROUP_ID]: selected === null,
         }
 
-        if (FIELD_ORDER.some((fieldId) => invalid[fieldId])) {
-            focusFirstInvalid(FIELD_ORDER, (fieldId) => invalid[fieldId])
-            return
-        }
+        if (focusFirstInvalid(FIELD_ORDER, (fieldId) => invalid[fieldId])) return
 
-        setIsOpen(true)
+        setConfirming(selected)
     }, [isEmpty, isOverLimit, selected])
 
     const onSelect = useCallback((next: OutputsDecision) => {
@@ -114,10 +115,10 @@ export function useOutputsDecision({
         setShowDecisionError(false)
     }, [])
 
+    // No null guard needed: the modal only exists while `confirming` holds a decision.
     const confirmSubmit = useCallback(() => {
-        if (selected === null) return
-        submit(selected)
-    }, [selected, submit])
+        if (confirming) submit(confirming)
+    }, [confirming, submit])
 
     return {
         feedback,
@@ -129,8 +130,8 @@ export function useOutputsDecision({
         onSelect,
         onDecisionBlur: () => setShowDecisionError(true),
         decisionError,
-        isModalOpen: isOpen,
-        closeModal: () => setIsOpen(false),
+        confirming,
+        closeModal: () => setConfirming(null),
         attemptSubmit,
         confirmSubmit,
         isSubmitting: isPending,

--- a/src/hooks/use-outputs-decision.ts
+++ b/src/hooks/use-outputs-decision.ts
@@ -2,11 +2,9 @@
 
 import { useCallback, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import type { HocuspocusProvider } from '@hocuspocus/provider'
 import { useMutation, useQueryClient } from '@/common'
 import { reportMutationError } from '@/components/errors'
 import { DECISION_GROUP_ID, FEEDBACK_INPUT_ID } from '@/components/study/outputs-decision-section'
-import { useProviderSaveStatus } from '@/lib/realtime/use-provider-save-status'
 import { countWordsFromLexical } from '@/lib/lexical'
 import { focusFirstInvalid } from '@/lib/focus-first-invalid'
 import { buildSharedFiles } from '@/lib/re-wrap-results'
@@ -42,14 +40,12 @@ export function useOutputsDecision({
 
     const [feedback, setFeedback] = useState('')
     const [selected, setSelected] = useState<OutputsDecision | null>(null)
-    const [provider, setProvider] = useState<HocuspocusProvider | null>(null)
     // Errors surface only after the user has left a field or pressed Submit; a pristine form
     // must not open with everything flagged red.
     const [showFeedbackError, setShowFeedbackError] = useState(false)
     const [showDecisionError, setShowDecisionError] = useState(false)
     const [isOpen, setIsOpen] = useState(false)
 
-    const saveStatus = useProviderSaveStatus(provider)
     const wordCount = countWordsFromLexical(feedback)
     const isEmpty = wordCount < OUTPUTS_FEEDBACK_MIN_WORDS
     const isOverLimit = wordCount > maxWords
@@ -74,10 +70,9 @@ export function useOutputsDecision({
             return actionResult(
                 await submitOutputsDecisionAction({
                     orgSlug,
-                    jobInfo: { studyId, studyJobId: jobId, orgSlug },
+                    studyJobId: jobId,
                     decision,
                     feedback,
-                    maxWords,
                     sharedFiles,
                 }),
             )
@@ -86,9 +81,12 @@ export function useOutputsDecision({
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['org-studies', orgSlug] })
             setIsOpen(false)
-            // The decision is recorded, so bare /review re-resolves through the reviewer state
-            // machine to the post-decision screen.
+            // push() alone would be a no-op here: /review is already the current URL, so the
+            // decrypted review form would stay mounted with plaintext on screen even though the
+            // decision is final. refresh() is what re-runs the server components and lets the
+            // reviewer screen rules resolve to the post-decision screen.
             router.push(Routes.studyReview({ orgSlug, studyId }))
+            router.refresh()
         },
     })
 
@@ -125,10 +123,8 @@ export function useOutputsDecision({
         feedback,
         onFeedbackChange: setFeedback,
         onFeedbackBlur: () => setShowFeedbackError(true),
-        onProviderReady: setProvider,
         feedbackError,
         wordCount,
-        saveStatus,
         selected,
         onSelect,
         onDecisionBlur: () => setShowDecisionError(true),

--- a/src/hooks/use-outputs-files.ts
+++ b/src/hooks/use-outputs-files.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useMemo, useState } from 'react'
+import { captureException } from '@sentry/nextjs'
 import { useMutation, useQuery, useQueryClient } from '@/common'
 import { reportMutationError } from '@/components/errors'
 import type { OutputFileRowData } from '@/components/study/outputs-file-row'
@@ -49,7 +50,11 @@ export function useOutputsFiles({ jobId, decryptedFiles }: UseOutputsFilesOption
                     action: variables.action,
                 }),
             ),
-        onError: reportMutationError('Failed to record file activity'),
+        // Deliberately not surfaced to the user. This is an audit side effect of an action that
+        // already succeeded: the file was viewed or downloaded either way, so a toast reading
+        // "Failed to record file activity" would report a failure the reviewer cannot act on and
+        // did not cause. Sentry still sees it.
+        onError: (error) => captureException(error),
         // Refetch rather than optimistically patch: the row shows the actor's name and the
         // server's timestamp, neither of which the client can produce accurately.
         onSettled: () => queryClient.invalidateQueries({ queryKey: activityQueryKey(jobId) }),
@@ -84,7 +89,15 @@ export function useOutputsFiles({ jobId, decryptedFiles }: UseOutputsFilesOption
         [recordActivity],
     )
 
-    // "Download all" counts as a download of every file, so each row's Last activity updates —
+    // The reused preview modal carries its own download link, which does the transfer itself. Log
+    // it anyway, or a reviewer who opens a file and downloads it from there would keep showing as
+    // having only "Viewed" it.
+    const onViewerDownload = useCallback(() => {
+        if (!viewing) return
+        recordActivity({ files: [viewing], action: 'DOWNLOADED' })
+    }, [viewing, recordActivity])
+
+    // "Download all" counts as a download of every file, so each row's Last activity updates,
     // not just one aggregate row.
     const onDownloadAll = useCallback(async () => {
         if (!rows.length) return
@@ -93,6 +106,11 @@ export function useOutputsFiles({ jobId, decryptedFiles }: UseOutputsFilesOption
             const blob = await zipFiles(rows.map((row) => ({ name: row.name, contents: row.contents })))
             downloadBlob('outputs.zip', blob)
             recordActivity({ files: rows, action: 'DOWNLOADED' })
+        } catch (error) {
+            // Zipping happens in the browser over in-memory plaintext; a failure here (out of
+            // memory on a large result set) would otherwise surface as an unhandled rejection from
+            // the click handler and leave the user with no feedback at all.
+            reportMutationError('Failed to prepare the download')(error as Error)
         } finally {
             setIsPreparingZip(false)
         }
@@ -105,6 +123,7 @@ export function useOutputsFiles({ jobId, decryptedFiles }: UseOutputsFilesOption
         isPreparingZip,
         onView,
         onDownload,
+        onViewerDownload,
         onDownloadAll,
     }
 }

--- a/src/hooks/use-outputs-files.ts
+++ b/src/hooks/use-outputs-files.ts
@@ -1,0 +1,110 @@
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@/common'
+import { reportMutationError } from '@/components/errors'
+import type { OutputFileRowData } from '@/components/study/outputs-file-row'
+import { downloadBlob } from '@/lib/download-blob'
+import { zipFiles } from '@/lib/zip-files'
+import type { JobFileInfo } from '@/lib/types'
+import { actionResult } from '@/lib/utils'
+import {
+    fetchJobFileActivityAction,
+    recordJobFileActivityAction,
+} from '@/server/actions/study-job-file-activity.actions'
+import type { StudyJobFileAction } from '@/database/types'
+
+const activityQueryKey = (jobId: string) => ['job-file-activity', jobId]
+
+const rowKey = (file: JobFileInfo) => `${file.sourceId}:${file.path}`
+
+// The inner path can carry directories ("results/summary.csv"); the table shows the leaf, which
+// is what the reviewer recognizes.
+const displayName = (path: string) => path.split('/').pop() || path
+
+type UseOutputsFilesOptions = {
+    jobId: string
+    decryptedFiles: JobFileInfo[]
+}
+
+export function useOutputsFiles({ jobId, decryptedFiles }: UseOutputsFilesOptions) {
+    const queryClient = useQueryClient()
+    const [viewing, setViewing] = useState<OutputFileRowData | null>(null)
+    const [isPreparingZip, setIsPreparingZip] = useState(false)
+
+    const { data: activity } = useQuery({
+        queryKey: activityQueryKey(jobId),
+        queryFn: () => fetchJobFileActivityAction({ jobId }),
+    })
+
+    const { mutate: recordActivity } = useMutation({
+        mutationFn: async (variables: { files: OutputFileRowData[]; action: StudyJobFileAction }) =>
+            actionResult(
+                await recordJobFileActivityAction({
+                    jobId,
+                    files: variables.files.map((file) => ({
+                        studyJobFileId: file.studyJobFileId,
+                        filePath: file.filePath,
+                    })),
+                    action: variables.action,
+                }),
+            ),
+        onError: reportMutationError('Failed to record file activity'),
+        // Refetch rather than optimistically patch: the row shows the actor's name and the
+        // server's timestamp, neither of which the client can produce accurately.
+        onSettled: () => queryClient.invalidateQueries({ queryKey: activityQueryKey(jobId) }),
+    })
+
+    const rows = useMemo<OutputFileRowData[]>(() => {
+        const activityRows = Array.isArray(activity) ? activity : []
+        return decryptedFiles.map((file) => ({
+            key: rowKey(file),
+            studyJobFileId: file.sourceId,
+            filePath: file.path,
+            name: displayName(file.path),
+            contents: file.contents,
+            activity:
+                activityRows.find((row) => row.studyJobFileId === file.sourceId && row.filePath === file.path) ?? null,
+        }))
+    }, [decryptedFiles, activity])
+
+    const onView = useCallback(
+        (row: OutputFileRowData) => {
+            setViewing(row)
+            recordActivity({ files: [row], action: 'VIEWED' })
+        },
+        [recordActivity],
+    )
+
+    const onDownload = useCallback(
+        (row: OutputFileRowData) => {
+            downloadBlob(row.name, new Blob([row.contents]))
+            recordActivity({ files: [row], action: 'DOWNLOADED' })
+        },
+        [recordActivity],
+    )
+
+    // "Download all" counts as a download of every file, so each row's Last activity updates —
+    // not just one aggregate row.
+    const onDownloadAll = useCallback(async () => {
+        if (!rows.length) return
+        setIsPreparingZip(true)
+        try {
+            const blob = await zipFiles(rows.map((row) => ({ name: row.name, contents: row.contents })))
+            downloadBlob('outputs.zip', blob)
+            recordActivity({ files: rows, action: 'DOWNLOADED' })
+        } finally {
+            setIsPreparingZip(false)
+        }
+    }, [rows, recordActivity])
+
+    return {
+        rows,
+        viewing,
+        closeViewer: () => setViewing(null),
+        isPreparingZip,
+        onView,
+        onDownload,
+        onDownloadAll,
+    }
+}

--- a/src/hooks/use-outputs-files.ts
+++ b/src/hooks/use-outputs-files.ts
@@ -33,7 +33,7 @@ export function useOutputsFiles({ jobId, decryptedFiles }: UseOutputsFilesOption
     const [viewing, setViewing] = useState<OutputFileRowData | null>(null)
     const [isPreparingZip, setIsPreparingZip] = useState(false)
 
-    const { data: activity } = useQuery({
+    const { data: activity, isSuccess: isActivityLoaded } = useQuery({
         queryKey: activityQueryKey(jobId),
         queryFn: () => fetchJobFileActivityAction({ jobId }),
     })
@@ -68,10 +68,14 @@ export function useOutputsFiles({ jobId, decryptedFiles }: UseOutputsFilesOption
             filePath: file.path,
             name: displayName(file.path),
             contents: file.contents,
+            // Distinguishes "asked, nothing came back" from "haven't asked yet". Without it, a
+            // pending or failed query renders as a confident "No activity yet" on every row, which
+            // is a false statement about who has accessed the outputs.
+            isActivityKnown: isActivityLoaded,
             activity:
                 activityRows.find((row) => row.studyJobFileId === file.sourceId && row.filePath === file.path) ?? null,
         }))
-    }, [decryptedFiles, activity])
+    }, [decryptedFiles, activity, isActivityLoaded])
 
     const onView = useCallback(
         (row: OutputFileRowData) => {

--- a/src/lib/collaboration-documents.test.ts
+++ b/src/lib/collaboration-documents.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
     codeReviewFeedbackDocName,
+    outputsReviewFeedbackDocName,
     parseDocumentName,
     proposalFieldsDocName,
     proposalResubmissionNoteDocNameForVersion,
@@ -77,6 +78,27 @@ describe('collaboration document naming', () => {
         expect(parseDocumentName(name)).toEqual({ kind: 'code-review-feedback', jobId: JOB_ID })
     })
 
+    it('round-trips outputs-review-feedback docs', () => {
+        const JOB_ID = '01949c1a-1aaa-7000-9000-0000000000ff'
+        const name = outputsReviewFeedbackDocName(JOB_ID)
+        expect(name).toBe(`outputs-review-feedback-${JOB_ID}`)
+        expect(parseDocumentName(name)).toEqual({ kind: 'outputs-review-feedback', jobId: JOB_ID })
+    })
+
+    // Both job-keyed feedback prefixes end in "review-feedback-", so a prefix check in the wrong
+    // order would mis-parse one as the other.
+    it('keeps the two job-keyed feedback prefixes distinct', () => {
+        const JOB_ID = '01949c1a-1aaa-7000-9000-0000000000ff'
+        expect(parseDocumentName(outputsReviewFeedbackDocName(JOB_ID))).toEqual({
+            kind: 'outputs-review-feedback',
+            jobId: JOB_ID,
+        })
+        expect(parseDocumentName(codeReviewFeedbackDocName(JOB_ID))).toEqual({
+            kind: 'code-review-feedback',
+            jobId: JOB_ID,
+        })
+    })
+
     it('rejects malformed names', () => {
         expect(parseDocumentName('')).toBeNull()
         expect(parseDocumentName('proposal-not-a-uuid-fields')).toBeNull()
@@ -85,5 +107,6 @@ describe('collaboration document naming', () => {
         expect(parseDocumentName(`unknown-${STUDY_ID}`)).toBeNull()
         expect(parseDocumentName(`review-feedback-not-a-uuid`)).toBeNull()
         expect(parseDocumentName(`code-review-feedback-not-a-uuid`)).toBeNull()
+        expect(parseDocumentName(`outputs-review-feedback-not-a-uuid`)).toBeNull()
     })
 })

--- a/src/lib/collaboration-documents.ts
+++ b/src/lib/collaboration-documents.ts
@@ -9,6 +9,7 @@ const PROPOSAL_TEXT_FIELD_KEYS: ProposalTextFieldKey[] = [
 
 export const REVIEW_FEEDBACK_PREFIX = 'review-feedback-'
 export const CODE_REVIEW_FEEDBACK_PREFIX = 'code-review-feedback-'
+export const OUTPUTS_REVIEW_FEEDBACK_PREFIX = 'outputs-review-feedback-'
 export const PROPOSAL_PREFIX = 'proposal-'
 export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -57,14 +58,28 @@ export const RESUBMISSION_NOTE_SUFFIX_RE = /^resubmission-note-v([1-9]\d*)$/
 
 export const codeReviewFeedbackDocName = (jobId: string) => `${CODE_REVIEW_FEEDBACK_PREFIX}${jobId}`
 
+/**
+ * The DO's outputs-review feedback for one job (OTTER-675). Job-keyed like code-review
+ * feedback rather than study-keyed: a study's outputs are reviewed once per job, and keying
+ * on the job keeps a later round's editor in a different Yjs room from this one's.
+ */
+export const outputsReviewFeedbackDocName = (jobId: string) => `${OUTPUTS_REVIEW_FEEDBACK_PREFIX}${jobId}`
+
 export type ParsedDocumentName =
     | { kind: 'proposal-fields'; studyId: string }
     | { kind: 'proposal-text'; studyId: string; fieldKey: ProposalTextFieldKey }
     | { kind: 'proposal-resubmission-note'; studyId: string; version: number }
     | { kind: 'review-feedback'; studyId: string; version: number }
     | { kind: 'code-review-feedback'; jobId: string }
+    | { kind: 'outputs-review-feedback'; jobId: string }
 
 export const parseDocumentName = (name: string): ParsedDocumentName | null => {
+    if (name.startsWith(OUTPUTS_REVIEW_FEEDBACK_PREFIX)) {
+        const jobId = name.slice(OUTPUTS_REVIEW_FEEDBACK_PREFIX.length)
+        if (!UUID_RE.test(jobId)) return null
+        return { kind: 'outputs-review-feedback', jobId }
+    }
+
     // The longer prefix must be checked first; otherwise the review-feedback
     // branch would match a `code-review-feedback-<uuid>` doc and mis-parse it.
     if (name.startsWith(CODE_REVIEW_FEEDBACK_PREFIX)) {

--- a/src/lib/download-blob.ts
+++ b/src/lib/download-blob.ts
@@ -2,7 +2,7 @@
  * Triggers a browser download for in-memory bytes.
  *
  * A programmatic download rather than a `<a download>` element because the click has to do two
- * things at once — record the internal "downloaded" event and hand over the file — and an anchor
+ * things at once, record the internal "downloaded" event and hand over the file, and an anchor
  * only does the second.
  *
  * The object URL is revoked on the next tick: revoking synchronously races the browser's own

--- a/src/lib/download-blob.ts
+++ b/src/lib/download-blob.ts
@@ -1,0 +1,20 @@
+/**
+ * Triggers a browser download for in-memory bytes.
+ *
+ * A programmatic download rather than a `<a download>` element because the click has to do two
+ * things at once — record the internal "downloaded" event and hand over the file — and an anchor
+ * only does the second.
+ *
+ * The object URL is revoked on the next tick: revoking synchronously races the browser's own
+ * fetch of the blob, and holding it forever leaves plaintext output reachable from a stale URL.
+ */
+export function downloadBlob(fileName: string, blob: Blob): void {
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = fileName
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+    setTimeout(() => URL.revokeObjectURL(url), 0)
+}

--- a/src/lib/focus-first-invalid.test.ts
+++ b/src/lib/focus-first-invalid.test.ts
@@ -38,4 +38,37 @@ describe('focusFirstInvalid', () => {
     it('reports the field even when it is not in the DOM', () => {
         expect(focusFirstInvalid(['missing'], () => true)).toBe('missing')
     })
+
+    // A Mantine Radio.Group puts the field id on a plain <div>. Calling focus() on that is a
+    // silent no-op, which would leave the user on the submit button with nothing indicating which
+    // field failed, so the helper descends to the first focusable control inside.
+    it('focuses the first focusable control when the id sits on a non-focusable wrapper', () => {
+        const wrapper = document.createElement('div')
+        wrapper.id = 'radio-group'
+        wrapper.scrollIntoView = vi.fn()
+        const label = document.createElement('label')
+        const radio = document.createElement('input')
+        radio.type = 'radio'
+        label.appendChild(radio)
+        wrapper.appendChild(label)
+        document.body.appendChild(wrapper)
+
+        expect(focusFirstInvalid(['radio-group'], () => true)).toBe('radio-group')
+        expect(document.activeElement).toBe(radio)
+    })
+
+    it('skips disabled controls inside a wrapper', () => {
+        const wrapper = document.createElement('div')
+        wrapper.id = 'group-with-disabled'
+        wrapper.scrollIntoView = vi.fn()
+        const disabled = document.createElement('input')
+        disabled.disabled = true
+        const enabled = document.createElement('input')
+        wrapper.append(disabled, enabled)
+        document.body.appendChild(wrapper)
+
+        focusFirstInvalid(['group-with-disabled'], () => true)
+
+        expect(document.activeElement).toBe(enabled)
+    })
 })

--- a/src/lib/focus-first-invalid.test.ts
+++ b/src/lib/focus-first-invalid.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from '@/tests/unit.helpers'
+import { focusFirstInvalid } from './focus-first-invalid'
+
+const addField = (id: string) => {
+    const node = document.createElement('input')
+    node.id = id
+    node.scrollIntoView = vi.fn()
+    document.body.appendChild(node)
+    return node
+}
+
+describe('focusFirstInvalid', () => {
+    it('returns null and focuses nothing when every field is valid', () => {
+        addField('a')
+        expect(focusFirstInvalid(['a'], () => false)).toBeNull()
+        expect(document.activeElement?.id).not.toBe('a')
+    })
+
+    // The array order is the contract: the user was promised the first flagged field reading
+    // top to bottom, so a later-but-listed-first field must not win.
+    it('focuses the first invalid field in the given order, not the first invalid found in the DOM', () => {
+        const first = addField('first')
+        addField('second')
+
+        expect(focusFirstInvalid(['first', 'second'], () => true)).toBe('first')
+        expect(document.activeElement).toBe(first)
+        expect(first.scrollIntoView).toHaveBeenCalled()
+    })
+
+    it('skips valid fields to reach the invalid one', () => {
+        addField('valid')
+        const invalid = addField('invalid')
+
+        expect(focusFirstInvalid(['valid', 'invalid'], (id) => id === 'invalid')).toBe('invalid')
+        expect(document.activeElement).toBe(invalid)
+    })
+
+    it('reports the field even when it is not in the DOM', () => {
+        expect(focusFirstInvalid(['missing'], () => true)).toBe('missing')
+    })
+})

--- a/src/lib/focus-first-invalid.test.ts
+++ b/src/lib/focus-first-invalid.test.ts
@@ -35,6 +35,9 @@ describe('focusFirstInvalid', () => {
         expect(document.activeElement).toBe(invalid)
     })
 
+    // Returns the field name so callers can still report it, but focuses nothing. A component whose
+    // id never reaches the DOM lands here and loses the focus jump entirely, which is why
+    // OutputsDecisionSection anchors its radio group on an element it owns.
     it('reports the field even when it is not in the DOM', () => {
         expect(focusFirstInvalid(['missing'], () => true)).toBe('missing')
     })

--- a/src/lib/focus-first-invalid.ts
+++ b/src/lib/focus-first-invalid.ts
@@ -1,0 +1,21 @@
+/**
+ * Scrolls to and focuses the first invalid field, reading the page top to bottom.
+ *
+ * `fieldIds` must be in visual/DOM order — that ordering IS the "first" the caller promises the
+ * user, and nothing else in the DOM recovers it (a Lexical contenteditable and a radio group
+ * share no common wrapper to compare positions against).
+ *
+ * Focus, not just scroll: a highlighted field the caret never reaches leaves a screen-reader
+ * user with no idea which control failed.
+ */
+export function focusFirstInvalid(fieldIds: string[], hasError: (fieldId: string) => boolean): string | null {
+    const target = fieldIds.find(hasError)
+    if (!target) return null
+
+    const node = typeof document === 'undefined' ? null : document.getElementById(target)
+    if (!node) return target
+
+    node.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    node.focus({ preventScroll: true })
+    return target
+}

--- a/src/lib/focus-first-invalid.ts
+++ b/src/lib/focus-first-invalid.ts
@@ -1,7 +1,7 @@
 /**
  * Scrolls to and focuses the first invalid field, reading the page top to bottom.
  *
- * `fieldIds` must be in visual/DOM order — that ordering IS the "first" the caller promises the
+ * `fieldIds` must be in visual/DOM order, because that ordering IS the "first" the caller promises the
  * user, and nothing else in the DOM recovers it (a Lexical contenteditable and a radio group
  * share no common wrapper to compare positions against).
  *

--- a/src/lib/focus-first-invalid.ts
+++ b/src/lib/focus-first-invalid.ts
@@ -16,6 +16,22 @@ export function focusFirstInvalid(fieldIds: string[], hasError: (fieldId: string
     if (!node) return target
 
     node.scrollIntoView({ block: 'center', behavior: 'smooth' })
-    node.focus({ preventScroll: true })
+    focusable(node).focus({ preventScroll: true })
     return target
+}
+
+/**
+ * The element to actually put the caret on.
+ *
+ * A field's id may sit on a wrapper rather than a control: a Mantine `Radio.Group` renders its id
+ * on a non-focusable `<div>`, so calling focus() on it silently does nothing and leaves the user on
+ * the submit button with no idea which field failed. Descend to the first focusable descendant in
+ * that case.
+ */
+function focusable(node: HTMLElement): HTMLElement {
+    if (node.tabIndex >= 0) return node
+    const inner = node.querySelector<HTMLElement>(
+        'input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [contenteditable="true"], [tabindex]:not([tabindex="-1"])',
+    )
+    return inner ?? node
 }

--- a/src/lib/lexical.ts
+++ b/src/lib/lexical.ts
@@ -80,6 +80,29 @@ export function isValidLexicalState(json: string | undefined): boolean {
 /**
  * Create Lexical JSON from plain text (for testing)
  */
+/**
+ * Accepts either a serialized Lexical state or raw text and returns Lexical JSON plus its word
+ * count. Editor-backed fields post Lexical JSON; plain-text callers (and tests) post a string.
+ */
+export function normalizeFeedbackToLexical(raw: string): { json: string; wordCount: number } {
+    let parsed: unknown
+    try {
+        parsed = JSON.parse(raw)
+    } catch {
+        parsed = null
+    }
+
+    // Loose check: non-Lexical JSON that passes will yield 0 words and fail min-word validation.
+    const looksLikeLexicalRoot =
+        parsed != null &&
+        typeof parsed === 'object' &&
+        'root' in (parsed as Record<string, unknown>) &&
+        typeof (parsed as { root: unknown }).root === 'object'
+
+    const json = looksLikeLexicalRoot ? raw : lexicalJson(raw)
+    return { json, wordCount: countWordsFromLexical(json) }
+}
+
 export function lexicalJson(text: string): string {
     return JSON.stringify({
         root: {

--- a/src/lib/outputs-review.test.ts
+++ b/src/lib/outputs-review.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from '@/tests/unit.helpers'
+import {
+    COMPLETED_OUTPUTS_FEEDBACK_MAX_WORDS,
+    ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS,
+    OUTPUTS_DECISION_ERRORS,
+    OUTPUTS_DECISIONS,
+    OUTPUTS_FILE_NAME_MAX_LENGTH,
+    toOutputsReviewDecision,
+} from './outputs-review'
+
+describe('outputs review decisions', () => {
+    it('maps sharing the outputs to an approval', () => {
+        expect(toOutputsReviewDecision('share-outputs')).toBe('APPROVE')
+    })
+
+    // Not REJECT: withholding the files asks the lab to revise and resubmit, whereas REJECT is
+    // the terminal decision that ends a study.
+    it('maps feedback-only to a clarification request, not a rejection', () => {
+        expect(toOutputsReviewDecision('share-feedback-only')).toBe('NEEDS-CLARIFICATION')
+    })
+
+    it('offers exactly two mutually exclusive decisions', () => {
+        expect(OUTPUTS_DECISIONS).toEqual(['share-outputs', 'share-feedback-only'])
+    })
+
+    it('caps errored-run feedback at 300 words and completed-run feedback higher', () => {
+        expect(ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS).toBe(300)
+        expect(COMPLETED_OUTPUTS_FEEDBACK_MAX_WORDS).toBe(1500)
+    })
+
+    it('truncates file names at 50 characters', () => {
+        expect(OUTPUTS_FILE_NAME_MAX_LENGTH).toBe(50)
+    })
+
+    it('names the lab in the empty-feedback error and the cap in the too-long error', () => {
+        expect(OUTPUTS_DECISION_ERRORS.feedbackEmpty('Rice Lab')).toBe(
+            'Enter your feedback for Rice Lab before submitting.',
+        )
+        expect(OUTPUTS_DECISION_ERRORS.feedbackTooLong(300)).toBe(
+            'Feedback exceeds the 300 word limit. Shorten it to continue.',
+        )
+        expect(OUTPUTS_DECISION_ERRORS.decisionMissing).toBe('Select an option before submitting')
+    })
+})

--- a/src/lib/outputs-review.ts
+++ b/src/lib/outputs-review.ts
@@ -1,4 +1,5 @@
 import type { ReviewDecision, StudyJobStatus } from '@/database/types'
+import { ROUND_CLOSING_JOB_STATUSES } from '@/lib/study-job-status'
 
 // OTTER-675: the Data Partner's decision on a job's decrypted outputs.
 export type OutputsDecision = 'share-outputs' | 'share-feedback-only'
@@ -6,7 +7,7 @@ export type OutputsDecision = 'share-outputs' | 'share-feedback-only'
 export const OUTPUTS_DECISIONS: readonly OutputsDecision[] = ['share-outputs', 'share-feedback-only']
 
 // Sharing the files is an approval of the outputs; withholding them asks the lab to revise the
-// code, which is NEEDS-CLARIFICATION, not REJECT — reject is the terminal "this study is over"
+// code, which is NEEDS-CLARIFICATION, not REJECT. Reject is the terminal "this study is over"
 // decision and the copy explicitly invites a resubmission ("so {lab} can revise the code").
 const OUTPUTS_DECISION_TO_REVIEW: Record<OutputsDecision, ReviewDecision> = {
     'share-outputs': 'APPROVE',
@@ -25,13 +26,15 @@ export const OUTPUTS_FEEDBACK_MIN_WORDS = 1
 export const ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS = 300
 export const COMPLETED_OUTPUTS_FEEDBACK_MAX_WORDS = 1500
 
-/** Job statuses whose outputs a reviewer may decide on: the run reached a terminal result. */
+/**
+ * Job statuses whose outputs a reviewer may decide on: the run reached a terminal result but no
+ * decision has closed it yet. This is STUDY_RESULTS_JOB_STATUSES minus the round-closing pair,
+ * spelled out because the two-element list reads clearer than the subtraction.
+ */
 export const OUTPUTS_REVIEWABLE_JOB_STATUSES: readonly StudyJobStatus[] = ['JOB-ERRORED', 'RUN-COMPLETE']
 
-const DECIDED_STATUSES: readonly StudyJobStatus[] = ['FILES-APPROVED', 'FILES-REJECTED']
-
-// These three read a job's status history, which arrives from queries whose select shape widens
-// the status type, so they take plain strings and compare against the typed constants above.
+// These read a job's status history, which arrives from queries whose select shape widens the
+// status type, so they take plain strings and compare against the typed constants above.
 const includesStatus = (jobStatuses: readonly string[], wanted: readonly StudyJobStatus[]) =>
     jobStatuses.some((status) => (wanted as readonly string[]).includes(status))
 
@@ -39,9 +42,13 @@ const includesStatus = (jobStatuses: readonly string[], wanted: readonly StudyJo
 export const hasReviewableOutputs = (jobStatuses: readonly string[]): boolean =>
     includesStatus(jobStatuses, OUTPUTS_REVIEWABLE_JOB_STATUSES)
 
-/** Whether a files decision has already been recorded, making this job's outcome final. */
+/**
+ * Whether a files decision has already been recorded, making this job's outcome final. Reuses
+ * ROUND_CLOSING_JOB_STATUSES rather than restating the pair: closing the round and deciding the
+ * files are the same event, so a second copy of the list could only drift.
+ */
 export const hasOutputsDecision = (jobStatuses: readonly string[]): boolean =>
-    includesStatus(jobStatuses, DECIDED_STATUSES)
+    includesStatus(jobStatuses, ROUND_CLOSING_JOB_STATUSES)
 
 /**
  * The authoritative cap for a job, derived from its own status history rather than taken from the

--- a/src/lib/outputs-review.ts
+++ b/src/lib/outputs-review.ts
@@ -1,4 +1,4 @@
-import type { ReviewDecision } from '@/database/types'
+import type { ReviewDecision, StudyJobStatus } from '@/database/types'
 
 // OTTER-675: the Data Partner's decision on a job's decrypted outputs.
 export type OutputsDecision = 'share-outputs' | 'share-feedback-only'
@@ -24,6 +24,36 @@ export const OUTPUTS_FEEDBACK_MIN_WORDS = 1
  */
 export const ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS = 300
 export const COMPLETED_OUTPUTS_FEEDBACK_MAX_WORDS = 1500
+
+/** Job statuses whose outputs a reviewer may decide on: the run reached a terminal result. */
+export const OUTPUTS_REVIEWABLE_JOB_STATUSES: readonly StudyJobStatus[] = ['JOB-ERRORED', 'RUN-COMPLETE']
+
+const DECIDED_STATUSES: readonly StudyJobStatus[] = ['FILES-APPROVED', 'FILES-REJECTED']
+
+// These three read a job's status history, which arrives from queries whose select shape widens
+// the status type, so they take plain strings and compare against the typed constants above.
+const includesStatus = (jobStatuses: readonly string[], wanted: readonly StudyJobStatus[]) =>
+    jobStatuses.some((status) => (wanted as readonly string[]).includes(status))
+
+/** Whether the run has reached a terminal result, so its outputs can be decided on at all. */
+export const hasReviewableOutputs = (jobStatuses: readonly string[]): boolean =>
+    includesStatus(jobStatuses, OUTPUTS_REVIEWABLE_JOB_STATUSES)
+
+/** Whether a files decision has already been recorded, making this job's outcome final. */
+export const hasOutputsDecision = (jobStatuses: readonly string[]): boolean =>
+    includesStatus(jobStatuses, DECIDED_STATUSES)
+
+/**
+ * The authoritative cap for a job, derived from its own status history rather than taken from the
+ * request. An errored run is capped shorter than a completed one; JOB-ERRORED wins when both
+ * statuses are present, matching the screen rules, which keep an errored run on the errored view
+ * even after a RUN-COMPLETE also landed.
+ */
+export function outputsFeedbackMaxWords(jobStatuses: readonly string[]): number {
+    return jobStatuses.includes('JOB-ERRORED')
+        ? ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS
+        : COMPLETED_OUTPUTS_FEEDBACK_MAX_WORDS
+}
 
 // File names are truncated in the table so a long name cannot push the other columns off screen.
 export const OUTPUTS_FILE_NAME_MAX_LENGTH = 50

--- a/src/lib/outputs-review.ts
+++ b/src/lib/outputs-review.ts
@@ -1,0 +1,35 @@
+import type { ReviewDecision } from '@/database/types'
+
+// OTTER-675: the Data Partner's decision on a job's decrypted outputs.
+export type OutputsDecision = 'share-outputs' | 'share-feedback-only'
+
+export const OUTPUTS_DECISIONS: readonly OutputsDecision[] = ['share-outputs', 'share-feedback-only']
+
+// Sharing the files is an approval of the outputs; withholding them asks the lab to revise the
+// code, which is NEEDS-CLARIFICATION, not REJECT — reject is the terminal "this study is over"
+// decision and the copy explicitly invites a resubmission ("so {lab} can revise the code").
+const OUTPUTS_DECISION_TO_REVIEW: Record<OutputsDecision, ReviewDecision> = {
+    'share-outputs': 'APPROVE',
+    'share-feedback-only': 'NEEDS-CLARIFICATION',
+}
+
+export const toOutputsReviewDecision = (decision: OutputsDecision): ReviewDecision =>
+    OUTPUTS_DECISION_TO_REVIEW[decision]
+
+export const OUTPUTS_FEEDBACK_MIN_WORDS = 1
+
+/**
+ * Feedback length caps, keyed by the run outcome being reviewed. An errored run gets the shorter
+ * cap because the reviewer is explaining a failure, not summarizing results.
+ */
+export const ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS = 300
+export const COMPLETED_OUTPUTS_FEEDBACK_MAX_WORDS = 1500
+
+// File names are truncated in the table so a long name cannot push the other columns off screen.
+export const OUTPUTS_FILE_NAME_MAX_LENGTH = 50
+
+export const OUTPUTS_DECISION_ERRORS = {
+    feedbackEmpty: (labName: string) => `Enter your feedback for ${labName} before submitting.`,
+    feedbackTooLong: (maxWords: number) => `Feedback exceeds the ${maxWords} word limit. Shorten it to continue.`,
+    decisionMissing: 'Select an option before submitting',
+} as const

--- a/src/lib/zip-files.test.ts
+++ b/src/lib/zip-files.test.ts
@@ -1,0 +1,43 @@
+import { BlobReader, ZipReader } from '@zip.js/zip.js'
+import { describe, expect, it } from '@/tests/unit.helpers'
+import { zipFiles } from './zip-files'
+
+const toArrayBuffer = (text: string): ArrayBuffer => {
+    const buf = Buffer.from(text, 'utf-8')
+    return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+}
+
+const entryNames = async (blob: Blob): Promise<string[]> => {
+    const reader = new ZipReader(new BlobReader(blob))
+    const entries = await reader.getEntries()
+    await reader.close()
+    return entries.map((entry) => entry.filename)
+}
+
+describe('zipFiles', () => {
+    it('bundles every file into one archive', async () => {
+        const blob = await zipFiles([
+            { name: 'run.log', contents: toArrayBuffer('started') },
+            { name: 'results.csv', contents: toArrayBuffer('a,b\n1,2') },
+        ])
+
+        expect(await entryNames(blob)).toEqual(['run.log', 'results.csv'])
+    })
+
+    // Two artifacts can legitimately carry the same inner path (the same log re-delivered across
+    // job attempts); duplicate zip entries extract unpredictably, so the later one is renamed.
+    it('de-duplicates repeated names instead of writing colliding entries', async () => {
+        const blob = await zipFiles([
+            { name: 'run.log', contents: toArrayBuffer('first') },
+            { name: 'run.log', contents: toArrayBuffer('second') },
+            { name: 'notes', contents: toArrayBuffer('third') },
+            { name: 'notes', contents: toArrayBuffer('fourth') },
+        ])
+
+        expect(await entryNames(blob)).toEqual(['run.log', 'run (1).log', 'notes', 'notes (1)'])
+    })
+
+    it('produces an empty archive for no files', async () => {
+        expect(await entryNames(await zipFiles([]))).toEqual([])
+    })
+})

--- a/src/lib/zip-files.ts
+++ b/src/lib/zip-files.ts
@@ -9,7 +9,7 @@ export type ZippableFile = {
  * Bundles decrypted output files into a single zip, in the browser.
  *
  * SECURITY: the inputs are plaintext. The archive is built client-side and handed straight to a
- * blob URL — it must never be uploaded, and the caller should revoke the URL once the download
+ * blob URL. It must never be uploaded, and the caller should revoke the URL once the download
  * starts so the plaintext isn't reachable from a stale object URL.
  *
  * Names are de-duplicated because the table can legitimately show two artifacts with the same

--- a/src/lib/zip-files.ts
+++ b/src/lib/zip-files.ts
@@ -1,0 +1,39 @@
+import { BlobWriter, Uint8ArrayReader, ZipWriter } from '@zip.js/zip.js'
+
+export type ZippableFile = {
+    name: string
+    contents: ArrayBuffer
+}
+
+/**
+ * Bundles decrypted output files into a single zip, in the browser.
+ *
+ * SECURITY: the inputs are plaintext. The archive is built client-side and handed straight to a
+ * blob URL — it must never be uploaded, and the caller should revoke the URL once the download
+ * starts so the plaintext isn't reachable from a stale object URL.
+ *
+ * Names are de-duplicated because the table can legitimately show two artifacts with the same
+ * inner path (e.g. the same log re-delivered across job attempts), and a zip with duplicate
+ * entries extracts unpredictably.
+ */
+export async function zipFiles(files: ZippableFile[]): Promise<Blob> {
+    const writer = new ZipWriter(new BlobWriter('application/zip'))
+    const used = new Map<string, number>()
+
+    for (const file of files) {
+        const seen = used.get(file.name) ?? 0
+        used.set(file.name, seen + 1)
+        await writer.add(
+            seen === 0 ? file.name : suffixName(file.name, seen),
+            new Uint8ArrayReader(new Uint8Array(file.contents)),
+        )
+    }
+
+    return await writer.close()
+}
+
+function suffixName(name: string, index: number): string {
+    const dot = name.lastIndexOf('.')
+    if (dot <= 0) return `${name} (${index})`
+    return `${name.slice(0, dot)} (${index})${name.slice(dot)}`
+}

--- a/src/server/actions/study-job-file-activity.actions.test.ts
+++ b/src/server/actions/study-job-file-activity.actions.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from 'vitest'
+import { actionResult, db, insertTestStudyJobData, mockSessionWithTestData } from '@/tests/unit.helpers'
+import { fetchJobFileActivityAction, recordJobFileActivityAction } from './study-job-file-activity.actions'
+
+const insertArchive = async (jobId: string, name = 'encrypted-logs.zip') =>
+    await db
+        .insertInto('studyJobFile')
+        .values({ studyJobId: jobId, name, path: `results/${name}`, fileType: 'ENCRYPTED-CODE-RUN-LOG' })
+        .returning('id')
+        .executeTakeFirstOrThrow()
+
+const setup = async () => {
+    const session = await mockSessionWithTestData({ orgType: 'enclave' })
+    const { job } = await insertTestStudyJobData({ org: session.org, jobStatus: 'JOB-ERRORED' })
+    const archive = await insertArchive(job.id)
+    return { ...session, job, archive }
+}
+
+describe('recordJobFileActivityAction', () => {
+    test('records a view against one inner file', async () => {
+        const { job, archive, user } = await setup()
+
+        actionResult(
+            await recordJobFileActivityAction({
+                jobId: job.id,
+                files: [{ studyJobFileId: archive.id, filePath: 'run.log' }],
+                action: 'VIEWED',
+            }),
+        )
+
+        const rows = await db
+            .selectFrom('studyJobFileActivity')
+            .selectAll('studyJobFileActivity')
+            .where('studyJobFileId', '=', archive.id)
+            .execute()
+        expect(rows).toHaveLength(1)
+        expect(rows[0]).toMatchObject({ action: 'VIEWED', filePath: 'run.log', userId: user.id })
+    })
+
+    // "Download all" is one round trip that has to land on every file, because the column reports
+    // per-file activity rather than a single aggregate event.
+    test('records one row per file for a bulk download', async () => {
+        const { job, archive } = await setup()
+
+        actionResult(
+            await recordJobFileActivityAction({
+                jobId: job.id,
+                files: [
+                    { studyJobFileId: archive.id, filePath: 'run.log' },
+                    { studyJobFileId: archive.id, filePath: 'results.csv' },
+                ],
+                action: 'DOWNLOADED',
+            }),
+        )
+
+        const rows = await db
+            .selectFrom('studyJobFileActivity')
+            .selectAll('studyJobFileActivity')
+            .where('studyJobFileId', '=', archive.id)
+            .execute()
+        expect(rows).toHaveLength(2)
+        expect(rows.map((r) => r.filePath).sort()).toEqual(['results.csv', 'run.log'])
+        expect(rows.every((r) => r.action === 'DOWNLOADED')).toBe(true)
+    })
+
+    // A forged id must not be able to attach activity to another study's file.
+    test('ignores archives that belong to a different job', async () => {
+        const { job, org } = await setup()
+        const { job: otherJob } = await insertTestStudyJobData({ org, jobStatus: 'JOB-ERRORED' })
+        const foreignArchive = await insertArchive(otherJob.id, 'other.zip')
+
+        actionResult(
+            await recordJobFileActivityAction({
+                jobId: job.id,
+                files: [{ studyJobFileId: foreignArchive.id, filePath: 'run.log' }],
+                action: 'VIEWED',
+            }),
+        )
+
+        const rows = await db
+            .selectFrom('studyJobFileActivity')
+            .selectAll('studyJobFileActivity')
+            .where('studyJobFileId', '=', foreignArchive.id)
+            .execute()
+        expect(rows).toHaveLength(0)
+    })
+
+    test('permission denied for an unrelated org', async () => {
+        const { job, archive } = await setup()
+        await mockSessionWithTestData({ orgSlug: 'unrelated-org', orgType: 'lab' })
+
+        const result = await recordJobFileActivityAction({
+            jobId: job.id,
+            files: [{ studyJobFileId: archive.id, filePath: 'run.log' }],
+            action: 'VIEWED',
+        })
+
+        expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+    })
+})
+
+describe('fetchJobFileActivityAction', () => {
+    test('returns nothing before any activity', async () => {
+        const { job } = await setup()
+
+        expect(actionResult(await fetchJobFileActivityAction({ jobId: job.id }))).toEqual([])
+    })
+
+    test('returns the actor name alongside the action', async () => {
+        const { job, archive, user } = await setup()
+
+        actionResult(
+            await recordJobFileActivityAction({
+                jobId: job.id,
+                files: [{ studyJobFileId: archive.id, filePath: 'run.log' }],
+                action: 'DOWNLOADED',
+            }),
+        )
+
+        const activity = actionResult(await fetchJobFileActivityAction({ jobId: job.id }))
+        expect(activity).toHaveLength(1)
+        expect(activity[0]).toMatchObject({
+            studyJobFileId: archive.id,
+            filePath: 'run.log',
+            action: 'DOWNLOADED',
+        })
+        const dbUser = await db
+            .selectFrom('user')
+            .select('fullName')
+            .where('id', '=', user.id)
+            .executeTakeFirstOrThrow()
+        expect(activity[0].actorName).toBe(dbUser.fullName)
+    })
+
+    // The column shows the latest action, not a history, so a later event must replace the
+    // earlier one rather than stacking beside it.
+    test('collapses each file to its most recent action', async () => {
+        const { job, archive } = await setup()
+
+        actionResult(
+            await recordJobFileActivityAction({
+                jobId: job.id,
+                files: [{ studyJobFileId: archive.id, filePath: 'run.log' }],
+                action: 'VIEWED',
+            }),
+        )
+        actionResult(
+            await recordJobFileActivityAction({
+                jobId: job.id,
+                files: [{ studyJobFileId: archive.id, filePath: 'run.log' }],
+                action: 'DOWNLOADED',
+            }),
+        )
+
+        const activity = actionResult(await fetchJobFileActivityAction({ jobId: job.id }))
+        expect(activity).toHaveLength(1)
+        expect(activity[0].action).toBe('DOWNLOADED')
+    })
+
+    test('keeps activity separate per inner file of the same archive', async () => {
+        const { job, archive } = await setup()
+
+        actionResult(
+            await recordJobFileActivityAction({
+                jobId: job.id,
+                files: [{ studyJobFileId: archive.id, filePath: 'run.log' }],
+                action: 'VIEWED',
+            }),
+        )
+
+        const activity = actionResult(await fetchJobFileActivityAction({ jobId: job.id }))
+        expect(activity).toHaveLength(1)
+        expect(activity[0].filePath).toBe('run.log')
+    })
+})

--- a/src/server/actions/study-job-file-activity.actions.ts
+++ b/src/server/actions/study-job-file-activity.actions.ts
@@ -1,0 +1,65 @@
+'use server'
+
+import { getStudyJobInfo, latestActivityPerJobFile } from '@/server/db/queries'
+import { Action, z } from './action'
+
+// One decrypted output file: the archive row it was extracted from, plus its inner path.
+const jobFileRefSchema = z.object({ studyJobFileId: z.string(), filePath: z.string() })
+
+const jobFileActivitySchema = z.object({
+    jobId: z.string(),
+    // A "Download all" click records the same action against every file in one round trip, so
+    // this is a list rather than a single value.
+    files: z.array(jobFileRefSchema).min(1),
+    action: z.enum(['VIEWED', 'DOWNLOADED']),
+})
+
+// OTTER-675: internal events behind the outputs table's "Last activity" column. Writing is
+// gated on 'view StudyJob' rather than an approve/reject ability: looking at a file is exactly
+// what a viewer is allowed to do, and the row records that it happened.
+export const recordJobFileActivityAction = new Action('recordJobFileActivityAction', { performsMutations: true })
+    .params(jobFileActivitySchema)
+    .middleware(async ({ params: { jobId } }) => {
+        const studyJob = await getStudyJobInfo(jobId)
+        return { studyJob, orgId: studyJob.orgId, submittedByOrgId: studyJob.submittedByOrgId, status: studyJob.status }
+    })
+    .requireAbilityTo('view', 'StudyJob')
+    .handler(async ({ params: { jobId, files, action }, session, db }) => {
+        // Scope the insert to archives that really belong to this job, so a forged id cannot
+        // attach activity to another study's file.
+        const ownArchives = await db
+            .selectFrom('studyJobFile')
+            .select('id')
+            .where('studyJobId', '=', jobId)
+            .where(
+                'id',
+                'in',
+                files.map((file) => file.studyJobFileId),
+            )
+            .execute()
+
+        const ownIds = new Set(ownArchives.map((archive) => archive.id))
+        const rows = files
+            .filter((file) => ownIds.has(file.studyJobFileId))
+            .map((file) => ({
+                studyJobFileId: file.studyJobFileId,
+                filePath: file.filePath,
+                userId: session.user.id,
+                action,
+            }))
+
+        if (!rows.length) return
+
+        await db.insertInto('studyJobFileActivity').values(rows).execute()
+    })
+
+export const fetchJobFileActivityAction = new Action('fetchJobFileActivityAction')
+    .params(z.object({ jobId: z.string() }))
+    .middleware(async ({ params: { jobId } }) => {
+        const studyJob = await getStudyJobInfo(jobId)
+        return { studyJob, orgId: studyJob.orgId, submittedByOrgId: studyJob.submittedByOrgId, status: studyJob.status }
+    })
+    .requireAbilityTo('view', 'StudyJob')
+    .handler(async ({ params: { jobId } }) => {
+        return await latestActivityPerJobFile(jobId)
+    })

--- a/src/server/actions/study-job.actions.test.ts
+++ b/src/server/actions/study-job.actions.test.ts
@@ -206,7 +206,6 @@ describe('Study Job Actions', () => {
             const { job, study } = await insertTestStudyJobData({ org, jobStatus: 'RUN-COMPLETE' })
 
             await rejectStudyJobFilesAction({
-                studyId: study.id,
                 studyJobId: job.id,
                 orgSlug: org.slug,
             })
@@ -236,7 +235,7 @@ describe('Study Job Actions', () => {
             actionResult(
                 await approveStudyJobFilesAction({
                     orgSlug: enclave.slug,
-                    jobInfo: { studyId: study.id, studyJobId: job.id, orgSlug: enclave.slug },
+                    studyJobId: job.id,
                     sharedFiles,
                 }),
             )
@@ -271,10 +270,9 @@ describe('Study Job Actions', () => {
 
         test('permission denied for non-enclave user', async () => {
             const { org } = await mockSessionWithTestData({ orgType: 'lab' })
-            const { job, study } = await insertTestStudyJobData({ org, jobStatus: 'RUN-COMPLETE' })
+            const { job } = await insertTestStudyJobData({ org, jobStatus: 'RUN-COMPLETE' })
 
             const result = await rejectStudyJobFilesAction({
-                studyId: study.id,
                 studyJobId: job.id,
                 orgSlug: org.slug,
             })
@@ -456,8 +454,8 @@ describe('Study Job Actions', () => {
             expect(await resultsComment(study.id)).toBeUndefined()
         })
 
-        // Approving is a promise that the lab gets the files, so a request carrying no re-wrapped
-        // keys must not be able to record FILES-APPROVED.
+        // Approving promises the lab can open the files, so these three shapes must all be refused
+        // rather than recorded as an approval nobody can act on.
         test('refuses to approve while sharing no files', async () => {
             const { enclave, job, study } = await setupResultApprovalFixture()
 
@@ -467,6 +465,52 @@ describe('Study Job Actions', () => {
                 decision: 'share-outputs',
                 feedback: 'Looks fine.',
                 sharedFiles: [],
+            })
+
+            expect(result).toEqual({ error: expect.objectContaining({ files: expect.any(String) }) })
+            expect((await jobStatuses(job.id)).map((s) => s.status)).not.toContain('FILES-APPROVED')
+            expect(await resultsComment(study.id)).toBeUndefined()
+        })
+
+        // This is what buildSharedFiles produces when the lab has no registered public key, so it
+        // happens without anyone acting in bad faith: entries exist but wrap no keys, and
+        // insertSharedFileKeys would write nothing and return silently.
+        test('refuses to approve when the entries carry no usable keys', async () => {
+            const { enclave, file, job, study } = await setupResultApprovalFixture()
+
+            const result = await submitOutputsDecisionAction({
+                orgSlug: enclave.slug,
+                studyJobId: job.id,
+                decision: 'share-outputs',
+                feedback: 'Looks fine.',
+                sharedFiles: [{ studyJobFileId: file.id, filePath: 'results.csv', keys: [] }],
+            })
+
+            expect(result).toEqual({ error: expect.objectContaining({ files: expect.any(String) }) })
+            expect((await jobStatuses(job.id)).map((s) => s.status)).not.toContain('FILES-APPROVED')
+            expect(await resultsComment(study.id)).toBeUndefined()
+        })
+
+        test('refuses to approve when an artifact is left out', async () => {
+            const { enclave, job, study, sharedFiles } = await setupResultApprovalFixture()
+
+            // A second encrypted artifact nobody prepared keys for.
+            await db
+                .insertInto('studyJobFile')
+                .values({
+                    path: 'results/encrypted-logs.zip',
+                    name: 'encrypted-logs.zip',
+                    studyJobId: job.id,
+                    fileType: 'ENCRYPTED-CODE-RUN-LOG',
+                })
+                .executeTakeFirstOrThrow()
+
+            const result = await submitOutputsDecisionAction({
+                orgSlug: enclave.slug,
+                studyJobId: job.id,
+                decision: 'share-outputs',
+                feedback: 'Sharing only part of it.',
+                sharedFiles,
             })
 
             expect(result).toEqual({ error: expect.objectContaining({ files: expect.any(String) }) })

--- a/src/server/actions/study-job.actions.test.ts
+++ b/src/server/actions/study-job.actions.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, vi, type Mock } from 'vitest'
+import type { StudyJobStatus } from '@/database/types'
 import {
     actionResult,
     buildFeedback,
@@ -12,7 +13,7 @@ import {
     setTestStudyStatus,
 } from '@/tests/unit.helpers'
 import { outputsReviewFeedbackDocName } from '@/lib/collaboration-documents'
-import { ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS } from '@/lib/outputs-review'
+import { COMPLETED_OUTPUTS_FEEDBACK_MAX_WORDS, ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS } from '@/lib/outputs-review'
 import {
     approveStudyJobFilesAction,
     fetchEncryptedJobFilesAction,
@@ -48,7 +49,7 @@ vi.mock('@/server/events', async (importOriginal) => ({
     onStudyReviewRequested: vi.fn(),
 }))
 
-async function setupResultApprovalFixture() {
+async function setupResultApprovalFixture({ jobStatus = 'RUN-COMPLETE' as StudyJobStatus } = {}) {
     const { user: reviewer, org: enclave } = await mockSessionWithTestData({ orgType: 'enclave' })
     const lab = await insertTestOrg({ slug: 'otter-635-lab', type: 'lab' })
     const { user: researcher } = await insertTestUser({ org: lab })
@@ -62,7 +63,7 @@ async function setupResultApprovalFixture() {
     const { job, study } = await insertTestStudyJobData({
         org: enclave,
         researcherId: researcher.id,
-        jobStatus: 'RUN-COMPLETE',
+        jobStatus,
     })
     await db.updateTable('study').set({ submittedByOrgId: lab.id }).where('id', '=', study.id).execute()
     const file = await db
@@ -302,10 +303,9 @@ describe('Study Job Actions', () => {
             actionResult(
                 await submitOutputsDecisionAction({
                     orgSlug: enclave.slug,
-                    jobInfo: { studyId: study.id, studyJobId: job.id, orgSlug: enclave.slug },
+                    studyJobId: job.id,
                     decision: 'share-outputs',
                     feedback: 'The outputs look clean and contain no PII.',
-                    maxWords: ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS,
                     sharedFiles,
                 }),
             )
@@ -335,10 +335,9 @@ describe('Study Job Actions', () => {
             actionResult(
                 await submitOutputsDecisionAction({
                     orgSlug: enclave.slug,
-                    jobInfo: { studyId: study.id, studyJobId: job.id, orgSlug: enclave.slug },
+                    studyJobId: job.id,
                     decision: 'share-feedback-only',
                     feedback: 'The log leaks a participant identifier, please remove it.',
-                    maxWords: ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS,
                     sharedFiles: [],
                 }),
             )
@@ -359,10 +358,9 @@ describe('Study Job Actions', () => {
 
             const result = await submitOutputsDecisionAction({
                 orgSlug: enclave.slug,
-                jobInfo: { studyId: study.id, studyJobId: job.id, orgSlug: enclave.slug },
+                studyJobId: job.id,
                 decision: 'share-outputs',
                 feedback: '   ',
-                maxWords: ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS,
                 sharedFiles: [],
             })
 
@@ -371,15 +369,50 @@ describe('Study Job Actions', () => {
             expect(await resultsComment(study.id)).toBeUndefined()
         })
 
-        test('rejects feedback over the cap', async () => {
-            const { enclave, job, study } = await setupResultApprovalFixture()
+        // The cap is derived from the job's own status, never from the request, so a caller cannot
+        // raise its own limit. These two tests are the pair that proves it: the same word count is
+        // rejected for an errored run and accepted for a completed one.
+        test('applies the 300-word errored cap regardless of what the caller asks for', async () => {
+            const { enclave, job, study } = await setupResultApprovalFixture({ jobStatus: 'JOB-ERRORED' })
 
             const result = await submitOutputsDecisionAction({
                 orgSlug: enclave.slug,
-                jobInfo: { studyId: study.id, studyJobId: job.id, orgSlug: enclave.slug },
+                studyJobId: job.id,
                 decision: 'share-feedback-only',
                 feedback: buildFeedback(ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS + 1),
-                maxWords: ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS,
+                sharedFiles: [],
+            })
+
+            expect(result).toEqual({ error: expect.objectContaining({ feedback: expect.any(String) }) })
+            expect((await jobStatuses(job.id)).map((s) => s.status)).not.toContain('FILES-REJECTED')
+            expect(await resultsComment(study.id)).toBeUndefined()
+        })
+
+        test('allows the same length on a completed run, which carries the higher cap', async () => {
+            const { enclave, job, study } = await setupResultApprovalFixture()
+
+            actionResult(
+                await submitOutputsDecisionAction({
+                    orgSlug: enclave.slug,
+                    studyJobId: job.id,
+                    decision: 'share-feedback-only',
+                    feedback: buildFeedback(ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS + 1),
+                    sharedFiles: [],
+                }),
+            )
+
+            expect((await jobStatuses(job.id)).map((s) => s.status)).toContain('FILES-REJECTED')
+            expect(await resultsComment(study.id)).toBeDefined()
+        })
+
+        test('rejects feedback over the completed cap', async () => {
+            const { enclave, job } = await setupResultApprovalFixture()
+
+            const result = await submitOutputsDecisionAction({
+                orgSlug: enclave.slug,
+                studyJobId: job.id,
+                decision: 'share-feedback-only',
+                feedback: buildFeedback(COMPLETED_OUTPUTS_FEEDBACK_MAX_WORDS + 1),
                 sharedFiles: [],
             })
 
@@ -387,16 +420,69 @@ describe('Study Job Actions', () => {
             expect((await jobStatuses(job.id)).map((s) => s.status)).not.toContain('FILES-REJECTED')
         })
 
+        // The study is derived from the job, so naming a job in an org the caller cannot review is
+        // refused. Trusting a caller-supplied studyId alongside the job id would let a reviewer
+        // authorized for their own study finalize someone else's.
+        test('permission denied when the job belongs to another org', async () => {
+            const { job } = await setupResultApprovalFixture()
+            const { org: otherEnclave } = await mockSessionWithTestData({ orgType: 'enclave' })
+
+            const result = await submitOutputsDecisionAction({
+                orgSlug: otherEnclave.slug,
+                studyJobId: job.id,
+                decision: 'share-feedback-only',
+                feedback: 'Not my study.',
+                sharedFiles: [],
+            })
+
+            expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+            expect((await jobStatuses(job.id)).map((s) => s.status)).not.toContain('FILES-REJECTED')
+        })
+
+        // UI routing is not a server-side invariant: a direct caller must not be able to finalize a
+        // job that never produced outputs.
+        test('refuses a job that has not reached a terminal result', async () => {
+            const { enclave, job, study } = await setupResultApprovalFixture({ jobStatus: 'JOB-RUNNING' })
+
+            const result = await submitOutputsDecisionAction({
+                orgSlug: enclave.slug,
+                studyJobId: job.id,
+                decision: 'share-feedback-only',
+                feedback: 'Too early to decide.',
+                sharedFiles: [],
+            })
+
+            expect(result).toEqual({ error: expect.objectContaining({ study: expect.stringContaining('no outputs') }) })
+            expect(await resultsComment(study.id)).toBeUndefined()
+        })
+
+        // Approving is a promise that the lab gets the files, so a request carrying no re-wrapped
+        // keys must not be able to record FILES-APPROVED.
+        test('refuses to approve while sharing no files', async () => {
+            const { enclave, job, study } = await setupResultApprovalFixture()
+
+            const result = await submitOutputsDecisionAction({
+                orgSlug: enclave.slug,
+                studyJobId: job.id,
+                decision: 'share-outputs',
+                feedback: 'Looks fine.',
+                sharedFiles: [],
+            })
+
+            expect(result).toEqual({ error: expect.objectContaining({ files: expect.any(String) }) })
+            expect((await jobStatuses(job.id)).map((s) => s.status)).not.toContain('FILES-APPROVED')
+            expect(await resultsComment(study.id)).toBeUndefined()
+        })
+
         // The (studyJobId, reviewKind, round) unique constraint is the race-loser guard; the
         // second reviewer must get a readable message, not a raw duplicate-key error.
         test('refuses a second decision on the same outputs', async () => {
-            const { enclave, job, study, sharedFiles } = await setupResultApprovalFixture()
+            const { enclave, job, sharedFiles } = await setupResultApprovalFixture()
             const params = {
                 orgSlug: enclave.slug,
-                jobInfo: { studyId: study.id, studyJobId: job.id, orgSlug: enclave.slug },
+                studyJobId: job.id,
                 decision: 'share-outputs' as const,
                 feedback: 'Looks good to share.',
-                maxWords: ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS,
                 sharedFiles,
             }
 
@@ -417,10 +503,9 @@ describe('Study Job Actions', () => {
             actionResult(
                 await submitOutputsDecisionAction({
                     orgSlug: enclave.slug,
-                    jobInfo: { studyId: study.id, studyJobId: job.id, orgSlug: enclave.slug },
+                    studyJobId: job.id,
                     decision: 'share-outputs',
                     feedback: 'Ready to share.',
-                    maxWords: ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS,
                     sharedFiles,
                 }),
             )
@@ -435,14 +520,13 @@ describe('Study Job Actions', () => {
 
         test('permission denied for a lab user', async () => {
             const { org } = await mockSessionWithTestData({ orgType: 'lab' })
-            const { job, study } = await insertTestStudyJobData({ org, jobStatus: 'JOB-ERRORED' })
+            const { job } = await insertTestStudyJobData({ org, jobStatus: 'JOB-ERRORED' })
 
             const result = await submitOutputsDecisionAction({
                 orgSlug: org.slug,
-                jobInfo: { studyId: study.id, studyJobId: job.id, orgSlug: org.slug },
+                studyJobId: job.id,
                 decision: 'share-feedback-only',
                 feedback: 'Not allowed.',
-                maxWords: ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS,
                 sharedFiles: [],
             })
 

--- a/src/server/actions/study-job.actions.test.ts
+++ b/src/server/actions/study-job.actions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi, type Mock } from 'vitest'
 import {
     actionResult,
+    buildFeedback,
     db,
     insertTestOrg,
     insertTestStudyJobData,
@@ -10,6 +11,8 @@ import {
     createTestProposalDraft,
     setTestStudyStatus,
 } from '@/tests/unit.helpers'
+import { outputsReviewFeedbackDocName } from '@/lib/collaboration-documents'
+import { ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS } from '@/lib/outputs-review'
 import {
     approveStudyJobFilesAction,
     fetchEncryptedJobFilesAction,
@@ -17,6 +20,7 @@ import {
     loadStudyJobAction,
     regenerateStudyReviewAction,
     rejectStudyJobFilesAction,
+    submitOutputsDecisionAction,
 } from './study-job.actions'
 import { sendStudyResultsRejectedEmail } from '@/server/mailer'
 import { onStudyReviewRequested } from '@/server/events'
@@ -272,6 +276,174 @@ describe('Study Job Actions', () => {
                 studyId: study.id,
                 studyJobId: job.id,
                 orgSlug: org.slug,
+            })
+
+            expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+        })
+    })
+
+    // OTTER-675: the DP's single decision on decrypted outputs. Feedback and the files status are
+    // written together, so each test asserts both halves.
+    describe('submitOutputsDecisionAction', () => {
+        const jobStatuses = (jobId: string) =>
+            db.selectFrom('jobStatusChange').select('status').where('studyJobId', '=', jobId).execute()
+
+        const resultsComment = (studyId: string) =>
+            db
+                .selectFrom('studyReviewComment')
+                .selectAll('studyReviewComment')
+                .where('studyId', '=', studyId)
+                .where('reviewKind', '=', 'RESULTS')
+                .executeTakeFirst()
+
+        test('sharing the outputs approves the files, records the keys and stores the feedback', async () => {
+            const { enclave, file, job, reviewer, sharedFiles, study } = await setupResultApprovalFixture()
+
+            actionResult(
+                await submitOutputsDecisionAction({
+                    orgSlug: enclave.slug,
+                    jobInfo: { studyId: study.id, studyJobId: job.id, orgSlug: enclave.slug },
+                    decision: 'share-outputs',
+                    feedback: 'The outputs look clean and contain no PII.',
+                    maxWords: ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS,
+                    sharedFiles,
+                }),
+            )
+
+            expect((await jobStatuses(job.id)).map((s) => s.status)).toContain('FILES-APPROVED')
+
+            const comment = await resultsComment(study.id)
+            expect(comment).toMatchObject({
+                decision: 'APPROVE',
+                entryType: 'DECISION',
+                studyJobId: job.id,
+                authorId: reviewer.id,
+            })
+            expect(JSON.stringify(comment!.body)).toContain('The outputs look clean and contain no PII.')
+
+            const keys = await db
+                .selectFrom('studyJobFileRecipientKey')
+                .selectAll('studyJobFileRecipientKey')
+                .where('studyJobFileId', '=', file.id)
+                .execute()
+            expect(keys).toHaveLength(1)
+        })
+
+        test('sharing feedback only rejects the files and shares no keys', async () => {
+            const { enclave, file, job, study } = await setupResultApprovalFixture()
+
+            actionResult(
+                await submitOutputsDecisionAction({
+                    orgSlug: enclave.slug,
+                    jobInfo: { studyId: study.id, studyJobId: job.id, orgSlug: enclave.slug },
+                    decision: 'share-feedback-only',
+                    feedback: 'The log leaks a participant identifier, please remove it.',
+                    maxWords: ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS,
+                    sharedFiles: [],
+                }),
+            )
+
+            expect((await jobStatuses(job.id)).map((s) => s.status)).toContain('FILES-REJECTED')
+            expect(await resultsComment(study.id)).toMatchObject({ decision: 'NEEDS-CLARIFICATION' })
+
+            const keys = await db
+                .selectFrom('studyJobFileRecipientKey')
+                .selectAll('studyJobFileRecipientKey')
+                .where('studyJobFileId', '=', file.id)
+                .execute()
+            expect(keys).toHaveLength(0)
+        })
+
+        test('rejects empty feedback without touching the job status', async () => {
+            const { enclave, job, study } = await setupResultApprovalFixture()
+
+            const result = await submitOutputsDecisionAction({
+                orgSlug: enclave.slug,
+                jobInfo: { studyId: study.id, studyJobId: job.id, orgSlug: enclave.slug },
+                decision: 'share-outputs',
+                feedback: '   ',
+                maxWords: ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS,
+                sharedFiles: [],
+            })
+
+            expect(result).toEqual({ error: expect.objectContaining({ feedback: expect.any(String) }) })
+            expect((await jobStatuses(job.id)).map((s) => s.status)).not.toContain('FILES-APPROVED')
+            expect(await resultsComment(study.id)).toBeUndefined()
+        })
+
+        test('rejects feedback over the cap', async () => {
+            const { enclave, job, study } = await setupResultApprovalFixture()
+
+            const result = await submitOutputsDecisionAction({
+                orgSlug: enclave.slug,
+                jobInfo: { studyId: study.id, studyJobId: job.id, orgSlug: enclave.slug },
+                decision: 'share-feedback-only',
+                feedback: buildFeedback(ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS + 1),
+                maxWords: ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS,
+                sharedFiles: [],
+            })
+
+            expect(result).toEqual({ error: expect.objectContaining({ feedback: expect.any(String) }) })
+            expect((await jobStatuses(job.id)).map((s) => s.status)).not.toContain('FILES-REJECTED')
+        })
+
+        // The (studyJobId, reviewKind, round) unique constraint is the race-loser guard; the
+        // second reviewer must get a readable message, not a raw duplicate-key error.
+        test('refuses a second decision on the same outputs', async () => {
+            const { enclave, job, study, sharedFiles } = await setupResultApprovalFixture()
+            const params = {
+                orgSlug: enclave.slug,
+                jobInfo: { studyId: study.id, studyJobId: job.id, orgSlug: enclave.slug },
+                decision: 'share-outputs' as const,
+                feedback: 'Looks good to share.',
+                maxWords: ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS,
+                sharedFiles,
+            }
+
+            actionResult(await submitOutputsDecisionAction(params))
+            const second = await submitOutputsDecisionAction(params)
+
+            expect(second).toEqual({ error: expect.objectContaining({ study: expect.stringContaining('already') }) })
+        })
+
+        test('clears the collaborative feedback draft once submitted', async () => {
+            const { enclave, job, study, sharedFiles } = await setupResultApprovalFixture()
+            const docName = outputsReviewFeedbackDocName(job.id)
+            await db
+                .insertInto('yjsDocument')
+                .values({ name: docName, studyId: study.id, data: Buffer.from('draft-state') })
+                .execute()
+
+            actionResult(
+                await submitOutputsDecisionAction({
+                    orgSlug: enclave.slug,
+                    jobInfo: { studyId: study.id, studyJobId: job.id, orgSlug: enclave.slug },
+                    decision: 'share-outputs',
+                    feedback: 'Ready to share.',
+                    maxWords: ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS,
+                    sharedFiles,
+                }),
+            )
+
+            const draft = await db
+                .selectFrom('yjsDocument')
+                .select('name')
+                .where('name', '=', docName)
+                .executeTakeFirst()
+            expect(draft).toBeUndefined()
+        })
+
+        test('permission denied for a lab user', async () => {
+            const { org } = await mockSessionWithTestData({ orgType: 'lab' })
+            const { job, study } = await insertTestStudyJobData({ org, jobStatus: 'JOB-ERRORED' })
+
+            const result = await submitOutputsDecisionAction({
+                orgSlug: org.slug,
+                jobInfo: { studyId: study.id, studyJobId: job.id, orgSlug: org.slug },
+                decision: 'share-feedback-only',
+                feedback: 'Not allowed.',
+                maxWords: ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS,
+                sharedFiles: [],
             })
 
             expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })

--- a/src/server/actions/study-job.actions.ts
+++ b/src/server/actions/study-job.actions.ts
@@ -163,7 +163,7 @@ export const rejectStudyJobFilesAction = new Action('rejectStudyJobFilesAction',
 
 // OTTER-675: the Data Partner's single decision on a job's decrypted outputs. Feedback and the
 // files decision land together so the reviewer's rationale can never be orphaned from the status
-// that acted on it — the reason this exists instead of calling approve/reject plus a second write.
+// that acted on it. That is why this exists instead of calling approve/reject plus a second write.
 //
 // 'share-outputs' does exactly what approveStudyJobFilesAction does (persist the browser's
 // re-wrapped keys, then FILES-APPROVED); 'share-feedback-only' does what

--- a/src/server/actions/study-job.actions.ts
+++ b/src/server/actions/study-job.actions.ts
@@ -1,9 +1,13 @@
 'use server'
 
-import { ActionFailure } from '@/lib/errors'
+import { ActionFailure, isPgUniqueViolation, throwNotFound } from '@/lib/errors'
 import { isApprovedLogType, isEncryptedLogType } from '@/lib/file-type-helpers'
+import { normalizeFeedbackToLexical } from '@/lib/lexical'
+import { outputsReviewFeedbackDocName } from '@/lib/collaboration-documents'
+import { OUTPUTS_FEEDBACK_MIN_WORDS, toOutputsReviewDecision } from '@/lib/outputs-review'
 import { JobFile, minimalJobInfoSchema, sharedFileSchema } from '@/lib/types'
 import {
+    codeSubmissionVersion,
     getLabPublicKeysForStudy,
     getUserPublicKey,
     getSharedFileIdsForJob,
@@ -115,6 +119,129 @@ export const rejectStudyJobFilesAction = new Action('rejectStudyJobFilesAction',
 
         // TODO Confirm / Make sure we delete files from S3 when rejecting?
         onStudyResultsRejected({ studyId: info.studyId, userId: session.user.id })
+    })
+
+// OTTER-675: the Data Partner's single decision on a job's decrypted outputs. Feedback and the
+// files decision land together so the reviewer's rationale can never be orphaned from the status
+// that acted on it — the reason this exists instead of calling approve/reject plus a second write.
+//
+// 'share-outputs' does exactly what approveStudyJobFilesAction does (persist the browser's
+// re-wrapped keys, then FILES-APPROVED); 'share-feedback-only' does what
+// rejectStudyJobFilesAction does (FILES-REJECTED, files stay unshared). Those two actions remain
+// for the older results screen.
+export const submitOutputsDecisionAction = new Action('submitOutputsDecisionAction', { performsMutations: true })
+    .params(
+        z.object({
+            orgSlug: z.string(),
+            jobInfo: minimalJobInfoSchema,
+            decision: z.enum(['share-outputs', 'share-feedback-only']),
+            feedback: z.string(),
+            maxWords: z.number().int().positive(),
+            // Empty for 'share-feedback-only': nothing is shared, so there are no keys to re-wrap.
+            sharedFiles: z.array(sharedFileSchema),
+        }),
+    )
+    .middleware(async ({ params: { jobInfo }, db }) => {
+        const study = await db
+            .selectFrom('study')
+            .select('orgId')
+            .where('id', '=', jobInfo.studyId)
+            .executeTakeFirstOrThrow(throwNotFound('study'))
+        return { orgId: study.orgId }
+    })
+    .requireAbilityTo('review', 'Study')
+    .handler(async ({ params: { jobInfo: info, decision, feedback, maxWords, sharedFiles }, session, db }) => {
+        const userId = session.user.id
+
+        const { json, wordCount } = normalizeFeedbackToLexical(feedback)
+        if (wordCount < OUTPUTS_FEEDBACK_MIN_WORDS) {
+            throw new ActionFailure({ feedback: 'Feedback is required' })
+        }
+        if (wordCount > maxWords) {
+            throw new ActionFailure({ feedback: `Feedback must be ${maxWords} words or fewer (got ${wordCount})` })
+        }
+
+        const shareOutputs = decision === 'share-outputs'
+
+        // A files decision is final, so refuse outright if one already exists. This cannot be left
+        // to the (studyJobId, reviewKind, round) unique constraint: FILES-APPROVED/FILES-REJECTED
+        // are themselves round-opening events, so once the first decision lands
+        // codeSubmissionVersion returns the NEXT round and a second attempt would slot in beside
+        // it rather than collide — writing a phantom decision for a round whose code was never
+        // resubmitted. The constraint still covers the genuine same-round race below, where two
+        // reviewers both read the pre-decision round before either commits.
+        const existingDecision = await db
+            .selectFrom('jobStatusChange')
+            .select('id')
+            .where('studyJobId', '=', info.studyJobId)
+            .where('status', 'in', ['FILES-APPROVED', 'FILES-REJECTED'])
+            .executeTakeFirst()
+
+        if (existingDecision) {
+            throw new ActionFailure({
+                study: 'another reviewer has already submitted a decision for these outputs',
+            })
+        }
+
+        // Read the round BEFORE writing the status below, for the same reason.
+        const round = await codeSubmissionVersion(info.studyId, db)
+
+        try {
+            await db
+                .insertInto('studyReviewComment')
+                .values({
+                    studyId: info.studyId,
+                    studyJobId: info.studyJobId,
+                    authorId: userId,
+                    reviewKind: 'RESULTS',
+                    entryType: 'DECISION',
+                    decision: toOutputsReviewDecision(decision),
+                    body: JSON.parse(json),
+                    round,
+                })
+                .executeTakeFirstOrThrow()
+        } catch (err) {
+            // The (studyJobId, reviewKind, round) unique constraint fires when two reviewers submit
+            // a decision on the same outputs within the same round. The first write is already
+            // safe, so the loser gets a clean message rather than a duplicate-key error.
+            if (isPgUniqueViolation(err)) {
+                throw new ActionFailure({
+                    study: 'another reviewer has already submitted a decision for these outputs',
+                })
+            }
+            throw err
+        }
+
+        if (shareOutputs) {
+            // Re-wrap, not re-encrypt: only the wrapped keys the reviewer's browser produced are
+            // persisted. Ciphertext untouched; the server never sees plaintext or a raw AES key.
+            await insertSharedFileKeys(db, info.studyJobId, sharedFiles)
+        }
+
+        await db
+            .insertInto('jobStatusChange')
+            .values({
+                userId,
+                status: shareOutputs ? 'FILES-APPROVED' : 'FILES-REJECTED',
+                studyJobId: info.studyJobId,
+            })
+            .executeTakeFirstOrThrow()
+
+        await db
+            .updateTable('study')
+            .set({ reviewerId: userId, lastUpdatedAt: new Date() })
+            .where('id', '=', info.studyId)
+            .execute()
+
+        // The decision is final, so the collaborative draft has no further purpose; dropping it
+        // also stops a stale tab from resurrecting text after submission.
+        await db.deleteFrom('yjsDocument').where('name', '=', outputsReviewFeedbackDocName(info.studyJobId)).execute()
+
+        if (shareOutputs) {
+            onStudyResultsApproved({ studyId: info.studyId, userId })
+        } else {
+            onStudyResultsRejected({ studyId: info.studyId, userId })
+        }
     })
 
 export const loadStudyJobAction = new Action('loadStudyJobAction')

--- a/src/server/actions/study-job.actions.ts
+++ b/src/server/actions/study-job.actions.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { ActionFailure, isPgUniqueViolation } from '@/lib/errors'
-import { isApprovedLogType, isEncryptedLogType } from '@/lib/file-type-helpers'
+import { isApprovedLogType, isEncryptedArtifact, isEncryptedLogType } from '@/lib/file-type-helpers'
 import { normalizeFeedbackToLexical } from '@/lib/lexical'
 import { outputsReviewFeedbackDocName } from '@/lib/collaboration-documents'
 import {
@@ -11,7 +11,8 @@ import {
     outputsFeedbackMaxWords,
     toOutputsReviewDecision,
 } from '@/lib/outputs-review'
-import { JobFile, minimalJobInfoSchema, sharedFileSchema } from '@/lib/types'
+import { JobFile, sharedFileSchema, type SharedFile } from '@/lib/types'
+import type { FileType } from '@/database/types'
 import {
     codeSubmissionVersion,
     getLabPublicKeysForStudy,
@@ -26,24 +27,55 @@ import { insertSharedFileKeys } from '@/server/results-sharing'
 import { fetchFileContents } from '@/server/storage'
 import { Action, z } from './action'
 
+/**
+ * Guards what "share outputs" actually promises: the lab can open every encrypted artifact of
+ * this job.
+ *
+ * Three ways a request can fail that promise, none of which insertSharedFileKeys catches:
+ *  - no entries at all, so FILES-APPROVED is recorded while nothing is granted;
+ *  - entries whose `keys` array is empty, which insertSharedFileKeys turns into zero rows and
+ *    returns silently (this is also what buildSharedFiles produces when the lab has no
+ *    registered public keys, so it happens without anyone acting in bad faith);
+ *  - a subset: one valid artifact named while the job's other artifacts are omitted.
+ *
+ * Failing loudly is the point. Recording an approval the lab cannot act on is worse than
+ * refusing, because the study looks finished to everyone while the results stay unreadable.
+ */
+function assertSharesEveryArtifact(
+    jobFiles: ReadonlyArray<{ id: string; fileType: FileType }>,
+    sharedFiles: SharedFile[],
+): void {
+    const keyed = new Set(sharedFiles.filter((file) => file.keys.length > 0).map((file) => file.studyJobFileId))
+
+    if (!keyed.size) {
+        throw new ActionFailure({
+            files: 'no files could be shared with the lab. Confirm the lab has a registered security key.',
+        })
+    }
+
+    const unshared = jobFiles.filter((file) => isEncryptedArtifact(file.fileType) && !keyed.has(file.id))
+    if (unshared.length) {
+        throw new ActionFailure({ files: 'some outputs were not prepared for sharing' })
+    }
+}
+
+// The study is resolved from the job, not taken alongside it. Authorizing a caller-supplied
+// studyId while mutating a caller-supplied studyJobId lets a reviewer entitled to study A name a
+// job in study B and have the ability check pass against the wrong study.
 export const approveStudyJobFilesAction = new Action('approveStudyJobFilesAction', { performsMutations: true })
     .params(
         z.object({
             orgSlug: z.string(),
-            jobInfo: minimalJobInfoSchema,
+            studyJobId: z.string(),
             sharedFiles: z.array(sharedFileSchema),
         }),
     )
-    .middleware(async ({ params: { jobInfo }, db }) => {
-        const study = await db
-            .selectFrom('study')
-            .select('orgId')
-            .where('id', '=', jobInfo.studyId)
-            .executeTakeFirstOrThrow()
-        return { orgId: study.orgId }
+    .middleware(async ({ params: { studyJobId } }) => {
+        const studyJob = await getStudyJobInfo(studyJobId)
+        return { studyJob, orgId: studyJob.orgId, status: studyJob.status }
     })
     .requireAbilityTo('approve', 'Study')
-    .handler(async ({ params: { jobInfo: info, sharedFiles }, session, db }) => {
+    .handler(async ({ params: { sharedFiles }, studyJob, session, db }) => {
         // Re-wrap, not re-encrypt: persist only the wrapped-key rows the reviewer's browser
         // produced. Ciphertext untouched; server never sees plaintext. The FILES-APPROVED status
         // below is the all-or-nothing approval fact.
@@ -51,24 +83,24 @@ export const approveStudyJobFilesAction = new Action('approveStudyJobFilesAction
         // No backfill for late joiners: keys are wrapped only for lab members with a registered key
         // at approval time. Registering a key later can't unlock already-approved results —
         // re-wrapping needs the raw AES key, which the browser no longer holds.
-        await insertSharedFileKeys(db, info.studyJobId, sharedFiles)
+        await insertSharedFileKeys(db, studyJob.studyJobId, sharedFiles)
 
         await db
             .insertInto('jobStatusChange')
             .values({
                 userId: session.user.id,
                 status: 'FILES-APPROVED',
-                studyJobId: info.studyJobId,
+                studyJobId: studyJob.studyJobId,
             })
             .executeTakeFirstOrThrow()
 
         await db
             .updateTable('study')
             .set({ reviewerId: session.user.id, lastUpdatedAt: new Date() })
-            .where('id', '=', info.studyId)
+            .where('id', '=', studyJob.studyId)
             .execute()
 
-        onStudyResultsApproved({ studyId: info.studyId, userId: session.user.id })
+        onStudyResultsApproved({ studyId: studyJob.studyId, userId: session.user.id })
     })
 
 // Lab (researcher) public keys the reviewer's browser re-wraps approved files for.
@@ -96,35 +128,37 @@ export const fetchSharedFileIdsAction = new Action('fetchSharedFileIdsAction')
         return await getSharedFileIdsForJob(jobId)
     })
 
+// Study resolved from the job, for the same reason as approveStudyJobFilesAction above.
 export const rejectStudyJobFilesAction = new Action('rejectStudyJobFilesAction', { performsMutations: true })
     .params(
-        minimalJobInfoSchema.extend({
+        z.object({
             orgSlug: z.string(),
+            studyJobId: z.string(),
         }),
     )
-    .middleware(async ({ params: { studyId }, db }) => {
-        const study = await db.selectFrom('study').select('orgId').where('id', '=', studyId).executeTakeFirstOrThrow()
-        return { orgId: study.orgId }
+    .middleware(async ({ params: { studyJobId } }) => {
+        const studyJob = await getStudyJobInfo(studyJobId)
+        return { studyJob, orgId: studyJob.orgId, status: studyJob.status }
     })
     .requireAbilityTo('reject', 'Study')
-    .handler(async ({ params: info, session, db }) => {
+    .handler(async ({ studyJob, session, db }) => {
         await db
             .insertInto('jobStatusChange')
             .values({
                 userId: session.user.id,
                 status: 'FILES-REJECTED',
-                studyJobId: info.studyJobId,
+                studyJobId: studyJob.studyJobId,
             })
             .executeTakeFirstOrThrow()
 
         await db
             .updateTable('study')
             .set({ reviewerId: session.user.id, lastUpdatedAt: new Date() })
-            .where('id', '=', info.studyId)
+            .where('id', '=', studyJob.studyId)
             .execute()
 
         // TODO Confirm / Make sure we delete files from S3 when rejecting?
-        onStudyResultsRejected({ studyId: info.studyId, userId: session.user.id })
+        onStudyResultsRejected({ studyId: studyJob.studyId, userId: session.user.id })
     })
 
 // OTTER-675: the Data Partner's single decision on a job's decrypted outputs. Feedback and the
@@ -195,11 +229,8 @@ export const submitOutputsDecisionAction = new Action('submitOutputsDecisionActi
 
         const shareOutputs = decision === 'share-outputs'
 
-        // Sharing nothing is not a way to approve: the decision means the lab gets the files, so a
-        // request that carries no re-wrapped keys is either a bug or a direct call trying to record
-        // FILES-APPROVED without granting access.
-        if (shareOutputs && !sharedFiles.length) {
-            throw new ActionFailure({ files: 'no files were prepared for sharing' })
+        if (shareOutputs) {
+            assertSharesEveryArtifact(studyJob.files, sharedFiles)
         }
 
         // Read the round BEFORE writing the status below, for the same reason.
@@ -252,8 +283,10 @@ export const submitOutputsDecisionAction = new Action('submitOutputsDecisionActi
             .where('id', '=', studyId)
             .execute()
 
-        // The decision is final, so the collaborative draft has no further purpose; dropping it
-        // also stops a stale tab from resurrecting text after submission.
+        // The decision is final, so the collaborative draft has no further purpose. Deleting it is
+        // only half the job: the editor service's persist gate refuses further writes to a decided
+        // job's document (shouldPersistDocument), which is what stops an already-connected tab from
+        // recreating the row a moment later.
         await db.deleteFrom('yjsDocument').where('name', '=', outputsReviewFeedbackDocName(studyJobId)).execute()
 
         if (shareOutputs) {

--- a/src/server/actions/study-job.actions.ts
+++ b/src/server/actions/study-job.actions.ts
@@ -1,10 +1,16 @@
 'use server'
 
-import { ActionFailure, isPgUniqueViolation, throwNotFound } from '@/lib/errors'
+import { ActionFailure, isPgUniqueViolation } from '@/lib/errors'
 import { isApprovedLogType, isEncryptedLogType } from '@/lib/file-type-helpers'
 import { normalizeFeedbackToLexical } from '@/lib/lexical'
 import { outputsReviewFeedbackDocName } from '@/lib/collaboration-documents'
-import { OUTPUTS_FEEDBACK_MIN_WORDS, toOutputsReviewDecision } from '@/lib/outputs-review'
+import {
+    hasOutputsDecision,
+    hasReviewableOutputs,
+    OUTPUTS_FEEDBACK_MIN_WORDS,
+    outputsFeedbackMaxWords,
+    toOutputsReviewDecision,
+} from '@/lib/outputs-review'
 import { JobFile, minimalJobInfoSchema, sharedFileSchema } from '@/lib/types'
 import {
     codeSubmissionVersion,
@@ -133,25 +139,51 @@ export const submitOutputsDecisionAction = new Action('submitOutputsDecisionActi
     .params(
         z.object({
             orgSlug: z.string(),
-            jobInfo: minimalJobInfoSchema,
+            // Only the job id is trusted; the study and its org are derived from it in the
+            // middleware. Accepting a caller-supplied studyId alongside it would let a reviewer
+            // authorized for study A name a job belonging to study B and have the ability check
+            // pass against the wrong study.
+            studyJobId: z.string(),
             decision: z.enum(['share-outputs', 'share-feedback-only']),
             feedback: z.string(),
-            maxWords: z.number().int().positive(),
             // Empty for 'share-feedback-only': nothing is shared, so there are no keys to re-wrap.
             sharedFiles: z.array(sharedFileSchema),
         }),
     )
-    .middleware(async ({ params: { jobInfo }, db }) => {
-        const study = await db
-            .selectFrom('study')
-            .select('orgId')
-            .where('id', '=', jobInfo.studyId)
-            .executeTakeFirstOrThrow(throwNotFound('study'))
-        return { orgId: study.orgId }
+    .middleware(async ({ params: { studyJobId } }) => {
+        const studyJob = await getStudyJobInfo(studyJobId)
+        return { studyJob, orgId: studyJob.orgId, status: studyJob.status }
     })
     .requireAbilityTo('review', 'Study')
-    .handler(async ({ params: { jobInfo: info, decision, feedback, maxWords, sharedFiles }, session, db }) => {
+    .handler(async ({ params: { decision, feedback, sharedFiles }, studyJob, session, db }) => {
         const userId = session.user.id
+        const studyId = studyJob.studyId
+        const studyJobId = studyJob.studyJobId
+        const jobStatuses = studyJob.statusChanges.map((change) => change.status)
+
+        // Server-side state gate. UI routing decides which screen renders, but it is not an
+        // invariant a server action can lean on: without this, an authorized direct caller could
+        // finalize an INITIATED, still-running, or long-closed job.
+        if (!hasReviewableOutputs(jobStatuses)) {
+            throw new ActionFailure({ study: 'has no outputs ready for a decision' })
+        }
+
+        // A files decision is final, so refuse outright if one already exists. This cannot be left
+        // to the (studyJobId, reviewKind, round) unique constraint: FILES-APPROVED/FILES-REJECTED
+        // are themselves round-opening events, so once the first decision lands
+        // codeSubmissionVersion returns the NEXT round and a second attempt would slot in beside
+        // it rather than collide, writing a phantom decision for a round whose code was never
+        // resubmitted. The constraint still covers the genuine same-round race below, where two
+        // reviewers both read the pre-decision round before either commits.
+        if (hasOutputsDecision(jobStatuses)) {
+            throw new ActionFailure({
+                study: 'another reviewer has already submitted a decision for these outputs',
+            })
+        }
+
+        // The cap is a property of the run being reviewed, not of the request. Taking it from the
+        // client would let a caller raise its own limit to anything.
+        const maxWords = outputsFeedbackMaxWords(jobStatuses)
 
         const { json, wordCount } = normalizeFeedbackToLexical(feedback)
         if (wordCount < OUTPUTS_FEEDBACK_MIN_WORDS) {
@@ -163,35 +195,22 @@ export const submitOutputsDecisionAction = new Action('submitOutputsDecisionActi
 
         const shareOutputs = decision === 'share-outputs'
 
-        // A files decision is final, so refuse outright if one already exists. This cannot be left
-        // to the (studyJobId, reviewKind, round) unique constraint: FILES-APPROVED/FILES-REJECTED
-        // are themselves round-opening events, so once the first decision lands
-        // codeSubmissionVersion returns the NEXT round and a second attempt would slot in beside
-        // it rather than collide — writing a phantom decision for a round whose code was never
-        // resubmitted. The constraint still covers the genuine same-round race below, where two
-        // reviewers both read the pre-decision round before either commits.
-        const existingDecision = await db
-            .selectFrom('jobStatusChange')
-            .select('id')
-            .where('studyJobId', '=', info.studyJobId)
-            .where('status', 'in', ['FILES-APPROVED', 'FILES-REJECTED'])
-            .executeTakeFirst()
-
-        if (existingDecision) {
-            throw new ActionFailure({
-                study: 'another reviewer has already submitted a decision for these outputs',
-            })
+        // Sharing nothing is not a way to approve: the decision means the lab gets the files, so a
+        // request that carries no re-wrapped keys is either a bug or a direct call trying to record
+        // FILES-APPROVED without granting access.
+        if (shareOutputs && !sharedFiles.length) {
+            throw new ActionFailure({ files: 'no files were prepared for sharing' })
         }
 
         // Read the round BEFORE writing the status below, for the same reason.
-        const round = await codeSubmissionVersion(info.studyId, db)
+        const round = await codeSubmissionVersion(studyId, db)
 
         try {
             await db
                 .insertInto('studyReviewComment')
                 .values({
-                    studyId: info.studyId,
-                    studyJobId: info.studyJobId,
+                    studyId,
+                    studyJobId,
                     authorId: userId,
                     reviewKind: 'RESULTS',
                     entryType: 'DECISION',
@@ -215,7 +234,7 @@ export const submitOutputsDecisionAction = new Action('submitOutputsDecisionActi
         if (shareOutputs) {
             // Re-wrap, not re-encrypt: only the wrapped keys the reviewer's browser produced are
             // persisted. Ciphertext untouched; the server never sees plaintext or a raw AES key.
-            await insertSharedFileKeys(db, info.studyJobId, sharedFiles)
+            await insertSharedFileKeys(db, studyJobId, sharedFiles)
         }
 
         await db
@@ -223,24 +242,24 @@ export const submitOutputsDecisionAction = new Action('submitOutputsDecisionActi
             .values({
                 userId,
                 status: shareOutputs ? 'FILES-APPROVED' : 'FILES-REJECTED',
-                studyJobId: info.studyJobId,
+                studyJobId,
             })
             .executeTakeFirstOrThrow()
 
         await db
             .updateTable('study')
             .set({ reviewerId: userId, lastUpdatedAt: new Date() })
-            .where('id', '=', info.studyId)
+            .where('id', '=', studyId)
             .execute()
 
         // The decision is final, so the collaborative draft has no further purpose; dropping it
         // also stops a stale tab from resurrecting text after submission.
-        await db.deleteFrom('yjsDocument').where('name', '=', outputsReviewFeedbackDocName(info.studyJobId)).execute()
+        await db.deleteFrom('yjsDocument').where('name', '=', outputsReviewFeedbackDocName(studyJobId)).execute()
 
         if (shareOutputs) {
-            onStudyResultsApproved({ studyId: info.studyId, userId })
+            onStudyResultsApproved({ studyId, userId })
         } else {
-            onStudyResultsRejected({ studyId: info.studyId, userId })
+            onStudyResultsRejected({ studyId, userId })
         }
     })
 

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -5,7 +5,7 @@ import { sql } from 'kysely'
 import { ActionFailure, isPgUniqueViolation, throwNotFound } from '@/lib/errors'
 import { ActionSuccessType, sharedFileSchema, type SharedFile } from '@/lib/types'
 import type { StudyStatus } from '@/database/types'
-import { countWordsFromLexical, lexicalJson } from '@/lib/lexical'
+import { normalizeFeedbackToLexical } from '@/lib/lexical'
 import { CODE_REVIEW_FEEDBACK_MAX_WORDS, FEEDBACK_MAX_WORDS, FEEDBACK_MIN_WORDS } from '@/lib/proposal-review'
 import { toReviewDecision, type Decision } from '@/lib/review-decision'
 import { codeReviewFeedbackDocName, reviewFeedbackDocNameForVersion } from '@/lib/collaboration-documents'
@@ -497,25 +497,6 @@ export const rejectStudyProposalAction = new Action('rejectStudyProposalAction',
     .handler(async ({ params: { studyId }, session, db }) => {
         await performStudyCodeRejection({ db, studyId, userId: session.user.id })
     })
-
-function normalizeFeedbackToLexical(raw: string): { json: string; wordCount: number } {
-    let parsed: unknown
-    try {
-        parsed = JSON.parse(raw)
-    } catch {
-        parsed = null
-    }
-
-    // Loose check: non-Lexical JSON that passes will yield 0 words and fail min-word validation below.
-    const looksLikeLexicalRoot =
-        parsed != null &&
-        typeof parsed === 'object' &&
-        'root' in (parsed as Record<string, unknown>) &&
-        typeof (parsed as { root: unknown }).root === 'object'
-
-    const json = looksLikeLexicalRoot ? raw : lexicalJson(raw)
-    return { json, wordCount: countWordsFromLexical(json) }
-}
 
 async function claimInitialProposalReviewStudy({
     db,

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -4,7 +4,7 @@ import { ActionSuccessType } from '@/lib/types'
 import { AccessDeniedError, throwNotFound } from '@/lib/errors'
 import { wasCalledFromAPI } from '../api-context'
 import { findOrCreateSiUserId } from './mutations'
-import { FileType } from '@/database/types'
+import { FileType, StudyJobFileAction } from '@/database/types'
 import { Selectable } from 'kysely'
 import { Action } from '../actions/action'
 import { fetchFileContents } from '@/server/storage'
@@ -503,6 +503,38 @@ export async function getLabPublicKeysForStudy(studyId: string): Promise<PublicK
 // IDs of this job's artifacts with at least one re-wrapped key row — i.e. shared with researchers.
 // Empty before approval (rows only exist post-approval). Removing a researcher from the lab leaves
 // their key rows, so this never retroactively un-shares.
+// OTTER-675: the most recent view/download per output file, for the outputs table's
+// "Last activity" column. One row per file at most — the column reports the latest action,
+// not a history — so the DISTINCT ON collapses each file's rows to its newest.
+export type JobFileActivity = {
+    studyJobFileId: string
+    filePath: string
+    action: StudyJobFileAction
+    createdAt: Date
+    actorName: string
+}
+
+export async function latestActivityPerJobFile(jobId: string): Promise<JobFileActivity[]> {
+    return await Action.db
+        .selectFrom('studyJobFileActivity')
+        .innerJoin('studyJobFile', 'studyJobFile.id', 'studyJobFileActivity.studyJobFileId')
+        .innerJoin('user', 'user.id', 'studyJobFileActivity.userId')
+        .where('studyJobFile.studyJobId', '=', jobId)
+        .select([
+            'studyJobFileActivity.studyJobFileId',
+            'studyJobFileActivity.filePath',
+            'studyJobFileActivity.action',
+            'studyJobFileActivity.createdAt',
+            'user.fullName as actorName',
+        ])
+        .distinctOn(['studyJobFileActivity.studyJobFileId', 'studyJobFileActivity.filePath'])
+        .orderBy('studyJobFileActivity.studyJobFileId')
+        .orderBy('studyJobFileActivity.filePath')
+        .orderBy('studyJobFileActivity.createdAt', 'desc')
+        .orderBy('studyJobFileActivity.id', 'desc')
+        .execute()
+}
+
 export async function getSharedFileIdsForJob(jobId: string): Promise<string[]> {
     const rows = await Action.db
         .selectFrom('studyJobFileRecipientKey')

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -504,8 +504,8 @@ export async function getLabPublicKeysForStudy(studyId: string): Promise<PublicK
 // Empty before approval (rows only exist post-approval). Removing a researcher from the lab leaves
 // their key rows, so this never retroactively un-shares.
 // OTTER-675: the most recent view/download per output file, for the outputs table's
-// "Last activity" column. One row per file at most — the column reports the latest action,
-// not a history — so the DISTINCT ON collapses each file's rows to its newest.
+// "Last activity" column. One row per file at most, because the column reports the latest
+// action rather than a history, so the DISTINCT ON collapses each file's rows to its newest.
 export type JobFileActivity = {
     studyJobFileId: string
     filePath: string

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -307,8 +307,9 @@ async function reviewerApprovesResults(page: Page, studyTitle: string): Promise<
     await page.waitForURL('**/dashboard')
 }
 
-// OTTER-667: the errored screen now uses the SecurityKeyForm (decrypt only).
-// The post-decryption approve flow is OTTER-675; until then, verify decrypt succeeds.
+// OTTER-667 + OTTER-675: the errored outputs screen, both phases. The key form gives way to
+// the outputs table and Decision section without a navigation — decryption is client-side, so
+// the swap is a local phase flip on the same URL.
 async function reviewerDecryptsErrorLogs(page: Page, studyTitle: string): Promise<void> {
     await visitAsRole(page, REVIEWER_DASHBOARD)
     await expect(page.getByText('Review Studies')).toBeVisible()
@@ -326,24 +327,58 @@ async function reviewerDecryptsErrorLogs(page: Page, studyTitle: string): Promis
     await expect(viewButton).toBeEnabled()
     await viewButton.click()
 
-    await expect(page.getByText('Security key accepted.')).toBeVisible()
+    await expect(page.getByTestId('outputs-files-section')).toBeVisible()
+    await expect(page.getByText('Review the outputs before sharing')).toBeVisible()
 }
 
-// OTTER-675: restore once the reviewer approve flow is built — the researcher's
-// errored view is gated on file approval (isErroredResultHiddenFromResearcher).
-// async function verifyFailedStatusDisplay(page: Page, studyTitle: string): Promise<void> {
-//     await visitAsRole(page, RESEARCHER_DASHBOARD)
-//
-//     const studyRow = page.getByRole('row').filter({ hasText: studyTitle })
-//     await expect(studyRow.getByText(/Errored/i)).toBeVisible()
-//
-//     await viewStudyDetails(page, studyTitle)
-//
-//     await expect(page.getByText(/The code errored/i)).toBeVisible()
-//     await expect(page.getByText(/Job ID/i)).toBeVisible()
-//
-//     await expect(page.getByText('Code Run Log')).toBeVisible()
-// }
+// OTTER-675: submitting the decision from the decrypted view. Shares the outputs so the
+// researcher-side assertions below have something to see.
+async function reviewerSharesOutputs(page: Page, feedback: string): Promise<void> {
+    await expect(page.getByTestId('outputs-decision-section')).toBeVisible()
+
+    const editor = page.getByLabel('Decision feedback')
+    await expect(editor).toBeVisible()
+    await editor.click()
+    await editor.fill(feedback)
+
+    await page.getByTestId('outputs-decision-share-outputs').check()
+
+    await page.getByTestId('outputs-submit-decision').click()
+
+    // The confirmation modal names what is about to be shared before anything is written.
+    await expect(page.getByText('Submit your decision?')).toBeVisible()
+    await expect(page.getByText(/You are sharing the output files and your feedback with/)).toBeVisible()
+
+    await page.getByRole('button', { name: 'Submit decision' }).click()
+
+    // The decision re-resolves the reviewer screen; leaving the errored view is the signal.
+    await expect(page.getByTestId('outputs-decision-section')).toBeHidden()
+}
+
+// OTTER-675: blank submit must flag both fields and open no modal.
+async function reviewerSeesValidationOnBlankSubmit(page: Page): Promise<void> {
+    await page.getByTestId('outputs-submit-decision').click()
+
+    await expect(page.getByText(/Enter your feedback for .* before submitting\./)).toBeVisible()
+    await expect(page.getByText('Select an option before submitting')).toBeVisible()
+    await expect(page.getByText('Submit your decision?')).toBeHidden()
+}
+
+// The researcher's errored view is gated on the reviewer having shared the files, so this
+// runs only after reviewerSharesOutputs (OTTER-675).
+async function verifyFailedStatusDisplay(page: Page, studyTitle: string): Promise<void> {
+    await visitAsRole(page, RESEARCHER_DASHBOARD)
+
+    const studyRow = page.getByRole('row').filter({ hasText: studyTitle })
+    await expect(studyRow.getByText(/Errored/i)).toBeVisible()
+
+    await viewStudyDetails(page, studyTitle)
+
+    await expect(page.getByText(/The code errored/i)).toBeVisible()
+    await expect(page.getByText(/Job ID/i)).toBeVisible()
+
+    await expect(page.getByText('Code Run Log')).toBeVisible()
+}
 
 // ============================================================================
 // Tests
@@ -456,8 +491,8 @@ test('Successful results review', async ({ browser, studyFeatures }) => {
     })
 })
 
-// OTTER-667: reviewer decrypts error logs on the new errored-outputs screen.
-// OTTER-675: uncomment the researcher step once the approve flow is built.
+// Owns the errored-outputs surface end to end (OTTER-667 + OTTER-675): decrypt, the
+// validation gate, the confirmation modal, and the researcher's view of the shared logs.
 test('Error log review', async ({ browser, studyFeatures }) => {
     const studyTitle = studyFeatures.uniqueTitle('error-log')
     const { jobId } = await seedCodeApprovedJobReady(studyTitle)
@@ -465,11 +500,13 @@ test('Error log review', async ({ browser, studyFeatures }) => {
 
     await withRole(browser, 'reviewer', async (page) => {
         await reviewerDecryptsErrorLogs(page, studyTitle)
+        await reviewerSeesValidationOnBlankSubmit(page)
+        await reviewerSharesOutputs(page, 'The run failed on a timeout; the logs contain no PII.')
     })
 
-    // await withRole(browser, 'researcher', async (page) => {
-    //     await verifyFailedStatusDisplay(page, studyTitle)
-    // })
+    await withRole(browser, 'researcher', async (page) => {
+        await verifyFailedStatusDisplay(page, studyTitle)
+    })
 })
 
 // Owns the reviewer reject-proposal surface + the researcher rejected-proposal view.

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -353,10 +353,10 @@ async function reviewerSharesOutputs(page: Page, feedback: string): Promise<void
     // The modal names what is about to be shared before anything is written.
     await expect(modal.getByText(/You are sharing the output files and your feedback with/)).toBeVisible()
 
-    // Focus must come back to the trigger on every dismissal. The modal unmounts itself to keep
-    // its body text fresh, which pre-empts Mantine's own focus-return effect, so the panel does it
-    // explicitly. Checked here rather than in jsdom, where the Lexical editor this flow needs is
-    // not typeable. Escape first, then the X, then reopen for the real submit.
+    // Focus must come back to the trigger on every dismissal. The modal stays mounted while
+    // closed so Mantine's own returnFocus can do it; unmounting it would take useFocusReturn
+    // along with it. Checked here rather than in jsdom, where the Lexical editor this flow needs
+    // is not typeable. Escape first, then the X, then reopen for the real submit.
     await page.keyboard.press('Escape')
     await expect(modal).toBeHidden()
     await expect(trigger).toBeFocused()

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -345,11 +345,14 @@ async function reviewerSharesOutputs(page: Page, feedback: string): Promise<void
 
     await page.getByTestId('outputs-submit-decision').click()
 
-    // The confirmation modal names what is about to be shared before anything is written.
-    await expect(page.getByText('Submit your decision?')).toBeVisible()
-    await expect(page.getByText(/You are sharing the output files and your feedback with/)).toBeVisible()
+    // Scope to the dialog: the page's own trigger and the modal's confirm share the label
+    // "Submit decision", so an unscoped role query matches both once the modal is open.
+    const modal = page.getByRole('dialog', { name: 'Submit your decision?' })
+    await expect(modal).toBeVisible()
+    // The modal names what is about to be shared before anything is written.
+    await expect(modal.getByText(/You are sharing the output files and your feedback with/)).toBeVisible()
 
-    await page.getByRole('button', { name: 'Submit decision' }).click()
+    await modal.getByRole('button', { name: 'Submit decision' }).click()
 
     // The decision re-resolves the reviewer screen; leaving the errored view is the signal.
     await expect(page.getByTestId('outputs-decision-section')).toBeHidden()
@@ -361,7 +364,7 @@ async function reviewerSeesValidationOnBlankSubmit(page: Page): Promise<void> {
 
     await expect(page.getByText(/Enter your feedback for .* before submitting\./)).toBeVisible()
     await expect(page.getByText('Select an option before submitting')).toBeVisible()
-    await expect(page.getByText('Submit your decision?')).toBeHidden()
+    await expect(page.getByRole('dialog', { name: 'Submit your decision?' })).toBeHidden()
 }
 
 // The researcher's errored view is gated on the reviewer having shared the files, so this

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -308,7 +308,7 @@ async function reviewerApprovesResults(page: Page, studyTitle: string): Promise<
 }
 
 // OTTER-667 + OTTER-675: the errored outputs screen, both phases. The key form gives way to
-// the outputs table and Decision section without a navigation — decryption is client-side, so
+// the outputs table and Decision section without a navigation, because decryption is client-side, so
 // the swap is a local phase flip on the same URL.
 async function reviewerDecryptsErrorLogs(page: Page, studyTitle: string): Promise<void> {
     await visitAsRole(page, REVIEWER_DASHBOARD)

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -343,7 +343,8 @@ async function reviewerSharesOutputs(page: Page, feedback: string): Promise<void
 
     await page.getByTestId('outputs-decision-share-outputs').check()
 
-    await page.getByTestId('outputs-submit-decision').click()
+    const trigger = page.getByTestId('outputs-submit-decision')
+    await trigger.click()
 
     // Scope to the dialog: the page's own trigger and the modal's confirm share the label
     // "Submit decision", so an unscoped role query matches both once the modal is open.
@@ -352,6 +353,22 @@ async function reviewerSharesOutputs(page: Page, feedback: string): Promise<void
     // The modal names what is about to be shared before anything is written.
     await expect(modal.getByText(/You are sharing the output files and your feedback with/)).toBeVisible()
 
+    // Focus must come back to the trigger on every dismissal. The modal unmounts itself to keep
+    // its body text fresh, which pre-empts Mantine's own focus-return effect, so the panel does it
+    // explicitly. Checked here rather than in jsdom, where the Lexical editor this flow needs is
+    // not typeable. Escape first, then the X, then reopen for the real submit.
+    await page.keyboard.press('Escape')
+    await expect(modal).toBeHidden()
+    await expect(trigger).toBeFocused()
+
+    await trigger.click()
+    await expect(modal).toBeVisible()
+    await modal.getByRole('button', { name: 'Close' }).click()
+    await expect(modal).toBeHidden()
+    await expect(trigger).toBeFocused()
+
+    await trigger.click()
+    await expect(modal).toBeVisible()
     await modal.getByRole('button', { name: 'Submit decision' }).click()
 
     // The decision re-resolves the reviewer screen; leaving the errored view is the signal.


### PR DESCRIPTION
see [OTTER-675](https://openstax.atlassian.net/browse/OTTER-675)

**Now targets `main` and includes it.** `origin/main` (with #921) is merged in, so the diff is this card alone.

## What this adds

The post-decryption half of the Data Partner "job errored" outputs screen: once a valid security key decrypts the artifacts, the key form gives way to an outputs table, a Decision section, and a confirmation modal that records the reviewer's files decision.

## Key design point: this is a client phase, not a new screen

Decryption happens in the browser and changes no server state, so "advancing" to the review view is a local phase flip inside the screen #921 registered (`reviewer-outputs-errored`). `reviewer-screen-rules.ts` and `screens.ts` are untouched.

The card's AC reads "the user must be redirected to this page when status == job-errored AND they have successfully validated their security key", which sounds like routing; it is really this two-part client gate. Holding both phases in one component is also what keeps the decrypted plaintext in memory and off the server.

```
OutputsReviewPanel
  ├─ locked   : errored banner + SecurityKeyForm          (OTTER-667)
  └─ unlocked : review banner + files table + Decision    (this card)
```

Page and section headers are identical either side of the flip; only the banner and the body below it change.

## Changes

**Migrations (2)**
- `study_job_file_activity`, the per-file view/download log behind the "Last activity" column. Addressed by `(study_job_file_id, file_path)` following `study_job_file_recipient_key`: a `study_job_file` row is the encrypted *archive*, and what the reviewer opens is one inner file, so keying on the archive alone would smear one file's activity across every sibling extracted from the same zip.
- `'RESULTS'` added to `study_review_comment_kind`, plus a `study_job_id`-required CHECK mirroring the existing CODE one. The outputs decision is stored as a `studyReviewComment` exactly like a code decision.

**Server**
- `submitOutputsDecisionAction`, one action so the feedback and the files status land together and a rationale can never be orphaned from the status that acted on it. The study and org are derived from the job id, never taken alongside it. Gated on the job having reached a terminal result and having no decision yet, with the word cap derived from the job's own status rather than the request.
- `assertSharesEveryArtifact` refuses a "share outputs" that carries no usable keys or omits an artifact, so an approval the lab cannot open is never recorded.
- `approveStudyJobFilesAction` / `rejectStudyJobFilesAction` were carrying the same derive-from-job flaw and are fixed alongside.
- `recordJobFileActivityAction` / `fetchJobFileActivityAction`, scoped so a forged id cannot attach activity to another study's file. `latestActivityPerJobFile` collapses each file to its newest action via `DISTINCT ON`.
- `normalizeFeedbackToLexical` moved from `study.actions.ts` into `@/lib/lexical` and shared rather than duplicated.

**Yjs**
- New `outputs-review-feedback-{jobId}` document kind, mirrored into `services/editor/auth.ts`. Job-keyed like `code-review-feedback`, but persistence is refused once the job has a files decision, so a stale tab cannot recreate the draft the submit deletes.

**Client**
- `OutputsFilesSection` / `OutputsFileRow`: semantic table in a scroll container, 50-char truncation, tooltip on hover *and* focus, per-row `aria-label="Download {file}"`, `Download all` (≥2 files) zipping in the browser via `@zip.js/zip.js`.
- `OutputsDecisionSection`: the code-review Lexical + Yjs editor, word counter, native radio group.
- `SubmitOutputsDecisionModal`, `useOutputsDecision`, `useOutputsFiles`, `focusFirstInvalid`.
- `SecurityKeyForm` now reports decrypted files through `onDecrypted`; a key that decrypts nothing is no longer treated as success.

## Notable findings

**Focus was not returning to "Submit decision" when the modal closed.** Caught in review. The modal returned null while closed, which unmounted `ModalBase` and took the `useFocusReturn` effect inside it along with it, leaving focus on `<body>` after Escape, Cancel and X alike. The comment justifying that early return was itself wrong: `keepMounted` defaults to false and `ModalBaseContent` renders children inside the exit transition, so every open already mounts fresh copy and the body text could never have been a stale cached announcement. The modal now stays mounted and `opened={decision !== null}` lets Mantine's own `returnFocus` do the work. Asserted in the e2e run rather than jsdom, where the Lexical editor this flow needs is not typeable.

**"Modal open" was not a state of its own.** Also from review: an `isOpen` flag beside the selected decision made "open with nothing chosen" representable, and two guards were paying for the gap. Collapsed into a single `confirming: OutputsDecision | null`, which made both dead: the mutation's null check and the modal's own re-check. `focusFirstInvalid` now returns the field it moved to, so its scan doubles as the "is anything invalid" test instead of a second identical pass.

**The unique constraint alone would not have blocked a double decision.** `FILES-APPROVED`/`FILES-REJECTED` are themselves round-opening events for `codeSubmissionVersion`, so after the first decision the round advances and a second attempt would slot in beside it rather than collide, writing a phantom decision for a round whose code was never resubmitted. There is now an explicit guard; the constraint still covers the genuine same-round race.

**Mantine's `Radio.Group` swallows an `id` prop without rendering it**, so `document.getElementById` found nothing and the submit-time focus jump was a silent no-op. The id now lives on a wrapper we own. Found by rendering the real DOM, not by unit tests, which had built the wrapper by hand.

**Mantine's `Radio` renders `description` visually but never wires `aria-describedby`.** The AC requires the association, so the description is wrapped in an element we own and referenced explicitly.

## Testing

- 247 files / 2332 unit tests pass; `pnpm run checks` clean (typecheck, eslint, prettier, action validation).
- The screen test drives a genuine decrypt: it seeds a real encrypted artifact and enters the real test private key, so the phase flip is exercised end to end rather than through a stubbed callback.
- E2E: `Error log review` runs decrypt, blank-submit validation, the modal's three dismissal paths with focus assertions, then the real submit, and re-enables `verifyFailedStatusDisplay`, which #922 had commented out pending this card.
- Every state was also inspected in a browser against the Figma frames, which is how the two Mantine issues above and a missing counter unit were found.

## Where the submitted feedback is read

This card writes the decision feedback as a `studyReviewComment` with `reviewKind: 'RESULTS'`. Nothing reads that kind yet, by design; the read paths are separate cards in this epic:

- [OTTER-677](https://openstax.atlassian.net/browse/OTTER-677) DP post-review page, which declares this card a dependency and reuses this card's outputs table. It owns the "Feedback & Notes" panel and the "View outputs again" re-decrypt section (Figma `12287:25855` / `25966`).
- [OTTER-696](https://openstax.atlassian.net/browse/OTTER-696) / [OTTER-697](https://openstax.atlassian.net/browse/OTTER-697) the Research Lab views for the errored flow, outputs-and-feedback and feedback-only respectively.

Until 677 lands, submitting redirects to `/review` and the reviewer screen rules resolve to the existing post-decision screen. The redirect target is expected to change when 677 adds its rule; no change is needed here for that.

Two things worth flagging to PM before this epic closes: OTTER-697 currently has an empty description, so the lab-side read of feedback-only is unspecified; and OTTER-677 will need text-override props on `SecurityKeyForm` for its "View outputs again" heading and body.

## For Iris (non-blocking copy flags)

- AC says "character limit" / `maxCharacter`; every errored-flow frame says `words`, including the unit next to the count. Shipping words, which review agreed reads as the AC being wrong rather than the build. Still wants an explicit sign-off before the card is validated.
- AC says "Outputs files"; frame `25892` says "Output files". Shipping "Output files".
- Frames `25572`/`25724` label the table card "Review outputs", which collides with the STEP 3 page heading. Not shipped.
- The confirmation-modal frames still read "Modal header"; shipping the AC's "Submit your decision?".
- No 675 frame renders the `Title: {study title}` line the reused section header includes; kept, since the AC says reuse it unmodified.
- The feedback field is the shared Lexical editor, so it carries a formatting toolbar the Figma textarea does not show.

## One thing for QA

The "All changes saved" autosave indicator cannot be verified on a PR preview: no editor websocket connects there, so Yjs autosave is not running. The doc kind is registered and parsed correctly and the decision submits without it, so this reads as environmental, but it is the one AC row worth re-checking on QA before the card closes.

[OTTER-675]: https://openstax.atlassian.net/browse/OTTER-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OTTER-677]: https://openstax.atlassian.net/browse/OTTER-677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
