### PR TITLE
security: bump brace-expansion, fast-uri, and postcss past audit advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   form-data: ^4.0.6
   minimatch: ^10.2.1
   picomatch: ^4.0.4
-  postcss: ^8.5.18
+  postcss: ^8.5.23
   vite: ^8.0.16
   ws: ^8.21.0
   js-yaml@>=4.0.0 <4.3.0: '>=4.3.0 <5'
@@ -21,8 +21,8 @@ overrides:
   '@vitest/coverage-istanbul>@babel/core': 7.29.7
   shell-quote@<1.8.5: '>=1.8.5'
   axios@>=1.0.0 <1.18.0: '>=1.18.0 <2'
-  brace-expansion@>=5.0.0 <5.0.8: '>=5.0.8 <6'
-  fast-uri@>=3.0.0 <3.1.4: '>=3.1.4 <4'
+  brace-expansion@>=5.0.0 <5.0.9: '>=5.0.9 <6'
+  fast-uri@>=3.0.0 <3.1.5: '>=3.1.5 <4'
   sharp@>=0.34.0 <0.35.0: '>=0.35.0 <0.36'
 
 importers:
@@ -3016,8 +3016,8 @@ packages:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -3757,8 +3757,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -5233,8 +5233,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.21:
-    resolution: {integrity: sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -9338,7 +9338,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -9521,7 +9521,7 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -10346,7 +10346,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -11831,7 +11831,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist-options@4.1.0:
     dependencies:
@@ -11923,7 +11923,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.11.0
       caniuse-lite: 1.0.30001806
-      postcss: 8.5.21
+      postcss: 8.5.25
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.4)
@@ -12196,7 +12196,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.21:
+  postcss@8.5.25:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -13348,7 +13348,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.21
+      postcss: 8.5.25
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,8 +16,10 @@ overrides:
     form-data: ^4.0.6
     minimatch: ^10.2.1
     picomatch: ^4.0.4
-    # postcss <8.5.18: GHSA-r28c-9q8g-f849 — path traversal via sourceMappingURL auto-loading.
-    postcss: ^8.5.18
+    # postcss <8.5.23: GHSA-r28c-9q8g-f849 (path traversal via sourceMappingURL auto-loading), then
+    # GHSA-fxqj-rqcc-2cmp, an incomplete fix of the follow-up GHSA-6g55-p6wh-862q: an
+    # attacker-controlled sourceMappingURL still reads arbitrary .map files when `from` is unset.
+    postcss: ^8.5.23
     vite: ^8.0.16
     ws: ^8.21.0
     # js-yaml <4.3.0: CVE-2026-59869 (HIGH) — DoS via crafted YAML. Range also covers the older
@@ -40,10 +42,13 @@ overrides:
     # the bump stays a patch/minor, never a breaking major.
     # axios <1.18.0: GHSA-gcfj-64vw-6mp9 — Node adapter can reuse an inherited proxy after config clone.
     'axios@>=1.0.0 <1.18.0': '>=1.18.0 <2'
-    # brace-expansion <5.0.8: CVE-2026-13149, then CVE-2026-14257 against 5.0.7 itself — DoS via
-    # exponential-time expansion. Range widened to carry past the version the earlier pin landed on.
-    'brace-expansion@>=5.0.0 <5.0.8': '>=5.0.8 <6'
-    # fast-uri <3.1.4: CVE-2026-13676 + CVE-2026-16221 — policy bypass via bad Unicode hostname canon.
-    'fast-uri@>=3.0.0 <3.1.4': '>=3.1.4 <4'
+    # brace-expansion <5.0.9: CVE-2026-13149, then CVE-2026-14257 against 5.0.7, now CVE-2026-69152
+    # against 5.0.8 (DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation).
+    # Range widened again to carry past the version the earlier pin landed on.
+    'brace-expansion@>=5.0.0 <5.0.9': '>=5.0.9 <6'
+    # fast-uri <3.1.5: CVE-2026-13676 + CVE-2026-16221 (policy bypass via bad Unicode hostname
+    # canon), then GHSA-7p8r-x3mc-p8w7 against 3.1.4: host confusion via a backslash authority
+    # introducer, so a crafted URI parses to an unintended host.
+    'fast-uri@>=3.0.0 <3.1.5': '>=3.1.5 <4'
     # sharp <0.35.0: GHSA-f88m-g3jw-g9cj — inherited libvips CVEs.
     'sharp@>=0.34.0 <0.35.0': '>=0.35.0 <0.36'


### PR DESCRIPTION
Resolves all three findings from `pnpm audit` (2 high, 1 moderate), including the single HIGH that failed the `infosec` (Trivy) job on #919. `pnpm audit` now reports **no known vulnerabilities**.

All three are transitive-only, and each advisory was published against the exact version an existing override had already pinned to, so every entry here is a range widening rather than a new override.

- **brace-expansion** `<5.0.9`: CVE-2026-69152, DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation. The prior override pinned `>=5.0.8`, which is the version now flagged, so the range is widened to `>=5.0.9`. Reached only through `minimatch`. This is the one finding that failed Trivy on #919.
- **fast-uri** `<3.1.5`: GHSA-7p8r-x3mc-p8w7, host confusion via a backslash authority introducer, so a crafted URI parses to an unintended host. Prior override pinned `>=3.1.4`, widened to `>=3.1.5`. Reached through `ajv` under the Sentry webpack plugin.
- **postcss** `<=8.5.22`: GHSA-fxqj-rqcc-2cmp, an incomplete fix of GHSA-6g55-p6wh-862q, where an attacker-controlled `sourceMappingURL` still reads arbitrary `.map` files when `from` is unset. Override raised from `^8.5.18` to `^8.5.23`, resolving to 8.5.25. Reached through `next` and `vite`.

Each is bounded to its current major, so all three bumps stay patches. Every patched release is at least four days old, so nothing here needed `minimumReleaseAge` relaxed, and no advisory was suppressed via `.trivyignore.yaml`.

The lockfile delta is exactly these three packages plus the `minimatch` / `ajv` / `next` / `vite` edges that point at them. Nothing else re-resolved.

Verified: `pnpm audit` clean, and Trivy v0.70.0 run locally against this repo's `trivy.yaml` reports 0 vulnerabilities for `pnpm-lock.yaml`, which is the step that failed on #919. `pnpm run checks` (typecheck + lint + action validation) passes; unit and e2e run in CI here.

No SIINFOSEC cards have been filed for these three advisories yet, so there is no Jira key to reference.
