### PR TITLE
OTTER-724: restrict data-source URLs to http(s) schemes

### DIFF
--- a/src/app/[orgSlug]/admin/settings/data-sources-view.tsx
+++ b/src/app/[orgSlug]/admin/settings/data-sources-view.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from 'react'
 import { Anchor, Box, Button, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core'
 import { PlusCircleIcon } from '@phosphor-icons/react/dist/ssr'
+import { isHttpUrl } from '@/schema/url'
 
 // Presentational pieces for the "Data Sources" settings card. They own the card chrome
 // and the visible row (name / code-env names / description / linked URLs) but NOT data
@@ -25,7 +26,35 @@ export type DataSourceRowViewProps = {
     actions: ReactNode
 }
 
+// Defense in depth for rows persisted before the schema restricted schemes (OTTER-724): a
+// stored `javascript:` URL still executes when React renders it into an href, so refuse to
+// link anything that is not http(s) and show the raw text instead.
+function DataSourceUrlLink({ url, description }: { url: string; description: string | null }) {
+    const linkable = isHttpUrl(url)
+
+    return (
+        <Group gap="sm" wrap="nowrap">
+            <Text>
+                {linkable ? (
+                    <Anchor size="sm" href={url} target="_blank" rel="noopener noreferrer">
+                        {url}
+                    </Anchor>
+                ) : (
+                    <Text component="span" size="sm">
+                        {url}
+                    </Text>
+                )}
+            </Text>
+            <Text c="dimmed" size="sm">
+                {description}
+            </Text>
+        </Group>
+    )
+}
+
 export function DataSourceRowView({ name, codeEnvNames, description, urls, actions }: DataSourceRowViewProps) {
+    const linkedUrls = urls.filter((u): u is DataSourceUrlView & { url: string } => Boolean(u.url))
+
     return (
         <Box style={{ borderBottom: '1px solid var(--mantine-color-gray-3)' }}>
             <Group justify="space-between" p="sm" wrap="nowrap">
@@ -41,21 +70,9 @@ export function DataSourceRowView({ name, codeEnvNames, description, urls, actio
                             {description}
                         </Text>
                     )}
-                    {urls.map(
-                        (u) =>
-                            u.url && (
-                                <Group key={u.id} gap="sm" wrap="nowrap">
-                                    <Text>
-                                        <Anchor size="sm" href={u.url} target="_blank" rel="noopener noreferrer">
-                                            {u.url}
-                                        </Anchor>
-                                    </Text>
-                                    <Text c="dimmed" size="sm">
-                                        {u.description}
-                                    </Text>
-                                </Group>
-                            ),
-                    )}
+                    {linkedUrls.map((u) => (
+                        <DataSourceUrlLink key={u.id} url={u.url} description={u.description} />
+                    ))}
                 </Box>
                 <Group gap={4} wrap="nowrap">
                     {actions}

--- a/src/app/[orgSlug]/admin/settings/data-sources.actions.test.ts
+++ b/src/app/[orgSlug]/admin/settings/data-sources.actions.test.ts
@@ -7,8 +7,11 @@ import {
     updateOrgDataSourceAction,
 } from './data-sources.actions'
 import { deleteOrgCodeEnvAction } from './code-envs.actions'
+import { createOrgDataSourceSchema, dataSourceFormSchema } from './data-sources.schema'
 import { db } from '@/database'
 import { isActionError } from '@/lib/errors'
+
+const XSS_URLS = ['javascript:alert(1)', 'data:text/html,<script>alert(1)</script>', 'vbscript:msgbox(1)']
 
 vi.mock('@/server/aws', async () => {
     const actual = await vi.importActual('@/server/aws')
@@ -248,6 +251,51 @@ describe('Data Source Actions', () => {
         })
 
         expect(isActionError(result)).toBe(true)
+    })
+
+    it.each(XSS_URLS)('rejects the non-http scheme %s on a url row', (url) => {
+        const result = createOrgDataSourceSchema.safeParse({
+            name: 'Some Records',
+            urls: [{ url, description: 'Looks harmless' }],
+        })
+
+        expect(result.success).toBe(false)
+    })
+
+    it.each(XSS_URLS)('rejects the non-http scheme %s on the draft url field', (url) => {
+        const result = dataSourceFormSchema.safeParse({
+            name: 'Some Records',
+            urls: [],
+            newUrl: url,
+            newUrlDescription: 'Looks harmless',
+        })
+
+        expect(result.success).toBe(false)
+    })
+
+    it.each(['http://example.com/data', 'https://example.com/data'])('accepts %s', (url) => {
+        expect(
+            createOrgDataSourceSchema.safeParse({ name: 'Some Records', urls: [{ url, description: 'd' }] }).success,
+        ).toBe(true)
+        expect(
+            dataSourceFormSchema.safeParse({ name: 'Some Records', urls: [], newUrl: url, newUrlDescription: 'd' })
+                .success,
+        ).toBe(true)
+    })
+
+    it('rejects a javascript: url at the server action', async () => {
+        const { org } = await mockSessionWithTestData({ isAdmin: true })
+
+        const result = await createOrgDataSourceAction({
+            orgSlug: org.slug,
+            name: 'Should Fail',
+            urls: [{ url: 'javascript:alert(1)', description: 'Looks harmless' }],
+        })
+
+        expect(isActionError(result)).toBe(true)
+
+        const rows = await db.selectFrom('orgDataSource').where('name', '=', 'Should Fail').execute()
+        expect(rows).toHaveLength(0)
     })
 
     it('blocks code env deletion when linked data sources exist', async () => {

--- a/src/app/[orgSlug]/admin/settings/data-sources.schema.ts
+++ b/src/app/[orgSlug]/admin/settings/data-sources.schema.ts
@@ -1,8 +1,9 @@
 import { z } from 'zod'
+import { isHttpUrl } from '@/schema/url'
 
 const dataSourceUrlSchema = z.object({
     id: z.uuid().optional(),
-    url: z.url('Enter a valid URL'),
+    url: z.url('Enter a valid URL').refine(isHttpUrl, { message: 'URL must start with http:// or https://' }),
     description: z.string().trim().nonempty('URL description is required'),
 })
 
@@ -45,5 +46,11 @@ export const dataSourceFormSchema = z
         }
         if (hasUrl && !z.url().safeParse(data.newUrl.trim()).success) {
             ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Enter a valid URL', path: ['newUrl'] })
+        } else if (hasUrl && !isHttpUrl(data.newUrl.trim())) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: 'URL must start with http:// or https://',
+                path: ['newUrl'],
+            })
         }
     })

--- a/src/schema/researcher-profile.ts
+++ b/src/schema/researcher-profile.ts
@@ -1,32 +1,11 @@
 import { z } from 'zod'
+import { httpUrl, httpUrlOptionalItem } from './url'
 
 // -----------------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------------
 
 const trimmedRequired = (label: string) => z.string().trim().min(1, `${label} is a required field.`)
-
-const httpUrl = (label: string) =>
-    z
-        .string()
-        .trim()
-        .min(1, `${label} is a required field.`)
-        .url(`Please enter a valid URL (e.g., must start with http:// or https://).`)
-        .refine((v) => v.startsWith('http://') || v.startsWith('https://'), {
-            message: `Please enter a valid URL (e.g., must start with http:// or https://).`,
-        })
-
-// For form fields that use empty string as "unset" (e.g., array fields with fixed slots).
-const httpUrlOptionalItem = (label: string) =>
-    z
-        .string()
-        .trim()
-        .refine((v) => !v || v.startsWith('http://') || v.startsWith('https://'), {
-            message: `${label}: please enter a valid URL (must start with http:// or https://).`,
-        })
-        .refine((v) => !v || z.string().url().safeParse(v).success, {
-            message: `${label}: please enter a valid URL.`,
-        })
 
 // -----------------------------------------------------------------------------
 // Personal information

--- a/src/schema/url.ts
+++ b/src/schema/url.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod'
+
+// `z.url()` accepts any parseable URI, including `javascript:`, `data:` and `vbscript:`.
+// Those reach an `href` unsanitized and execute, so every user-supplied URL that we later
+// render as a link must be restricted to the two schemes we actually intend to support.
+export const isHttpUrl = (value: string) => value.startsWith('http://') || value.startsWith('https://')
+
+export const httpUrl = (label: string) =>
+    z
+        .string()
+        .trim()
+        .min(1, `${label} is a required field.`)
+        .url(`Please enter a valid URL (e.g., must start with http:// or https://).`)
+        .refine(isHttpUrl, {
+            message: `Please enter a valid URL (e.g., must start with http:// or https://).`,
+        })
+
+// For form fields that use empty string as "unset" (e.g., array fields with fixed slots).
+export const httpUrlOptionalItem = (label: string) =>
+    z
+        .string()
+        .trim()
+        .refine((v) => !v || isHttpUrl(v), {
+            message: `${label}: please enter a valid URL (must start with http:// or https://).`,
+        })
+        .refine((v) => !v || z.string().url().safeParse(v).success, {
+            message: `${label}: please enter a valid URL.`,
+        })


### PR DESCRIPTION
https://openstax.atlassian.net/browse/OTTER-724 (finding MA-12)

Org data-source URLs were validated with a bare `z.url()`, which accepts any parseable URI — `javascript:alert(1)`, `data:text/html,...` and `vbscript:` all passed. The stored value is rendered directly into an `<Anchor href>`, and `next.config.ts` sets only frame-ancestors/form-action/base-uri (no script-src or default-src), so there is no CSP backstop. That makes this admin-plantable stored XSS against anyone viewing the org settings page.

Changes:
- Lift the existing `httpUrl` / `httpUrlOptionalItem` helpers from `src/schema/researcher-profile.ts` into a shared `src/schema/url.ts` (new `isHttpUrl` predicate) rather than duplicating the logic.
- Apply the scheme check to both offending spots in `data-sources.schema.ts`: the URL row schema and the draft-URL superRefine. The same zod schema runs client and server side, so both paths are covered.
- Render-time guard in `data-sources-view.tsx`: rows persisted before this change still hold arbitrary schemes, so non-http(s) values render as plain text instead of a link.
- Schema-level tests covering the three payloads plus ordinary http/https, and an action-level test asserting nothing is written.