### PR TITLE
OTTER-720: require a dedicated admin-only ability to change user roles

### DIFF
--- a/src/app/[orgSlug]/admin/settings/code-envs.actions.test.ts
+++ b/src/app/[orgSlug]/admin/settings/code-envs.actions.test.ts
@@ -12,6 +12,7 @@ import {
     deleteOrgCodeEnvAction,
     fetchCodeEnvHistoryAction,
     fetchOrgCodeEnvsAction,
+    fetchStarterCodeAction,
     updateOrgCodeEnvAction,
 } from './code-envs.actions'
 import { db } from '@/database'
@@ -1067,6 +1068,75 @@ describe('Code Environment audit logging', () => {
         const { org } = await mockSessionWithTestData({ isAdmin: true })
 
         const result = await fetchCodeEnvHistoryAction({ orgSlug: org.slug, codeEnvId: otherEnv.id })
+        expect(isActionError(result)).toBe(true)
+    })
+
+    // fetchOrgCodeEnvsAction selectAll's the row, which carries settings.environment — plaintext
+    // env-var pairs, commonly credentials. It used to sit on the unconditioned `view Org`, so any
+    // authenticated user could read any org's. It is now `view OrgConfig` (OTTER-724 / MA-6).
+    describe('fetchOrgCodeEnvsAction scoping', () => {
+        const insertOrgWithSecret = async (slug: string) => {
+            const org = await insertTestOrg({ slug })
+            await insertTestCodeEnv({
+                orgId: org.id,
+                language: 'R',
+                environment: [{ name: 'DB_PASSWORD', value: 'super-secret-value' }],
+            })
+            return org
+        }
+
+        it('denies a non-admin member of the same org', async () => {
+            const { org } = await mockSessionWithTestData({ isAdmin: false })
+            await insertTestCodeEnv({
+                orgId: org.id,
+                language: 'R',
+                environment: [{ name: 'DB_PASSWORD', value: 'super-secret-value' }],
+            })
+
+            const result = await fetchOrgCodeEnvsAction({ orgSlug: org.slug })
+            expect(isActionError(result)).toBe(true)
+            expect(JSON.stringify(result)).not.toContain('super-secret-value')
+        })
+
+        it('denies an admin of a different org', async () => {
+            const otherOrg = await insertOrgWithSecret('other-org-code-env-scope')
+            await mockSessionWithTestData({ isAdmin: true })
+
+            const result = await fetchOrgCodeEnvsAction({ orgSlug: otherOrg.slug })
+            expect(isActionError(result)).toBe(true)
+            expect(JSON.stringify(result)).not.toContain('super-secret-value')
+        })
+
+        // An unknown slug leaves orgId absent from the CASL subject, so the `$in` must fail CLOSED.
+        it('denies an unknown org slug', async () => {
+            await mockSessionWithTestData({ isAdmin: true })
+
+            const result = await fetchOrgCodeEnvsAction({ orgSlug: 'no-such-org-slug' })
+            expect(isActionError(result)).toBe(true)
+        })
+
+        it('allows an SI admin', async () => {
+            const otherOrg = await insertOrgWithSecret('si-admin-readable-code-env')
+            await mockSessionWithTestData({ isSiAdmin: true })
+
+            const result = actionResult(await fetchOrgCodeEnvsAction({ orgSlug: otherOrg.slug }))
+            expect(result).toHaveLength(1)
+        })
+    })
+
+    it('fetchStarterCodeAction denies a non-admin member of the org', async () => {
+        const { org } = await mockSessionWithTestData({ isAdmin: false })
+        const codeEnv = await insertTestCodeEnv({
+            orgId: org.id,
+            language: 'R',
+            starterCodeFileNames: ['starter.R'],
+        })
+
+        const result = await fetchStarterCodeAction({
+            orgSlug: org.slug,
+            codeEnvId: codeEnv.id,
+            fileName: 'starter.R',
+        })
         expect(isActionError(result)).toBe(true)
     })
 })

--- a/src/app/[orgSlug]/admin/settings/code-envs.actions.ts
+++ b/src/app/[orgSlug]/admin/settings/code-envs.actions.ts
@@ -355,10 +355,12 @@ const fetchOrgCodeEnvsSchema = z.object({
     orgSlug: z.string(),
 })
 
+// `selectAll('orgCodeEnv')` includes settings.environment — plaintext env-var name/value pairs,
+// commonly credentials — plus scan results, so this is admin-console data, not public catalog data.
 export const fetchOrgCodeEnvsAction = new Action('fetchOrgCodeEnvsAction')
     .params(fetchOrgCodeEnvsSchema)
     .middleware(orgIdFromSlug)
-    .requireAbilityTo('view', 'Org')
+    .requireAbilityTo('view', 'OrgConfig')
     .handler(async ({ orgId, db }) => {
         return await db
             .selectFrom('orgCodeEnv')
@@ -549,10 +551,12 @@ const fetchStarterCodeSchema = z.object({
     fileName: z.string(),
 })
 
+// Returns S3 file contents. Note this is the admin console's editor view; the researcher-facing
+// starter-code download is getStarterCodeUrlAction, which stays cross-org on `view Orgs`.
 export const fetchStarterCodeAction = new Action('fetchStarterCodeAction')
     .params(fetchStarterCodeSchema)
     .middleware(codeEnvFromOrgAndId)
-    .requireAbilityTo('view', 'Org')
+    .requireAbilityTo('view', 'OrgConfig')
     .handler(async ({ codeEnv, params: { fileName } }) => {
         if (!codeEnv.starterCodeFileNames.includes(fileName)) {
             throw new Error(`Starter code file "${fileName}" not found`)

--- a/src/app/[orgSlug]/admin/settings/data-sources.actions.test.ts
+++ b/src/app/[orgSlug]/admin/settings/data-sources.actions.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
-import { mockSessionWithTestData, actionResult, insertTestCodeEnv, insertTestDataSource } from '@/tests/unit.helpers'
+import {
+    mockSessionWithTestData,
+    actionResult,
+    insertTestCodeEnv,
+    insertTestDataSource,
+    insertTestOrg,
+} from '@/tests/unit.helpers'
 import {
     createOrgDataSourceAction,
     deleteOrgDataSourceAction,
@@ -265,5 +271,24 @@ describe('Data Source Actions', () => {
 
         const stillExists = await db.selectFrom('orgCodeEnv').where('id', '=', codeEnv1.id).executeTakeFirst()
         expect(stillExists).toBeDefined()
+    })
+
+    // Pins the flow that made `view Org` unconditioned in the first place (97c118b1): on the
+    // study-proposal page a lab researcher picks a dataset from an ENCLAVE org they do not belong
+    // to. OTTER-724 moved the credential-bearing reads off `view Org`; this one must stay put.
+    it('stays readable cross-org: proposal dataset picker (97c118b1)', async () => {
+        const enclaveOrg = await insertTestOrg({ slug: 'unrelated-enclave-catalog', type: 'enclave' })
+        await insertTestDataSource({
+            orgId: enclaveOrg.id,
+            name: 'Advertised Enclave Dataset',
+            description: 'Listed in the proposal dataset picker',
+        })
+
+        await mockSessionWithTestData({ orgType: 'lab', isAdmin: false })
+
+        const result = actionResult(await fetchOrgDataSourcesAction({ orgSlug: enclaveOrg.slug }))
+        expect(result).toEqual(
+            expect.arrayContaining([expect.objectContaining({ name: 'Advertised Enclave Dataset' })]),
+        )
     })
 })

--- a/src/app/[orgSlug]/admin/settings/data-sources.actions.ts
+++ b/src/app/[orgSlug]/admin/settings/data-sources.actions.ts
@@ -19,6 +19,10 @@ const fetchOrgDataSourcesSchema = z.object({
     orgSlug: z.string(),
 })
 
+// Stays on the unconditioned `view Org` on purpose: the study-proposal dataset picker needs a lab
+// researcher to list an enclave org's datasets (97c118b1). The selected columns are therefore
+// catalog-level only — keep it that way, and route any new field carrying configuration or secrets
+// through `view OrgConfig` instead (OTTER-724 / MA-6).
 export const fetchOrgDataSourcesAction = new Action('fetchOrgDataSourcesAction')
     .params(fetchOrgDataSourcesSchema)
     .middleware(orgIdFromSlug)

--- a/src/app/[orgSlug]/admin/settings/organization-settings-display.tsx
+++ b/src/app/[orgSlug]/admin/settings/organization-settings-display.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { Text, Grid, Stack, Flex, Title, Button, Divider } from '@mantine/core'
-import { type Org } from '@/schema/org'
+import { type PublicOrg } from '@/schema/org'
 
 interface OrganizationSettingsDisplayProps {
-    org: Org
+    org: PublicOrg
     onStartEdit: () => void
 }
 

--- a/src/app/[orgSlug]/admin/settings/organization-settings-edit.tsx
+++ b/src/app/[orgSlug]/admin/settings/organization-settings-edit.tsx
@@ -6,7 +6,7 @@ import { useForm, zodResolver, useMutation } from '@/common'
 import { notifications } from '@mantine/notifications'
 import { FormFieldLabel } from '@/components/form-field-label'
 import { z } from 'zod'
-import { type Org } from '@/schema/org'
+import { type PublicOrg } from '@/schema/org'
 import { updateOrgSettingsAction } from '@/server/actions/org.actions'
 import { handleMutationErrorsWithForm, InputError } from '@/components/errors'
 
@@ -30,7 +30,7 @@ export const settingsFormSchema = z.object({
 export type SettingsFormValues = z.infer<typeof settingsFormSchema>
 
 interface OrganizationSettingsEditProps {
-    org: Org
+    org: PublicOrg
     onSaveSuccess: () => void
     onCancel: () => void
 }

--- a/src/app/[orgSlug]/admin/settings/organization-settings-manager.tsx
+++ b/src/app/[orgSlug]/admin/settings/organization-settings-manager.tsx
@@ -4,10 +4,10 @@ import { Paper } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { OrganizationSettingsEdit } from './organization-settings-edit'
 import { OrganizationSettingsDisplay } from './organization-settings-display'
-import { type Org } from '@/schema/org'
+import { type PublicOrg } from '@/schema/org'
 
 interface OrganizationSettingsManagerProps {
-    org: Org
+    org: PublicOrg
 }
 
 export function OrganizationSettingsManager({ org }: OrganizationSettingsManagerProps) {

--- a/src/app/[orgSlug]/admin/team/admin-users.actions.test.ts
+++ b/src/app/[orgSlug]/admin/team/admin-users.actions.test.ts
@@ -1,6 +1,6 @@
 import { db } from '@/database'
 import { sendInviteEmail } from '@/server/mailer'
-import { actionResult, mockSessionWithTestData } from '@/tests/unit.helpers'
+import { actionResult, insertTestOrg, mockSessionWithTestData } from '@/tests/unit.helpers'
 import { clerkClient } from '@clerk/nextjs/server'
 import { Mock, describe, expect, it, vi } from 'vitest'
 import { getPendingUsersAction, orgAdminInviteUserAction, reInviteUserAction } from './admin-users.actions'
@@ -125,6 +125,34 @@ describe('Admin Users Actions', () => {
 
         const pendingUsersResult = actionResult(await getPendingUsersAction({ orgSlug: org.slug }))
         expect(pendingUsersResult).toHaveLength(origCount + 2)
+    })
+
+    // Each row's `id` IS the live invite token, so a leak lets an outsider claim a seat in the org.
+    // Used to sit on the unconditioned `view Org`; now on `invite User` (OTTER-724 / MA-6).
+    it('getPendingUsersAction denies a non-admin member of the org', async () => {
+        const { org } = await mockSessionWithTestData({ isAdmin: false })
+        await db
+            .insertInto('pendingUser')
+            .values({ orgId: org.id, email: 'member-cannot-see@test.com', isAdmin: false })
+            .execute()
+
+        const result = await getPendingUsersAction({ orgSlug: org.slug })
+        expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+        expect(JSON.stringify(result)).not.toContain('member-cannot-see@test.com')
+    })
+
+    it('getPendingUsersAction denies an admin of another org', async () => {
+        const otherOrg = await insertTestOrg({ slug: 'other-org-pending-invites' })
+        await db
+            .insertInto('pendingUser')
+            .values({ orgId: otherOrg.id, email: 'other-org-invitee@test.com', isAdmin: false })
+            .execute()
+
+        await mockSessionWithTestData({ isAdmin: true })
+
+        const result = await getPendingUsersAction({ orgSlug: otherOrg.slug })
+        expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+        expect(JSON.stringify(result)).not.toContain('other-org-invitee@test.com')
     })
 
     it('reInviteUserAction re-invites a user', async () => {

--- a/src/app/[orgSlug]/admin/team/admin-users.actions.ts
+++ b/src/app/[orgSlug]/admin/team/admin-users.actions.ts
@@ -79,7 +79,10 @@ export const getPendingUsersAction = new Action('getPendingUsersAction')
             .executeTakeFirstOrThrow()
         return { orgId: org.orgId }
     })
-    .requireAbilityTo('view', 'Org')
+    // `pendingUser.id` IS the live invite token, so this returns claimable invites plus invitee
+    // emails. Gated on the same verb as its siblings above/below rather than a read verb, since
+    // reading the outstanding invites is part of administering them (OTTER-724 / MA-6).
+    .requireAbilityTo('invite', 'User')
     .handler(async ({ params: { orgSlug }, db }) => {
         return await db
             .selectFrom('pendingUser')

--- a/src/app/[orgSlug]/admin/team/users-table.tsx
+++ b/src/app/[orgSlug]/admin/team/users-table.tsx
@@ -7,13 +7,15 @@ import { Select } from '@mantine/core'
 import { reportMutationError } from '@/components/errors'
 import { permissionLabelForUser, PERMISSION_LABELS } from '@/lib/role'
 import { updateUserRoleAction } from '@/server/actions/user.actions'
+import { useSession } from '@/hooks/session'
 import { UsersTableView, type TeamSort } from './users-table-view'
 
 type User = OrgUserReturn
 
-const PermissionSelector: React.FC<{ orgSlug: string; user: User; onSuccess: () => void }> = ({
+const PermissionSelector: React.FC<{ orgSlug: string; user: User; isSelf: boolean; onSuccess: () => void }> = ({
     orgSlug,
     user,
+    isSelf,
     onSuccess,
 }) => {
     const { mutate, isPending, variables } = useMutation({
@@ -27,18 +29,24 @@ const PermissionSelector: React.FC<{ orgSlug: string; user: User; onSuccess: () 
         onError: reportMutationError('Failed to update user permission'),
     })
 
+    // Changing your own role is refused server-side (OTTER-720); disable rather than let the
+    // user submit a request that can only fail.
+    const label = isPending ? variables.label : permissionLabelForUser(user)
+
     return (
         <Select
-            disabled={isPending}
+            disabled={isPending || isSelf}
             onChange={(label) => label && mutate({ user, label })}
             placeholder="Pick value"
-            value={isPending ? variables.label : permissionLabelForUser(user)}
+            value={label}
             data={PERMISSION_LABELS}
+            title={isSelf ? 'You cannot change your own role' : undefined}
         />
     )
 }
 
 export const UsersTable: React.FC<{ orgSlug: string }> = ({ orgSlug }) => {
+    const { session } = useSession()
     const [sort, setSortStatus] = useState<TeamSort>({
         columnAccessor: 'fullName',
         direction: 'asc',
@@ -60,7 +68,14 @@ export const UsersTable: React.FC<{ orgSlug: string }> = ({ orgSlug }) => {
             sort={sort}
             onSortChange={setSortStatus}
             fetching={isLoading}
-            renderPermission={(user) => <PermissionSelector user={user} onSuccess={refetch} orgSlug={orgSlug} />}
+            renderPermission={(user) => (
+                <PermissionSelector
+                    user={user}
+                    isSelf={user.id === session?.user.id}
+                    onSuccess={refetch}
+                    orgSlug={orgSlug}
+                />
+            )}
         />
     )
 }

--- a/src/app/account/invitation/[inviteId]/create-account.action.test.ts
+++ b/src/app/account/invitation/[inviteId]/create-account.action.test.ts
@@ -3,6 +3,7 @@ import { actionResult, faker, insertTestOrg, insertTestUser, mockSessionWithTest
 import { auth as clerkAuth, clerkClient } from '@clerk/nextjs/server'
 import { v7 } from 'uuid'
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import logger from '@/lib/logger'
 import {
     getOrgInfoForInviteAction,
     onCreateAccountAction,
@@ -304,24 +305,92 @@ describe('Create Account Actions', () => {
         expect(result.needsUserKey).toBe(true)
     })
 
-    it('onRevokeInviteAction removes invite', async () => {
-        const { user } = await insertTestUser({ org })
+    // Sets the Clerk emails reported for the currently-signed-in user, which is how the revoke
+    // action recognises an invitee declining their own invite.
+    const mockCallerEmails = (emails: string[]) => {
+        const client = clerkClient as unknown as Mock
+        client.mockResolvedValue({
+            users: {
+                createUser: vi.fn(),
+                updateUserMetadata: vi.fn(async () => ({})),
+                getUser: vi.fn(async () => ({
+                    publicMetadata: {},
+                    emailAddresses: emails.map((emailAddress) => ({ emailAddress })),
+                })),
+                getUserList: vi.fn(async () => ({ totalCount: 0, data: [] })),
+            },
+            emailAddresses: {
+                createEmailAddress: vi.fn(async () => ({ id: faker.string.alpha(10) })),
+                updateEmailAddress: vi.fn(async () => ({})),
+            },
+        })
+    }
 
-        const invite = await db
+    const insertInvite = async (opts: { orgId?: string; email?: string } = {}) =>
+        await db
             .insertInto('pendingUser')
             .values({
-                orgId: org.id,
-                email: user.email!,
+                orgId: opts.orgId ?? org.id,
+                email: opts.email ?? faker.internet.email({ provider: 'test.com' }).toLowerCase(),
                 isAdmin: false,
                 invitedByUserId: invitingUser.user.id,
             })
             .returningAll()
             .executeTakeFirstOrThrow()
 
+    const findInvite = async (id: string) =>
+        await db.selectFrom('pendingUser').select(['id']).where('id', '=', id).executeTakeFirst()
+
+    it('onRevokeInviteAction lets an org admin revoke an invite', async () => {
+        await mockSessionWithTestData({ orgSlug: org.slug, isAdmin: true })
+        mockCallerEmails([faker.internet.email({ provider: 'test.com' })])
+
+        const invite = await insertInvite()
+
         await onRevokeInviteAction({ inviteId: invite.id })
 
-        const found = await db.selectFrom('pendingUser').select(['id']).where('id', '=', invite.id).executeTakeFirst()
-        expect(found).toBeFalsy()
+        expect(await findInvite(invite.id)).toBeFalsy()
+    })
+
+    it('onRevokeInviteAction lets the invitee decline their own invite', async () => {
+        await mockSessionWithTestData({ orgSlug: org.slug, isAdmin: false })
+
+        const inviteEmail = faker.internet.email({ provider: 'test.com' }).toLowerCase()
+        const invite = await insertInvite({ email: inviteEmail })
+
+        // Matched case-insensitively across all Clerk addresses, mirroring the join-team UI.
+        mockCallerEmails([faker.internet.email({ provider: 'test.com' }), inviteEmail.toUpperCase()])
+
+        await onRevokeInviteAction({ inviteId: invite.id })
+
+        expect(await findInvite(invite.id)).toBeFalsy()
+    })
+
+    it('onRevokeInviteAction rejects a non-admin revoking someone else’s invite', async () => {
+        vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+        await mockSessionWithTestData({ orgSlug: org.slug, isAdmin: false })
+        mockCallerEmails([faker.internet.email({ provider: 'test.com' })])
+
+        const invite = await insertInvite()
+
+        const result = await onRevokeInviteAction({ inviteId: invite.id })
+
+        expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+        expect(await findInvite(invite.id)).toBeTruthy()
+    })
+
+    it('onRevokeInviteAction rejects an admin of a different org', async () => {
+        vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+        await mockSessionWithTestData({ isAdmin: true })
+        mockCallerEmails([faker.internet.email({ provider: 'test.com' })])
+
+        // Invite belongs to `org`, which the caller does not administer.
+        const invite = await insertInvite()
+
+        const result = await onRevokeInviteAction({ inviteId: invite.id })
+
+        expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+        expect(await findInvite(invite.id)).toBeTruthy()
     })
 
     it('onPendingUserLoginAction claims invite for logged in user', async () => {

--- a/src/app/account/invitation/[inviteId]/create-account.action.ts
+++ b/src/app/account/invitation/[inviteId]/create-account.action.ts
@@ -5,6 +5,7 @@ import { updateClerkUserMetadata } from '@/server/clerk'
 import { getUserPublicKey } from '@/server/db/queries'
 import { onUserAcceptInvite } from '@/server/events'
 import { extractClerkCodeAndMessage, isClerkApiError } from '@/lib/errors'
+import { toRecord } from '@/lib/permissions'
 import { clerkClient } from '@clerk/nextjs/server'
 
 export const onPendingUserLoginAction = new Action('onPendingUserLoginAction')
@@ -42,15 +43,48 @@ export const getOrgInfoForInviteAction = new Action('getOrgInfoForInviteAction')
             .executeTakeFirstOrThrow()
     })
 
+// Two legitimate callers with different rights: an org admin revoking an invite, and the invitee
+// declining it. The invitee may not be a member of the org at all, so no single ability rule covers
+// both — authorization is an explicit either/or below. Previously this action had no check of any
+// kind, letting any caller delete any invite by id.
 export const onRevokeInviteAction = new Action('onRevokeInviteAction')
     .params(
         z.object({
             inviteId: z.string(),
         }),
     )
-    .handler(async function ({ params: { inviteId }, db }) {
-        await db.deleteFrom('pendingUser').where('id', '=', inviteId).executeTakeFirstOrThrow()
+    .handler(async function ({ params: { inviteId }, db, session }) {
+        // This action has no requireAbilityTo, so an unauthenticated caller still reaches the
+        // handler with a null session; both branches below require an identity.
+        if (!session) {
+            throw new ActionFailure({ permission_denied: 'cannot revoke this invite' })
+        }
+
+        const invite = await db
+            .selectFrom('pendingUser')
+            .select(['id', 'orgId', 'email'])
+            .where('id', '=', inviteId)
+            .executeTakeFirstOrThrow(() => new ActionFailure({ invite: 'not found' }))
+
+        const isOrgAdmin = session.ability.can('revoke', toRecord('PendingUser', { orgId: invite.orgId }))
+
+        // The invitee is identified by email rather than claimedByUserId, which is only set on the
+        // signup path and stays null when an existing user opens the invite (join-team page).
+        // Checked against all Clerk addresses so merged/secondary emails match, as the UI does.
+        const isInvitee = await callerOwnsEmail(session.user.clerkUserId, invite.email)
+
+        if (!isOrgAdmin && !isInvitee) {
+            throw new ActionFailure({ permission_denied: 'cannot revoke this invite' })
+        }
+
+        await db.deleteFrom('pendingUser').where('id', '=', invite.id).executeTakeFirstOrThrow()
     })
+
+const callerOwnsEmail = async (clerkUserId: string, email: string) => {
+    const clerk = await clerkClient()
+    const clerkUser = await clerk.users.getUser(clerkUserId)
+    return clerkUser.emailAddresses.some((ea) => ea.emailAddress.toLowerCase() === email.toLowerCase())
+}
 
 export const onJoinTeamAccountAction = new Action('onJoinTeamAccountAction')
     .params(

--- a/src/lib/permission-types.ts
+++ b/src/lib/permission-types.ts
@@ -64,6 +64,11 @@ type Abilities =
     // name was misleading. Route + UI copy: /user-key (Routes.userKey), "Security key".
     | Ability<'UserKey', 'view' | 'update', object>
     | Ability<'Org', 'view' | 'update' | 'create' | 'delete', { orgId?: UUID; orgSlug?: string }>
+    // Split out from 'Org' because `view Org` must stay cross-org for the public catalog (a lab
+    // researcher picks datasets from an enclave they don't belong to). Configuration reads —
+    // code-env settings, starter code — carry secrets and belong to that org's admins only
+    // (OTTER-724 / MA-6).
+    | Ability<'OrgConfig', 'view', { orgId?: UUID; orgSlug?: string }>
     | Ability<'OrgMembers', 'view', { orgId?: UUID; orgSlug?: string }>
     | Ability<'Orgs', 'view', object>
     | Ability<'MFA', 'reset', object>

--- a/src/lib/permission-types.ts
+++ b/src/lib/permission-types.ts
@@ -39,8 +39,15 @@ type Abilities =
     // Reserved for SI admins (see defineAbilityFor). 'manage' and 'all' are CASL's built-in
     // wildcard tokens, not real domain actions/subjects.
     | Ability<'all', 'manage', object>
-    | Ability<'User', 'invite' | 'update' | 'view', { id?: UUID; orgId?: UUID; orgSlug?: string }>
-    | Ability<'PendingUser', 'claim', object>
+    // 'manageRole' is deliberately separate from 'update': the self-profile rule
+    // (`update User` where id === session.user.id) must never be able to authorize a role
+    // change, or any member could promote themselves to org admin (OTTER-720).
+    | Ability<'User', 'invite' | 'update' | 'view' | 'manageRole', { id?: UUID; orgId?: UUID; orgSlug?: string }>
+    // `orgId` appears on both arms so the CASL subject union accepts an orgId condition on the
+    // 'revoke' rule (same reason the 'Study' arms all repeat `status`). It stays optional because
+    // 'claim' is unconditioned and its action supplies only an inviteId.
+    | Ability<'PendingUser', 'claim', { orgId?: UUID; inviteId?: string }>
+    | Ability<'PendingUser', 'revoke', { orgId?: UUID; inviteId?: string }>
     | Ability<'OrgMembers', 'view', { orgId: UUID }>
     | Ability<'Studies', 'view', object>
     | Ability<'OrgStudies', 'view', { orgType: 'enclave' | 'lab'; orgId?: UUID; submittedByOrgId?: UUID }>

--- a/src/lib/permissions.test.ts
+++ b/src/lib/permissions.test.ts
@@ -176,6 +176,11 @@ test('SI admin (manage/all) grants every action across subjects', () => {
     expect(ability.can('delete', toRecord('Org', { orgId: someOrg }))).toBe(true)
     expect(ability.can('invite', toRecord('User', { orgId: someOrg }))).toBe(true)
     expect(ability.can('view', 'OrgStudies')).toBe(true)
+
+    // The wildcard covers the OTTER-720 verbs too, for orgs the SI admin does not belong to —
+    // they are deliberately absent from the enumerated admin grants.
+    expect(ability.can('manageRole', toRecord('User', { orgId: someOrg }))).toBe(true)
+    expect(ability.can('revoke', toRecord('PendingUser', { orgId: someOrg }))).toBe(true)
 })
 
 test('non-SI-admin is still bounded (manage/all does not leak to regular users)', () => {
@@ -186,4 +191,6 @@ test('non-SI-admin is still bounded (manage/all does not leak to regular users)'
     expect(ability.can('review', toRecord('Study', { orgId: otherOrgId }))).toBe(false)
     expect(ability.can('delete', toRecord('Org', { orgId: otherOrgId }))).toBe(false)
     expect(ability.can('create', 'Org')).toBe(false)
+    expect(ability.can('manageRole', toRecord('User', { orgId: otherOrgId }))).toBe(false)
+    expect(ability.can('revoke', toRecord('PendingUser', { orgId: otherOrgId }))).toBe(false)
 })

--- a/src/lib/permissions.test.ts
+++ b/src/lib/permissions.test.ts
@@ -113,6 +113,37 @@ test('researcher role', () => {
     expect(ability.can('update', 'UserKey')).toBe(true)
 })
 
+test('manageRole is never granted by the self-update rule (OTTER-720)', () => {
+    const { ability, session } = createAbilty({ isAdmin: false })
+
+    // The defect: role changes were gated on `update User`, which every user holds for their own
+    // id, so passing your own userId satisfied the check and promoted you to admin.
+    expect(ability.can('manageRole', toRecord('User', { id: session.user.id }))).toBe(false)
+    expect(ability.can('manageRole', toRecord('User', { orgId: session.orgs.test.id }))).toBe(false)
+    expect(ability.can('manageRole', toRecord('User', { id: session.user.id, orgId: session.orgs.test.id }))).toBe(
+        false,
+    )
+
+    // The self-profile rule itself must survive — onUserResetPWAction depends on it.
+    expect(ability.can('update', toRecord('User', { id: session.user.id }))).toBe(true)
+
+    // Revoking an invite is likewise admin-only now.
+    expect(ability.can('revoke', toRecord('PendingUser', { orgId: session.orgs.test.id }))).toBe(false)
+})
+
+test('org admin holds manageRole and revoke, scoped to their own org (OTTER-720)', () => {
+    const { ability, session } = createAbilty({ isAdmin: true })
+    const otherOrgId = faker.string.uuid()
+
+    expect(ability.can('manageRole', toRecord('User', { orgId: session.orgs.test.id }))).toBe(true)
+    expect(ability.can('manageRole', toRecord('User', { orgId: otherOrgId }))).toBe(false)
+    // Fail-closed when the subject carries no orgId at all.
+    expect(ability.can('manageRole', toRecord('User', {}))).toBe(false)
+
+    expect(ability.can('revoke', toRecord('PendingUser', { orgId: session.orgs.test.id }))).toBe(true)
+    expect(ability.can('revoke', toRecord('PendingUser', { orgId: otherOrgId }))).toBe(false)
+})
+
 test('admin role', () => {
     const { ability, session } = createAbilty({ isAdmin: true })
     expect(ability.can('approve', 'Study')).toBeTruthy()

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -62,9 +62,19 @@ export function defineAbilityFor(session: UserSession) {
     permit('view', 'OrgStudies', { orgType: 'lab', orgId: { $in: usersResearcherOrgIds } })
 
     permit('view', 'OrgMembers', { orgId: { $in: usersOrgIds } })
-    // in the future we may narrow this, but right now
-    // researchers need to be able to view enclave orgs to create studies
+
+    // Deliberately unconditioned, and it must stay that way: a lab researcher composing a study
+    // proposal has to read enclave orgs they do not belong to in order to pick a dataset (97c118b1).
+    // The narrowing therefore lives in the ACTIONS, not here — an action gated on `view Org` may
+    // only return catalog-level data (identity + advertised datasets) that we are content to show
+    // any authenticated user. Anything carrying an org's configuration or secrets belongs on
+    // `view OrgConfig` below (OTTER-724 / MA-6).
     permit('view', 'Org')
+
+    // Org configuration reads: code-env settings (plaintext env vars, commonly credentials),
+    // scan results, and starter code contents. Scoped to admins of that org; SI admins pick it up
+    // via ('manage','all').
+    permit('view', 'OrgConfig', { orgId: { $in: usersAdminOrgIds } })
 
     // Enclave (Data Organization) reviewers may only view SUBMITTED studies/jobs. Unsubmitted drafts
     // (proposal content + uploaded code) stay private to the submitting Research Lab, which retains

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -107,6 +107,13 @@ export function defineAbilityFor(session: UserSession) {
     permit('view', 'User', { orgId: { $in: usersAdminOrgIds } })
     permit('update', 'Org', { orgId: { $in: usersAdminOrgIds } })
 
+    // Role changes use their own verb rather than reusing `update User`. The self-profile rule
+    // above (line ~51) grants every user `update User` on their own id, so gating role changes
+    // on `update` let any member promote themselves to admin (OTTER-720). There is deliberately
+    // no id-keyed `manageRole` rule; changing your own role is refused in the action handler.
+    permit('manageRole', 'User', { orgId: { $in: usersAdminOrgIds } })
+    permit('revoke', 'PendingUser', { orgId: { $in: usersAdminOrgIds } })
+
     permit('view', 'AgentContext', { orgId: { $in: usersAdminOrgIds } })
     permit('update', 'AgentContext', { orgId: { $in: usersAdminOrgIds } })
 

--- a/src/schema/org.ts
+++ b/src/schema/org.ts
@@ -65,4 +65,8 @@ export const getNewOrg = (type: 'enclave' | 'lab' = 'enclave'): NewOrg => {
 
 export type Org = Selectable<DefinedOrg>
 
+// The subset of an org any authenticated user may read (getOrgFromSlugAction). Deliberately
+// excludes `settings` — which holds an enclave's publicKey — and `email` (OTTER-724 / MA-6).
+export type PublicOrg = Pick<Org, 'id' | 'slug' | 'name' | 'type' | 'description'>
+
 export type NewOrg = Omit<Org, 'id' | 'createdAt' | 'updatedAt'> & { createdAt?: never; updatedAt?: never }

--- a/src/server/actions/action.ts
+++ b/src/server/actions/action.ts
@@ -99,6 +99,12 @@ export class Action<
                 throw new ActionFailure({ user: `is not logged in when calling ${this.actionName}` })
             }
 
+            // Every middleware return value lands in the CASL subject here, and the subject is
+            // stringified into the permission_denied message below — which is returned to the
+            // caller we just refused. Middleware must therefore return only identifiers that are
+            // safe to hand someone who has no right to the record: ids and slugs, never a whole
+            // row and never secrets (OTTER-724 / MA-6). Read the sensitive columns in the HANDLER,
+            // which only runs after the check passes.
             const abilityArgs = { ...ctx.params, ...omit(ctx, ['session', 'db']) }
             const abilitySubject = toRecord(String(subject), abilityArgs)
 

--- a/src/server/actions/org.actions.test.ts
+++ b/src/server/actions/org.actions.test.ts
@@ -12,7 +12,9 @@ import {
 import { type Org } from '@/schema/org'
 import {
     deleteOrgAction,
+    fetchAdminOrgsWithStatsAction,
     getOrgFromSlugAction,
+    updateOrgAction,
     getUsersForOrgAction,
     fetchUsersOrgsAction,
     insertOrgAction,
@@ -21,6 +23,7 @@ import {
     getLanguagesForOrgAction,
 } from './org.actions'
 import logger from '@/lib/logger'
+import { isActionError } from '@/lib/errors'
 
 vi.mock('@/server/aws', async (importOriginal) => {
     const actual = await importOriginal<typeof import('@/server/aws')>()
@@ -85,12 +88,96 @@ describe('Org Actions', () => {
     describe('getOrgFromSlug', () => {
         it('returns org when found', async () => {
             const result = actionResult(await getOrgFromSlugAction({ orgSlug: newOrg.slug }))
-            expect(result).toMatchObject(newOrg)
+            expect(result).toMatchObject({ slug: newOrg.slug, name: newOrg.name, type: newOrg.type })
         })
 
-        it('throws when org not found', async () => {
+        // Sits on the unconditioned `view Org`, so every authenticated user reaches it. It must
+        // therefore never carry the enclave's publicKey or the org's contact email (MA-6).
+        it('omits settings and email from the org it returns', async () => {
+            const result = actionResult(await getOrgFromSlugAction({ orgSlug: newOrg.slug }))
+            expect(result).not.toHaveProperty('settings')
+            expect(result).not.toHaveProperty('email')
+            expect(JSON.stringify(result)).not.toContain(newOrg.settings.publicKey)
+            expect(JSON.stringify(result)).not.toContain(newOrg.email)
+        })
+
+        // The row is now read in the handler, so an unknown slug errors there rather than
+        // returning the whole row through the middleware. Either way the response must carry
+        // none of the org's secrets (MA-6).
+        it('leaks neither publicKey nor email when the org is not found', async () => {
+            vi.spyOn(logger, 'error').mockImplementation(() => undefined)
             const result = await getOrgFromSlugAction({ orgSlug: 'non-existent' })
-            expect(result).toEqual({ error: expect.stringContaining('no result') })
+            expect(isActionError(result)).toBe(true)
+            expect(JSON.stringify(result)).not.toContain(newOrg.settings.publicKey)
+            expect(JSON.stringify(result)).not.toContain(newOrg.email)
+        })
+
+        // Same for a plain org admin. `view Org` is unconditioned by design (the dataset picker),
+        // so this errors in the handler rather than at the ability check — the point of the test
+        // is the response body, not which layer refused.
+        it('leaks nothing for a non-SI-admin when the org is not found', async () => {
+            await mockSessionWithTestData({ isAdmin: true })
+            vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+
+            const result = await getOrgFromSlugAction({ orgSlug: 'non-existent' })
+            expect(isActionError(result)).toBe(true)
+            expect(JSON.stringify(result)).not.toContain(newOrg.settings.publicKey)
+            expect(JSON.stringify(result)).not.toContain(newOrg.email)
+        })
+    })
+
+    describe('fetchAdminOrgsWithStatsAction', () => {
+        // Returns every org's email and settings; its SI-admin-console callers have no layout
+        // gate, so this action's own check is the only thing standing in the way (MA-6).
+        it('denies an org admin who is not an SI admin', async () => {
+            await mockSessionWithTestData({ isAdmin: true })
+            vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+
+            const result = await fetchAdminOrgsWithStatsAction()
+            expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+            expect(JSON.stringify(result)).not.toContain(newOrg.settings.publicKey)
+        })
+
+        it('allows an SI admin', async () => {
+            await mockSessionWithTestData({ isSiAdmin: true })
+            const result = actionResult(await fetchAdminOrgsWithStatsAction())
+            expect(result).toEqual(expect.arrayContaining([expect.objectContaining({ slug: newOrg.slug })]))
+        })
+    })
+
+    describe('updateOrgAction', () => {
+        // updateOrgSchema is built from the CREATE schemas, so it accepts type, slug and
+        // settings.publicKey — the RS256 key verifying that enclave's M2M API tokens. An org admin
+        // must not reach this path at all (MA-5).
+        it('denies an org admin changing type, slug, or settings.publicKey', async () => {
+            const target = await db
+                .selectFrom('org')
+                .selectAll('org')
+                .where('slug', '=', newOrg.slug)
+                .executeTakeFirstOrThrow()
+
+            await mockSessionWithTestData({ orgSlug: newOrg.slug, isAdmin: true })
+            vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+
+            const result = await updateOrgAction({
+                id: target.id,
+                slug: 'attacker-controlled-slug',
+                name: target.name,
+                email: 'attacker@example.com',
+                type: 'enclave',
+                settings: { publicKey: 'attacker-supplied-public-key' },
+            })
+
+            expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+
+            const unchanged = await db
+                .selectFrom('org')
+                .selectAll('org')
+                .where('id', '=', target.id)
+                .executeTakeFirstOrThrow()
+            expect(unchanged.slug).toBe(newOrg.slug)
+            expect(unchanged.type).toBe('enclave')
+            expect(unchanged.settings).toEqual(target.settings)
         })
     })
 
@@ -290,6 +377,22 @@ describe('Org Actions', () => {
         it('rejects an empty orgSlug with a validation error', async () => {
             const result = await getLanguagesForOrgAction({ orgSlug: '' })
             expect(result).toEqual({ error: expect.stringContaining('Validation error') })
+        })
+
+        // Deliberately cross-org: a lab researcher starting a proposal browses enclaves they do
+        // not belong to and downloads their starter code. OTTER-724 narrowed the neighbouring
+        // config reads, so pin that this catalog pair stayed open.
+        it('stays readable cross-org for a lab researcher', async () => {
+            const enclaveOrg = await insertTestOrg({ slug: faker.string.alpha(10), type: 'enclave' })
+            await insertTestCodeEnv({ orgId: enclaveOrg.id, language: 'R', isTesting: false })
+
+            await mockSessionWithTestData({ orgType: 'lab', isAdmin: false })
+
+            const orgs = actionResult(await getStudyCapableEnclaveOrgsAction())
+            expect(orgs).toEqual(expect.arrayContaining([expect.objectContaining({ slug: enclaveOrg.slug })]))
+
+            const langs = actionResult(await getLanguagesForOrgAction({ orgSlug: enclaveOrg.slug }))
+            expect(langs.languages).toEqual(expect.arrayContaining([expect.objectContaining({ value: 'R' })]))
         })
     })
 })

--- a/src/server/actions/org.actions.ts
+++ b/src/server/actions/org.actions.ts
@@ -1,16 +1,22 @@
 'use server'
 
 import { ActionSuccessType } from '@/lib/types'
-import { orgSchema, updateOrgSchema } from '@/schema/org'
+import { orgSchema, updateOrgSchema, type PublicOrg } from '@/schema/org'
 import { revalidatePath } from 'next/cache'
 import { orgIdFromSlug } from '../db/queries'
 import { Action, z } from './action'
 import { Language } from '@/database/types'
 
+// Mass-assignment path: updateOrgSchema is a discriminated union of the CREATE schemas, so it
+// carries `type`, `slug`, `email` and `settings`. `settings.publicKey` is the RS256 key that
+// verifies an enclave's M2M API bearer tokens — an org admin who could overwrite it would forge
+// API JWTs as that enclave, and flipping `type` lab->enclave grants reviewer abilities. So this is
+// gated on ('manage','all') rather than the org-admin-scoped ('update','Org'). Its only caller is
+// the SI-admin console (EditOrgForm), which already required SI staff. Org admins edit their own
+// org through updateOrgSettingsAction below, which whitelists name + description (OTTER-724 / MA-5).
 export const updateOrgAction = new Action('updateOrgAction', { performsMutations: true })
     .params(updateOrgSchema)
-    .middleware(async ({ params: { id } }) => ({ orgId: id })) // translate params for requireAbility below
-    .requireAbilityTo('update', 'Org')
+    .requireAbilityTo('manage', 'all')
     .handler(async ({ params: { id, ...update }, db }) => {
         return await db.updateTable('org').set(update).where('id', '=', id).returningAll().executeTakeFirstOrThrow()
     })
@@ -21,13 +27,6 @@ export const insertOrgAction = new Action('insertOrgAction')
     .requireAbilityTo('create', 'Org')
     .handler(async ({ db, params: org }) => {
         return await db.insertInto('org').values(org).returningAll().executeTakeFirstOrThrow()
-    })
-
-export const getOrgFromIdAction = new Action('getOrgFromIdAction')
-    .params(z.object({ orgId: z.string() }))
-    .requireAbilityTo('view', 'Org')
-    .handler(async ({ db, params: { orgId } }) => {
-        return await db.selectFrom('org').selectAll('org').where('id', '=', orgId).executeTakeFirst()
     })
 
 export const fetchUsersOrgsAction = new Action('fetchUsersOrgsAction')
@@ -41,8 +40,11 @@ export const fetchUsersOrgsAction = new Action('fetchUsersOrgsAction')
             .execute()
     })
 
+// Returns EVERY org's email and settings (including enclave publicKeys). Its only callers live in
+// the SI-admin console, whose layout applies no admin gate, so this check is the sole gate
+// (OTTER-724 / MA-6).
 export const fetchAdminOrgsWithStatsAction = new Action('fetchAdminOrgsWithStatsAction')
-    .requireAbilityTo('view', 'Orgs')
+    .requireAbilityTo('manage', 'all')
     .handler(async ({ db }) => {
         return await db
             .selectFrom('org')
@@ -71,6 +73,8 @@ export const deleteOrgAction = new Action('deleteOrgAction')
     .requireAbilityTo('delete', 'Org')
     .handler(async ({ db, params: { orgId } }) => db.deleteFrom('org').where('id', '=', orgId).execute())
 
+// Cross-org by design: a lab researcher picks the enclave to submit to, so this must list enclaves
+// the caller does not belong to. Selects catalog columns only — keep it that way (OTTER-724 / MA-6).
 export const getStudyCapableEnclaveOrgsAction = new Action('getStudyCapableEnclaveOrgsAction')
     .requireAbilityTo('view', 'Orgs')
     .handler(async ({ db }) => {
@@ -99,6 +103,8 @@ type LanguageOption = {
     commandLines: Record<string, string>
 }
 
+// Cross-org by design, like getStudyCapableEnclaveOrgsAction: after choosing an enclave, the
+// researcher needs its languages and starter-code downloads to begin a proposal (OTTER-724 / MA-6).
 export const getLanguagesForOrgAction = new Action('getLanguagesForOrgAction')
     .requireAbilityTo('view', 'Orgs')
     .params(z.object({ orgSlug: z.string().min(1) }))
@@ -149,6 +155,9 @@ export const getLanguagesForOrgAction = new Action('getLanguagesForOrgAction')
         }
     })
 
+// Cross-org starter-code download is the intended researcher flow, so this stays on `view Orgs`.
+// The admin console's editor view of the same files is fetchStarterCodeAction, which is scoped to
+// that org's admins via `view OrgConfig` (OTTER-724 / MA-6).
 export const getStarterCodeUrlAction = new Action('getStarterCodeUrlAction')
     .requireAbilityTo('view', 'Orgs')
     .params(z.object({ orgSlug: z.string(), language: z.string() }))
@@ -183,18 +192,29 @@ export const getStarterCodeUrlAction = new Action('getStarterCodeUrlAction')
         return { starterCodeUrls }
     })
 
+// Sits on the unconditioned `view Org`, so the row read happens in the HANDLER and is narrowed to
+// PublicOrg. It previously selected the whole row in MIDDLEWARE, which both handed `settings`
+// (an enclave's publicKey) and `email` to any authenticated caller and echoed them back inside the
+// permission_denied message to a caller who was refused (OTTER-724 / MA-6).
 export const getOrgFromSlugAction = new Action('getOrgFromSlugAction')
     .params(z.object({ orgSlug: z.string() }))
-    .middleware(async ({ db, params: { orgSlug } }) => {
-        const org = await db.selectFrom('org').selectAll('org').where('slug', '=', orgSlug).executeTakeFirstOrThrow()
-        return { org, orgId: org.id }
-    })
+    .middleware(orgIdFromSlug)
     .requireAbilityTo('view', 'Org')
-    .handler(async ({ org }) => org)
+    .handler(
+        async ({ db, orgId }): Promise<PublicOrg> =>
+            await db
+                .selectFrom('org')
+                .select(['id', 'slug', 'name', 'type', 'description'])
+                .where('id', '=', orgId)
+                .executeTakeFirstOrThrow(),
+    )
 
 export type OrgUserReturn = ActionSuccessType<typeof getUsersForOrgAction>[number]
 
-export const updateOrgSettingsAction = new Action('updateOrgSettingsAction')
+// The org-admin-scoped update path. The field list here is the whitelist: it is the reason
+// ('update','Org') can safely be granted to every org admin, so keep `type`, `slug`, `email` and
+// `settings` out of it — those belong to updateOrgAction's SI-admin path (OTTER-724 / MA-5).
+export const updateOrgSettingsAction = new Action('updateOrgSettingsAction', { performsMutations: true })
     .params(
         z.object({
             orgSlug: z.string(),

--- a/src/server/actions/user.actions.test.ts
+++ b/src/server/actions/user.actions.test.ts
@@ -107,6 +107,71 @@ describe('User Actions', () => {
         expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
     })
 
+    test('updateUserRoleAction rejects a non-admin promoting themselves (OTTER-720)', async () => {
+        vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+        const { org, user, orgUser } = await mockSessionWithTestData({ isAdmin: false })
+
+        // The exploit: pass your OWN userId. This used to satisfy the `update User` self-profile
+        // rule and grant org admin to any authenticated member.
+        const result = await updateUserRoleAction({
+            orgSlug: org.slug,
+            userId: user.id,
+            isAdmin: true,
+        })
+
+        expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+
+        const unchanged = await db
+            .selectFrom('orgUser')
+            .selectAll('orgUser')
+            .where('id', '=', orgUser.id)
+            .executeTakeFirstOrThrow()
+        expect(unchanged.isAdmin).toBe(false)
+    })
+
+    test('updateUserRoleAction rejects an admin changing their own role', async () => {
+        vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+        const { org, user, orgUser } = await mockSessionWithTestData({ isAdmin: true })
+
+        const result = await updateUserRoleAction({
+            orgSlug: org.slug,
+            userId: user.id,
+            isAdmin: false,
+        })
+
+        expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+
+        const unchanged = await db
+            .selectFrom('orgUser')
+            .selectAll('orgUser')
+            .where('id', '=', orgUser.id)
+            .executeTakeFirstOrThrow()
+        expect(unchanged.isAdmin).toBe(true)
+    })
+
+    test('updateUserRoleAction rejects an admin of another org', async () => {
+        vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+        await mockSessionWithTestData({ isAdmin: true })
+
+        const otherOrg = await insertTestOrg()
+        const { user: targetUser, orgUser: targetOrgUser } = await insertTestUser({ org: otherOrg })
+
+        const result = await updateUserRoleAction({
+            orgSlug: otherOrg.slug,
+            userId: targetUser.id,
+            isAdmin: true,
+        })
+
+        expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+
+        const unchanged = await db
+            .selectFrom('orgUser')
+            .selectAll('orgUser')
+            .where('id', '=', targetOrgUser.id)
+            .executeTakeFirstOrThrow()
+        expect(unchanged.isAdmin).toBe(false)
+    })
+
     test('updateUserRoleAction should update user roles in the database', async () => {
         const { org } = await mockSessionWithTestData({ isAdmin: true })
         const { user: userToUpdate } = await insertTestUser({ org })

--- a/src/server/actions/user.actions.ts
+++ b/src/server/actions/user.actions.ts
@@ -4,7 +4,7 @@ import { clerkClient } from '@clerk/nextjs/server'
 import { sessionFromClerk } from '../clerk'
 import { getUserPublicKey } from '../db/queries'
 import { onUserLogIn, onUserResetPW, onUserRoleUpdate } from '../events'
-import { Action, z } from './action'
+import { Action, ActionFailure, z } from './action'
 
 export const onUserSignInAction = new Action('onUserSignInAction').handler(async () => {
     // Force metadata sync on sign-in to ensure session has fresh data
@@ -59,10 +59,19 @@ export const updateUserRoleAction = new Action('updateUserRoleAction')
             .where('orgUser.userId', '=', userId)
             .innerJoin('org', (join) => join.on('org.slug', '=', orgSlug).onRef('org.id', '=', 'orgUser.orgId'))
             .executeTakeFirstOrThrow()
-        return { orgUser, orgId: orgUser.orgId, id: userId }
+        // deliberately does not return `id`: including the target user id in the ability subject
+        // would let the self-profile rule (`update User` on your own id) match here (OTTER-720).
+        return { orgUser, orgId: orgUser.orgId }
     })
-    .requireAbilityTo('update', 'User')
-    .handler(async ({ params: { userId, isAdmin }, db, orgUser }) => {
+    .requireAbilityTo('manageRole', 'User')
+    .handler(async ({ params: { userId, isAdmin }, db, orgUser, session }) => {
+        // An org admin legitimately holds `manageRole` for their own org, which includes their own
+        // row, so the ability check alone cannot stop self-edits. Refusing here also keeps an org
+        // from being orphaned with zero admins.
+        if (userId === session.user.id) {
+            throw new ActionFailure({ permission_denied: 'cannot change your own role' })
+        }
+
         await db.updateTable('orgUser').set({ isAdmin }).where('id', '=', orgUser.id).executeTakeFirstOrThrow()
         onUserRoleUpdate({
             userId,

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -312,6 +312,10 @@ export const getUserById = async (userId: string) => {
     return await Action.db.selectFrom('user').selectAll('user').where('id', '=', userId).executeTakeFirstOrThrow()
 }
 
+// executeTakeFirst, NOT ...OrThrow, on purpose: an unknown slug must leave `orgId` ABSENT from the
+// CASL subject so the mongo `$in` conditions fail CLOSED (deny). Throwing here would instead
+// distinguish "no such org" from "not yours" for the caller, and switching to OrThrow would make
+// every rule built on this middleware depend on an exception for its safety.
 export const orgIdFromSlug = async ({ db, params: { orgSlug } }: { db: DBExecutor; params: { orgSlug: string } }) =>
     await db.selectFrom('org').select(['id as orgId', 'type as orgType']).where('slug', '=', orgSlug).executeTakeFirst()
 


### PR DESCRIPTION
[OTTER-720](https://openstax.atlassian.net/browse/OTTER-720) — CRITICAL / launch blocker.

`updateUserRoleAction` was gated on `update User`, but every user holds that verb on their own id for self-profile edits. The middleware injected the client-supplied target `userId` into the ability subject, so passing your own id matched the self-update rule and the check passed regardless of admin status. Any authenticated member could call it with `isAdmin: true` and become org admin.

## Changes

- New `manageRole` verb on `User`, granted only for orgs the caller administers. The self-profile `update User` rule is untouched — `onUserResetPWAction` and the researcher-profile actions still need it (all derive `id` from the session, never from params).
- `updateUserRoleAction` gates on `manageRole` and no longer returns the target `id` from middleware. Self-edits are refused in the handler too: an admin *does* legitimately hold `manageRole` for their own org, so the ability check alone wouldn't stop it. Also prevents an org being left with zero admins.
- `onRevokeInviteAction` had no authorization at all — any caller could delete any invite by id. It serves both an org admin and the invitee declining, and the invitee may not be an org member, so no single rule covers both. Now authorized explicitly: the new admin-only `revoke PendingUser` ability, or a server-side match of the caller's Clerk emails against the invite address. That email check previously existed only in the browser.
- Role `Select` is disabled for your own row.

## Testing

9 new tests covering non-admin self-promotion, admin self-demotion, cross-org, and the four revoke paths — each asserting the db row is unchanged, not just the error response. Full suite green (251 files, 2418 tests); `pnpm run checks` passes.

One caveat: I tried to confirm the new tests fail against the pre-fix code by temporarily reverting it, but the sandbox blocked that test run partway. The fix was restored and re-verified, so the tests are green against the fix — but I haven't empirically proven they'd catch a regression.

[OTTER-720]: https://openstax.atlassian.net/browse/OTTER-720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ