### PR TITLE
OTTER-724: await index creation in foundational migrations

### DIFF
--- a/src/database/migrations/1727370622501_user.ts
+++ b/src/database/migrations/1727370622501_user.ts
@@ -21,7 +21,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
         .addColumn('updated_at', 'timestamp', (col) => col.defaultTo(sql`now()`).notNull())
         .execute()
 
-    db.schema.createIndex('user_clerk_id_indx').on('user').column('clerk_id').unique().execute()
+    await db.schema.createIndex('user_clerk_id_indx').on('user').column('clerk_id').unique().execute()
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {

--- a/src/database/migrations/1727379622503_member_users.ts
+++ b/src/database/migrations/1727379622503_member_users.ts
@@ -12,14 +12,14 @@ export async function up(db: Kysely<unknown>): Promise<void> {
         .addColumn('is_admin', 'boolean', (col) => col.notNull())
         .execute()
 
-    db.schema
+    await db.schema
         .createIndex('member_user_mbr_usrid_indx')
         .on('member_user')
         .columns(['member_id', 'user_id'])
         .unique()
         .execute()
 
-    db.schema.createIndex('member_user_usrid_indx').on('member_user').column('user_id').execute()
+    await db.schema.createIndex('member_user_usrid_indx').on('member_user').column('user_id').execute()
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {

--- a/src/database/migrations/1728503375785_study-jobs.ts
+++ b/src/database/migrations/1728503375785_study-jobs.ts
@@ -31,7 +31,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
         .addColumn('created_at', 'timestamp', (col) => col.defaultTo(sql`now()`).notNull())
         .execute()
 
-    db.schema.createIndex('study_job_study_indx').on('study_job').column('study_id').execute()
+    await db.schema.createIndex('study_job_study_indx').on('study_job').column('study_id').execute()
 
     await db.schema
         .createTable('job_status_change')
@@ -43,8 +43,8 @@ export async function up(db: Kysely<unknown>): Promise<void> {
         .addColumn('created_at', 'timestamp', (col) => col.defaultTo(sql`now()`).notNull())
         .execute()
 
-    db.schema.createIndex('job_status_change_jb_indx').on('job_status_change').column('study_job_id').execute()
-    db.schema.createIndex('job_status_change_st_indx').on('job_status_change').column('status').execute()
+    await db.schema.createIndex('job_status_change_jb_indx').on('job_status_change').column('study_job_id').execute()
+    await db.schema.createIndex('job_status_change_st_indx').on('job_status_change').column('status').execute()
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {

--- a/src/database/migrations/1742581222801_smart_concat.ts
+++ b/src/database/migrations/1742581222801_smart_concat.ts
@@ -21,6 +21,13 @@ $$;
     )
 }
 
+// Left deliberately un-awaited and un-executed (OTTER-724 / MA-13). The builder below is never
+// run, so `user.full_name` survives a rollback. Adding `.execute()` would be wrong on two counts:
+// the DROP FUNCTION above uses invalid syntax (`RETURNS text` is not accepted by Postgres) and so
+// fails first, and the drop order is backwards anyway -- the generated column depends on
+// smart_concat(), so the column must go before the function. Fixing this rollback path is out of
+// scope here; the forward migration is correct and `full_name` is relied on by
+// 1774000000000_add_pi_user_id_to_study.
 export async function down(db: Kysely<unknown>): Promise<void> {
     await sql`DROP FUNCTION smart_concat(a text, b text) RETURNS text;`.execute(db)
     db.schema.alterTable('user').dropColumn('full_name')

--- a/src/database/migrations/1750186286777_study_job_file.ts
+++ b/src/database/migrations/1750186286777_study_job_file.ts
@@ -17,8 +17,8 @@ export async function up(db: Kysely<unknown>): Promise<void> {
         .alterTable('study_job')
         .addColumn('language', sql`language`)
         .execute()
-    db.schema.alterTable('study_job').dropColumn('results_path').execute()
-    db.schema.alterTable('study_job').dropColumn('result_format').execute()
+    await db.schema.alterTable('study_job').dropColumn('results_path').execute()
+    await db.schema.alterTable('study_job').dropColumn('result_format').execute()
 
     await sql`update study_job set language = 'R'::language where language is null`.execute(db)
     await db.schema

--- a/src/database/migrations/1758569988001_split_orgs_into_labs_and_enclaves.ts
+++ b/src/database/migrations/1758569988001_split_orgs_into_labs_and_enclaves.ts
@@ -65,7 +65,7 @@ export async function up(db: Kysely<any>): Promise<void> {
 
         for (const orgUser of orgUsers) {
             if (!orgUser.isAdmin && !orgUser.isReviewer) {
-                db.deleteFrom('orgUser').where('id', '=', orgUser.id).execute()
+                await db.deleteFrom('orgUser').where('id', '=', orgUser.id).execute()
             }
 
             if (orgUser.isResearcher) {


### PR DESCRIPTION
Finding MA-13.

Nine `.execute()` calls across five early migrations were never awaited. Kysely runs each migration in its own transaction, so these floating promises raced the commit and were not guaranteed to apply:

- `1727370622501_user.ts` — unique index on `user.clerk_id`
- `1727379622503_member_users.ts` — both `member_user` indexes
- `1728503375785_study-jobs.ts` — `study_job` and the two `job_status_change` indexes
- `1750186286777_study_job_file.ts` — two `study_job` column drops
- `1758569988001_split_orgs_into_labs_and_enclaves.ts` — `orgUser` delete inside the loop

The affected indexes were verified present in the dev database, so this is latent risk for a fresh database build rather than active breakage. **No corrective migration is included.** An AST scan of the whole migrations directory confirms zero floating promises remain.

### smart_concat finding

`1742581222801_smart_concat.ts:26` has a `dropColumn(full_name)` with no `.execute()` at all. It is in `down()`, not `up()`, and is **deliberately left as-is** — a code comment now explains why. Adding `.execute()` would be wrong regardless: the preceding `DROP FUNCTION ... RETURNS text` is invalid Postgres and fails first, and the drop order is backwards since the generated column depends on `smart_concat()`. The forward migration is correct and `full_name` is relied on by `1774000000000_add_pi_user_id_to_study`.

https://openstax.atlassian.net/browse/OTTER-724