### PR TITLE
OTTER-675 follow-up: announce the autosave status in a live region

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/proposal/form.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/form.test.tsx
@@ -1,0 +1,41 @@
+import { BLANK_UUID, describe, expect, it, renderWithProviders, screen } from '@/tests/unit.helpers'
+import { ProposalProvider, type ProposalDraftData } from '@/contexts/proposal'
+import { ProposalForm } from './form'
+import { type ProposalFormValues } from './schema'
+
+const STUDY_ID = '11111111-1111-4111-8111-111111111111'
+
+const draftData: ProposalFormValues = {
+    title: 'A study title',
+    datasets: ['dataset-1'],
+    researchQuestions: '',
+    projectSummary: '',
+    impact: '',
+    additionalNotes: '',
+    piName: 'Jane Smith',
+    piUserId: BLANK_UUID,
+}
+
+const renderForm = (data: ProposalDraftData = draftData) =>
+    renderWithProviders(
+        <ProposalProvider studyId={STUDY_ID} draftData={data}>
+            <ProposalForm members={[{ value: BLANK_UUID, label: 'Jane Smith' }]} orgName="Rice University" />
+        </ProposalProvider>,
+    )
+
+describe('ProposalForm autosave announcements', () => {
+    // Title, datasets and PI all mirror one Yjs provider, so a live region on each would have a
+    // screen reader read "All changes saved" three times per save cycle. The isolated save-status
+    // tests cannot catch that; only the assembled page can. Counted by the announcer's own testid
+    // rather than page-wide: the collaborative text editors below own separate providers, so their
+    // regions are correct, and they mount asynchronously behind an ssr:false import.
+    it('announces a save once for the whole fields form (OTTER-675)', () => {
+        renderForm()
+        expect(screen.getAllByTestId('autosave-announcer')).toHaveLength(1)
+    })
+
+    it('starts the announcement region empty, so the first save is announced (OTTER-675)', () => {
+        renderForm()
+        expect(screen.getByTestId('autosave-announcer')).toBeEmptyDOMElement()
+    })
+})

--- a/src/app/[orgSlug]/study/[studyId]/proposal/form.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/form.tsx
@@ -10,7 +10,12 @@ import { FormFieldLabel } from '@/components/form-field-label'
 import { FormField, nativeFieldProps } from '@/components/form-field'
 import { WordCounter } from '@/components/word-counter'
 import { DatasetMultiSelect } from '@/components/dataset-multi-select'
-import { SaveStatusIndicator, type SaveStatusValue } from '@/components/save-status'
+import {
+    SaveStatusAnnouncer,
+    SaveStatusIndicator,
+    announcedSaveStatus,
+    type SaveStatusValue,
+} from '@/components/save-status'
 import { useProviderSaveStatus } from '@/lib/realtime/use-provider-save-status'
 import { countWords } from '@/lib/lexical'
 import { Routes, ExternalLinks } from '@/lib/routes'
@@ -77,12 +82,19 @@ export const ProposalForm: FC<ProposalFormProps> = ({
 
     // The Yjs provider saves the whole fields doc, so its status is form-wide;
     // each field only surfaces it after the user has actually edited that field
-    // (OTTER-594 QA: pristine fields must not claim "All changes saved").
-    const saveStatusFor = (key: CollabFieldKey): SaveStatusValue =>
-        yjsForm.editedKeys.has(key) ? fieldsSaveStatus : 'idle'
-    const titleSaveStatus = saveStatusFor('title')
-    const datasetsSaveStatus = saveStatusFor('datasets')
-    const piSaveStatus = saveStatusFor('piName')
+    // (OTTER-594 QA: pristine fields must not claim "All changes saved"), and stands down while
+    // that field's validation error owns the row (OTTER-674).
+    const saveStatusFor = (key: CollabFieldKey, error: unknown): SaveStatusValue =>
+        yjsForm.editedKeys.has(key) && !error ? fieldsSaveStatus : 'idle'
+    const titleSaveStatus = saveStatusFor('title', form.errors.title)
+    const datasetsSaveStatus = saveStatusFor('datasets', form.errors.datasets)
+    const piSaveStatus = saveStatusFor('piName', form.errors.piName)
+
+    // All three read the same provider, so a live region on each would have a screen reader read
+    // "All changes saved" three times per save cycle. They stay visual and announce from here
+    // once (OTTER-675). The collaborative text editors below own separate providers and so keep
+    // their own regions.
+    const fieldsAnnouncedStatus = announcedSaveStatus([titleSaveStatus, datasetsSaveStatus, piSaveStatus])
 
     useSubmissionRedirectListener({
         provider: yjsForm.provider,
@@ -99,6 +111,7 @@ export const ProposalForm: FC<ProposalFormProps> = ({
             redirectTarget="studySubmitted"
         >
             <Stack gap="xxl">
+                <SaveStatusAnnouncer status={fieldsAnnouncedStatus} />
                 <Paper p="xxl">
                     <Text fz={10} fw={700} c="charcoal.7" pb={4}>
                         STEP 2
@@ -135,7 +148,7 @@ export const ProposalForm: FC<ProposalFormProps> = ({
                                 value={form.values.title ?? ''}
                                 {...nativeFieldProps(form.errors.title, { required: true, description: true })}
                             />
-                            <SaveStatusIndicator status={titleSaveStatus} isVisible={!form.errors.title} />
+                            <SaveStatusIndicator status={titleSaveStatus} announce={false} />
                         </FormField>
 
                         <FormField
@@ -175,7 +188,7 @@ export const ProposalForm: FC<ProposalFormProps> = ({
                                     </Group>
                                 </Anchor>
                             </Group>
-                            <SaveStatusIndicator status={datasetsSaveStatus} isVisible={!form.errors.datasets} />
+                            <SaveStatusIndicator status={datasetsSaveStatus} announce={false} />
                         </FormField>
                     </Stack>
                 </Paper>
@@ -221,7 +234,7 @@ export const ProposalForm: FC<ProposalFormProps> = ({
                                     {...nativeFieldProps(form.errors.piName, { required: true, description: true })}
                                 />
                             </Box>
-                            <SaveStatusIndicator status={piSaveStatus} isVisible={!form.errors.piName} />
+                            <SaveStatusIndicator status={piSaveStatus} announce={false} />
                         </FormField>
 
                         <Box>

--- a/src/components/save-status.test.tsx
+++ b/src/components/save-status.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { renderWithProviders, screen } from '@/tests/unit.helpers'
 import { theme } from '@/theme'
-import { SaveStatusIndicator } from './save-status'
+import { SaveStatusAnnouncer, SaveStatusIndicator, announcedSaveStatus } from './save-status'
 
 describe('SaveStatusIndicator', () => {
     it('renders nothing while idle', () => {
@@ -59,5 +59,48 @@ describe('SaveStatusIndicator', () => {
     it('empties the live region when hidden by a validation error (OTTER-674)', () => {
         renderWithProviders(<SaveStatusIndicator status="saved" isVisible={false} />)
         expect(screen.getByRole('status')).toBeEmptyDOMElement()
+    })
+
+    it('leaves the live region unnamed, so the name is not spoken ahead of the save (OTTER-675)', () => {
+        // Several screen readers read a live region's accessible name before its content, which
+        // would turn each save into "<name>, All changes saved". Tests select the region by
+        // data-testid instead.
+        renderWithProviders(<SaveStatusIndicator status="saved" />)
+        const region = screen.getByTestId('autosave-live-region')
+        expect(region).not.toHaveAttribute('aria-label')
+        expect(region).not.toHaveAttribute('aria-labelledby')
+    })
+
+    it('drops its own live region when announce is false, keeping the visible label (OTTER-675)', () => {
+        renderWithProviders(<SaveStatusIndicator status="saved" announce={false} />)
+        expect(screen.getByTestId('autosave-status')).toHaveTextContent('All changes saved')
+        expect(screen.queryByRole('status')).not.toBeInTheDocument()
+        expect(screen.getByTestId('autosave-status').closest('[aria-live]')).toBeNull()
+    })
+})
+
+describe('SaveStatusAnnouncer', () => {
+    it('announces the save from a polite, atomic region', () => {
+        renderWithProviders(<SaveStatusAnnouncer status="saved" />)
+        const region = screen.getByRole('status')
+        expect(region).toHaveAttribute('aria-live', 'polite')
+        expect(region).toHaveAttribute('aria-atomic', 'true')
+        expect(region).toHaveTextContent('All changes saved')
+    })
+
+    it('stays mounted and empty until a save lands', () => {
+        renderWithProviders(<SaveStatusAnnouncer status="saving" />)
+        expect(screen.getByRole('status')).toBeEmptyDOMElement()
+    })
+})
+
+describe('announcedSaveStatus', () => {
+    it('announces once when any field of a shared save source is saved', () => {
+        expect(announcedSaveStatus(['idle', 'saved', 'idle'])).toBe('saved')
+    })
+
+    it('stays idle while no field is showing a save', () => {
+        expect(announcedSaveStatus(['idle', 'saving', 'idle'])).toBe('idle')
+        expect(announcedSaveStatus([])).toBe('idle')
     })
 })

--- a/src/components/save-status.test.tsx
+++ b/src/components/save-status.test.tsx
@@ -34,4 +34,30 @@ describe('SaveStatusIndicator', () => {
         renderWithProviders(<SaveStatusIndicator status="saved" isVisible={false} />)
         expect(screen.queryByTestId('autosave-status')).not.toBeInTheDocument()
     })
+
+    it('announces "All changes saved" from a polite live region (OTTER-675)', () => {
+        renderWithProviders(<SaveStatusIndicator status="saved" />)
+        const region = screen.getByRole('status')
+        expect(region).toHaveAttribute('aria-live', 'polite')
+        expect(region).toHaveAttribute('aria-atomic', 'true')
+        expect(region).toHaveTextContent('All changes saved')
+    })
+
+    it('keeps the live region mounted and empty while idle, so the save is announced (OTTER-675)', () => {
+        // A live region is only announced when content it already owns changes, so the region
+        // has to be in the DOM before the label lands in it.
+        renderWithProviders(<SaveStatusIndicator status="idle" />)
+        expect(screen.getByRole('status')).toBeEmptyDOMElement()
+    })
+
+    it('leaves the transient saving label out of the live region (OTTER-675)', () => {
+        renderWithProviders(<SaveStatusIndicator status="saving" />)
+        expect(screen.getByTestId('autosave-status').closest('[aria-live]')).toBeNull()
+        expect(screen.getByRole('status')).toBeEmptyDOMElement()
+    })
+
+    it('empties the live region when hidden by a validation error (OTTER-674)', () => {
+        renderWithProviders(<SaveStatusIndicator status="saved" isVisible={false} />)
+        expect(screen.getByRole('status')).toBeEmptyDOMElement()
+    })
 })

--- a/src/components/save-status.tsx
+++ b/src/components/save-status.tsx
@@ -1,10 +1,12 @@
 'use client'
 
-import { FC } from 'react'
-import { Box, Group, Text, useMantineTheme } from '@mantine/core'
+import { FC, ReactNode } from 'react'
+import { Box, Group, Text, VisuallyHidden, useMantineTheme } from '@mantine/core'
 import { CheckCircleIcon } from '@phosphor-icons/react/dist/ssr'
 
 export type SaveStatusValue = 'idle' | 'saving' | 'saved'
+
+export const SAVED_LABEL = 'All changes saved'
 
 const SavingLabel: FC<{ isVisible: boolean }> = ({ isVisible }) => {
     if (!isVisible) return null
@@ -25,22 +27,71 @@ const SavedLabel: FC<{ isVisible: boolean }> = ({ isVisible }) => {
         <Group gap={8} wrap="nowrap" data-testid="autosave-status">
             <CheckCircleIcon size={16} color={theme.colors.green[9]} weight="fill" />
             <Text size="xs" c="green.9" fw={600}>
-                All changes saved
+                {SAVED_LABEL}
             </Text>
         </Group>
     )
 }
 
+// Holds the saved label, or passes it straight through on a surface that announces from one
+// shared region instead (see SaveStatusAnnouncer). Carries no accessible name on purpose:
+// several screen readers speak a live region's name ahead of its content, which would turn one
+// announcement into "Autosave status, All changes saved" on every save. `data-testid` gives tests
+// something unambiguous to select, since a page legitimately holds one region per save source.
+const SavedLiveRegion: FC<{ isVisible: boolean; children: ReactNode }> = ({ isVisible, children }) => {
+    if (!isVisible) return <>{children}</>
+
+    return (
+        <Box role="status" aria-live="polite" aria-atomic="true" data-testid="autosave-live-region">
+            {children}
+        </Box>
+    )
+}
+
+// Empty until a save lands, so the region owns its content before the text arrives.
+const announcedText = (status: SaveStatusValue) => (status === 'saved' ? SAVED_LABEL : '')
+
+/**
+ * Announces a save once for a surface that draws several indicators from a single save source.
+ *
+ * Live regions are announced independently, so three field indicators mirroring one Yjs provider
+ * mean three announcements per save cycle. Pair this with `announce={false}` on those indicators:
+ * they keep their visible labels and this one region does the talking.
+ */
+export const SaveStatusAnnouncer: FC<{ status: SaveStatusValue }> = ({ status }) => (
+    <VisuallyHidden role="status" aria-live="polite" aria-atomic="true" data-testid="autosave-announcer">
+        {announcedText(status)}
+    </VisuallyHidden>
+)
+
+/**
+ * Collapses the per-field statuses of one save source into the single status to announce.
+ *
+ * Each field is already gated on whether the user edited it and whether a validation error owns
+ * its row, so "any field is showing saved" is what the announcement should follow: it never
+ * claims a save the user cannot see confirmed somewhere on screen.
+ */
+export const announcedSaveStatus = (statuses: SaveStatusValue[]): SaveStatusValue =>
+    statuses.includes('saved') ? 'saved' : 'idle'
+
 interface SaveStatusIndicatorProps {
     status: SaveStatusValue
-    /** False while the field's validation error is showing — the error takes the slot (OTTER-674). */
+    /** False while the field's validation error is showing, since the error takes the slot (OTTER-674). */
     isVisible?: boolean
+    /**
+     * False on a surface where several indicators share one save source and a single
+     * {@link SaveStatusAnnouncer} announces for all of them. The visible label is unchanged;
+     * only this indicator's own live region is dropped.
+     */
+    announce?: boolean
 }
 
 // Single autosave indicator shared across every surface (collaborative editor,
 // proposal fields, resubmission note). Draws no visible label until there is something to
 // report, so it can be dropped under any field unconditionally.
-export const SaveStatusIndicator: FC<SaveStatusIndicatorProps> = ({ status, isVisible = true }) => {
+export const SaveStatusIndicator: FC<SaveStatusIndicatorProps> = ({ status, isVisible = true, announce = true }) => {
+    // Collapsing a hidden indicator to 'idle' empties the region rather than unmounting it, so a
+    // save that lands while an error owns the slot is announced when the error clears, not lost.
     const shown = isVisible ? status : 'idle'
 
     return (
@@ -55,9 +106,9 @@ export const SaveStatusIndicator: FC<SaveStatusIndicatorProps> = ({ status, isVi
                 with its text (what returning null while idle did) left screen reader users with
                 no confirmation that their work was saved. `role="status"` and `aria-live` are
                 both spelled out because AT/browser pairs differ on which one they act on. */}
-            <Box role="status" aria-live="polite" aria-atomic="true">
+            <SavedLiveRegion isVisible={announce}>
                 <SavedLabel isVisible={shown === 'saved'} />
-            </Box>
+            </SavedLiveRegion>
         </>
     )
 }

--- a/src/components/save-status.tsx
+++ b/src/components/save-status.tsx
@@ -1,19 +1,25 @@
 'use client'
 
 import { FC } from 'react'
-import { Group, Text, useMantineTheme } from '@mantine/core'
+import { Box, Group, Text, useMantineTheme } from '@mantine/core'
 import { CheckCircleIcon } from '@phosphor-icons/react/dist/ssr'
 
 export type SaveStatusValue = 'idle' | 'saving' | 'saved'
 
-const SavingLabel: FC = () => (
-    <Text size="xs" c="dimmed" data-testid="autosave-status">
-        Saving…
-    </Text>
-)
+const SavingLabel: FC<{ isVisible: boolean }> = ({ isVisible }) => {
+    if (!isVisible) return null
 
-const SavedLabel: FC = () => {
+    return (
+        <Text size="xs" c="dimmed" data-testid="autosave-status">
+            Saving…
+        </Text>
+    )
+}
+
+const SavedLabel: FC<{ isVisible: boolean }> = ({ isVisible }) => {
     const theme = useMantineTheme()
+
+    if (!isVisible) return null
 
     return (
         <Group gap={8} wrap="nowrap" data-testid="autosave-status">
@@ -32,11 +38,26 @@ interface SaveStatusIndicatorProps {
 }
 
 // Single autosave indicator shared across every surface (collaborative editor,
-// proposal fields, resubmission note). Renders nothing until there is something
-// to report so it can be dropped under any field unconditionally.
+// proposal fields, resubmission note). Draws no visible label until there is something to
+// report, so it can be dropped under any field unconditionally.
 export const SaveStatusIndicator: FC<SaveStatusIndicatorProps> = ({ status, isVisible = true }) => {
-    if (!isVisible) return null
-    if (status === 'saving') return <SavingLabel />
-    if (status === 'saved') return <SavedLabel />
-    return null
+    const shown = isVisible ? status : 'idle'
+
+    return (
+        <>
+            {/* Deliberately outside the live region. "Saving…" is transient and flips back to
+                "saved" on every pause in typing, so announcing it too would double the
+                interruptions the AC asks us to hold down. It stays plain visible text, which a
+                screen reader still reads when the user navigates to it (OTTER-675). */}
+            <SavingLabel isVisible={shown === 'saving'} />
+            {/* The region is mounted unconditionally and starts empty. A live region is only
+                announced when content it already owns changes, so mounting the wrapper together
+                with its text (what returning null while idle did) left screen reader users with
+                no confirmation that their work was saved. `role="status"` and `aria-live` are
+                both spelled out because AT/browser pairs differ on which one they act on. */}
+            <Box role="status" aria-live="polite" aria-atomic="true">
+                <SavedLabel isVisible={shown === 'saved'} />
+            </Box>
+        </>
+    )
 }

--- a/src/components/study/collaborative-resubmission-note-section.test.tsx
+++ b/src/components/study/collaborative-resubmission-note-section.test.tsx
@@ -88,4 +88,16 @@ describe('CollaborativeResubmissionNoteSection', () => {
         expect(screen.getByText('A resubmission note is required.')).toBeInTheDocument()
         expect(screen.queryByTestId('autosave-status')).not.toBeInTheDocument()
     })
+
+    it('keeps the live region mounted through a validation error, so a later save is announced (OTTER-675)', () => {
+        // The error must empty the region rather than unmount it: a region handed back with its
+        // text already inside is silent in most AT/browser pairs.
+        renderSingleUserSection({ initialError: 'A resubmission note is required.' })
+        expect(screen.getByTestId('autosave-live-region')).toBeEmptyDOMElement()
+    })
+
+    it('mounts no live region at all in collaborative mode, where the editor owns one', () => {
+        renderSection()
+        expect(screen.queryByTestId('autosave-live-region')).not.toBeInTheDocument()
+    })
 })

--- a/src/components/study/collaborative-resubmission-note-section.tsx
+++ b/src/components/study/collaborative-resubmission-note-section.tsx
@@ -47,12 +47,18 @@ interface CollaborativeResubmissionNoteSectionProps {
 
 // In collaborative mode the editor renders its own provider-driven indicator;
 // showing this one too would double up.
-const SingleUserSaveStatus: FC<{ isVisible: boolean; autosaveStatus: ResubmissionNoteAutosaveStatus }> = ({
-    isVisible,
-    autosaveStatus,
-}) => {
+//
+// The error case goes through the indicator's own `isVisible` rather than unmounting here. A live
+// region is only announced when content it already owns changes, so unmounting on error and
+// mounting again once it clears would hand the region back with "All changes saved" already
+// inside it, and the save would never be announced (OTTER-675).
+const SingleUserSaveStatus: FC<{
+    isVisible: boolean
+    hasError: boolean
+    autosaveStatus: ResubmissionNoteAutosaveStatus
+}> = ({ isVisible, hasError, autosaveStatus }) => {
     if (!isVisible) return null
-    return <SaveStatusIndicator status={noteSaveStatus(autosaveStatus)} />
+    return <SaveStatusIndicator status={noteSaveStatus(autosaveStatus)} isVisible={!hasError} />
 }
 
 export const CollaborativeResubmissionNoteSection: FC<CollaborativeResubmissionNoteSectionProps> = ({
@@ -108,7 +114,11 @@ export const CollaborativeResubmissionNoteSection: FC<CollaborativeResubmissionN
                         <Box id={fieldErrorId('resubmissionNote')}>
                             <InputError error={error} />
                         </Box>
-                        <SingleUserSaveStatus isVisible={singleUserEditing && !error} autosaveStatus={autosaveStatus} />
+                        <SingleUserSaveStatus
+                            isVisible={singleUserEditing}
+                            hasError={!!error}
+                            autosaveStatus={autosaveStatus}
+                        />
                     </Group>
                 </Box>
             </Stack>

--- a/src/components/study/outputs-decision-section.test.tsx
+++ b/src/components/study/outputs-decision-section.test.tsx
@@ -254,4 +254,20 @@ describe('OutputsDecisionSection radio buttons', () => {
 
         expect(screen.getByText('Select an option before submitting')).toBeInTheDocument()
     })
+
+    it('marks the options invalid while the unselected error is showing (OTTER-675)', () => {
+        renderSection({ decisionError: 'Select an option before submitting' })
+
+        for (const option of screen.getAllByRole('radio')) {
+            expect(option).toHaveAttribute('aria-invalid', 'true')
+        }
+    })
+
+    it('leaves the options valid when no error is showing', () => {
+        renderSection()
+
+        for (const option of screen.getAllByRole('radio')) {
+            expect(option).not.toHaveAttribute('aria-invalid')
+        }
+    })
 })

--- a/src/components/study/outputs-decision-section.tsx
+++ b/src/components/study/outputs-decision-section.tsx
@@ -75,6 +75,12 @@ const DecisionRadioGroup: FC<DecisionRadioGroupProps> = ({ value, onChange, onBl
     // `aria-describedby`: Mantine renders `description` for sighted users but never associates it
     // with the input, so without this a screen reader announces only the title and the user never
     // hears which option withholds the files.
+    //
+    // `aria-invalid` sits on the inputs rather than on the `role="radiogroup"` element, which is
+    // where the group's invalid state belongs: Mantine renders that element itself, inside
+    // Radio.Group, and passes nothing through to it, so the inputs are the only reachable target.
+    // Without it the group was flagged visually and via `aria-describedby` but never announced as
+    // invalid, unlike the feedback editor right above it (OTTER-675).
     const options = buildDecisionOptions(labName).map((option) => (
         <Radio
             key={option.value}
@@ -82,6 +88,7 @@ const DecisionRadioGroup: FC<DecisionRadioGroupProps> = ({ value, onChange, onBl
             label={option.title}
             description={<span id={descriptionId(option.value)}>{option.description}</span>}
             aria-describedby={descriptionId(option.value)}
+            aria-invalid={error ? true : undefined}
             styles={RADIO_STYLES}
             data-testid={`outputs-decision-${option.value}`}
         />

--- a/src/components/study/resubmission-note-section.test.tsx
+++ b/src/components/study/resubmission-note-section.test.tsx
@@ -127,4 +127,13 @@ describe('ResubmissionNoteSection', () => {
         expect(screen.getByText(/resubmission note is required/i)).toBeInTheDocument()
         expect(screen.queryByTestId('autosave-status')).not.toBeInTheDocument()
     })
+
+    it('keeps the live region out of the textarea description (OTTER-675)', () => {
+        // The textarea's aria-describedby points at the error node. A live region inside it would
+        // fold "All changes saved" into the field's description and re-read it on every refocus.
+        renderSection({ autosaveStatus: { isSaving: false, lastSavedAt: new Date('2026-05-20T10:15:00Z') } })
+        const errorNode = document.getElementById('resubmissionNote-error')
+        expect(errorNode).toBeInTheDocument()
+        expect(errorNode!.querySelector('[aria-live]')).toBeNull()
+    })
 })

--- a/src/components/study/resubmission-note-section.tsx
+++ b/src/components/study/resubmission-note-section.tsx
@@ -66,8 +66,13 @@ export const ResubmissionNoteSection: FC<ResubmissionNoteSectionProps> = ({ note
                         {...nativeFieldProps(error, { required: true })}
                     />
                     <Group justify="space-between" align="center" mt={4}>
-                        <Box id={fieldErrorId('resubmissionNote')}>
-                            <InputError error={error} />
+                        {/* The indicator sits beside the error node, not inside it: the textarea's
+                            aria-describedby points at that id, and a live region in its subtree
+                            would fold "All changes saved" into the field's description. */}
+                        <Box>
+                            <Box id={fieldErrorId('resubmissionNote')}>
+                                <InputError error={error} />
+                            </Box>
                             <SaveStatusIndicator status={saveStatus} isVisible={!error} />
                         </Box>
                         <WordCounter wordCount={wordCount} maxWords={RESUBMIT_NOTE_MAX_WORDS} />


### PR DESCRIPTION
see [OTTER-675](https://openstax.atlassian.net/browse/OTTER-675?focusedCommentId=45895)

Follow-up to #924, which QA rejected on a single acceptance-criteria row.

## The failure

The Decision input AC requires: *&#34;&#39;All changes saved&#39; must render in an `aria-live=&#34;polite&#34;` region so it&#39;s announced without stealing focus; confirm debounce/throttle so the announcement doesn&#39;t fire so frequently it becomes noisy.&#34;*

Autosave itself worked, and the indicator appeared, but QA found it had no `aria-live` and no `role=&#34;status&#34;` ancestor, so a screen reader user got no confirmation that their work was saved.

The root cause is not a missing attribute. `SaveStatusIndicator` returned `null` until it had something to report, so the wrapper and its text entered the DOM in the same step. A live region is only announced when content it **already owns** changes; a region mounted together with its content is silent in most AT/browser pairs. Adding `aria-live` to the label as it was would not have fixed it.

## The fix

`src/components/save-status.tsx`, the shared indicator, so every surface that uses it (collaborative editor, proposal fields, resubmission note) gets the fix:

* The region is now mounted unconditionally and starts empty; only the label inside it comes and goes. `role=&#34;status&#34;` and `aria-live=&#34;polite&#34;` are both spelled out, plus `aria-atomic=&#34;true&#34;`, because AT/browser pairs differ on which one they act on.
* `&#34;Saving…&#34;` is rendered **outside** the region on purpose. It flips back to `&#34;saved&#34;` on every pause in typing, so announcing it as well would produce two interruptions per save cycle, which is exactly the noise the AC asks us to hold down. It stays plain visible text that a screen reader still reads when the user navigates to it. This gives one announcement per save cycle with no timer.
* The `isVisible={false}` behavior from OTTER-674 is unchanged: while a field&#39;s validation error owns the slot, no label is drawn, and the region simply sits empty. The announcement is deferred to when the error clears, not dropped.

No visual change on any surface. The region is a zero-size empty element when it has nothing to say, and `data-testid=&#34;autosave-status&#34;` stays on the label, so existing tests and the e2e `getByText(/All changes saved/i)` are unaffected.

## One announcement per save source

Raised in review, and the more substantive half of this PR. Mounting the region unconditionally means every surface that drops a `SaveStatusIndicator` gains a permanent region, and the proposal form drops three of them (title, datasets, PI). All three mirror **one** Yjs provider (`useProviderSaveStatus(yjsForm.provider)`, gated per field on `editedKeys`), so once a researcher has touched all three, every save cycle filled three live regions in the same tick.

Live regions are announced independently; there is no deduplication across regions in NVDA, JAWS or VoiceOver. That is three announcements per save, which is precisely the noise the AC asks us to hold down.

* `SaveStatusIndicator` takes an `announce` prop (default `true`). With `announce={false}` the visible label is unchanged and only that indicator&#39;s own live region is dropped.
* `SaveStatusAnnouncer`, a visually hidden `role=&#34;status&#34;` region, announces once for a surface whose indicators share a save source. `announcedSaveStatus()` collapses the per-field statuses into the one status it reports, so it never claims a save the user cannot see confirmed on screen.
* The proposal form&#39;s three fields now pass `announce={false}` and announce through a single announcer. The four collaborative text editors on that page own separate providers, so they keep their own regions and are unaffected.

The regions carry no accessible name. Several screen readers speak a live region&#39;s name ahead of its content ([MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/status_role), [ARIA22](https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA22)), which would turn every save into &#34;&lt;name&gt;, All changes saved&#34;. Disambiguation for tests is done with `data-testid` (`autosave-live-region` / `autosave-announcer`), which costs no speech.

## Two further live-region fixes

* `collaborative-resubmission-note-section.tsx` gated the whole indicator behind `singleUserEditing && !error`, so a validation error unmounted the region and clearing it handed the region back with &#34;All changes saved&#34; already inside, which is silent. The error gate now goes through the indicator&#39;s `isVisible` instead; only the collaborative-mode gate still unmounts, which is correct because the editor draws its own indicator there.
* `resubmission-note-section.tsx` rendered the indicator **inside** `&lt;Box id={fieldErrorId(&#39;resubmissionNote&#39;)}&gt;`, the node the textarea&#39;s `aria-describedby` points at. It is not reachable today, because Mantine only folds the error id into `describedBy` when the error is truthy and the indicator is hidden in exactly that state, but a live region inside a field&#39;s description is a trap for the next edit. The indicator is now a sibling of the error node, with the row layout unchanged.

## Also addressed

QA logged this under *Also observed* rather than as a failure, noting it was &#34;worth a look if you touch this area&#34;:

&gt; The radio group is flagged without `aria-invalid`. On a failed submit, the group gets `aria-describedby` pointing at &#34;Select an option before submitting&#34;, but neither the group nor the inputs get `aria-invalid` [...] the feedback field does set `aria-invalid` and the two are now inconsistent.

The decision radios now carry `aria-invalid` while the unselected error is showing, which satisfies the `aria-invalid` + `aria-describedby` branch the Navigation AC allows. Note on placement: per ARIA, the invalid state belongs on the `role=&#34;radiogroup&#34;` element, but Mantine renders that element itself inside `Radio.Group` (`InputsGroupFieldset`) and passes nothing through to it, so the inputs are the only reachable target. Left as a comment in the code.

## Deliberately not changed

* **The two copy deviations** (&#34;Output files&#34; vs &#34;Outputs files&#34;, and words vs characters for the 300 limit). Both follow Figma, both were flagged for Iris&#39;s sign-off on #924, and that sign-off is still outstanding. Unchanged here so the decision stays with PM.
* **`cursor: pointer` on the file name in its default state.** It follows from the file name being a real ``, which the AC separately requires. QA recorded no user impact.

## Testing

* Nine cases in `save-status.test.tsx`: the saved label announces from a polite, atomic live region; the region stays mounted and empty while idle; the saving label is kept out of it; the region empties when a validation error takes the slot; the region carries no accessible name; `announce={false}` drops the region and keeps the label; plus the announcer and `announcedSaveStatus`.
* `proposal/form.test.tsx` (new) asserts at page level that the three fields announce through exactly one region. The isolated component tests cannot catch cross-field duplication.
* `collaborative-resubmission-note-section.test.tsx` pins that the region survives a validation error and that collaborative mode mounts none.
* `resubmission-note-section.test.tsx` pins that no live region sits inside the textarea&#39;s description.
* Two cases in `outputs-decision-section.test.tsx` for the radio `aria-invalid` state, present with an error and absent without.
* Full unit suite green twice (251 files, 2404 tests), plus `pnpm run checks`.

### Browser verification

Both components were driven in a real Chromium session against a locally served build, re-running the exact DOM queries from the QA report. 19/19 checks passed:

| check | before (QA) | after |
| --- | --- | --- |
| `el.closest(&#39;[aria-live]&#39;)` on &#34;All changes saved&#34; | `null` | `polite` |
| `el.closest(&#39;[role=&#34;status&#34;],[role=&#34;alert&#34;]&#39;)` | `null` | `status` |
| region `aria-atomic` | n/a | `true` |
| region accessible name (must stay absent) | n/a | `null` |
| region content across a real save cycle | n/a | `&#34;&#34;` → `&#34;All changes saved&#34;` |
| &#34;Saving…&#34; ancestors (must stay outside the region) | n/a | `null` / `null` |
| `announce={false}`: label rendered, no region | n/a | holds, pixel-identical to `announce={true}` |
| announcer size and positioning | n/a | 1x1, `position: absolute`, no layout impact |
| `isVisible=false`: label absent, region mounted and empty | n/a | holds |
| live region inside the field&#39;s `aria-describedby` target | present | absent |
| resubmission note footer row, saved / saving / error | n/a | unchanged, no layout shift |
| decision radios `aria-invalid` on failed submit | `[null, null]` | `[&#34;true&#34;, &#34;true&#34;]` |
| decision radios `aria-invalid` with no error | n/a | `[null, null]`, not `&#34;false&#34;` |

Re-checked alongside these, all still holding: two native radios sharing one `name`, the radiogroup&#39;s accessible name &#34;Sharing decision&#34;, per-option `aria-describedby`, the group error reachable through `aria-describedby`, the feedback error&#39;s own polite live region, `aria-required` on the editor, and both options unselected on load.


[OTTER-675]: https://openstax.atlassian.net/browse/OTTER-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ