### PR TITLE
Scope load IDE to the submitting lab (OTTER-719)

### DIFF
--- a/src/lib/permission-types.ts
+++ b/src/lib/permission-types.ts
@@ -60,7 +60,10 @@ type Abilities =
     | Ability<'OrgMembers', 'view', { orgId?: UUID; orgSlug?: string }>
     | Ability<'Orgs', 'view', object>
     | Ability<'MFA', 'reset', object>
-    | Ability<'IDE', 'load', { researcherId: UUID }>
+    // Both fields optional: `load IDE` is granted by two OR-combined rules — the study's own
+    // researcher (researcherId) and any member of the submitting lab (submittedByOrgId, OTTER-719).
+    // Every field used in a condition must appear on the arm for the CASL subject union to accept it.
+    | Ability<'IDE', 'load', { researcherId?: UUID; submittedByOrgId?: UUID }>
     | Ability<
           'AgentContext',
           'create' | 'update' | 'view',

--- a/src/lib/permissions.test.ts
+++ b/src/lib/permissions.test.ts
@@ -93,17 +93,21 @@ test('researcher role', () => {
         ability.can('approve', toRecord('Study', { orgId: ownLabId })),
     ).toBe(false)
 
-    expect(ability.can('create', 'Study')).toBe(true)
-
-    // update/delete are scoped to studies the researcher's own lab submitted
+    // create/update/delete are scoped to studies the researcher's own lab submitted
+    expect(ability.can('create', toRecord('Study', { submittedByOrgId: ownLabId }))).toBe(true)
     expect(ability.can('update', toRecord('Study', { submittedByOrgId: ownLabId }))).toBe(true)
     expect(ability.can('delete', toRecord('Study', { submittedByOrgId: ownLabId }))).toBe(true)
     expect(ability.can('create', toRecord('StudyJob', { submittedByOrgId: ownLabId }))).toBe(true)
 
     // ...but not studies submitted by a different lab
+    expect(ability.can('create', toRecord('Study', { submittedByOrgId: otherLabId }))).toBe(false)
     expect(ability.can('update', toRecord('Study', { submittedByOrgId: otherLabId }))).toBe(false)
     expect(ability.can('delete', toRecord('Study', { submittedByOrgId: otherLabId }))).toBe(false)
     expect(ability.can('create', toRecord('StudyJob', { submittedByOrgId: otherLabId }))).toBe(false)
+
+    // Fail-closed: creating with no submitting lab in the subject is denied, so a caller cannot
+    // slip past the scope by omitting the field (OTTER-719).
+    expect(ability.can('create', toRecord('Study', {}))).toBe(false)
 
     // Researchers cannot invite users to their org (not admins)
     expect(ability.can('invite', toRecord('User', { orgId: ownLabId }))).toBe(false)

--- a/src/lib/permissions.test.ts
+++ b/src/lib/permissions.test.ts
@@ -113,6 +113,38 @@ test('researcher role', () => {
     expect(ability.can('update', 'UserKey')).toBe(true)
 })
 
+test('load IDE is scoped to the submitting lab (OTTER-719)', () => {
+    const { ability, session } = createAbilty({}, 'lab')
+    const ownLabId = session.orgs.test.id
+    const otherLabId = faker.string.uuid()
+
+    // A lab member reaches the IDE for a study their own lab submitted...
+    expect(ability.can('load', toRecord('IDE', { submittedByOrgId: ownLabId }))).toBe(true)
+
+    // ...but not another lab's study. This was the defect: the grant was unconditioned, so supplying
+    // any studyId gave read/write/delete on that study's workspace files.
+    expect(ability.can('load', toRecord('IDE', { submittedByOrgId: otherLabId }))).toBe(false)
+
+    // The study's own researcher keeps access regardless of which lab submitted it.
+    expect(ability.can('load', toRecord('IDE', { submittedByOrgId: otherLabId, researcherId: session.user.id }))).toBe(
+        true,
+    )
+    expect(
+        ability.can('load', toRecord('IDE', { submittedByOrgId: otherLabId, researcherId: faker.string.uuid() })),
+    ).toBe(false)
+
+    // Fail-closed: a subject missing submittedByOrgId is denied rather than silently granted
+    expect(ability.can('load', toRecord('IDE', {}))).toBe(false)
+})
+
+test('enclave-only members cannot load the IDE (OTTER-719)', () => {
+    // The scoped grant lives behind `if (usersResearcherOrgIds.length)`, so a user with no lab
+    // membership never receives it.
+    const { ability } = createAbilty({}, 'enclave')
+
+    expect(ability.can('load', toRecord('IDE', { submittedByOrgId: faker.string.uuid() }))).toBe(false)
+})
+
 test('admin role', () => {
     const { ability, session } = createAbilty({ isAdmin: true })
     expect(ability.can('approve', 'Study')).toBeTruthy()

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -75,15 +75,13 @@ export function defineAbilityFor(session: UserSession) {
     permit('view', 'Study', { submittedByOrgId: { $in: usersResearcherOrgIds } })
     permit('view', 'StudyJob', { submittedByOrgId: { $in: usersResearcherOrgIds } })
 
-    // users who belong to any research orgs can create studies for ANY org.
-    // create is unconditioned: a new draft has no submittedByOrgId yet — the
-    // submitting lab is chosen in the handler and validated against the user's
-    // own lab orgs there (onSaveDraftStudyAction), since the slug arrives as a
-    // client param. update, delete, job mutations, and IDE access are scoped to
-    // studies the user's lab submitted, so a lab member can't reach another
-    // lab's study by guessing its id.
+    // users who belong to any research orgs can create studies for ANY enclave org, but only ON
+    // BEHALF OF one of their own labs: onSaveDraftStudyAction's middleware resolves the requested
+    // submitting-lab slug into submittedByOrgId, so create is scoped here exactly like update and
+    // delete (OTTER-719). A lab member can neither reach another lab's study by guessing its id nor
+    // create one attributed to a lab they don't belong to.
     if (usersResearcherOrgIds.length) {
-        permit('create', 'Study')
+        permit('create', 'Study', { submittedByOrgId: { $in: usersResearcherOrgIds } })
         permit('update', 'Study', { submittedByOrgId: { $in: usersResearcherOrgIds } })
         permit('delete', 'Study', { submittedByOrgId: { $in: usersResearcherOrgIds } })
         permit('create', 'StudyJob', { submittedByOrgId: { $in: usersResearcherOrgIds } })

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -77,15 +77,19 @@ export function defineAbilityFor(session: UserSession) {
 
     // users who belong to any research orgs can create studies for ANY org.
     // create is unconditioned: a new draft has no submittedByOrgId yet — the
-    // submitting lab is chosen in the handler from the user's own orgs. update,
-    // delete, and job mutations are scoped to studies the user's lab submitted,
-    // so a lab member can't mutate another lab's study by guessing its id.
+    // submitting lab is chosen in the handler and validated against the user's
+    // own lab orgs there (onSaveDraftStudyAction), since the slug arrives as a
+    // client param. update, delete, job mutations, and IDE access are scoped to
+    // studies the user's lab submitted, so a lab member can't reach another
+    // lab's study by guessing its id.
     if (usersResearcherOrgIds.length) {
         permit('create', 'Study')
         permit('update', 'Study', { submittedByOrgId: { $in: usersResearcherOrgIds } })
         permit('delete', 'Study', { submittedByOrgId: { $in: usersResearcherOrgIds } })
         permit('create', 'StudyJob', { submittedByOrgId: { $in: usersResearcherOrgIds } })
-        permit('load', 'IDE')
+        // OTTER-719: previously unconditioned, which granted every lab member read/write/delete
+        // on every study's workspace files. A `$in` fails closed when the field is missing.
+        permit('load', 'IDE', { submittedByOrgId: { $in: usersResearcherOrgIds } })
     }
 
     // can view studies and jobs for all orgs that the user's org has submitted

--- a/src/server/actions/study-request.test.ts
+++ b/src/server/actions/study-request.test.ts
@@ -97,6 +97,33 @@ describe('Request Study Actions', () => {
         expect(study?.status).toEqual('DRAFT')
     })
 
+    // OTTER-719: submittingOrgSlug is a client param and `create Study` is unconditioned by design
+    // (a new draft has no submittedByOrgId yet), so the handler is the only place this can be checked.
+    // Without it a caller could stamp another lab's id onto a study, handing that lab IDE access to it.
+    it('onSaveDraftStudyAction rejects a submitting lab the caller does not belong to', async () => {
+        const enclave = await insertTestOrg({ type: 'enclave', slug: 'foreign-submit' })
+        const victimLab = await insertTestOrg({ slug: `${enclave.slug}-lab`, type: 'lab' })
+        const callersLab = await insertTestOrg({ slug: 'foreign-submit-callers-lab', type: 'lab' })
+        await mockSessionWithTestData({ orgSlug: callersLab.slug, orgType: 'lab' })
+
+        const result = await onSaveDraftStudyAction({
+            orgSlug: enclave.slug,
+            studyInfo: { title: 'Smuggled', piName: 'PI', language: 'R' as const },
+            submittingOrgSlug: victimLab.slug,
+        })
+
+        expect(result).toMatchObject({
+            error: expect.objectContaining({ permission_denied: expect.any(String) }),
+        })
+
+        const smuggled = await db
+            .selectFrom('study')
+            .selectAll('study')
+            .where('submittedByOrgId', '=', victimLab.id)
+            .executeTakeFirst()
+        expect(smuggled).toBeUndefined()
+    })
+
     it('onSubmitDraftStudyAction creates job and finalizeStudySubmissionAction converts to PENDING-REVIEW', async () => {
         // create the enclave that owns the data
         const enclave = await insertTestOrg({ type: 'enclave', slug: 'test-submit' })

--- a/src/server/actions/study-request.ts
+++ b/src/server/actions/study-request.ts
@@ -5,7 +5,7 @@ import { Readable } from 'node:stream'
 import { DB } from '@/database/types'
 import { throwNotFound } from '@/lib/errors'
 import { pathForStudyDocuments, pathForStudyJobCode, pathForStudyJobCodeFile } from '@/lib/paths'
-import { getOrgBySlug, isLabOrg, StudyDocumentType, type UserSession } from '@/lib/types'
+import { StudyDocumentType } from '@/lib/types'
 import { sanitizeFileName, sleep } from '@/lib/utils'
 import { Action, ActionFailure, z } from '@/server/actions/action'
 import {
@@ -161,30 +161,20 @@ const onSaveDraftStudyActionArgsSchema = z.object({
     studyInfo: draftStudyApiSchema,
 })
 
-// OTTER-719: `submittingOrgSlug` arrives as a client param and `getOrgIdFromSlug` resolves any slug,
-// so without this a caller could stamp another lab's id onto a new study — which would then grant that
-// lab IDE access to it under the submittedByOrgId-scoped `load IDE` rule. `create Study` is
-// unconditioned by design (a new draft has no submittedByOrgId yet), making this the only place the
-// submitting lab can be checked. SI admins hold `manage all` and are exempt.
-function requireSubmittingLabMembership(session: UserSession, submittingOrgSlug: string) {
-    if (session.user.isSiAdmin) return
-
-    const org = getOrgBySlug(session, submittingOrgSlug)
-    if (!org || !isLabOrg(org)) {
-        throw new ActionFailure({
-            permission_denied: `is not a member of research lab ${submittingOrgSlug}`,
-        })
-    }
-}
-
 export const onSaveDraftStudyAction = new Action('onSaveDraftStudyAction', { performsMutations: true })
     .params(onSaveDraftStudyActionArgsSchema)
-    .middleware(async ({ params: { orgSlug } }) => await getOrgIdFromSlug({ orgSlug }))
+    // OTTER-719: `submittingOrgSlug` is a client param and `getOrgIdFromSlug` resolves any slug, so a
+    // caller could otherwise stamp another lab's id onto a new study and gain IDE access to it under
+    // the submittedByOrgId-scoped `load IDE` rule. Resolving the slug to `submittedByOrgId` here puts
+    // it in the ability subject, so `create Study` enforces lab membership through the same CASL rule
+    // as update/delete rather than a hand-rolled check in the handler that authz review would miss.
+    .middleware(async ({ params: { orgSlug, submittingOrgSlug } }) => ({
+        ...(await getOrgIdFromSlug({ orgSlug })),
+        submittedByOrgId: (await getOrgIdFromSlug({ orgSlug: submittingOrgSlug })).orgId,
+    }))
     .requireAbilityTo('create', 'Study')
-    .handler(async ({ db, params: { orgSlug, studyInfo, submittingOrgSlug }, session, orgId }) => {
+    .handler(async ({ db, params: { orgSlug, studyInfo }, session, orgId, submittedByOrgId }) => {
         const userId = session.user.id
-        requireSubmittingLabMembership(session, submittingOrgSlug)
-        const submittingLab = await getOrgIdFromSlug({ orgSlug: submittingOrgSlug })
         const studyId = uuidv7()
         const containerLocation = await codeBuildRepositoryUrl({ studyId, orgSlug })
 
@@ -201,7 +191,7 @@ export const onSaveDraftStudyAction = new Action('onSaveDraftStudyAction', { per
                 agreementDocPath: studyInfo.agreementDocPath || null,
                 orgId,
                 researcherId: userId,
-                submittedByOrgId: submittingLab.orgId,
+                submittedByOrgId,
                 containerLocation,
                 status: 'DRAFT',
             })

--- a/src/server/actions/study-request.ts
+++ b/src/server/actions/study-request.ts
@@ -5,7 +5,7 @@ import { Readable } from 'node:stream'
 import { DB } from '@/database/types'
 import { throwNotFound } from '@/lib/errors'
 import { pathForStudyDocuments, pathForStudyJobCode, pathForStudyJobCodeFile } from '@/lib/paths'
-import { StudyDocumentType } from '@/lib/types'
+import { getOrgBySlug, isLabOrg, StudyDocumentType, type UserSession } from '@/lib/types'
 import { sanitizeFileName, sleep } from '@/lib/utils'
 import { Action, ActionFailure, z } from '@/server/actions/action'
 import {
@@ -161,12 +161,29 @@ const onSaveDraftStudyActionArgsSchema = z.object({
     studyInfo: draftStudyApiSchema,
 })
 
+// OTTER-719: `submittingOrgSlug` arrives as a client param and `getOrgIdFromSlug` resolves any slug,
+// so without this a caller could stamp another lab's id onto a new study — which would then grant that
+// lab IDE access to it under the submittedByOrgId-scoped `load IDE` rule. `create Study` is
+// unconditioned by design (a new draft has no submittedByOrgId yet), making this the only place the
+// submitting lab can be checked. SI admins hold `manage all` and are exempt.
+function requireSubmittingLabMembership(session: UserSession, submittingOrgSlug: string) {
+    if (session.user.isSiAdmin) return
+
+    const org = getOrgBySlug(session, submittingOrgSlug)
+    if (!org || !isLabOrg(org)) {
+        throw new ActionFailure({
+            permission_denied: `is not a member of research lab ${submittingOrgSlug}`,
+        })
+    }
+}
+
 export const onSaveDraftStudyAction = new Action('onSaveDraftStudyAction', { performsMutations: true })
     .params(onSaveDraftStudyActionArgsSchema)
     .middleware(async ({ params: { orgSlug } }) => await getOrgIdFromSlug({ orgSlug }))
     .requireAbilityTo('create', 'Study')
     .handler(async ({ db, params: { orgSlug, studyInfo, submittingOrgSlug }, session, orgId }) => {
         const userId = session.user.id
+        requireSubmittingLabMembership(session, submittingOrgSlug)
         const submittingLab = await getOrgIdFromSlug({ orgSlug: submittingOrgSlug })
         const studyId = uuidv7()
         const containerLocation = await codeBuildRepositoryUrl({ studyId, orgSlug })

--- a/src/server/actions/workspaces.actions.test.ts
+++ b/src/server/actions/workspaces.actions.test.ts
@@ -1,9 +1,13 @@
 import {
     mockSessionWithTestData,
     actionResult,
+    createTestProposalDraft,
     insertTestBaselineJob,
+    insertTestOrg,
     insertTestStudyJobData,
     insertTestCodeEnv,
+    insertTestUser,
+    mockClerkSession,
     db,
 } from '@/tests/unit.helpers'
 import { describe, expect, test, afterEach, beforeEach, vi } from 'vitest'
@@ -294,6 +298,82 @@ describe('Workspace Actions', () => {
             actionResult(await ensureWorkspaceAction({ studyId: study.id }))
 
             expect((await jobCreatedAt(job.id)).getTime()).toBeGreaterThan(backdated.getTime())
+        })
+    })
+
+    // OTTER-719: the `load IDE` grant used to be unconditioned, so any member of any lab org could
+    // read, overwrite, or delete another lab's in-progress code just by supplying its studyId. These
+    // exercise the RPC endpoints themselves, not just the ability object.
+    describe('cross-lab workspace access', () => {
+        const setupOtherLabStudy = async () => {
+            const { studyId } = await createTestProposalDraft({ enclaveSlug: 'otter719-enclave' })
+
+            // Switch to a member of an unrelated lab. orgType defaults to 'enclave', and the rule
+            // under test only applies to lab members, so 'lab' must be explicit here.
+            const otherLab = await insertTestOrg({ slug: 'otter719-other-lab', type: 'lab' })
+            const { user: intruder } = await insertTestUser({ org: otherLab })
+            mockClerkSession({
+                clerkUserId: intruder.clerkId,
+                orgSlug: otherLab.slug,
+                userId: intruder.id,
+                orgId: otherLab.id,
+                orgType: 'lab',
+            })
+
+            // No logger spy here: this suite's beforeEach calls vi.resetModules(), so the
+            // dynamically-imported action binds a fresh logger instance a spy would not cover.
+            // The denial messages in stderr are the expected, deliberate audit log.
+            return { studyId }
+        }
+
+        const expectDenied = (result: unknown) =>
+            expect(result).toMatchObject({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+
+        test('a lab member cannot list another lab study workspace files', async () => {
+            process.env.CODER_FILES = TEST_CODER_FILES
+            const { studyId } = await setupOtherLabStudy()
+
+            const { listWorkspaceFilesAction } = await import('./workspaces.actions')
+
+            expectDenied(await listWorkspaceFilesAction({ studyId }))
+        })
+
+        test('a lab member cannot read or delete another lab study workspace files', async () => {
+            process.env.CODER_FILES = TEST_CODER_FILES
+            const { studyId } = await setupOtherLabStudy()
+
+            const studyDir = path.join(TEST_CODER_FILES, studyId)
+            await fs.mkdir(studyDir, { recursive: true })
+            await fs.writeFile(path.join(studyDir, 'main.r'), 'print("secret")')
+
+            const { readWorkspaceFileAction, deleteWorkspaceFileAction } = await import('./workspace-files.actions')
+
+            expectDenied(await readWorkspaceFileAction({ studyId, fileName: 'main.r' }))
+            expectDenied(await deleteWorkspaceFileAction({ studyId, fileName: 'main.r' }))
+
+            // The denial must actually protect the bytes on disk, not merely return an error.
+            await expect(fs.readFile(path.join(studyDir, 'main.r'), 'utf8')).resolves.toBe('print("secret")')
+        })
+
+        test('a lab member cannot launch a workspace for another lab study', async () => {
+            process.env.CODER_FILES = TEST_CODER_FILES
+            const { studyId } = await setupOtherLabStudy()
+
+            const { ensureWorkspaceAction, getLastSubmissionInfoAction } = await import('./workspaces.actions')
+
+            expectDenied(await ensureWorkspaceAction({ studyId }))
+            expectDenied(await getLastSubmissionInfoAction({ studyId }))
+        })
+
+        test('the submitting lab still reaches its own study workspace', async () => {
+            process.env.CODER_FILES = TEST_CODER_FILES
+
+            // Regression guard: the fix must not break the legitimate path.
+            const { studyId } = await createTestProposalDraft({ enclaveSlug: 'otter719-owner-enclave' })
+
+            const { listWorkspaceFilesAction } = await import('./workspaces.actions')
+
+            expect(actionResult(await listWorkspaceFilesAction({ studyId }))).toMatchObject({ files: [] })
         })
     })
 })


### PR DESCRIPTION
[OTTER-719](https://openstax.atlassian.net/browse/OTTER-719)

## Problem

`permit('load', 'IDE')` inside the lab-membership block was unconditioned. CASL OR-combines rules, so every member of any lab org held it on every study. Eight workspace server actions are gated solely by this check and do no further ownership testing in their handlers, so a researcher could supply another study's id and read, overwrite, or delete that lab's in-progress code on the shared `CODER_FILES` volume.

## Fix

- Condition the `load IDE` grant on `submittedByOrgId`, matching the sibling `update`/`delete`/`create StudyJob` rules. A `$in` denies when the field is absent, so a subject missing it fails closed.
- Widen the `IDE` ability arm — a condition may only reference fields declared on it, so the ticket's one-line change would not have compiled. No middleware change was needed for the IDE actions; `getInfoForStudyId` already supplies `submittedByOrgId`.
- Scope `create Study` the same way. `submittingOrgSlug` arrives as a client param and `getOrgIdFromSlug` resolves any slug, so a caller could otherwise stamp another lab's id onto a new study and gain IDE access to it under the new rule. `onSaveDraftStudyAction`'s middleware now resolves that slug into `submittedByOrgId`, putting it in the ability subject so the CASL rule enforces lab membership — rather than a hand-rolled check in the handler, which would sit where someone auditing `permissions.ts` would never look.

## Note

The `researcherId` grant is deliberately left in place, so a study's author keeps IDE access regardless of current lab membership. Narrower than the cross-lab hole, but it is a second unscoped path worth tracking separately.

## Tests

Full suite passes (2410 tests, 251 files), typecheck and lint clean. New coverage:

- The ticket's required lab-B denial, plus fail-closed on a missing field and the enclave-only case.
- Cross-lab denial against the RPC endpoints themselves, asserting the file bytes survive on disk rather than only that an error returns.
- Regression guard that the submitting lab still reaches its own workspace.
- `create Study` scoped to the caller's own labs and fail-closed with no submitting lab in the subject, plus an end-to-end denial for `onSaveDraftStudyAction` with a foreign `submittingOrgSlug` asserting no row is written.

[OTTER-719]: https://openstax.atlassian.net/browse/OTTER-719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ