### PR TITLE
Otter 676 outputs available after decryption

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/_screens/registry.ts
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/registry.ts
@@ -13,6 +13,7 @@ import { ReviewerCodeReviewScreen } from './reviewer-code-review-screen'
 import { ReviewerCodeFeedbackScreen } from './reviewer-code-feedback-screen'
 import { ReviewerOutputsPendingScreen } from './reviewer-outputs-pending-screen'
 import { ReviewerOutputsErroredScreen } from './reviewer-outputs-errored-screen'
+import { ReviewerOutputsAvailableScreen } from './reviewer-outputs-available-screen'
 import { ReviewerStudyResultsScreen } from './reviewer-study-results-screen'
 
 // Screens may be async server components (they load their own data). Returned node is awaited
@@ -36,5 +37,6 @@ export const SCREEN_COMPONENTS: Record<ScreenId, ScreenComponent> = {
     'reviewer-code-feedback': ReviewerCodeFeedbackScreen,
     'reviewer-outputs-pending': ReviewerOutputsPendingScreen,
     'reviewer-outputs-errored': ReviewerOutputsErroredScreen,
+    'reviewer-outputs-available': ReviewerOutputsAvailableScreen,
     'reviewer-study-results': ReviewerStudyResultsScreen,
 }

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.test.tsx
@@ -36,11 +36,6 @@ vi.mock('@/server/actions/study-job.actions', async () => {
     return { ...actual, fetchEncryptedJobFilesAction: vi.fn(async () => []) }
 })
 
-// Real in-browser RSA/AES decryption drives the phase flip in these tests, and on a loaded CI
-// runner (sharded workers + coverage instrumentation) that chain can outlast the default 5s
-// per-test budget. The waitFor timeouts below stay inside this ceiling.
-vi.setConfig({ testTimeout: 30_000 })
-
 const toArrayBuffer = (str: string): ArrayBuffer => {
     const buf = Buffer.from(str, 'utf-8')
     return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
@@ -108,10 +103,6 @@ const unlock = async () => {
     fireEvent.click(screen.getByRole('button', { name: 'View' }))
 }
 
-// Generous asynchronous wait: CI shards run 4 workers with coverage instrumentation, and the
-// decrypt flow under test is CPU-bound, so the RTL default of 1s is far too tight there.
-const WAIT = { timeout: 15_000 }
-
 // Matches on an element's full textContent, so text split across child nodes (or differing
 // whitespace) can never produce a false negative the way an exact-string matcher can.
 const textIncludes = (needle: string) => (_: string, element: Element | null) =>
@@ -169,9 +160,7 @@ describe('ReviewerOutputsAvailableScreen before decryption', () => {
         fireEvent.change(screen.getByRole('textbox'), { target: { value: 'not-a-real-key' } })
         fireEvent.click(screen.getByRole('button', { name: 'View' }))
 
-        expect(
-            await screen.findByText(textIncludes('Invalid key. Check that you copied'), undefined, WAIT),
-        ).toBeInTheDocument()
+        expect(await screen.findByText(textIncludes('Invalid key. Check that you copied'))).toBeInTheDocument()
         expect(screen.queryByTestId('outputs-files-section')).toBeNull()
     })
 
@@ -185,6 +174,10 @@ describe('ReviewerOutputsAvailableScreen before decryption', () => {
         )
     })
 
+    // This test and the next are defensive-only: reviewer-screen-rules (rule 1b) routes this
+    // screen solely for a RUN-COMPLETE job with no files decision, so neither state can reach it
+    // through the resolved flow. Rendering the component directly is what makes them reachable
+    // here — they pin the guards, not a reviewer-visible state.
     it('shows a not-found alert when the study has no submitted job', async () => {
         const { org, study } = await setupStudyAction({ orgSlug: 'openstax', orgType: 'enclave', createJob: false })
         ;(useParams as Mock).mockReturnValue({ orgSlug: org.slug, studyId: study.id })
@@ -213,12 +206,12 @@ describe('ReviewerOutputsAvailableScreen after decryption', () => {
         await doRender(study, org.slug)
         await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
         await unlock()
-        await waitFor(() => expect(screen.getByTestId('outputs-files-section')).toBeInTheDocument(), WAIT)
+        await waitFor(() => expect(screen.getByTestId('outputs-files-section')).toBeInTheDocument())
         // Quiesce: the files table fires the last-activity query on mount. Waiting for its answer
         // here means no test ends with that DB query in flight — an in-flight query racing the
         // per-test transaction rollback closes the shared client and poisons every later test
         // (the deferred-callback race documented in tests/vitest.setup.ts, in query form).
-        await waitFor(() => expect(screen.getAllByText('No activity yet').length).toBeGreaterThan(0), WAIT)
+        await waitFor(() => expect(screen.getAllByText('No activity yet').length).toBeGreaterThan(0))
         return { org, study, job }
     }
 
@@ -271,7 +264,7 @@ describe('ReviewerOutputsAvailableScreen after decryption', () => {
         expect(screen.getByRole('button', { name: 'summary.txt' })).toBeInTheDocument()
         // Waits for the activity query: the cell stays blank until the answer is in, so it never
         // claims "No activity yet" on the strength of an unresolved request.
-        await waitFor(() => expect(screen.getAllByText('No activity yet')).toHaveLength(2), { timeout: 15_000 })
+        await waitFor(() => expect(screen.getAllByText('No activity yet')).toHaveLength(2))
     })
 
     it('keeps Submit decision enabled on arrival', async () => {
@@ -286,9 +279,7 @@ describe('ReviewerOutputsAvailableScreen after decryption', () => {
 
         fireEvent.click(screen.getByTestId('outputs-submit-decision'))
 
-        expect(
-            await screen.findByText(textIncludes(`Enter your feedback for ${labName}`), undefined, WAIT),
-        ).toBeInTheDocument()
+        expect(await screen.findByText(textIncludes(`Enter your feedback for ${labName}`))).toBeInTheDocument()
         expect(screen.getByText('Select an option before submitting')).toBeInTheDocument()
         expect(screen.queryByText('Submit your decision?')).toBeNull()
     })
@@ -298,6 +289,6 @@ describe('ReviewerOutputsAvailableScreen after decryption', () => {
     it('caps feedback at 1500 for a completed run', async () => {
         await setupDecrypted([{ name: 'results.csv', content: 'a,b\n1,2' }], renderScreenSingleUser)
 
-        await waitFor(() => expect(screen.getByText(textIncludes('0/1500'))).toBeInTheDocument(), WAIT)
+        await waitFor(() => expect(screen.getByText(textIncludes('0/1500'))).toBeInTheDocument())
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.test.tsx
@@ -1,72 +1,182 @@
-import { vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import { useParams } from 'next/navigation'
+import { MantineProvider } from '@mantine/core'
+import { ModalsProvider } from '@mantine/modals'
 import dayjs from 'dayjs'
+import { ResultsWriter } from 'si-encryption/job-results/writer'
+import { fingerprintKeyData, pemToArrayBuffer } from 'si-encryption/util'
 import {
     actionResult,
-    describe,
-    expect,
+    createTestQueryClient,
+    db,
+    fireEvent,
     insertTestStudyJobData,
-    it,
-    type Mock,
     mockSessionWithTestData,
+    QueryClientProvider,
+    readTestSupportFile,
+    render,
     renderWithProviders,
     screen,
+    waitFor,
 } from '@/tests/unit.helpers'
-import { useParams } from 'next/navigation'
-import type { StudyJobStatus } from '@/database/types'
+import { YjsWebsocketProvider } from '@/lib/realtime/yjs-websocket-context'
+import { theme } from '@/theme'
+import type { FileType, StudyJobStatus } from '@/database/types'
 import { getStudyAction } from '@/server/actions/study.actions'
+import { fetchEncryptedJobFilesAction } from '@/server/actions/study-job.actions'
+import { latestJobForStudy } from '@/server/db/queries'
 import { setupStudyAction } from '@/tests/db-action.helpers'
 import { ReviewerOutputsAvailableScreen } from './reviewer-outputs-available-screen'
 import type { ScreenComponentProps } from './types'
 
-// The screen embeds SecurityKeyForm, whose file query hits job-file storage; serve no artifacts so
-// the static render under test stays hermetic (same approach as security-key-form.test.tsx).
-vi.mock('@/server/actions/study-job.actions', () => ({
-    fetchEncryptedJobFilesAction: vi.fn(() => []),
-}))
+vi.mock('@/server/actions/study-job.actions', async () => {
+    const actual = await vi.importActual<typeof import('@/server/actions/study-job.actions')>(
+        '@/server/actions/study-job.actions',
+    )
+    return { ...actual, fetchEncryptedJobFilesAction: vi.fn(async () => []) }
+})
+
+// Real in-browser RSA/AES decryption drives the phase flip in these tests, and on a loaded CI
+// runner (sharded workers + coverage instrumentation) that chain can outlast the default 5s
+// per-test budget. The waitFor timeouts below stay inside this ceiling.
+vi.setConfig({ testTimeout: 30_000 })
+
+const toArrayBuffer = (str: string): ArrayBuffer => {
+    const buf = Buffer.from(str, 'utf-8')
+    return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+}
+
+// Encrypt an artifact the way the enclave would (whole-zip + embedded manifest) so the reviewer's
+// real key decrypts it — the phase flip is driven by genuine decryption, not a stubbed callback.
+// Results use ENCRYPTED-RESULT (not the errored screen's log type): this suite is also the proof
+// that a completed run's artifacts flow through the same panel.
+async function seedArtifact(jobId: string, files: { name: string; content: string }[]) {
+    const fileType: FileType = 'ENCRYPTED-RESULT'
+    const publicKey = pemToArrayBuffer(await readTestSupportFile('public_key.pem'))
+    const fingerprint = await fingerprintKeyData(publicKey)
+    const writer = new ResultsWriter([{ publicKey, fingerprint }])
+    for (const file of files) await writer.addFile(file.name, toArrayBuffer(file.content))
+    const zip = await writer.generate()
+
+    const row = await db
+        .insertInto('studyJobFile')
+        .values({
+            studyJobId: jobId,
+            name: 'encrypted-results.zip',
+            path: `test-org/${jobId}/results/encrypted-results.zip`,
+            fileType,
+        })
+        .returning('id')
+        .executeTakeFirstOrThrow()
+
+    return {
+        studyJobFileId: row.id,
+        fileType,
+        name: 'encrypted-results.zip',
+        encryptedBody: await zip.arrayBuffer(),
+        recipientKeys: {} as Record<string, string>,
+    }
+}
+
+const setupAvailable = async (jobStatus: StudyJobStatus = 'RUN-COMPLETE') => {
+    const { org, user } = await mockSessionWithTestData({ orgSlug: 'openstax', orgType: 'enclave' })
+    const { study: dbStudy } = await insertTestStudyJobData({ org, researcherId: user.id, jobStatus })
+    const study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+    const job = await latestJobForStudy(dbStudy.id)
+    ;(useParams as Mock).mockReturnValue({ orgSlug: org.slug, studyId: study.id })
+    return { org, study, job }
+}
 
 const renderScreen = async (study: ScreenComponentProps['study'], orgSlug: string) =>
     renderWithProviders(await ReviewerOutputsAvailableScreen({ study, orgSlug }))
 
-const setupWithJobStatus = async (jobStatus: StudyJobStatus) => {
-    const { org, user } = await mockSessionWithTestData({ orgSlug: 'openstax', orgType: 'enclave' })
-    const { study: dbStudy } = await insertTestStudyJobData({ org, researcherId: user.id, jobStatus })
-    const study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
-    ;(useParams as Mock).mockReturnValue({ orgSlug: org.slug, studyId: study.id })
-    return { org, study }
+// Like renderWithProviders, but with single-user editing on so the feedback editor (and the
+// word counter in its footer) renders synchronously instead of holding a collaborative skeleton.
+const renderScreenSingleUser = async (study: ScreenComponentProps['study'], orgSlug: string) =>
+    render(
+        <QueryClientProvider client={createTestQueryClient()}>
+            <MantineProvider theme={theme}>
+                <YjsWebsocketProvider singleUserEditing>
+                    <ModalsProvider>{await ReviewerOutputsAvailableScreen({ study, orgSlug })}</ModalsProvider>
+                </YjsWebsocketProvider>
+            </MantineProvider>
+        </QueryClientProvider>,
+    )
+
+const unlock = async () => {
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: await readTestSupportFile('private_key.pem') } })
+    fireEvent.click(screen.getByRole('button', { name: 'View' }))
 }
 
-describe('ReviewerOutputsAvailableScreen', () => {
-    it('renders the outputs-available banner with the date the run completed', async () => {
-        const { org, study } = await setupWithJobStatus('RUN-COMPLETE')
+// Generous asynchronous wait: CI shards run 4 workers with coverage instrumentation, and the
+// decrypt flow under test is CPU-bound, so the RTL default of 1s is far too tight there.
+const WAIT = { timeout: 15_000 }
+
+// Matches on an element's full textContent, so text split across child nodes (or differing
+// whitespace) can never produce a false negative the way an exact-string matcher can.
+const textIncludes = (needle: string) => (_: string, element: Element | null) =>
+    !!element && element.children.length === 0 && (element.textContent ?? '').includes(needle)
+
+describe('ReviewerOutputsAvailableScreen before decryption', () => {
+    beforeEach(() => {
+        vi.mocked(fetchEncryptedJobFilesAction).mockResolvedValue([])
+    })
+
+    it('renders the shared page and section headers', async () => {
+        const { org, study } = await setupAvailable()
         await renderScreen(study, org.slug)
 
         expect(screen.getByRole('heading', { level: 1, name: 'Secondary analysis study' })).toBeInTheDocument()
-        // The RUN-COMPLETE status row was just inserted, so the surfaced date is today.
-        expect(screen.getByTestId('status-alert')).toHaveTextContent(
-            `Outputs are available for review • ${dayjs().format('MMM DD, YYYY')}`,
-        )
+        expect(screen.getByTestId('proposal-section-header')).toHaveTextContent('STEP 3')
+        expect(screen.getByTestId('proposal-section-header')).toHaveTextContent('Review outputs')
     })
 
-    it('addresses the banner body to the submitting lab', async () => {
-        const { org, study } = await setupWithJobStatus('RUN-COMPLETE')
+    it('shows the outputs-available banner with the run-complete date, addressed to the lab', async () => {
+        const { org, study } = await setupAvailable()
         await renderScreen(study, org.slug)
 
-        expect(screen.getByTestId('status-alert')).toHaveTextContent(
+        // The RUN-COMPLETE status row was just inserted, so the surfaced date is today.
+        const alert = screen.getByTestId('status-alert')
+        expect(alert).toHaveTextContent(`Outputs are available for review • ${dayjs().format('MMM DD, YYYY')}`)
+        expect(alert).toHaveTextContent(
             `Enter your security key to decrypt the outputs, review them, and then share with ${study.submittingLabName}.`,
         )
     })
 
-    it('renders the reused security key form', async () => {
-        const { org, study } = await setupWithJobStatus('RUN-COMPLETE')
+    // The two-part gate: RUN-COMPLETE alone must not surface the outputs. Only a validated key
+    // does, which is why this screen is a client phase flip and not a route.
+    it('asks for the security key and hides the review view until a key validates', async () => {
+        const { org, study } = await setupAvailable()
         await renderScreen(study, org.slug)
 
         expect(screen.getByRole('heading', { name: /security key/i })).toBeInTheDocument()
-        expect(screen.getByRole('textbox')).toBeInTheDocument()
-        expect(screen.getByRole('button', { name: 'View' })).toBeInTheDocument()
+        expect(screen.queryByTestId('outputs-files-section')).toBeNull()
+        expect(screen.queryByTestId('outputs-decision-section')).toBeNull()
+        expect(screen.queryByTestId('outputs-submit-decision')).toBeNull()
     })
 
-    it('wires Previous step to the read-only code page', async () => {
-        const { org, study } = await setupWithJobStatus('RUN-COMPLETE')
+    // The empty-artifact refusal (a well-formed key with nothing to decrypt must not unlock) is
+    // owned by security-key-form.test.tsx — the same form instance this screen embeds. Screen-level
+    // gating is proven here by the wrong-key path below, which anchors on a visible error.
+    it('keeps the outputs hidden when the key is wrong', async () => {
+        const { org, study, job } = await setupAvailable()
+        vi.mocked(fetchEncryptedJobFilesAction).mockResolvedValue([
+            await seedArtifact(job.id, [{ name: 'results.csv', content: 'a,b\n1,2' }]),
+        ])
+        await renderScreen(study, org.slug)
+        await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
+
+        fireEvent.change(screen.getByRole('textbox'), { target: { value: 'not-a-real-key' } })
+        fireEvent.click(screen.getByRole('button', { name: 'View' }))
+
+        expect(
+            await screen.findByText(textIncludes('Invalid key. Check that you copied'), undefined, WAIT),
+        ).toBeInTheDocument()
+        expect(screen.queryByTestId('outputs-files-section')).toBeNull()
+    })
+
+    it('links Previous step to the read-only code page for this study', async () => {
+        const { org, study } = await setupAvailable()
         await renderScreen(study, org.slug)
 
         expect(screen.getByRole('link', { name: /previous step/i })).toHaveAttribute(
@@ -83,8 +193,111 @@ describe('ReviewerOutputsAvailableScreen', () => {
     })
 
     it('shows a not-found alert when the job has not completed a run', async () => {
-        const { org, study } = await setupWithJobStatus('JOB-RUNNING')
+        const { org, study } = await setupAvailable('JOB-RUNNING')
         await renderScreen(study, org.slug)
         expect(screen.getByText('Outputs not found')).toBeInTheDocument()
+    })
+})
+
+describe('ReviewerOutputsAvailableScreen after decryption', () => {
+    beforeEach(() => {
+        vi.mocked(fetchEncryptedJobFilesAction).mockResolvedValue([])
+    })
+
+    const setupDecrypted = async (
+        files: { name: string; content: string }[],
+        doRender: typeof renderScreen = renderScreen,
+    ) => {
+        const { org, study, job } = await setupAvailable()
+        vi.mocked(fetchEncryptedJobFilesAction).mockResolvedValue([await seedArtifact(job.id, files)])
+        await doRender(study, org.slug)
+        await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
+        await unlock()
+        await waitFor(() => expect(screen.getByTestId('outputs-files-section')).toBeInTheDocument(), WAIT)
+        // Quiesce: the files table fires the last-activity query on mount. Waiting for its answer
+        // here means no test ends with that DB query in flight — an in-flight query racing the
+        // per-test transaction rollback closes the shared client and poisons every later test
+        // (the deferred-callback race documented in tests/vitest.setup.ts, in query form).
+        await waitFor(() => expect(screen.getAllByText('No activity yet').length).toBeGreaterThan(0), WAIT)
+        return { org, study, job }
+    }
+
+    it('swaps the key form for the outputs table, decision section and submit button', async () => {
+        await setupDecrypted([{ name: 'results.csv', content: 'a,b\n1,2' }])
+
+        expect(screen.queryByRole('heading', { name: /security key/i })).toBeNull()
+        expect(screen.getByTestId('outputs-files-section')).toBeInTheDocument()
+        expect(screen.getByTestId('outputs-decision-section')).toBeInTheDocument()
+        expect(screen.getByTestId('outputs-submit-decision')).toBeInTheDocument()
+    })
+
+    it('replaces the available banner with the review-before-sharing warning', async () => {
+        const { study } = await setupDecrypted([{ name: 'results.csv', content: 'a,b\n1,2' }])
+        const labName = study.submittingLabName ?? study.submittedByOrgSlug
+
+        const alert = screen.getByTestId('status-alert')
+        expect(alert).toHaveTextContent('Review the outputs before sharing')
+        expect(alert).not.toHaveTextContent('Outputs are available for review')
+        expect(alert).toHaveTextContent(
+            `As the reviewer, you are responsible for checking the outputs for sensitive or restricted information* before they are shared with ${labName}.`,
+        )
+        expect(alert).toHaveTextContent(
+            '*Sensitive data could cause harm if disclosed, such as personally identifiable information (PII). Restricted data is limited by a data use agreement or policy.',
+        )
+        expect(alert).toHaveAttribute('data-variant', 'action')
+    })
+
+    // The asterisk's meaning has to reach AT programmatically; visual proximity to the footnote
+    // conveys nothing to a screen reader.
+    it('associates the footnote with the asterisked sentence via aria-describedby', async () => {
+        await setupDecrypted([{ name: 'results.csv', content: 'a,b\n1,2' }])
+
+        const described = screen
+            .getByTestId('status-alert')
+            .querySelector('[aria-describedby="outputs-sensitive-data-footnote"]')
+        expect(described).not.toBeNull()
+        expect(document.getElementById('outputs-sensitive-data-footnote')).toHaveTextContent(
+            /Sensitive data could cause harm if disclosed/,
+        )
+    })
+
+    it('lists every decrypted result file with an empty activity state', async () => {
+        await setupDecrypted([
+            { name: 'results.csv', content: 'a,b\n1,2' },
+            { name: 'summary.txt', content: 'all good' },
+        ])
+
+        expect(screen.getByRole('button', { name: 'results.csv' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'summary.txt' })).toBeInTheDocument()
+        // Waits for the activity query: the cell stays blank until the answer is in, so it never
+        // claims "No activity yet" on the strength of an unresolved request.
+        await waitFor(() => expect(screen.getAllByText('No activity yet')).toHaveLength(2), { timeout: 15_000 })
+    })
+
+    it('keeps Submit decision enabled on arrival', async () => {
+        await setupDecrypted([{ name: 'results.csv', content: 'a,b\n1,2' }])
+
+        expect(screen.getByTestId('outputs-submit-decision')).toBeEnabled()
+    })
+
+    it('flags both empty fields and opens no modal on a blank submit', async () => {
+        const { study } = await setupDecrypted([{ name: 'results.csv', content: 'a,b\n1,2' }])
+        const labName = study.submittingLabName ?? study.submittedByOrgSlug
+
+        fireEvent.click(screen.getByTestId('outputs-submit-decision'))
+
+        expect(
+            await screen.findByText(textIncludes(`Enter your feedback for ${labName}`), undefined, WAIT),
+        ).toBeInTheDocument()
+        expect(screen.getByText('Select an option before submitting')).toBeInTheDocument()
+        expect(screen.queryByText('Submit your decision?')).toBeNull()
+    })
+
+    // OTTER-676: a completed run gets the 1500 cap, not the errored screen's 300. Rendered in
+    // single-user mode so the editor footer (where the counter lives) exists synchronously.
+    it('caps feedback at 1500 for a completed run', async () => {
+        await setupDecrypted([{ name: 'results.csv', content: 'a,b\n1,2' }], renderScreenSingleUser)
+
+        await waitFor(() => expect(screen.getByText(textIncludes('0/1500'))).toBeInTheDocument(), WAIT)
     })
 })

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.test.tsx
@@ -1,0 +1,90 @@
+import { vi } from 'vitest'
+import dayjs from 'dayjs'
+import {
+    actionResult,
+    describe,
+    expect,
+    insertTestStudyJobData,
+    it,
+    type Mock,
+    mockSessionWithTestData,
+    renderWithProviders,
+    screen,
+} from '@/tests/unit.helpers'
+import { useParams } from 'next/navigation'
+import type { StudyJobStatus } from '@/database/types'
+import { getStudyAction } from '@/server/actions/study.actions'
+import { setupStudyAction } from '@/tests/db-action.helpers'
+import { ReviewerOutputsAvailableScreen } from './reviewer-outputs-available-screen'
+import type { ScreenComponentProps } from './types'
+
+// The screen embeds SecurityKeyForm, whose file query hits job-file storage; serve no artifacts so
+// the static render under test stays hermetic (same approach as security-key-form.test.tsx).
+vi.mock('@/server/actions/study-job.actions', () => ({
+    fetchEncryptedJobFilesAction: vi.fn(() => []),
+}))
+
+const renderScreen = async (study: ScreenComponentProps['study'], orgSlug: string) =>
+    renderWithProviders(await ReviewerOutputsAvailableScreen({ study, orgSlug }))
+
+const setupWithJobStatus = async (jobStatus: StudyJobStatus) => {
+    const { org, user } = await mockSessionWithTestData({ orgSlug: 'openstax', orgType: 'enclave' })
+    const { study: dbStudy } = await insertTestStudyJobData({ org, researcherId: user.id, jobStatus })
+    const study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+    ;(useParams as Mock).mockReturnValue({ orgSlug: org.slug, studyId: study.id })
+    return { org, study }
+}
+
+describe('ReviewerOutputsAvailableScreen', () => {
+    it('renders the outputs-available banner with the date the run completed', async () => {
+        const { org, study } = await setupWithJobStatus('RUN-COMPLETE')
+        await renderScreen(study, org.slug)
+
+        expect(screen.getByRole('heading', { level: 1, name: 'Secondary analysis study' })).toBeInTheDocument()
+        // The RUN-COMPLETE status row was just inserted, so the surfaced date is today.
+        expect(screen.getByTestId('status-alert')).toHaveTextContent(
+            `Outputs are available for review • ${dayjs().format('MMM DD, YYYY')}`,
+        )
+    })
+
+    it('addresses the banner body to the submitting lab', async () => {
+        const { org, study } = await setupWithJobStatus('RUN-COMPLETE')
+        await renderScreen(study, org.slug)
+
+        expect(screen.getByTestId('status-alert')).toHaveTextContent(
+            `Enter your security key to decrypt the outputs, review them, and then share with ${study.submittingLabName}.`,
+        )
+    })
+
+    it('renders the reused security key form', async () => {
+        const { org, study } = await setupWithJobStatus('RUN-COMPLETE')
+        await renderScreen(study, org.slug)
+
+        expect(screen.getByRole('heading', { name: /security key/i })).toBeInTheDocument()
+        expect(screen.getByRole('textbox')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'View' })).toBeInTheDocument()
+    })
+
+    it('wires Previous step to the read-only code page', async () => {
+        const { org, study } = await setupWithJobStatus('RUN-COMPLETE')
+        await renderScreen(study, org.slug)
+
+        expect(screen.getByRole('link', { name: /previous step/i })).toHaveAttribute(
+            'href',
+            `/${org.slug}/study/${study.id}/review/code`,
+        )
+    })
+
+    it('shows a not-found alert when the study has no submitted job', async () => {
+        const { org, study } = await setupStudyAction({ orgSlug: 'openstax', orgType: 'enclave', createJob: false })
+        ;(useParams as Mock).mockReturnValue({ orgSlug: org.slug, studyId: study.id })
+        await renderScreen(study, org.slug)
+        expect(screen.getByText('No submission found')).toBeInTheDocument()
+    })
+
+    it('shows a not-found alert when the job has not completed a run', async () => {
+        const { org, study } = await setupWithJobStatus('JOB-RUNNING')
+        await renderScreen(study, org.slug)
+        expect(screen.getByText('Outputs not found')).toBeInTheDocument()
+    })
+})

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.tsx
@@ -1,12 +1,9 @@
 import dayjs from 'dayjs'
-import { Box, Group, Stack } from '@mantine/core'
-import { CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
 import { AlertNotFound } from '@/components/errors'
-import { ButtonLink } from '@/components/links'
-import { StudyPageHeader } from '@/components/study/study-page-header'
-import { ProposalStepHeader } from '@/components/study/proposal-step-header'
+import { OutputsReviewPanel } from '@/components/study/outputs-review-panel'
+import { ReviewBeforeSharingBanner } from '@/components/study/review-before-sharing-banner'
 import { StatusAlert, STATUS_ALERT_VARIANT } from '@/components/study/status-alert'
-import { SecurityKeyForm } from '@/components/study/security-key-form'
+import { COMPLETED_OUTPUTS_FEEDBACK_MAX_WORDS } from '@/lib/outputs-review'
 import { Routes } from '@/lib/routes'
 import { latestSubmittedJobForStudy } from '@/server/db/queries'
 import type { ScreenComponentProps } from './types'
@@ -22,12 +19,16 @@ function availableTimestamp(
 const AvailableBanner = ({ availableAt, labName }: { availableAt: Date | string; labName: string }) => (
     <StatusAlert
         variant={STATUS_ALERT_VARIANT.action}
-        title={`Outputs are available for review \u2022 ${dayjs(availableAt).format('MMM DD, YYYY')}`}
+        title={`Outputs are available for review • ${dayjs(availableAt).format('MMM DD, YYYY')}`}
     >
         Enter your security key to decrypt the outputs, review them, and then share with {labName}.
     </StatusAlert>
 )
 
+// OTTER-676: same two-phase panel as the errored screen (OTTER-675) — the security key gate,
+// then the decrypted outputs table, feedback and sharing decision. Only the locked banner copy
+// and the feedback cap differ: a completed run gets the longer limit (see outputsFeedbackMaxWords,
+// which the server derives independently from the job's own status history).
 export async function ReviewerOutputsAvailableScreen({
     study,
     orgSlug,
@@ -47,29 +48,19 @@ export async function ReviewerOutputsAvailableScreen({
         )
     }
 
+    const labName = study.submittingLabName ?? study.submittedByOrgSlug
+
     return (
-        <Box bg="grey.10">
-            <Stack px="xl" gap="xxl" py="xl">
-                <StudyPageHeader>Secondary analysis study</StudyPageHeader>
-                <ProposalStepHeader
-                    stepLabel="STEP 3"
-                    heading="Review outputs"
-                    studyTitle={study.title ?? ''}
-                    banner={<AvailableBanner availableAt={availableAt} labName={study.submittingLabName} />}
-                />
-
-                <SecurityKeyForm job={job} />
-
-                <Group>
-                    <ButtonLink
-                        href={Routes.studyReviewCode({ orgSlug, studyId: study.id })}
-                        variant="subtle"
-                        leftSection={<CaretLeftIcon />}
-                    >
-                        Previous step
-                    </ButtonLink>
-                </Group>
-            </Stack>
-        </Box>
+        <OutputsReviewPanel
+            orgSlug={orgSlug}
+            studyId={study.id}
+            studyTitle={study.title ?? ''}
+            job={job}
+            labName={labName}
+            maxWords={COMPLETED_OUTPUTS_FEEDBACK_MAX_WORDS}
+            lockedBanner={<AvailableBanner availableAt={availableAt} labName={labName} />}
+            unlockedBanner={<ReviewBeforeSharingBanner labName={labName} />}
+            previousHref={Routes.studyReviewCode({ orgSlug, studyId: study.id })}
+        />
     )
 }

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.tsx
@@ -1,0 +1,75 @@
+import dayjs from 'dayjs'
+import { Box, Group, Stack } from '@mantine/core'
+import { CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
+import { AlertNotFound } from '@/components/errors'
+import { ButtonLink } from '@/components/links'
+import { StudyPageHeader } from '@/components/study/study-page-header'
+import { ProposalStepHeader } from '@/components/study/proposal-step-header'
+import { StatusAlert, STATUS_ALERT_VARIANT } from '@/components/study/status-alert'
+import { SecurityKeyForm } from '@/components/study/security-key-form'
+import { Routes } from '@/lib/routes'
+import { latestSubmittedJobForStudy } from '@/server/db/queries'
+import type { ScreenComponentProps } from './types'
+
+// statusChanges arrive newest-first (see latestJobForStudyQuery ordering), so `find` picks the
+// most recent RUN-COMPLETE — the moment the outputs became available for review.
+function availableTimestamp(
+    statusChanges: ReadonlyArray<{ status: string; createdAt: Date | string }>,
+): Date | string | null {
+    return statusChanges.find((c) => c.status === 'RUN-COMPLETE')?.createdAt ?? null
+}
+
+const AvailableBanner = ({ availableAt, labName }: { availableAt: Date | string; labName: string }) => (
+    <StatusAlert
+        variant={STATUS_ALERT_VARIANT.action}
+        title={`Outputs are available for review \u2022 ${dayjs(availableAt).format('MMM DD, YYYY')}`}
+    >
+        Enter your security key to decrypt the outputs, review them, and then share with {labName}.
+    </StatusAlert>
+)
+
+export async function ReviewerOutputsAvailableScreen({
+    study,
+    orgSlug,
+}: Pick<ScreenComponentProps, 'study' | 'orgSlug'>) {
+    const job = await latestSubmittedJobForStudy(study.id)
+    if (!job) {
+        return <AlertNotFound title="No submission found" message="This study has no submitted code to review." />
+    }
+
+    const availableAt = availableTimestamp(job.statusChanges)
+    if (!availableAt) {
+        return (
+            <AlertNotFound
+                title="Outputs not found"
+                message="This study does not have outputs available for review yet."
+            />
+        )
+    }
+
+    return (
+        <Box bg="grey.10">
+            <Stack px="xl" gap="xxl" py="xl">
+                <StudyPageHeader>Secondary analysis study</StudyPageHeader>
+                <ProposalStepHeader
+                    stepLabel="STEP 3"
+                    heading="Review outputs"
+                    studyTitle={study.title ?? ''}
+                    banner={<AvailableBanner availableAt={availableAt} labName={study.submittingLabName} />}
+                />
+
+                <SecurityKeyForm job={job} />
+
+                <Group>
+                    <ButtonLink
+                        href={Routes.studyReviewCode({ orgSlug, studyId: study.id })}
+                        variant="subtle"
+                        leftSection={<CaretLeftIcon />}
+                    >
+                        Previous step
+                    </ButtonLink>
+                </Group>
+            </Stack>
+        </Box>
+    )
+}

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.tsx
@@ -33,6 +33,9 @@ export async function ReviewerOutputsAvailableScreen({
     study,
     orgSlug,
 }: Pick<ScreenComponentProps, 'study' | 'orgSlug'>) {
+    // Both not-found branches below are defensive: reviewer-screen-rules (rule 1b) routes here
+    // only when a RUN-COMPLETE landed with no files decision, so a routed render always has a
+    // submitted job with a completed run. They guard direct renders, not a reachable state.
     const job = await latestSubmittedJobForStudy(study.id)
     if (!job) {
         return <AlertNotFound title="No submission found" message="This study has no submitted code to review." />

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.tsx
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs'
 import { AlertNotFound } from '@/components/errors'
 import { OutputsReviewPanel } from '@/components/study/outputs-review-panel'
+import { ReviewBeforeSharingBanner } from '@/components/study/review-before-sharing-banner'
 import { StatusAlert, STATUS_ALERT_VARIANT } from '@/components/study/status-alert'
 import { ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS } from '@/lib/outputs-review'
 import { Routes } from '@/lib/routes'
@@ -19,24 +20,6 @@ const ErroredBanner = ({ erroredAt }: { erroredAt: Date | string }) => (
         title={`Code errored • ${dayjs(erroredAt).format('MMM DD, YYYY')}`}
     >
         Enter your security key below to access the outputs and see what went wrong.
-    </StatusAlert>
-)
-
-// OTTER-675: once the key decrypts, the banner stops asking for a key and starts warning about
-// what the reviewer is about to share. The footnote is a real element referenced by
-// aria-describedby, so the asterisk's meaning reaches AT instead of being implied by position.
-const FOOTNOTE_ID = 'outputs-sensitive-data-footnote'
-
-const ReviewBeforeSharingBanner = ({ labName }: { labName: string }) => (
-    <StatusAlert variant={STATUS_ALERT_VARIANT.action} title="Review the outputs before sharing">
-        <span aria-describedby={FOOTNOTE_ID}>
-            As the reviewer, you are responsible for checking the outputs for sensitive or restricted information*
-            before they are shared with {labName}.
-        </span>
-        <span id={FOOTNOTE_ID} style={{ display: 'block', fontSize: 12, marginTop: 8 }}>
-            *Sensitive data could cause harm if disclosed, such as personally identifiable information (PII). Restricted
-            data is limited by a data use agreement or policy.
-        </span>
     </StatusAlert>
 )
 

--- a/src/components/study/review-before-sharing-banner.tsx
+++ b/src/components/study/review-before-sharing-banner.tsx
@@ -1,0 +1,22 @@
+import { FC } from 'react'
+import { StatusAlert, STATUS_ALERT_VARIANT } from '@/components/study/status-alert'
+
+// Once the key decrypts, the outputs step's banner stops asking for a key and starts warning about
+// what the reviewer is about to share. Shared by the errored (OTTER-675) and outputs-available
+// (OTTER-676) screens so the two flows cannot drift apart. The footnote is a real element
+// referenced by aria-describedby, so the asterisk's meaning reaches AT instead of being implied
+// by position.
+const FOOTNOTE_ID = 'outputs-sensitive-data-footnote'
+
+export const ReviewBeforeSharingBanner: FC<{ labName: string }> = ({ labName }) => (
+    <StatusAlert variant={STATUS_ALERT_VARIANT.action} title="Review the outputs before sharing">
+        <span aria-describedby={FOOTNOTE_ID}>
+            As the reviewer, you are responsible for checking the outputs for sensitive or restricted information*
+            before they are shared with {labName}.
+        </span>
+        <span id={FOOTNOTE_ID} style={{ display: 'block', fontSize: 12, marginTop: 8 }}>
+            *Sensitive data could cause harm if disclosed, such as personally identifiable information (PII). Restricted
+            data is limited by a data use agreement or policy.
+        </span>
+    </StatusAlert>
+)

--- a/src/components/study/security-key-input.tsx
+++ b/src/components/study/security-key-input.tsx
@@ -1,7 +1,7 @@
 import { Textarea, type TextareaProps } from '@mantine/core'
 import { forwardRef } from 'react'
 
-type SecurityKeyInputProps = Omit<TextareaProps, 'autoComplete' | 'aria-required'>
+type SecurityKeyInputProps = Omit<TextareaProps, 'autoComplete' | 'aria-required' | 'aria-label'>
 
 export const SecurityKeyInput = forwardRef<HTMLTextAreaElement, SecurityKeyInputProps>(
     ({ error, disabled, ...props }, ref) => {
@@ -12,6 +12,9 @@ export const SecurityKeyInput = forwardRef<HTMLTextAreaElement, SecurityKeyInput
                 ref={ref}
                 autoComplete="off"
                 aria-required
+                // The visible "Security key" section heading is not programmatically associated
+                // with the textarea, so without this the required field has no accessible name.
+                aria-label="Security key"
                 disabled={disabled}
                 error={error ? <span role="alert">{error}</span> : undefined}
                 styles={{ input: { minHeight: 72, borderColor } }}

--- a/src/lib/study-screen/resolve.test.ts
+++ b/src/lib/study-screen/resolve.test.ts
@@ -177,9 +177,18 @@ describe('resolveResearcherCodeScreen (read-only /view/code)', () => {
 })
 
 describe('resolveScreen (reviewer)', () => {
-    it('results present → reviewer-study-results (highest precedence)', () => {
+    it('decided results → reviewer-study-results (highest precedence)', () => {
+        expect(
+            resolveScreen(
+                'reviewer',
+                state({ hasResults: true, resultsApproved: true, codeDecision: 'CODE-APPROVED' }),
+                ctx,
+            ).screen,
+        ).toBe('reviewer-study-results')
+    })
+    it('undecided results → reviewer-outputs-available (decrypt-before-review, OTTER-668)', () => {
         expect(resolveScreen('reviewer', state({ hasResults: true, codeDecision: 'CODE-APPROVED' }), ctx).screen).toBe(
-            'reviewer-study-results',
+            'reviewer-outputs-available',
         )
     })
     it('pending review → reviewer-proposal-review', () => {

--- a/src/lib/study-screen/reviewer-screen-rules.test.ts
+++ b/src/lib/study-screen/reviewer-screen-rules.test.ts
@@ -102,6 +102,62 @@ describe('resolveScreen(reviewer)', () => {
         ).toBe('reviewer-outputs-errored')
     })
 
+    it('run complete, no files decision → reviewer-outputs-available (not study-results)', () => {
+        expect(
+            screen(
+                st({
+                    status: 'APPROVED',
+                    hasSubmittedCode: true,
+                    codeDecision: 'CODE-APPROVED',
+                    hasResults: true,
+                    resultsDisplayStatus: 'RUN-COMPLETE',
+                }),
+            ),
+        ).toBe('reviewer-outputs-available')
+    })
+
+    it('run complete AND errored → reviewer-outputs-errored (errored out-ranks available)', () => {
+        expect(
+            screen(
+                st({
+                    status: 'APPROVED',
+                    hasSubmittedCode: true,
+                    codeDecision: 'CODE-APPROVED',
+                    hasResults: true,
+                    resultsErrored: true,
+                    resultsDisplayStatus: 'JOB-ERRORED',
+                }),
+            ),
+        ).toBe('reviewer-outputs-errored')
+    })
+
+    it('run complete then files decision → reviewer-study-results (available no longer intercepted)', () => {
+        expect(
+            screen(
+                st({
+                    status: 'APPROVED',
+                    hasSubmittedCode: true,
+                    codeDecision: 'CODE-APPROVED',
+                    hasResults: true,
+                    resultsApproved: true,
+                    resultsDisplayStatus: 'FILES-APPROVED',
+                }),
+            ),
+        ).toBe('reviewer-study-results')
+        expect(
+            screen(
+                st({
+                    status: 'APPROVED',
+                    hasSubmittedCode: true,
+                    codeDecision: 'CODE-APPROVED',
+                    hasResults: true,
+                    resultsRejected: true,
+                    resultsDisplayStatus: 'FILES-REJECTED',
+                }),
+            ),
+        ).toBe('reviewer-study-results')
+    })
+
     it('job errored then files-rejected → reviewer-study-results (errored no longer intercepted)', () => {
         expect(
             screen(

--- a/src/lib/study-screen/reviewer-screen-rules.ts
+++ b/src/lib/study-screen/reviewer-screen-rules.ts
@@ -9,7 +9,16 @@ export const REVIEWER_SCREEN_RULES = [
     //     enters their security key to decrypt error logs before making a files decision.
     ['reviewer-outputs-errored', { when: (s) => s.resultsErrored && !s.resultsApproved && !s.resultsRejected }],
 
-    // 1b. Results exist → results-only Study Details (OTTER-538). Out-ranks the code decision
+    // 1b. Run completed, no files decision yet ("results pending review") → outputs-available view
+    //     (OTTER-668). The reviewer enters their security key to decrypt the outputs before making
+    //     a files decision. Sits below 1a so an errored run keeps the errored view even when a
+    //     RUN-COMPLETE also landed.
+    [
+        'reviewer-outputs-available',
+        { when: (s) => s.hasResults && !s.resultsApproved && !s.resultsRejected && !s.resultsErrored },
+    ],
+
+    // 1c. Results exist → results-only Study Details (OTTER-538). Out-ranks the code decision
     //     (CODE-APPROVED is always present once results land), mirroring legacy
     //     `decisionMade = hasLiveCodeDecision && !hasResultsStatus`.
     ['reviewer-study-results', { when: (s) => s.hasResults }],

--- a/src/lib/study-screen/screens.ts
+++ b/src/lib/study-screen/screens.ts
@@ -16,6 +16,7 @@ export type ScreenId =
     | 'reviewer-code-feedback'
     | 'reviewer-outputs-pending'
     | 'reviewer-outputs-errored'
+    | 'reviewer-outputs-available'
     | 'reviewer-study-results'
 
 // The rule table decides WHICH screen a study shows; each leaf view owns its own back/forward

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -281,9 +281,9 @@ function uploadResults(jobId: string): void {
     )
 }
 
-// OTTER-668: a successful run now lands on the outputs-available screen, which uses the
-// SecurityKeyForm (decrypt only). The post-decryption review+approve flow is OTTER-675;
-// until then, verify the banner renders and decrypt succeeds.
+// OTTER-668 + OTTER-676: the outputs-available screen, both phases. Like the errored screen,
+// a validated key swaps the form for the outputs table and Decision section on the same URL —
+// decryption is client-side, so the swap is a local phase flip, not a navigation.
 async function reviewerDecryptsAvailableOutputs(page: Page, studyTitle: string): Promise<void> {
     await visitAsRole(page, REVIEWER_DASHBOARD)
     await expect(page.getByText('Review Studies')).toBeVisible()
@@ -302,7 +302,8 @@ async function reviewerDecryptsAvailableOutputs(page: Page, studyTitle: string):
     await expect(viewButton).toBeEnabled()
     await viewButton.click()
 
-    await expect(page.getByText('Security key accepted.')).toBeVisible()
+    await expect(page.getByTestId('outputs-files-section')).toBeVisible()
+    await expect(page.getByText('Review the outputs before sharing')).toBeVisible()
 }
 
 // OTTER-667 + OTTER-675: the errored outputs screen, both phases. The key form gives way to
@@ -474,10 +475,10 @@ test('Reviewer approves submitted code', async ({ browser, studyFeatures }) => {
     })
 })
 
-// Owns the reviewer outputs-available decrypt surface. Seeds a JOB-READY job, uploads
-// an encrypted result via the debug script (no runner), then drives the UI.
-// OTTER-675: restore the approve step + researcher approved-results check once the
-// post-decryption review flow is built.
+// Owns the outputs-available surface end to end (OTTER-668 + OTTER-676): decrypt, the
+// validation gate, and sharing the outputs through the confirmation modal. Seeds a
+// JOB-READY job, uploads an encrypted result via the debug script (no runner), then
+// drives the UI. Researcher's approved-results view is owned by its own card.
 test('Successful results review', async ({ browser, studyFeatures }) => {
     const studyTitle = studyFeatures.uniqueTitle('results')
     const { jobId } = await seedCodeApprovedJobReady(studyTitle)
@@ -485,6 +486,8 @@ test('Successful results review', async ({ browser, studyFeatures }) => {
 
     await withRole(browser, 'reviewer', async (page) => {
         await reviewerDecryptsAvailableOutputs(page, studyTitle)
+        await reviewerSeesValidationOnBlankSubmit(page)
+        await reviewerSharesOutputs(page, 'Reviewed the outputs — no sensitive or restricted data present.')
     })
 })
 

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -281,30 +281,28 @@ function uploadResults(jobId: string): void {
     )
 }
 
-// Reviewer results-review (StudyDetailsReviewer) for a successful run: decrypt then
-// approve. Result files auto-select on decrypt, so the job-level Approve enables
-// without ticking a checkbox.
-async function reviewerApprovesResults(page: Page, studyTitle: string): Promise<void> {
+// OTTER-668: a successful run now lands on the outputs-available screen, which uses the
+// SecurityKeyForm (decrypt only). The post-decryption review+approve flow is OTTER-675;
+// until then, verify the banner renders and decrypt succeeds.
+async function reviewerDecryptsAvailableOutputs(page: Page, studyTitle: string): Promise<void> {
     await visitAsRole(page, REVIEWER_DASHBOARD)
     await expect(page.getByText('Review Studies')).toBeVisible()
     await viewStudyDetails(page, studyTitle)
     await page.waitForURL(/\/review$/)
 
+    await expect(page.getByText(/Outputs are available for review/)).toBeVisible()
+    await expect(page.getByRole('heading', { name: /security key/i })).toBeVisible()
+
     const privateKey = await readTestSupportFile('private_key.pem')
-    const privateKeyTextarea = page.getByPlaceholder('Enter your Results Key to access encrypted content.')
+    const privateKeyTextarea = page.getByRole('textbox')
     await expect(privateKeyTextarea).toBeVisible()
     await privateKeyTextarea.fill(privateKey)
 
-    const decryptButton = page.getByRole('button', { name: /Decrypt Files/i })
-    await expect(decryptButton).toBeEnabled()
-    await decryptButton.click()
+    const viewButton = page.getByRole('button', { name: 'View' })
+    await expect(viewButton).toBeEnabled()
+    await viewButton.click()
 
-    await expect(page.getByRole('button', { name: 'View' }).first()).toBeVisible()
-
-    const approveButton = page.getByRole('button', { name: /^Approve$/i }).last()
-    await expect(approveButton).toBeEnabled()
-    await approveButton.click()
-    await page.waitForURL('**/dashboard')
+    await expect(page.getByText('Security key accepted.')).toBeVisible()
 }
 
 // OTTER-667: the errored screen now uses the SecurityKeyForm (decrypt only).
@@ -438,21 +436,17 @@ test('Reviewer approves submitted code', async ({ browser, studyFeatures }) => {
     })
 })
 
-// Owns the reviewer results decrypt+approve surface. Seeds a JOB-READY job, uploads
+// Owns the reviewer outputs-available decrypt surface. Seeds a JOB-READY job, uploads
 // an encrypted result via the debug script (no runner), then drives the UI.
+// OTTER-675: restore the approve step + researcher approved-results check once the
+// post-decryption review flow is built.
 test('Successful results review', async ({ browser, studyFeatures }) => {
     const studyTitle = studyFeatures.uniqueTitle('results')
     const { jobId } = await seedCodeApprovedJobReady(studyTitle)
     uploadResults(jobId!)
 
     await withRole(browser, 'reviewer', async (page) => {
-        await reviewerApprovesResults(page, studyTitle)
-    })
-
-    await withRole(browser, 'researcher', async (page) => {
-        await visitAsRole(page, RESEARCHER_DASHBOARD)
-        await viewStudyDetails(page, studyTitle)
-        await expect(page.getByText(/results of your study have been approved/i)).toBeVisible()
+        await reviewerDecryptsAvailableOutputs(page, studyTitle)
     })
 })
 

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -294,7 +294,7 @@ async function reviewerDecryptsAvailableOutputs(page: Page, studyTitle: string):
     await expect(page.getByRole('heading', { name: /security key/i })).toBeVisible()
 
     const privateKey = await readTestSupportFile('private_key.pem')
-    const privateKeyTextarea = page.getByRole('textbox')
+    const privateKeyTextarea = page.getByRole('textbox', { name: 'Security key' })
     await expect(privateKeyTextarea).toBeVisible()
     await privateKeyTextarea.fill(privateKey)
 
@@ -318,7 +318,7 @@ async function reviewerDecryptsErrorLogs(page: Page, studyTitle: string): Promis
     await expect(page.getByRole('heading', { name: /security key/i })).toBeVisible()
 
     const privateKey = await readTestSupportFile('private_key.pem')
-    const privateKeyTextarea = page.getByRole('textbox')
+    const privateKeyTextarea = page.getByRole('textbox', { name: 'Security key' })
     await expect(privateKeyTextarea).toBeVisible()
     await privateKeyTextarea.fill(privateKey)
 
@@ -478,7 +478,8 @@ test('Reviewer approves submitted code', async ({ browser, studyFeatures }) => {
 // Owns the outputs-available surface end to end (OTTER-668 + OTTER-676): decrypt, the
 // validation gate, and sharing the outputs through the confirmation modal. Seeds a
 // JOB-READY job, uploads an encrypted result via the debug script (no runner), then
-// drives the UI. Researcher's approved-results view is owned by its own card.
+// drives the UI, then ends on the researcher's side: sharing records FILES-APPROVED, which is
+// what surfaces the approved-results message on their study view.
 test('Successful results review', async ({ browser, studyFeatures }) => {
     const studyTitle = studyFeatures.uniqueTitle('results')
     const { jobId } = await seedCodeApprovedJobReady(studyTitle)
@@ -488,6 +489,12 @@ test('Successful results review', async ({ browser, studyFeatures }) => {
         await reviewerDecryptsAvailableOutputs(page, studyTitle)
         await reviewerSeesValidationOnBlankSubmit(page)
         await reviewerSharesOutputs(page, 'Reviewed the outputs — no sensitive or restricted data present.')
+    })
+
+    await withRole(browser, 'researcher', async (page) => {
+        await visitAsRole(page, RESEARCHER_DASHBOARD)
+        await viewStudyDetails(page, studyTitle)
+        await expect(page.getByText(/results of your study have been approved/i)).toBeVisible()
     })
 })
 


### PR DESCRIPTION
OTTER-676: DP Outputs Refactoring — Outputs Available, After Decryption

After a completed run, the reviewer's outputs-available screen now uses the shared OutputsReviewPanel (OTTER-675): security key gate → decrypted files table, feedback, and the share-outputs / feedback-only decision with confirmation modals.

Stacked PR: base is OTTER-675-outputs-post-decryption-review, and the diff carries OTTER-668's commit. Merge #922 and #924 first, then retarget this to main — only the OTTER-676 commits are new.

Changes
reviewer-outputs-available-screen.tsx: swapped the static key-form layout for OutputsReviewPanel, with the completed-run feedback cap (1500).
review-before-sharing-banner.tsx (new): post-decryption warning banner extracted from the errored screen so both flows share it.
reviewer-outputs-errored-screen.tsx: imports the shared banner; no behavior change.

Notes: the ticket says 1500 characters; the existing panel and server validation count words (cap already defined as 1500 words in #924). Kept words for consistency — flag if characters are actually required.

Tests

15 new tests for the screen (gating on key validation, wrong key/no artifacts, exact banner copy + footnote a11y, blank-submit validation, 1500 cap; decrypts real ENCRYPTED-RESULT artifacts). Regression run over touched areas: 328 passed. typecheck/lint/validate-actions clean.

Depends on: #922, #924