### PR TITLE
OTTER-642 follow-up: keep re-deliveries from replacing artifacts under review

### DIFF
--- a/src/hooks/use-decrypt-files.test.tsx
+++ b/src/hooks/use-decrypt-files.test.tsx
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import {
+    db,
+    insertTestStudyJobData,
+    mockSessionWithTestData,
+    readTestSupportFile,
+    renderWithProviders,
+} from '@/tests/unit.helpers'
+import { EncryptedFilesPanel } from '@/components/encrypted-files-panel'
+import { latestJobForStudy } from '@/server/db/queries'
+import { insertSharedFileKeys } from '@/server/results-sharing'
+import { fetchFileContents } from '@/server/storage'
+import { ResultsWriter } from 'si-encryption/job-results/writer'
+import { ResultsReader } from 'si-encryption/job-results/reader'
+import { wrapAesKey } from 'si-encryption/job-results/crypto'
+import { fingerprintKeyData, pemToArrayBuffer } from 'si-encryption/util'
+import { generateKeyPair } from 'si-encryption/util/keypair'
+
+// Only the object-store read is mocked: the ciphertext is real, and so is every step between it and
+// the screen (fetchEncryptedJobFilesAction, the recipient-key lookup, ResultsReader, the panel).
+vi.mock('@/server/storage', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@/server/storage')>()),
+    fetchFileContents: vi.fn(),
+}))
+
+const KEY_PLACEHOLDER = 'Enter your Results Key to access encrypted content.'
+const MISMATCH_MESSAGE = 'Private key is not valid for these results, check with your administrator'
+
+// The researcher's own pair, generated once because RSA-4096 keygen is the slowest thing here. It is
+// deliberately NOT the shared fixture pair every seeded user holds: a researcher who shares the
+// enclave's key is a manifest recipient by accident, and would pass this suite without the
+// recipient-key path ever running.
+const researcher = await generateKeyPair()
+const researcherPrivateKeyPem = `-----BEGIN PRIVATE KEY-----\n${researcher.privateKeyString}\n-----END PRIVATE KEY-----`
+
+// The enclave writes the manifest against the reviewing org's keys, which is the fixture pair here.
+const enclaveRecipient = async () => {
+    const publicKey = pemToArrayBuffer(await readTestSupportFile('public_key.pem'))
+    return { publicKey, fingerprint: await fingerprintKeyData(publicKey) }
+}
+
+const toArrayBuffer = (str: string): ArrayBuffer => {
+    const buf = Buffer.from(str, 'utf-8')
+    return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+}
+
+// One encrypted artifact as TOA produces it: whole zip, embedded manifest, keys for the enclave only.
+async function encryptForEnclave(files: { name: string; content: string }[]) {
+    const recipient = await enclaveRecipient()
+    const writer = new ResultsWriter([recipient])
+    for (const file of files) await writer.addFile(file.name, toArrayBuffer(file.content))
+    return await writer.generate()
+}
+
+// What the reviewer's browser holds after decrypting: each inner file's raw AES key, the input the
+// approval flow re-wraps from.
+async function reviewerReads(zip: Blob) {
+    const recipient = await enclaveRecipient()
+    const privateKey = pemToArrayBuffer(await readTestSupportFile('private_key.pem'))
+    return await new ResultsReader(zip, privateKey, recipient.fingerprint).extractFilesWithKeys()
+}
+
+function serveCiphertext(zip: Blob) {
+    vi.mocked(fetchFileContents).mockResolvedValue(zip)
+}
+
+/**
+ * A lab study whose latest job holds one encrypted artifact, with the session set to a researcher of
+ * that lab who has their own enrolled key. Mirrors production: the researcher is absent from the
+ * manifest, so their only way in is a wrapped key row.
+ */
+async function setupSharedArtifact(files: { name: string; content: string }[]) {
+    const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+    await db
+        .insertInto('userPublicKey')
+        .values({
+            userId: user.id,
+            publicKey: Buffer.from(researcher.exportedPublicKey),
+            fingerprint: researcher.fingerprint,
+        })
+        .executeTakeFirstOrThrow()
+
+    const { study, job } = await insertTestStudyJobData({ org, jobStatus: 'JOB-ERRORED' })
+    await db.insertInto('jobStatusChange').values({ studyJobId: job.id, status: 'FILES-APPROVED' }).execute()
+
+    const zip = await encryptForEnclave(files)
+    const row = await db
+        .insertInto('studyJobFile')
+        .values({
+            studyJobId: job.id,
+            name: 'encrypted-logs.zip',
+            path: `${org.slug}/${job.id}/results/encrypted-logs.zip`,
+            fileType: 'ENCRYPTED-CODE-RUN-LOG',
+        })
+        .returning('id')
+        .executeTakeFirstOrThrow()
+
+    return { study, job, zip, studyJobFileId: row.id }
+}
+
+// The one line buildSharedFiles runs per recipient, kept here rather than calling it because that
+// action is gated on 'approve Study' and belongs to the reviewer's session, not the researcher's.
+async function shareWithResearcher(
+    jobId: string,
+    studyJobFileId: string,
+    entries: { path: string; rawAesKey: ArrayBuffer }[],
+) {
+    const sharedFiles = await Promise.all(
+        entries.map(async (entry) => ({
+            studyJobFileId,
+            filePath: entry.path,
+            keys: [{ fingerprint: researcher.fingerprint, crypt: await wrapAesKey(entry.rawAesKey, researcher.exportedPublicKey) }], // prettier-ignore
+        })),
+    )
+    await insertSharedFileKeys(db, jobId, sharedFiles)
+}
+
+async function renderResearcherPanel(studyId: string) {
+    const job = await latestJobForStudy(studyId)
+    renderWithProviders(<EncryptedFilesPanel isReviewer={false} job={job} onFilesApproved={vi.fn()} />)
+    await waitFor(() => expect(screen.getByPlaceholderText(KEY_PLACEHOLDER)).toBeDefined())
+}
+
+function decryptWith(privateKeyPem: string) {
+    fireEvent.change(screen.getByPlaceholderText(KEY_PLACEHOLDER), { target: { value: privateKeyPem } })
+    fireEvent.click(screen.getByRole('button', { name: 'Decrypt Files' }))
+}
+
+describe('researcher decryption of re-wrapped artifacts', () => {
+    // The gap this closes: every other test of this path asserts on placeholder crypt strings, so a
+    // real researcher unwrap - the splice of recipient keys into a manifest they are not named in -
+    // had no coverage at all and only ever ran on a deployed environment.
+    it('decrypts an artifact whose keys were re-wrapped for a key absent from the manifest', async () => {
+        const { study, job, zip, studyJobFileId } = await setupSharedArtifact([
+            { name: 'logs.json', content: '{"error":"Execution halted"}' },
+        ])
+        await shareWithResearcher(job.id, studyJobFileId, await reviewerReads(zip))
+        serveCiphertext(zip)
+
+        await renderResearcherPanel(study.id)
+        decryptWith(researcherPrivateKeyPem)
+
+        await waitFor(() => expect(screen.getByText('logs.json')).toBeDefined())
+        expect(screen.getByRole('button', { name: 'View' })).toBeDefined()
+        expect(screen.queryByText(MISMATCH_MESSAGE)).toBeNull()
+    })
+
+    // Recipient rows are found by the fingerprint enrolled for the user, while the browser splices them
+    // in under the fingerprint of the key that was typed. A key that is not the enrolled one therefore
+    // gets as far as unwrapping and fails there, which is the message a researcher actually sees when
+    // their account's enrolled key and the key they hold have drifted apart.
+    it('reports a mismatch when the typed key is not the enrolled one', async () => {
+        const { study, job, zip, studyJobFileId } = await setupSharedArtifact([
+            { name: 'logs.json', content: '{"error":"Execution halted"}' },
+        ])
+        await shareWithResearcher(job.id, studyJobFileId, await reviewerReads(zip))
+        serveCiphertext(zip)
+
+        await renderResearcherPanel(study.id)
+        decryptWith(await readTestSupportFile('private_key.pem'))
+
+        await waitFor(() => expect(screen.getByText(MISMATCH_MESSAGE)).toBeDefined())
+        expect(screen.queryByText('logs.json')).toBeNull()
+    })
+
+    // What a re-delivery used to do to a researcher: the reviewer wrapped the AES keys of the copy their
+    // browser had read, a retry replaced the object, and the keys then described bytes that were gone.
+    // The artifact still lists and the key is still theirs, so the failure is indistinguishable from a
+    // wrong key - which is why storeJobFile refusing the replacement is the fix, not a better message.
+    //
+    // The superseded copy renames its inner file, so the manifest lookup misses deterministically. A
+    // same-name replacement fails on AES padding instead, which the cipher does not guarantee to detect.
+    it('fails when the wrapped keys describe a superseded copy of the ciphertext', async () => {
+        const { study, job, zip, studyJobFileId } = await setupSharedArtifact([
+            { name: 'logs.json', content: '{"error":"Execution halted"}' },
+        ])
+        await shareWithResearcher(job.id, studyJobFileId, await reviewerReads(zip))
+        serveCiphertext(await encryptForEnclave([{ name: 'logs-retry.json', content: '{"error":"same run, again"}' }]))
+
+        await renderResearcherPanel(study.id)
+        decryptWith(researcherPrivateKeyPem)
+
+        await waitFor(() => expect(screen.getByText(MISMATCH_MESSAGE)).toBeDefined())
+    })
+})

--- a/src/server/storage.test.ts
+++ b/src/server/storage.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, vi } from 'vitest'
 import { db } from '@/database'
-import { insertTestJobInfo, testUploadFile } from '@/tests/unit.helpers'
+import { insertTestJobInfo, insertTestUser, testUploadFile } from '@/tests/unit.helpers'
 import { pathForStudyJob } from '@/lib/paths'
 import { storeStudyEncryptedLogFile, storeStudyEncryptedResultsFile } from './storage'
 import { storeS3File } from './aws'
@@ -80,6 +80,59 @@ test('refuses to replace an artifact whose keys are already shared on an open ro
 
     expect(redelivery.stored).toBe(false)
     expect(vi.mocked(storeS3File).mock.calls.length).toBe(uploadsBefore)
+})
+
+// Wrapped keys are written LAST, minutes after the reviewer's browser read the ciphertext and took
+// its AES keys into memory. A re-delivery inside that window passed both key and round guards, and the
+// wrap that followed described bytes that no longer existed, leaving the researcher with a key that
+// unwraps and decrypts to nothing. Having been opened is therefore reason enough to refuse.
+test('refuses to replace an artifact someone has already opened', async () => {
+    const { jobInfo: info, org } = await insertTestJobInfo()
+    const { user } = await insertTestUser({ org })
+    const stored = await storeStudyEncryptedLogFile(info, logFile(), 'ENCRYPTED-CODE-RUN-LOG')
+    await db
+        .insertInto('studyJobFileActivity')
+        .values({ studyJobFileId: stored.id, filePath: 'logs.json', userId: user.id, action: 'VIEWED' })
+        .execute()
+
+    const uploadsBefore = vi.mocked(storeS3File).mock.calls.length
+    const redelivery = await storeStudyEncryptedLogFile(info, logFile('re-delivered.zip'), 'ENCRYPTED-CODE-RUN-LOG')
+
+    expect(redelivery.stored).toBe(false)
+    expect(vi.mocked(storeS3File).mock.calls.length).toBe(uploadsBefore)
+    expect((await jobLogRows(info.studyJobId))[0].name).toBe('encrypted-logs.zip')
+})
+
+// An errored run is the exposed case: RUN-COMPLETE re-deliveries are turned away by the results route,
+// but JOB-ERRORED neither closes a round nor blocks the route, so the artifact stayed replaceable for
+// the whole review. Refuse from the announcement onward, which is before a reviewer can have opened it.
+test('refuses to replace an artifact once the run outcome has been announced', async () => {
+    const info = await setupJob()
+    await storeStudyEncryptedLogFile(info, logFile(), 'ENCRYPTED-CODE-RUN-LOG')
+    await db.insertInto('jobStatusChange').values({ studyJobId: info.studyJobId, status: 'JOB-ERRORED' }).execute()
+
+    const redelivery = await storeStudyEncryptedLogFile(info, logFile('re-delivered.zip'), 'ENCRYPTED-CODE-RUN-LOG')
+
+    expect(redelivery.stored).toBe(false)
+    expect((await jobLogRows(info.studyJobId))[0].name).toBe('encrypted-logs.zip')
+})
+
+// JOB-ERRORED is also written by the scanner, the containerizer and the generic status route, and one
+// of those can land BEFORE the run's own log arrives. Scoping the guard to statuses recorded after the
+// job already held the artifact is what keeps someone else's earlier failure from freezing an artifact
+// that nobody has reviewed yet - the same scoping the results route applies to its announcement check.
+test('still refreshes an artifact when the only announced outcome predates it', async () => {
+    const info = await setupJob()
+    await db
+        .insertInto('jobStatusChange')
+        .values({ studyJobId: info.studyJobId, status: 'JOB-ERRORED', createdAt: new Date('2020-01-01') })
+        .execute()
+
+    await storeStudyEncryptedLogFile(info, logFile(), 'ENCRYPTED-CODE-RUN-LOG')
+    const redelivery = await storeStudyEncryptedLogFile(info, logFile('re-delivered.zip'), 'ENCRYPTED-CODE-RUN-LOG')
+
+    expect(redelivery.stored).toBe(true)
+    expect((await jobLogRows(info.studyJobId))[0].name).toBe('re-delivered.zip')
 })
 
 // A closed round only protects artifacts it already has: dropping a never-seen one would lose data

--- a/src/server/storage.ts
+++ b/src/server/storage.ts
@@ -4,6 +4,7 @@ import { pathForStudyDocumentFile, pathForStudyJob, pathForStudyJobCodeFile } fr
 import { db, type DBExecutor } from '@/database'
 import { FileType } from '@/database/types'
 import { ROUND_CLOSING_JOB_STATUSES } from '@/lib/study-job-status'
+import { OUTPUTS_REVIEWABLE_JOB_STATUSES } from '@/lib/outputs-review'
 import logger from '@/lib/logger'
 
 export async function fetchFileContents(filePath: string) {
@@ -61,6 +62,40 @@ async function artifactWasShared(studyJobFileId: string): Promise<boolean> {
     return Boolean(shared)
 }
 
+// Whether this artifact has already been opened by someone. A reader holds the AES keys of the
+// ciphertext they opened, in browser memory, for as long as their review session lasts, and the wrap
+// they later persist is a snapshot of those keys. Replacing the object under an open session is what
+// turns that snapshot stale.
+async function artifactWasRead(studyJobFileId: string): Promise<boolean> {
+    const read = await db
+        .selectFrom('studyJobFileActivity')
+        .select('id')
+        .where('studyJobFileId', '=', studyJobFileId)
+        .executeTakeFirst()
+
+    return Boolean(read)
+}
+
+// Whether the run's outcome was announced after this job already held the artifact, which is the
+// moment reviewers were told there is something to review.
+//
+// Scoped to statuses recorded at or after `heldSince` for the same reason the results route scopes its
+// announcement check: JOB-ERRORED is also written by the scanner, the containerizer and the generic
+// status route, and one of those can land BEFORE the run's own artifacts arrive. A bare status lookup
+// would therefore read someone else's earlier failure as proof this artifact is under review and
+// refuse its first genuine refresh.
+async function outcomeAnnouncedSince(studyJobId: string, heldSince: Date): Promise<boolean> {
+    const announced = await db
+        .selectFrom('jobStatusChange')
+        .select('id')
+        .where('studyJobId', '=', studyJobId)
+        .where('status', 'in', OUTPUTS_REVIEWABLE_JOB_STATUSES)
+        .where('createdAt', '>=', heldSince)
+        .executeTakeFirst()
+
+    return Boolean(announced)
+}
+
 // Why a re-delivery must not replace this artifact, or null when replacing it is safe.
 //
 // Sharing is checked first and separately from the round, because the two do not coincide: a reviewer
@@ -68,9 +103,23 @@ async function artifactWasShared(studyJobFileId: string): Promise<boolean> {
 // CODE-APPROVED), and that round stays open afterwards. A round-status-only guard therefore left every
 // artifact shared at code approval, scan logs included, replaceable by a delayed scanner or
 // containerizer delivery. Keys are the thing being protected, so key existence is the question to ask.
-async function unreplaceableReason(studyJobFileId: string, studyJobId: string): Promise<string | null> {
-    if (await artifactWasShared(studyJobFileId)) return 'its keys have already been wrapped for recipients'
+//
+// Wrapped keys are not the whole story though, because they are written LAST. A reviewer decrypts the
+// artifact, spends minutes on the mandatory feedback, and only then does the browser wrap the AES keys
+// it has been holding since the fetch. A re-delivery inside that window passed both checks above,
+// replaced the ciphertext, and the wrap that followed described bytes that no longer exist: the
+// researcher then holds a key that unwraps fine and decrypts to nothing, reported to them as
+// "Private key is not valid for these results". Reading and being under review are therefore
+// unreplaceable too. An errored run is the exposed case, since RUN-COMPLETE deliveries are already
+// turned away by the results route and JOB-ERRORED does not close a round.
+async function unreplaceableReason(
+    existing: { id: string; createdAt: Date },
+    studyJobId: string,
+): Promise<string | null> {
+    if (await artifactWasShared(existing.id)) return 'its keys have already been wrapped for recipients'
     if (await roundIsClosed(studyJobId)) return 'the round is already decided'
+    if (await artifactWasRead(existing.id)) return 'it has already been opened, so a reader may hold its keys'
+    if (await outcomeAnnouncedSince(studyJobId, existing.createdAt)) return 'its outputs are already under review'
     return null
 }
 
@@ -104,8 +153,11 @@ async function artifactRowForSlot(studyJobId: string, path: string, fileType: Fi
  * and the loser is recovered below as the repeat it effectively is. It does not make a delivery atomic,
  * and nothing here holds a lock across the S3 upload, so three windows stay open:
  *
- *   - Keys can be wrapped, or the round closed, between the guard below and the upload, so a
- *     re-delivery landing inside that window still replaces a just-shared ciphertext.
+ *   - Any condition unreplaceableReason asks about can become true between the guard below and the
+ *     upload, so a re-delivery landing inside that window still replaces a ciphertext that someone
+ *     just read or shared. Narrower than it was: the guard now refuses from the announcement onward,
+ *     which is before a reviewer can have opened anything, so what remains is the millisecond between
+ *     the check and the upload rather than the whole review.
  *   - Both callers upload to the same key before either resolves its row, so S3 completion order need
  *     not match rename order: the row can end up naming one payload while holding the other's bytes.
  *     Same artifact in the same slot either way, so only the recorded name is affected.
@@ -129,7 +181,7 @@ async function storeJobFile(info: MinimalJobInfo, path: string, file: File, file
     //
     // The sender gets a success response either way (it has nothing to do differently), so log the
     // drop: without it, content that was accepted but never stored leaves no trace to diagnose from.
-    const unreplaceable = existing ? await unreplaceableReason(existing.id, info.studyJobId) : null
+    const unreplaceable = existing ? await unreplaceableReason(existing, info.studyJobId) : null
     if (existing && unreplaceable) {
         logger.warn(
             `ignoring re-delivered ${fileType} for job ${info.studyJobId} at ${path}: ${unreplaceable}, so the stored copy has to stay decryptable`,


### PR DESCRIPTION
see [OTTER-642](https://openstax.atlassian.net/browse/OTTER-642)

## Why

QA found that on an errored study the reviewer can read the logs, each listed exactly once, but the researcher cannot decrypt them: `Private key is not valid for these results, check with your administrator`. The researcher's key is fine, which was confirmed by the same account and the same key opening other studies. So the mismatch is per study, not per account.

Wrapped recipient keys are written **last**. The reviewer's browser fetches a ciphertext once at page mount, keeps each inner file's AES key in memory through the mandatory feedback, and persists the wrap only when the decision is submitted. Until that moment the artifact was still replaceable, because the only guards were "keys already wrapped" (`artifactWasShared`) and "round already decided" (`roundIsClosed`). A re-delivery landing inside that window replaced the object, and the wrap that followed described bytes that no longer existed. The researcher then holds a key that unwraps correctly and decrypts to nothing, which surfaces as the message above.

An errored run is the exposed case. `RUN-COMPLETE` re-deliveries are turned away by the results route's repeat guard, whereas `JOB-ERRORED` neither blocks that route nor closes a round, so the artifact stayed replaceable for the whole review. Repeated delivery on the errored path is not exotic either: it is what OTTER-642 was originally filed about.

## What changed

`unreplaceableReason` in `src/server/storage.ts` now asks two further questions before letting a re-delivery replace an artifact:

- **has it been opened**, via the `study_job_file_activity` rows OTTER-675 already writes. An opened artifact is one whose AES keys may already sit in someone's browser.
- **was the run outcome announced after the job already held it**, using `OUTPUTS_REVIEWABLE_JOB_STATUSES`. That is the moment reviewers were told there is something to review, and it lands before anyone can have opened anything, so it is the check that actually closes the window.

The announcement check is scoped to statuses recorded at or after the artifact's `createdAt`, mirroring the scoping the results route applies to its own announcement lookup. `JOB-ERRORED` is shared with the scanner, the containerizer and the generic status route, and one of those can land *before* the run's own log arrives, so a bare status lookup would read someone else's earlier failure as proof this artifact is under review and refuse its first genuine refresh. A test pins that.

Deliberately **not** done: extending the results route's early `alreadyReceived` 422 from `RUN-COMPLETE` to `JOB-ERRORED`. Same producer ambiguity, worse consequence: a pre-existing `JOB-ERRORED` from the containerizer would make the route reject the run's real error log before it is ever stored, losing it. The artifact-level guard reaches the same outcome without that risk.

## Researcher decryption test gap

This path had no real coverage. `study-job.actions.test.ts` asserts on placeholder crypt strings (`'wrapped-for-researcher'`), and the errored e2e stops at asserting `Code Run Log` is visible without ever entering the researcher's key, so the splice of recipient keys into a manifest the researcher is not named in only ever ran on a deployed environment.

`src/hooks/use-decrypt-files.test.tsx` now runs a genuine round trip: an artifact encrypted for the enclave's keypair, read the way the reviewer's browser reads it, re-wrapped for a **separately generated** researcher keypair, then decrypted through the real `fetchEncryptedJobFilesAction`, `ResultsReader` and `EncryptedFilesPanel`. The researcher's pair is deliberately not the shared fixture key every seeded user holds, since a researcher who shares the enclave's key is a manifest recipient by accident and would pass without the recipient-key path running at all. Only the object-store read is mocked.

Three cases: the happy path, a typed key that is not the enrolled one (the message QA saw), and keys wrapped against a superseded copy of the ciphertext (this bug, from the researcher's side). The superseded case renames the inner file so the manifest lookup misses deterministically; a same-name replacement fails on AES padding instead, which CBC does not guarantee to detect, and a probabilistic assertion has no place in the suite.

## Note for QA tooling

`/api/qa` study-state driving reuses these storage helpers, so re-attaching files to a QA study whose outcome has already been announced is now refused and logged rather than silently overwriting. Reaching a fresh artifact state means a fresh study.

## Tests

`./bin/docker-test`: 2393 passed, 251 files. `typecheck`, `validate-actions`, and eslint/prettier over the touched files are clean. No e2e change: adding a researcher decrypt step there is worth doing, but not in a PR whose full suite I have not run against a deployed stack.

## Not covered here

The message itself. A key that does not match the enrolled one still reports "not valid for these results" rather than "this key does not match the security key registered to your account", and no screen shows the enrolled fingerprint. That is a separate card, along with the finding that `bin/seed-environment.ts` and `bin/find-or-update-clerk-test-users.ts` enroll the shared test key for `admin` and `reviewer` only, never for `researcher`, and never reconcile a key row that has drifted.


[OTTER-642]: https://openstax.atlassian.net/browse/OTTER-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ