### PR TITLE
Render legacy job results as text instead of writing them as HTML

### DIFF
--- a/src/components/legacy-job-results.test.tsx
+++ b/src/components/legacy-job-results.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest'
+import { screen, userEvent, waitFor, renderWithProviders } from '@/tests/unit.helpers'
+import { ViewFile } from './legacy-job-results'
+import { JobFile } from '@/lib/types'
+
+const XSS_PAYLOAD = '<img src=x onerror="window.__pwned = true">'
+
+const encode = (text: string): ArrayBuffer => {
+    const bytes = new TextEncoder().encode(text)
+    return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer
+}
+
+const jobFile = (path: string, contents: string): JobFile => ({
+    path,
+    fileType: 'APPROVED-RESULT',
+    contents: encode(contents),
+})
+
+const clickView = async () => {
+    await userEvent.click(screen.getByRole('button', { name: /view/i }))
+}
+
+describe('LegacyJobResults ViewFile', () => {
+    // Legacy results were written into an about:blank tab via document.write, which executed
+    // researcher-controlled job output as HTML in the app origin (OTTER-721).
+    it('never opens a tab when viewing a result', async () => {
+        const open = vi.spyOn(window, 'open').mockReturnValue(null)
+        renderWithProviders(<ViewFile file={jobFile('results.txt', XSS_PAYLOAD)} />)
+
+        await clickView()
+
+        await screen.findByRole('dialog')
+        expect(open).not.toHaveBeenCalled()
+    })
+
+    it('renders a script payload as inert text rather than markup', async () => {
+        renderWithProviders(<ViewFile file={jobFile('results.txt', XSS_PAYLOAD)} />)
+
+        await clickView()
+
+        const dialog = await screen.findByRole('dialog')
+        expect(dialog).toHaveTextContent(XSS_PAYLOAD)
+        expect(dialog.querySelector('img')).toBeNull()
+        expect(dialog.querySelector('script')).toBeNull()
+        expect((window as unknown as { __pwned?: boolean }).__pwned).toBeUndefined()
+    })
+
+    // .html routes to the highlight.js viewer rather than the plain text viewer, so it is the
+    // extension most likely to regress into rendered markup.
+    it('renders an html result as inert text', async () => {
+        renderWithProviders(<ViewFile file={jobFile('report.html', XSS_PAYLOAD)} />)
+
+        await clickView()
+
+        const dialog = await screen.findByRole('dialog')
+        expect(dialog).toHaveTextContent(XSS_PAYLOAD)
+        expect(dialog.querySelector('img')).toBeNull()
+        expect((window as unknown as { __pwned?: boolean }).__pwned).toBeUndefined()
+    })
+
+    it('previews an image result as an image', async () => {
+        renderWithProviders(<ViewFile file={jobFile('plot.png', 'not-really-png-bytes')} />)
+
+        await clickView()
+
+        const dialog = await screen.findByRole('dialog')
+        await waitFor(() => expect(dialog.querySelector('img')).not.toBeNull())
+    })
+
+    it('offers a download link alongside the view link', () => {
+        renderWithProviders(<ViewFile file={jobFile('results.txt', 'plain output')} />)
+
+        expect(screen.getByRole('link', { name: /download/i })).toHaveAttribute('download', 'results.txt')
+    })
+})

--- a/src/components/legacy-job-results.tsx
+++ b/src/components/legacy-job-results.tsx
@@ -6,52 +6,35 @@ import { ArrowSquareOutIcon } from '@phosphor-icons/react/dist/ssr'
 import { useQuery } from '@/common'
 import { ErrorAlert } from '@/components/errors'
 import { DownloadBlobLink } from '@/components/download-blob-link'
-import { ImagePreviewModal } from '@/components/modals/image-preview-modal'
+import { FileOrImagePreviewModal } from '@/components/modals/file-or-image-preview-modal'
 import { isApprovedLogType, isPlaintextLogType, logLabel } from '@/lib/file-type-helpers'
-import { imageMimeType } from '@/lib/file-content-helpers'
 import { fetchApprovedJobFilesAction } from '@/server/actions/study-job.actions'
 import { JobFile } from '@/lib/types'
 import { LatestJobForStudy } from '@/server/db/queries'
 
-// Pre-PR #764 results: stored as plaintext APPROVED-RESULT / approved-log rows that were never
-// encrypted for the researcher, so there is no key to ask for. This is the original JobResults view,
-// retained for studies that finished before researcher result encryption shipped. JobResults routes
-// only legacy jobs here; encrypted jobs go through EncryptedFilesPanel.
+// Results are job output and therefore attacker-controlled, so they must never be written as
+// markup. FileOrImagePreviewModal renders them through the same escaped viewers the encrypted
+// path uses, and handles the image/text split itself (OTTER-721).
 const ViewResultsLink: FC<{ content: ArrayBuffer; path: string }> = ({ content, path }) => {
-    const [showImageModal, setShowImageModal] = useState(false)
-    const mime = imageMimeType(path)
-
-    const handleClick = () => {
-        if (mime) {
-            setShowImageModal(true)
-            return
-        }
-        const decoded = new TextDecoder('utf-8').decode(content)
-        const tab = window.open('about:blank', '_blank')
-        if (!tab) {
-            reportError('failed to open results window')
-            return
-        }
-        tab.document.write(decoded)
-        tab.document.close()
-    }
+    const [previewing, setPreviewing] = useState(false)
 
     return (
         <>
-            <Anchor role="button" onClick={handleClick} style={{ display: 'flex', alignItems: 'center' }}>
+            <Anchor role="button" onClick={() => setPreviewing(true)} style={{ display: 'flex', alignItems: 'center' }}>
                 View <ArrowSquareOutIcon size={16} style={{ marginLeft: 4 }} />
             </Anchor>
-            <ImagePreviewModal
-                isVisible={showImageModal}
-                name={path}
-                contents={content}
-                mime={mime}
-                onClose={() => setShowImageModal(false)}
+            <FileOrImagePreviewModal
+                file={previewing ? { name: path, contents: content } : null}
+                onClose={() => setPreviewing(false)}
             />
         </>
     )
 }
 
+// Pre-PR #764 results: stored as plaintext APPROVED-RESULT / approved-log rows that were never
+// encrypted for the researcher, so there is no key to ask for. This is the original JobResults view,
+// retained for studies that finished before researcher result encryption shipped. JobResults routes
+// only legacy jobs here; encrypted jobs go through EncryptedFilesPanel.
 export const LegacyJobResults: FC<{ job: LatestJobForStudy }> = ({ job }) => {
     const {
         data: approvedFiles,
@@ -109,7 +92,7 @@ export const ViewFile: FC<{ file: JobFile }> = ({ file }) => {
                     borderLeft: `1px solid ${theme.colors.charcoal[4]}`,
                 }}
             ></span>
-            <DownloadBlobLink target="_blank" filename={file.path} fileContent={file.contents} />
+            <DownloadBlobLink filename={file.path} fileContent={file.contents} />
         </Group>
     )
 }


### PR DESCRIPTION
[OTTER-721](https://openstax.atlassian.net/browse/OTTER-721)

Viewing a legacy `APPROVED-RESULT` or approved-log file opened an `about:blank` tab and called `document.write()` with the raw file bytes. Job output is researcher-controlled, so an inline script, an `img onerror`, or an `svg onload` executed in the app origin in the session of whoever opened the result.

The tab was also outside any CSP — an `about:blank` document has no HTTP response, so it inherits none of the headers set in `next.config.ts`. Removing the tab is the fix; tightening the policy would not have covered this.

## Change

Route the View link through `FileOrImagePreviewModal`, which is what the encrypted path already uses. It takes the `{name, contents}` shape this component already had and handles the image/text split itself, so the hand-rolled image branch goes away and legacy results pick up the JSON/CSV/log viewers.

Net −31/+14 lines. Also drops a stale `reportError()` call that was never imported in this file and so resolved to the DOM global rather than the app helper, meaning neither Sentry nor the toast ever fired (the Low finding noted on the ticket).

## Verification

New `legacy-job-results.test.tsx` asserts no tab is opened, and that an `<img src=x onerror=...>` payload renders as literal text for both `.txt` and `.html` results. Confirmed these fail against the pre-fix code (3 of 5).

- Full unit suite: 252 files / 2408 tests passing
- `pnpm checks` green

A follow-up PR adds a nonce-based `script-src` as defense-in-depth.

[OTTER-721]: https://openstax.atlassian.net/browse/OTTER-721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ