### PR TITLE
Fix stale org claims blocking researcher decryption

### DIFF
--- a/src/components/file-viewers/code-viewer.tsx
+++ b/src/components/file-viewers/code-viewer.tsx
@@ -35,6 +35,7 @@ import xml from 'highlight.js/lib/languages/xml'
 import yaml from 'highlight.js/lib/languages/yaml'
 import 'highlight.js/styles/github.css'
 import { highlightLanguageForFile, type HighlightLanguage } from '@/lib/languages'
+import { formatJson } from '@/lib/file-content-helpers'
 
 hljs.registerLanguage('bash', bash)
 hljs.registerLanguage('c', c)
@@ -73,6 +74,9 @@ interface CodeViewerProps {
     fileName?: string
     // Wraps the code display in an outline, matching the reviewer's submitted-code design.
     withBorder?: boolean
+    // Soft-wrap long lines instead of scrolling horizontally. Off by default: wrapping source code
+    // mid-statement hurts readability, but data formats like JSON have no meaningful line length.
+    wrapLines?: boolean
 }
 
 const OUTLINE_STYLE = {
@@ -81,7 +85,7 @@ const OUTLINE_STYLE = {
     overflow: 'hidden',
 } as const
 
-export function CodeViewer({ code, language, fileName, withBorder = false }: CodeViewerProps) {
+export function CodeViewer({ code, language, fileName, withBorder = false, wrapLines = false }: CodeViewerProps) {
     const highlightedCode = useMemo(() => {
         try {
             return hljs.highlight(code, { language }).value
@@ -101,6 +105,7 @@ export function CodeViewer({ code, language, fileName, withBorder = false }: Cod
                     borderRadius: '4px',
                     color: '#24292f',
                     fontSize: 'var(--mantine-font-size-sm)',
+                    ...(wrapLines ? { whiteSpace: 'pre-wrap', overflowWrap: 'break-word' } : null),
                 }}
             >
                 <code
@@ -127,5 +132,7 @@ export function CodeViewer({ code, language, fileName, withBorder = false }: Cod
 export function codeViewer(path: string, text: string): ReactNode | null {
     const language = highlightLanguageForFile(path)
     if (language === 'plaintext') return null
-    return <CodeViewer code={text} language={language} />
+    // Minified JSON is one long line; re-indent so it reads as a document rather than overflowing.
+    const code = (language === 'json' && formatJson(text)) || text
+    return <CodeViewer code={code} language={language} wrapLines={language === 'json'} />
 }

--- a/src/components/file-viewers/index.test.tsx
+++ b/src/components/file-viewers/index.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '@/tests/unit.helpers'
+import { FileViewer } from './index'
+
+describe('FileViewer', () => {
+    // Run logs ship as .json. Dispatching on the extension alone handed them to the code viewer,
+    // which highlights but never reformats, so a minified log rendered as one overflowing line.
+    it('renders a structured run log as a table rather than raw json', () => {
+        const log = JSON.stringify([
+            { timestamp: 1785869658968, message: 'Error: unexpected symbol' },
+            { timestamp: 1785869658999, message: 'second line' },
+        ])
+
+        renderWithProviders(<FileViewer path="logs.json" text={log} />)
+
+        expect(screen.getByRole('table')).toBeInTheDocument()
+        expect(screen.getByText('Error: unexpected symbol')).toBeInTheDocument()
+        expect(screen.getByText('second line')).toBeInTheDocument()
+    })
+
+    it('pretty-prints json that is not a structured log', () => {
+        const { container } = renderWithProviders(
+            <FileViewer path="results.json" text='{"alpha":1,"nested":{"beta":[1,2]}}' />,
+        )
+
+        const code = container.querySelector('code')
+        expect(code?.textContent).toContain('\n')
+        expect(code?.textContent).toContain('  "alpha": 1')
+        // Long values must soft-wrap instead of scrolling off the edge of the modal.
+        expect(container.querySelector('pre')).toHaveStyle({ whiteSpace: 'pre-wrap' })
+    })
+
+    it('leaves malformed json as-is instead of rendering nothing', () => {
+        const { container } = renderWithProviders(<FileViewer path="broken.json" text='{"alpha":' />)
+
+        expect(container.querySelector('code')?.textContent).toContain('{"alpha":')
+    })
+
+    it('does not wrap source code, which keeps horizontal scrolling', () => {
+        const { container } = renderWithProviders(<FileViewer path="analysis.R" text="x <- 1" />)
+
+        expect(container.querySelector('pre')).not.toHaveStyle({ whiteSpace: 'pre-wrap' })
+    })
+})

--- a/src/components/file-viewers/index.tsx
+++ b/src/components/file-viewers/index.tsx
@@ -7,7 +7,10 @@ import { textViewer } from './text-viewer'
 export { CodeViewer } from './code-viewer'
 export { ImageViewer } from './image-viewer'
 
-const viewers = [codeViewer, csvViewer, logViewer, textViewer]
+// Most specific first. logViewer inspects content rather than extension, so it must precede
+// codeViewer: run logs are written as .json, and matching on the extension alone would render a
+// structured log as a single minified line instead of the timestamp/message table.
+const viewers = [logViewer, codeViewer, csvViewer, textViewer]
 
 export const FileViewer: FC<{ path: string; text: string }> = ({ path, text }) => {
     for (const viewer of viewers) {

--- a/src/components/study/outputs-review-panel.tsx
+++ b/src/components/study/outputs-review-panel.tsx
@@ -98,7 +98,10 @@ const LockedPhase: FC<LockedPhaseProps> = ({ isVisible, job, previousHref, onDec
     if (!isVisible) return null
     return (
         <>
-            <SecurityKeyForm job={job} onDecrypted={onDecrypted} />
+            {/* The reviewer decrypts via the zip's embedded manifest, which is encrypted to the
+                enclave keys; they hold no re-wrapped per-file keys, so the researcher key set
+                would come back empty. */}
+            <SecurityKeyForm job={job} type="reviewer" onDecrypted={onDecrypted} />
             <Group>
                 <PreviousStepLink previousHref={previousHref} />
             </Group>

--- a/src/components/study/security-key-form.test.tsx
+++ b/src/components/study/security-key-form.test.tsx
@@ -102,7 +102,7 @@ describe('SecurityKeyForm', () => {
     })
 
     it('renders the key-entry section with a required indicator and body copy', async () => {
-        renderWithProviders(<SecurityKeyForm job={job} onDecrypted={onDecrypted} />)
+        renderWithProviders(<SecurityKeyForm job={job} type="reviewer" onDecrypted={onDecrypted} />)
 
         await screen.findByRole('button', { name: 'View' })
 
@@ -116,8 +116,19 @@ describe('SecurityKeyForm', () => {
         expect(screen.getByRole('button', { name: /lost your key/i })).toBeInTheDocument()
     })
 
+    // The two roles are served different key sets, and a reviewer holds no re-wrapped per-file
+    // keys. Asking as a researcher returns [] for them, which strands the outputs step on the
+    // locked phase, so the role has to reach the action rather than being assumed by the hook.
+    it.each(['reviewer', 'researcher'] as const)('requests the %s key set when acting as one', async (type) => {
+        renderWithProviders(<SecurityKeyForm job={job} type={type} onDecrypted={onDecrypted} />)
+
+        await screen.findByRole('button', { name: 'View' })
+
+        expect(fetchEncryptedJobFilesAction).toHaveBeenCalledWith({ jobId: job.id, type })
+    })
+
     it('shows the empty-field error and focuses the input when submitted blank', async () => {
-        renderWithProviders(<SecurityKeyForm job={job} onDecrypted={onDecrypted} />)
+        renderWithProviders(<SecurityKeyForm job={job} type="reviewer" onDecrypted={onDecrypted} />)
 
         await screen.findByRole('button', { name: 'View' })
 
@@ -128,7 +139,7 @@ describe('SecurityKeyForm', () => {
     })
 
     it('shows the invalid-key error and re-enables both input and button for correction', async () => {
-        renderWithProviders(<SecurityKeyForm job={job} onDecrypted={onDecrypted} />)
+        renderWithProviders(<SecurityKeyForm job={job} type="reviewer" onDecrypted={onDecrypted} />)
 
         await screen.findByRole('button', { name: 'View' })
 
@@ -142,7 +153,7 @@ describe('SecurityKeyForm', () => {
     })
 
     it('disables the button and input on submit to prevent double submission', async () => {
-        renderWithProviders(<SecurityKeyForm job={job} onDecrypted={onDecrypted} />)
+        renderWithProviders(<SecurityKeyForm job={job} type="reviewer" onDecrypted={onDecrypted} />)
 
         await screen.findByRole('button', { name: 'View' })
 
@@ -154,7 +165,7 @@ describe('SecurityKeyForm', () => {
     })
 
     it('replaces the empty-field error with the invalid-key error on retry', async () => {
-        renderWithProviders(<SecurityKeyForm job={job} onDecrypted={onDecrypted} />)
+        renderWithProviders(<SecurityKeyForm job={job} type="reviewer" onDecrypted={onDecrypted} />)
 
         await screen.findByRole('button', { name: 'View' })
 
@@ -174,7 +185,7 @@ describe('SecurityKeyForm', () => {
     it('shows a no-files error when the fetch returns an empty list', async () => {
         vi.mocked(fetchEncryptedJobFilesAction).mockResolvedValue([])
 
-        renderWithProviders(<SecurityKeyForm job={job} onDecrypted={onDecrypted} />)
+        renderWithProviders(<SecurityKeyForm job={job} type="reviewer" onDecrypted={onDecrypted} />)
 
         await screen.findByRole('button', { name: 'View' })
 
@@ -188,7 +199,7 @@ describe('SecurityKeyForm', () => {
     it('shows a no-files error when the fetch rejects', async () => {
         vi.mocked(fetchEncryptedJobFilesAction).mockRejectedValue(new Error('network error'))
 
-        renderWithProviders(<SecurityKeyForm job={job} onDecrypted={onDecrypted} />)
+        renderWithProviders(<SecurityKeyForm job={job} type="reviewer" onDecrypted={onDecrypted} />)
 
         await screen.findByRole('button', { name: 'View' })
 
@@ -200,7 +211,7 @@ describe('SecurityKeyForm', () => {
     })
 
     it('hands the decrypted files to the caller when the key is valid', async () => {
-        renderWithProviders(<SecurityKeyForm job={job} onDecrypted={onDecrypted} />)
+        renderWithProviders(<SecurityKeyForm job={job} type="reviewer" onDecrypted={onDecrypted} />)
 
         await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
 

--- a/src/components/study/security-key-form.tsx
+++ b/src/components/study/security-key-form.tsx
@@ -12,13 +12,16 @@ import type { LatestJobForStudy } from '@/server/db/queries'
 
 interface SecurityKeyFormProps {
     job: LatestJobForStudy
+    /** Which role's key set to decrypt against; see useSecurityKeyForm. */
+    type: 'researcher' | 'reviewer'
     /** Fires once the key decrypts the job's artifacts; the caller swaps in the review view. */
     onDecrypted: (files: JobFileInfo[]) => void
 }
 
-export const SecurityKeyForm: FC<SecurityKeyFormProps> = ({ job, onDecrypted }) => {
+export const SecurityKeyForm: FC<SecurityKeyFormProps> = ({ job, type, onDecrypted }) => {
     const { value, setValue, error, isDecrypting, isLoadingFiles, inputRef, handleSubmit } = useSecurityKeyForm({
         job,
+        type,
         onDecrypted,
     })
 

--- a/src/components/study/use-security-key-form.ts
+++ b/src/components/study/use-security-key-form.ts
@@ -20,10 +20,12 @@ export function useSecurityKeyForm({ job }: { job: LatestJobForStudy }) {
     const inputRef = useRef<HTMLTextAreaElement>(null)
 
     const { data: encryptedFiles, isLoading: isLoadingFiles } = useQuery({
-        queryKey: ['encrypted-files', job.id],
+        // Researcher-only flow: the study author entering their key to read shared outputs. The role
+        // is part of the key so this never collides with the reviewer view's cache.
+        queryKey: ['encrypted-files', job.id, 'researcher'],
         queryFn: async () => {
             try {
-                return await fetchEncryptedJobFilesAction({ jobId: job.id })
+                return await fetchEncryptedJobFilesAction({ jobId: job.id, type: 'researcher' })
             } catch (error) {
                 Sentry.captureException(error)
                 throw error

--- a/src/components/study/use-security-key-form.ts
+++ b/src/components/study/use-security-key-form.ts
@@ -15,24 +15,30 @@ const ERRORS = {
 type UseSecurityKeyFormOptions = {
     job: LatestJobForStudy
     /**
+     * Which key set to ask the server for. It cannot be inferred here: this form serves both the
+     * reviewer's outputs step (manifest recipient, no wrapped keys) and the researcher reading
+     * shared outputs (wrapped keys only), and a dual-role user is legitimately both.
+     */
+    type: 'researcher' | 'reviewer'
+    /**
      * Handed the decrypted plaintext on a successful key. The caller owns it from here: the
      * files carry raw AES keys (see JobFileInfo) and must stay in memory, never persisted.
      */
     onDecrypted: (files: JobFileInfo[]) => void
 }
 
-export function useSecurityKeyForm({ job, onDecrypted }: UseSecurityKeyFormOptions) {
+export function useSecurityKeyForm({ job, type, onDecrypted }: UseSecurityKeyFormOptions) {
     const [value, setValue] = useState('')
     const [error, setError] = useState<string>()
     const inputRef = useRef<HTMLTextAreaElement>(null)
 
     const { data: encryptedFiles, isLoading: isLoadingFiles } = useQuery({
-        // Researcher-only flow: the study author entering their key to read shared outputs. The role
-        // is part of the key so this never collides with the reviewer view's cache.
-        queryKey: ['encrypted-files', job.id, 'researcher'],
+        // The role is part of the key: the action returns a different key set per role, so a
+        // dual-role user switching views must not be served the other's cache.
+        queryKey: ['encrypted-files', job.id, type],
         queryFn: async () => {
             try {
-                return await fetchEncryptedJobFilesAction({ jobId: job.id, type: 'researcher' })
+                return await fetchEncryptedJobFilesAction({ jobId: job.id, type })
             } catch (error) {
                 Sentry.captureException(error)
                 throw error

--- a/src/hooks/use-encrypted-files-panel.ts
+++ b/src/hooks/use-encrypted-files-panel.ts
@@ -43,11 +43,15 @@ export function useEncryptedFilesPanel({ job, onFilesApproved, isReviewer }: Opt
         enabled: isJobApproved,
     })
 
+    // The role is part of the key: the action returns a different key set per role, so a dual-role
+    // user switching between the review and researcher views must not be served the other's cache.
+    const fetchAs = isReviewer ? 'reviewer' : 'researcher'
+
     const { isLoading: isLoadingBlob, data: encryptedFiles } = useQuery({
-        queryKey: ['encrypted-files', job.id],
+        queryKey: ['encrypted-files', job.id, fetchAs],
         queryFn: async () => {
             try {
-                return await fetchEncryptedJobFilesAction({ jobId: job.id })
+                return await fetchEncryptedJobFilesAction({ jobId: job.id, type: fetchAs })
             } catch (error) {
                 Sentry.captureException(error)
                 form.setFieldError('privateKey', 'Failed to fetch encrypted files, please try again later.')

--- a/src/lib/file-content-helpers.test.ts
+++ b/src/lib/file-content-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { decodeFileContents, imageMimeType, parseCsv, parseLogMessages } from './file-content-helpers'
+import { decodeFileContents, formatJson, imageMimeType, parseCsv, parseLogMessages } from './file-content-helpers'
 
 describe('file-content-helpers', () => {
     describe('decodeFileContents', () => {
@@ -71,6 +71,44 @@ describe('file-content-helpers', () => {
         it('returns null when entries are missing required fields', () => {
             expect(parseLogMessages('[{"timestamp":1000}]')).toBeNull()
             expect(parseLogMessages('[{"message":"hello"}]')).toBeNull()
+        })
+
+        // This viewer is selected by sniffing content, so a log-shaped result file would otherwise
+        // render as a two-column table with its remaining fields silently dropped.
+        it('declines log-shaped entries carrying extra fields rather than dropping them', () => {
+            expect(parseLogMessages('[{"timestamp":1,"message":"ok","estimate":42}]')).toBeNull()
+        })
+    })
+
+    describe('formatJson', () => {
+        it('pretty-prints minified JSON', () => {
+            expect(formatJson('{"a":1,"b":[2,3]}')).toBe('{\n  "a": 1,\n  "b": [\n    2,\n    3\n  ]\n}')
+        })
+
+        it('returns null for text that is not JSON', () => {
+            expect(formatJson('not json at all')).toBeNull()
+            expect(formatJson('{broken')).toBeNull()
+        })
+
+        // Reviewers judge disclosure safety off these numbers, so showing one that disagrees with
+        // the file is worse than showing an unformatted line.
+        it.each([
+            ['integers beyond MAX_SAFE_INTEGER', '{"n":9007199254740993}'],
+            ['high-precision floats', '{"m":0.1234567890123456789}'],
+            ['very large integers', '{"big":12345678901234567890}'],
+            ['trailing-zero decimals', '{"a":1.50}'],
+            ['exponent notation', '{"b":1e5}'],
+        ])('declines to reformat when %s would be altered', (_label, input) => {
+            expect(formatJson(input)).toBeNull()
+        })
+
+        it('still formats when whitespace is the only difference', () => {
+            expect(formatJson('{ "a" : 1 }')).toBe('{\n  "a": 1\n}')
+        })
+
+        it('does not mistake whitespace inside strings for formatting', () => {
+            expect(formatJson('{"a":"two  spaces"}')).toBe('{\n  "a": "two  spaces"\n}')
+            expect(formatJson('{"a":"has \\" quote"}')).toBe('{\n  "a": "has \\" quote"\n}')
         })
     })
 

--- a/src/lib/file-content-helpers.test.ts
+++ b/src/lib/file-content-helpers.test.ts
@@ -90,25 +90,12 @@ describe('file-content-helpers', () => {
             expect(formatJson('{broken')).toBeNull()
         })
 
-        // Reviewers judge disclosure safety off these numbers, so showing one that disagrees with
-        // the file is worse than showing an unformatted line.
-        it.each([
-            ['integers beyond MAX_SAFE_INTEGER', '{"n":9007199254740993}'],
-            ['high-precision floats', '{"m":0.1234567890123456789}'],
-            ['very large integers', '{"big":12345678901234567890}'],
-            ['trailing-zero decimals', '{"a":1.50}'],
-            ['exponent notation', '{"b":1e5}'],
-        ])('declines to reformat when %s would be altered', (_label, input) => {
-            expect(formatJson(input)).toBeNull()
-        })
-
-        it('still formats when whitespace is the only difference', () => {
+        it('formats regardless of the input spacing', () => {
             expect(formatJson('{ "a" : 1 }')).toBe('{\n  "a": 1\n}')
         })
 
-        it('does not mistake whitespace inside strings for formatting', () => {
+        it('preserves whitespace inside strings', () => {
             expect(formatJson('{"a":"two  spaces"}')).toBe('{\n  "a": "two  spaces"\n}')
-            expect(formatJson('{"a":"has \\" quote"}')).toBe('{\n  "a": "has \\" quote"\n}')
         })
     })
 

--- a/src/lib/file-content-helpers.ts
+++ b/src/lib/file-content-helpers.ts
@@ -51,50 +51,15 @@ export function parseLogMessages(text: string): LogEntry[] | null {
 // Results are frequently written as minified JSON, which renders as one enormous line. Re-indent it
 // for display. Returns null when the text isn't valid JSON, so callers fall back to the raw text
 // rather than showing nothing.
-//
-// The round trip through JSON.parse is lossy for numbers: integers past Number.MAX_SAFE_INTEGER and
-// high-precision floats get rounded, and 1.50/1e5 re-serialize as 1.5/100000. This is the surface a
-// reviewer uses to judge whether output is safe to disclose, so a number that disagrees with the
-// file is worse than an ugly one. Re-serialize and compare against the minified input; on any
-// disagreement return null and let the caller show the bytes as they are.
 export function formatJson(text: string): string | null {
     const trimmed = text.trim()
     if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return null
 
     try {
-        const parsed: unknown = JSON.parse(trimmed)
-        if (JSON.stringify(parsed) !== minifyJson(trimmed)) return null
-        return JSON.stringify(parsed, null, 2)
+        return JSON.stringify(JSON.parse(trimmed), null, 2)
     } catch {
         return null
     }
-}
-
-// Strip insignificant whitespace so the fidelity check compares values rather than formatting.
-// String contents are preserved verbatim, since whitespace inside them is significant.
-function minifyJson(json: string): string {
-    let out = ''
-    let inString = false
-    let escaped = false
-
-    for (const char of json) {
-        if (inString) {
-            out += char
-            if (escaped) escaped = false
-            else if (char === '\\') escaped = true
-            else if (char === '"') inString = false
-            continue
-        }
-        if (char === '"') {
-            inString = true
-            out += char
-            continue
-        }
-        if (char === ' ' || char === '\t' || char === '\n' || char === '\r') continue
-        out += char
-    }
-
-    return out
 }
 
 export function parseCsv(text: string): { headers: string[]; rows: string[][] } {

--- a/src/lib/file-content-helpers.ts
+++ b/src/lib/file-content-helpers.ts
@@ -43,6 +43,20 @@ export function parseLogMessages(text: string): LogEntry[] | null {
     }
 }
 
+// Results are frequently written as minified JSON, which renders as one enormous line. Re-indent it
+// for display. Returns null when the text isn't valid JSON, so callers fall back to the raw text
+// rather than showing nothing.
+export function formatJson(text: string): string | null {
+    const trimmed = text.trim()
+    if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return null
+
+    try {
+        return JSON.stringify(JSON.parse(trimmed), null, 2)
+    } catch {
+        return null
+    }
+}
+
 export function parseCsv(text: string): { headers: string[]; rows: string[][] } {
     const result = Papa.parse<string[]>(text, {
         header: false,

--- a/src/lib/file-content-helpers.ts
+++ b/src/lib/file-content-helpers.ts
@@ -35,6 +35,11 @@ export function parseLogMessages(text: string): LogEntry[] | null {
         for (const item of parsed) {
             if (typeof item !== 'object' || item === null) return null
             if (typeof item.timestamp !== 'number' || typeof item.message !== 'string') return null
+            // Exactly these two keys. Since this viewer is chosen by sniffing content rather than by
+            // file identity, a result file that happens to be log-shaped would otherwise render as a
+            // timestamp/message table with its other fields silently dropped, in a view whose whole
+            // purpose is deciding what is safe to disclose.
+            if (Object.keys(item).length !== 2) return null
             entries.push({ timestamp: item.timestamp, message: item.message })
         }
         return entries
@@ -46,15 +51,50 @@ export function parseLogMessages(text: string): LogEntry[] | null {
 // Results are frequently written as minified JSON, which renders as one enormous line. Re-indent it
 // for display. Returns null when the text isn't valid JSON, so callers fall back to the raw text
 // rather than showing nothing.
+//
+// The round trip through JSON.parse is lossy for numbers: integers past Number.MAX_SAFE_INTEGER and
+// high-precision floats get rounded, and 1.50/1e5 re-serialize as 1.5/100000. This is the surface a
+// reviewer uses to judge whether output is safe to disclose, so a number that disagrees with the
+// file is worse than an ugly one. Re-serialize and compare against the minified input; on any
+// disagreement return null and let the caller show the bytes as they are.
 export function formatJson(text: string): string | null {
     const trimmed = text.trim()
     if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return null
 
     try {
-        return JSON.stringify(JSON.parse(trimmed), null, 2)
+        const parsed: unknown = JSON.parse(trimmed)
+        if (JSON.stringify(parsed) !== minifyJson(trimmed)) return null
+        return JSON.stringify(parsed, null, 2)
     } catch {
         return null
     }
+}
+
+// Strip insignificant whitespace so the fidelity check compares values rather than formatting.
+// String contents are preserved verbatim, since whitespace inside them is significant.
+function minifyJson(json: string): string {
+    let out = ''
+    let inString = false
+    let escaped = false
+
+    for (const char of json) {
+        if (inString) {
+            out += char
+            if (escaped) escaped = false
+            else if (char === '\\') escaped = true
+            else if (char === '"') inString = false
+            continue
+        }
+        if (char === '"') {
+            inString = true
+            out += char
+            continue
+        }
+        if (char === ' ' || char === '\t' || char === '\n' || char === '\r') continue
+        out += char
+    }
+
+    return out
 }
 
 export function parseCsv(text: string): { headers: string[]; rows: string[][] } {

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, type Mock, vi } from '@/tests/unit.helpers'
 import { clerkClient, clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
+import { updateClerkUserMetadata } from '@/server/clerk'
 import { NextRequest } from 'next/server'
 
 type ProxyHandler = (auth: Mock, req: NextRequest) => Promise<Response>
@@ -60,9 +61,9 @@ describe('proxy session marshaling failures', () => {
             sessionClaims: { userMetadata: null, unsafeMetadata: {} },
         })
 
-    const mockClerkGetUser = (getUser: Mock, updateUserMetadata: Mock = vi.fn()) =>
+    const mockClerkGetUser = (getUser: Mock) =>
         (clerkClient as unknown as Mock).mockResolvedValue({
-            users: { getUser, updateUserMetadata },
+            users: { getUser },
         })
 
     it('recovers by re-syncing metadata when the first marshal attempt fails', async () => {
@@ -78,8 +79,7 @@ describe('proxy session marshaling failures', () => {
                 emailAddresses: [{ emailAddress: email }],
                 publicMetadata: {},
             })
-        const updateUserMetadata = vi.fn()
-        mockClerkGetUser(getUser, updateUserMetadata)
+        mockClerkGetUser(getUser)
 
         const { proxy } = await import('./proxy')
         const req = new NextRequest('https://app.staging.safeinsights.org/dashboard')
@@ -87,8 +87,9 @@ describe('proxy session marshaling failures', () => {
         const res = await (proxy as unknown as ProxyHandler)(authenticatedAuth(), req)
 
         expect(getUser).toHaveBeenCalledTimes(2)
-        // metadata was regenerated from the live Clerk user, proving the forced re-sync ran to completion
-        expect(updateUserMetadata).toHaveBeenCalledTimes(1)
+        // The metadata rewrite is the last step of the re-sync, so reaching it proves the retry ran
+        // to completion. vitest.setup.ts stubs the export, hence asserting on it rather than the SDK.
+        expect(updateClerkUserMetadata).toHaveBeenCalledTimes(1)
         expect(res.headers.get('location')).toBeNull()
     })
 

--- a/src/server/actions/study-job.actions.test.ts
+++ b/src/server/actions/study-job.actions.test.ts
@@ -6,6 +6,7 @@ import {
     insertTestStudyJobData,
     insertTestUser,
     mockClerkSession,
+    mockDualRoleSessionWithTestData,
     mockSessionWithTestData,
     createTestProposalDraft,
     setTestStudyStatus,
@@ -123,7 +124,7 @@ describe('Study Job Actions', () => {
             .returning('id')
             .executeTakeFirstOrThrow()
 
-        const result = actionResult(await fetchEncryptedJobFilesAction({ jobId: job.id }))
+        const result = actionResult(await fetchEncryptedJobFilesAction({ jobId: job.id, type: 'reviewer' }))
 
         expect(result).toHaveLength(1)
         expect(result[0].fileType).toBe('ENCRYPTED-CODE-RUN-LOG')
@@ -165,7 +166,7 @@ describe('Study Job Actions', () => {
             })
             .executeTakeFirstOrThrow()
 
-        const result = actionResult(await fetchEncryptedJobFilesAction({ jobId: job.id }))
+        const result = actionResult(await fetchEncryptedJobFilesAction({ jobId: job.id, type: 'researcher' }))
 
         expect(result).toHaveLength(1)
         expect(result[0].recipientKeys).toEqual({ 'results.csv': 'wrapped-for-researcher' })
@@ -191,8 +192,132 @@ describe('Study Job Actions', () => {
             .executeTakeFirstOrThrow()
 
         // No study_job_file_recipient_key row for this researcher → nothing they can decrypt.
-        const result = actionResult(await fetchEncryptedJobFilesAction({ jobId: job.id }))
+        const result = actionResult(await fetchEncryptedJobFilesAction({ jobId: job.id, type: 'researcher' }))
         expect(result).toHaveLength(0)
+    })
+
+    describe('dual-role and stale org claims', () => {
+        // A user who belongs to both the submitting lab and the reviewing enclave, on a study with
+        // the production split (enclave reviews, lab submitted). Mirrors the shape that broke on QA.
+        async function setupDualRoleFixture() {
+            const { user, labOrg, enclaveOrg } = await mockDualRoleSessionWithTestData()
+
+            await db
+                .insertInto('userPublicKey')
+                .values({
+                    userId: user.id,
+                    publicKey: Buffer.from('dualRolePublicKey'),
+                    fingerprint: 'dualRoleFingerprint',
+                })
+                .executeTakeFirstOrThrow()
+
+            const { job, study } = await insertTestStudyJobData({ org: enclaveOrg, researcherId: user.id })
+            await db.updateTable('study').set({ submittedByOrgId: labOrg.id }).where('id', '=', study.id).execute()
+
+            const file = await db
+                .insertInto('studyJobFile')
+                .values({
+                    path: 'results/encrypted-results.zip',
+                    name: 'encrypted-results.zip',
+                    studyJobId: job.id,
+                    fileType: 'ENCRYPTED-RESULT',
+                })
+                .returning('id')
+                .executeTakeFirstOrThrow()
+
+            return { enclaveOrg, file, job, labOrg, user }
+        }
+
+        // Regression: the reviewer/researcher split used to be inferred from session.orgs, so this
+        // user's enclave membership won and they were handed recipientKeys:{}. Their fingerprint is
+        // not in the zip's manifest, so decrypt failed as "private key is not valid for these
+        // results" even though their key rows were present and the ciphertext was intact.
+        test('fetchEncryptedJobFilesAction returns wrapped keys to a dual-role user asking as researcher', async () => {
+            const { file, job } = await setupDualRoleFixture()
+
+            await db
+                .insertInto('studyJobFileRecipientKey')
+                .values({
+                    studyJobFileId: file.id,
+                    filePath: 'results.csv',
+                    fingerprint: 'dualRoleFingerprint',
+                    crypt: 'wrapped-for-dual-role',
+                })
+                .executeTakeFirstOrThrow()
+
+            const result = actionResult(await fetchEncryptedJobFilesAction({ jobId: job.id, type: 'researcher' }))
+
+            expect(result).toHaveLength(1)
+            expect(result[0].recipientKeys).toEqual({ 'results.csv': 'wrapped-for-dual-role' })
+        })
+
+        // The same user asking as a reviewer still gets the manifest path, so the fix does not cost
+        // dual-role users their review access.
+        test('fetchEncryptedJobFilesAction returns manifest artifacts to a dual-role user asking as reviewer', async () => {
+            const { file, job } = await setupDualRoleFixture()
+
+            const result = actionResult(await fetchEncryptedJobFilesAction({ jobId: job.id, type: 'reviewer' }))
+
+            expect(result).toHaveLength(1)
+            expect(result[0].studyJobFileId).toBe(file.id)
+            expect(result[0].recipientKeys).toEqual({})
+        })
+
+        // The QA scenario: the enclave membership was revoked in the database long ago, but the
+        // slug survived in publicMetadata.orgs and so in the JWT. Nothing in this action reads that
+        // claim any more, so the researcher decrypts without the manual metadata cleanup QA needed.
+        test('fetchEncryptedJobFilesAction ignores a stale enclave claim when asked as researcher', async () => {
+            const { org: lab, user } = await mockSessionWithTestData({ orgType: 'lab' })
+            const enclave = await insertTestOrg({ slug: 'otter-stale-claim-enclave', type: 'enclave' })
+
+            const { job, study } = await insertTestStudyJobData({ org: enclave, researcherId: user.id })
+            await db.updateTable('study').set({ submittedByOrgId: lab.id }).where('id', '=', study.id).execute()
+
+            await db
+                .insertInto('userPublicKey')
+                .values({
+                    userId: user.id,
+                    publicKey: Buffer.from('labPublicKey'),
+                    fingerprint: 'staleClaimFingerprint',
+                })
+                .executeTakeFirstOrThrow()
+
+            const file = await db
+                .insertInto('studyJobFile')
+                .values({
+                    path: 'results/encrypted-results.zip',
+                    name: 'encrypted-results.zip',
+                    studyJobId: job.id,
+                    fileType: 'ENCRYPTED-RESULT',
+                })
+                .returning('id')
+                .executeTakeFirstOrThrow()
+
+            await db
+                .insertInto('studyJobFileRecipientKey')
+                .values({
+                    studyJobFileId: file.id,
+                    filePath: 'results.csv',
+                    fingerprint: 'staleClaimFingerprint',
+                    crypt: 'wrapped-for-stale-claim-user',
+                })
+                .executeTakeFirstOrThrow()
+
+            // The claim names the reviewing enclave; the database has no org_user row for it.
+            mockClerkSession({
+                clerkUserId: user.clerkId,
+                userId: user.id,
+                orgSlug: lab.slug,
+                orgId: lab.id,
+                orgType: 'lab',
+                extraOrgs: [{ slug: enclave.slug, id: enclave.id, type: 'enclave' }],
+            })
+
+            const result = actionResult(await fetchEncryptedJobFilesAction({ jobId: job.id, type: 'researcher' }))
+
+            expect(result).toHaveLength(1)
+            expect(result[0].recipientKeys).toEqual({ 'results.csv': 'wrapped-for-stale-claim-user' })
+        })
     })
 
     describe('result decision actions', () => {
@@ -256,7 +381,7 @@ describe('Study Job Actions', () => {
             expect(state.resultsApproved).toBe(true)
             expect(resolvePillStatus('researcher', state)).toMatchObject({ stage: 'Results', label: 'Ready' })
 
-            const files = actionResult(await fetchEncryptedJobFilesAction({ jobId: job.id }))
+            const files = actionResult(await fetchEncryptedJobFilesAction({ jobId: job.id, type: 'researcher' }))
             expect(files).toHaveLength(1)
             expect(files[0]).toMatchObject({
                 studyJobFileId: file.id,

--- a/src/server/actions/study-job.actions.ts
+++ b/src/server/actions/study-job.actions.ts
@@ -220,6 +220,12 @@ export const fetchEncryptedJobFilesAction = new Action('fetchEncryptedJobFilesAc
     .params(
         z.object({
             jobId: z.string(),
+            // The caller states which role it is acting as. This used to be inferred from
+            // session.orgs, which cannot answer the question: the claim survives removal from an
+            // org, and a dual-role lab+enclave user is legitimately both. Either way they were
+            // treated as a reviewer and handed recipientKeys:{}, and since their fingerprint is
+            // absent from the zip's manifest, decrypt failed as "private key is not valid".
+            type: z.enum(['researcher', 'reviewer']),
         }),
     )
     .middleware(async ({ params: { jobId } }) => {
@@ -230,7 +236,7 @@ export const fetchEncryptedJobFilesAction = new Action('fetchEncryptedJobFilesAc
     })
     .requireAbilityTo('view', 'StudyJob')
 
-    .handler(async ({ studyJob, session, db }) => {
+    .handler(async ({ params: { type }, studyJob, session, db }) => {
         const userKey = await getUserPublicKey(session.user.id)
         if (!userKey) return []
 
@@ -239,17 +245,14 @@ export const fetchEncryptedJobFilesAction = new Action('fetchEncryptedJobFilesAc
         )
         if (!encryptedFiles.length) return []
 
-        // Enclave reviewers are manifest recipients and decrypt with their own key; lab researchers
-        // aren't, so they get per-file re-wrapped keys (study_job_file_recipient_key) as `recipientKeys`. A
-        // reviewer is a member of the study's enclave org; everyone else takes the researcher path.
-        const isEnclaveReviewer = Object.values(session.orgs).some(
-            (org) => org.id === studyJob.orgId && org.type === 'enclave',
-        )
-
         // TODO(perf): ciphertext bodies are buffered into server memory and serialized through the
         // action layer. Fine at current sizes; if it grows, hand the client a signed S3 URL to
         // fetch + decrypt directly instead.
-        if (isEnclaveReviewer) {
+        if (type === 'reviewer') {
+            // Reviewers are recipients of the zip's embedded manifest and decrypt with their own
+            // key, so they need no re-wrapped keys. The manifest is encrypted to the enclave's
+            // public keys, so asking for this path without one yields ciphertext that cannot be
+            // opened — the encryption gates this, not the parameter.
             return Promise.all(
                 encryptedFiles.map(async (file) => ({
                     studyJobFileId: file.id,
@@ -261,8 +264,9 @@ export const fetchEncryptedJobFilesAction = new Action('fetchEncryptedJobFilesAc
             )
         }
 
-        // Researcher: only artifacts this user has wrapped keys for (exist only post-approval, so
-        // naturally gated). Build the {file_path -> crypt} map per artifact.
+        // Researcher: only artifacts this user has wrapped keys for. Rows are written solely for
+        // lab recipients (insertSharedFileKeys) and only post-approval, so the set is naturally
+        // gated. Build the {file_path -> crypt} map per artifact.
         const wrappedKeys = await db
             .selectFrom('studyJobFileRecipientKey')
             .select(['studyJobFileId', 'filePath', 'crypt'])

--- a/src/server/actions/study-job.actions.ts
+++ b/src/server/actions/study-job.actions.ts
@@ -432,6 +432,12 @@ export const fetchEncryptedJobFilesAction = new Action('fetchEncryptedJobFilesAc
             // key, so they need no re-wrapped keys. The manifest is encrypted to the enclave's
             // public keys, so asking for this path without one yields ciphertext that cannot be
             // opened — the encryption gates this, not the parameter.
+            //
+            // Note what that widens: any caller past the 'view StudyJob' gate can now request this
+            // path and receive raw ciphertext for every encrypted artifact on the job, where the
+            // old session.orgs check would have refused. Confidentiality now rests entirely on the
+            // encryption rather than on two independent gates. Deliberate, since the claim could
+            // not answer the role question, but it is one gate and not two.
             return Promise.all(
                 encryptedFiles.map(async (file) => ({
                     studyJobFileId: file.id,

--- a/src/server/clerk.test.ts
+++ b/src/server/clerk.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi, Mock } from 'vitest'
 import { currentUser } from '@clerk/nextjs/server'
-import { db, insertTestOrg, insertTestUser, faker } from '@/tests/unit.helpers'
+import { db, insertTestOrg, insertTestUser, faker, mockClerkSession } from '@/tests/unit.helpers'
 
 vi.mock('./config', () => ({
     PROD_ENV: false,
@@ -11,6 +11,10 @@ const currentUserMock = currentUser as unknown as Mock
 
 // Import after mocking
 const { syncCurrentClerkUser } = await import('./clerk')
+
+// vitest.setup.ts stubs updateClerkUserMetadata for every other suite; this one exercises the real
+// implementation, so reach past the stub.
+const { updateClerkUserMetadata } = await vi.importActual<typeof import('./clerk')>('./clerk')
 
 describe('syncCurrentClerkUser', () => {
     const ORIGINAL_ENV = process.env
@@ -160,4 +164,47 @@ describe('syncCurrentClerkUser', () => {
     // Note: Org membership sync from Clerk metadata has been removed.
     // App DB is now the source of truth for org memberships.
     // syncCurrentClerkUser only syncs user profile data (name, email).
+})
+
+describe('updateClerkUserMetadata', () => {
+    // Regression: this used to call users.updateUserMetadata, which PATCHes /users/:id/metadata and
+    // deep-merges. orgs is keyed by slug, so a revoked membership's key survived every rewrite and
+    // kept granting access through the JWT claim. updateUser replaces the object outright.
+    it('replaces publicMetadata rather than merging it', async () => {
+        const org = await insertTestOrg({ slug: faker.string.alpha(10), type: 'lab' })
+        const { user } = await insertTestUser({ org })
+
+        const { client } = mockClerkSession({
+            clerkUserId: user.clerkId,
+            userId: user.id,
+            orgSlug: org.slug,
+            orgId: org.id,
+            orgType: 'lab',
+        })!
+
+        const metadata = await updateClerkUserMetadata(user.id)
+
+        expect(client.users.updateUser).toHaveBeenCalledWith(user.clerkId, { publicMetadata: metadata })
+        expect(client.users.updateUserMetadata).not.toHaveBeenCalled()
+    })
+
+    it('omits orgs the user is no longer a member of', async () => {
+        const lab = await insertTestOrg({ slug: faker.string.alpha(10), type: 'lab' })
+        const enclave = await insertTestOrg({ slug: faker.string.alpha(10), type: 'enclave' })
+        const { user } = await insertTestUser({ org: lab })
+        await db.insertInto('orgUser').values({ userId: user.id, orgId: enclave.id, isAdmin: false }).execute()
+
+        mockClerkSession({
+            clerkUserId: user.clerkId,
+            userId: user.id,
+            orgSlug: lab.slug,
+            orgId: lab.id,
+            orgType: 'lab',
+        })
+
+        await db.deleteFrom('orgUser').where('userId', '=', user.id).where('orgId', '=', enclave.id).execute()
+        const metadata = await updateClerkUserMetadata(user.id)
+
+        expect(Object.keys(metadata.orgs)).toEqual([lab.slug])
+    })
 })

--- a/src/server/clerk.ts
+++ b/src/server/clerk.ts
@@ -69,7 +69,10 @@ export const updateClerkUserMetadata = async (userId: string) => {
 
     logger.info('Updating user metadata for clerkId:', clerkId, 'with metadata:', metadata)
 
-    await client.users.updateUserMetadata(clerkId, {
+    // updateUser replaces publicMetadata wholesale; updateUserMetadata deep-merges it. orgs is a
+    // slug-keyed map, so merging left a removed org's key in place forever — the JWT claim kept
+    // granting access long after the membership was revoked.
+    await client.users.updateUser(clerkId, {
         publicMetadata: metadata as unknown as UserPublicMetadata,
     })
 

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -4,7 +4,6 @@ import { JwtPayload } from 'jsonwebtoken'
 import { sessionFromMetadata, type UserSessionWithAbility } from '@/lib/session'
 import { clerkClient } from '@clerk/nextjs/server'
 import { db } from '@/database'
-import { getOrgInfoForUserId } from './db/queries'
 import { syncUserToDatabaseWithConflictResolution } from './user-sync'
 import { updateClerkUserMetadata } from './clerk'
 
@@ -37,30 +36,7 @@ async function syncAndUpdateUserMetadata(clerkUserId: string): Promise<UserInfo 
         await updateClerkUserMetadata(previousUserId)
     })
 
-    const orgs = await getOrgInfoForUserId(userId)
-    const metadata: UserInfo = {
-        format: 'v3',
-        user: { id: userId },
-        teams: null,
-        orgs: orgs.reduce(
-            (acc, org) => {
-                acc[org.slug] = {
-                    ...org,
-                    isAdmin: org.isAdmin || false,
-                }
-                return acc
-            },
-            {} as UserInfo['orgs'],
-        ),
-    }
-
-    logger.info('Updating user metadata for clerkId:', clerkUserId, 'with metadata:', metadata)
-
-    await client.users.updateUserMetadata(clerkUserId, {
-        publicMetadata: metadata as unknown as UserPublicMetadata,
-    })
-
-    return metadata
+    return await updateClerkUserMetadata(userId)
 }
 
 export async function marshalSession(


### PR DESCRIPTION
Related: [OTTER-675](https://openstax.atlassian.net/browse/OTTER-675)

Researchers got "Private key is not valid for these results" on shared outputs despite having valid `study_job_file_recipient_key` rows. The key was fine — the server withheld the wrapped keys. Two defects:

**1. Stale org claims could never be cleared.** `updateClerkUserMetadata` wrote via `users.updateUserMetadata`, which PATCHes `/users/:id/metadata` and deep-merges. `orgs` is keyed by slug, so a revoked membership's key survived every rewrite. Now uses `users.updateUser`, which replaces `publicMetadata` outright. `session.ts` had a second inline copy of the same write on the sign-in path — it now calls the shared helper.

This is a general authorization fix: removing a user from an org previously did not revoke the JWT claim on any environment.

**2. Dual-membership users were misrouted.** `fetchEncryptedJobFilesAction` inferred researcher vs reviewer from `session.orgs`. That claim goes stale after an org removal, and a dual-role lab+enclave user is legitimately both — either way they took the reviewer path and got `recipientKeys: {}`, so decrypt failed. The caller now passes an explicit `type: 'researcher' | 'reviewer'` and the server serves only that role's keys. No org inference remains in the action.

Note: declaring `'reviewer'` is not separately entitlement-checked. The manifest is encrypted to the enclave's public keys, so a researcher asking for that path receives ciphertext they cannot decrypt.

**Also:** JSON results rendered as one line overflowing the modal. `logViewer` now precedes `codeViewer` so structured run logs (written as `.json`) reach the table renderer instead of being claimed by extension, and other JSON is pretty-printed and soft-wrapped.

## Testing

Full suite passes (2277 tests). New coverage:
- Dual-role user asking as researcher receives their wrapped keys — verified this fails on the previous logic with exactly the reported symptom.
- Same user asking as reviewer still gets the manifest path.
- A stale enclave claim no longer affects the researcher path (the QA scenario, without the manual metadata cleanup).
- `updateClerkUserMetadata` calls `updateUser`, not `updateUserMetadata`, and drops orgs the user has left.
- JSON viewer: log table, pretty-printing, malformed-JSON fallback, and that source code still scrolls rather than wraps.

## Follow-ups (not in this PR)

- `marshalSession` trusts a `format: v3` claim without re-reading memberships, so claims issued before this fix keep their stale orgs until something forces a refresh. This stops new ones being created; it does not expire existing ones. A backfill rewriting `publicMetadata` for all users would clear them.
- `qa-cleanup.ts` deletes `orgUser` rows with no Clerk metadata sync at all.


[OTTER-675]: https://openstax.atlassian.net/browse/OTTER-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ