### PR TITLE
rich text editor modifications

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,6 +28,10 @@
 }
 
 /* EditableText (Lexical) formatting classes */
+.editable-text-paragraph {
+    margin: 0;
+}
+
 .editable-text-bold {
     font-weight: bold;
 }

--- a/src/components/editable-text.tsx
+++ b/src/components/editable-text.tsx
@@ -9,6 +9,7 @@ import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary'
 import { ListPlugin } from '@lexical/react/LexicalListPlugin'
 import { TabIndentationPlugin } from '@lexical/react/LexicalTabIndentationPlugin'
 import { LinkPlugin } from '@lexical/react/LexicalLinkPlugin'
+import { ClickableLinkPlugin } from '@lexical/react/LexicalClickableLinkPlugin'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import { $getRoot, EditorState, SerializedEditorState } from 'lexical'
 import { FC, ReactNode, useEffect, useState } from 'react'
@@ -18,7 +19,7 @@ import { countWords, isValidLexicalState } from '@/lib/lexical'
 import logger from '@/lib/logger'
 import { Toolbar } from './editable-text/toolbar'
 import { EscapeFocusPlugin } from './editable-text/escape-focus-plugin'
-import { lexicalTheme, lexicalNodes, isValidUrl } from './editable-text/config'
+import { lexicalTheme, lexicalNodes, isValidUrl, linkAttributes } from './editable-text/config'
 
 export interface EditableTextProps {
     /** Serialized Lexical JSON state */
@@ -188,7 +189,10 @@ export const EditableText: FC<EditableTextProps> = ({
                         <ListPlugin />
                         <TabIndentationPlugin />
                         <EscapeFocusPlugin />
-                        <LinkPlugin validateUrl={isValidUrl} />
+                        <LinkPlugin validateUrl={isValidUrl} attributes={linkAttributes} />
+                        {/* While editing, a click should land the caret in the link text rather
+                            than launch a tab. Read-only renders open the URL in a new tab. */}
+                        <ClickableLinkPlugin newTab disabled={isEditable} />
                         <OnChangePlugin onChange={handleChange} ignoreSelectionChange />
                         {onWordCount && <WordCountPlugin onWordCount={onWordCount} />}
                     </Box>

--- a/src/components/editable-text/collaborative-editor.tsx
+++ b/src/components/editable-text/collaborative-editor.tsx
@@ -22,7 +22,7 @@ import { useConnectionPhase } from '@/lib/realtime/yjs-websocket-context'
 import { useProviderSaveStatus } from '@/lib/realtime/use-provider-save-status'
 import { useTriggerStudyKickOut } from '@/hooks/use-study-status-on-reconnect'
 import { SaveStatusIndicator } from '@/components/save-status'
-import { lexicalTheme, lexicalNodes, isValidUrl, pickCursorColor } from './config'
+import { lexicalTheme, lexicalNodes, isValidUrl, linkAttributes, pickCursorColor } from './config'
 import { Toolbar } from './toolbar'
 import { EscapeFocusPlugin } from './escape-focus-plugin'
 import { widgetBlurHandler } from '@/components/form-field'
@@ -415,7 +415,7 @@ export function CollaborativeEditor({
                     <ListPlugin />
                     <TabIndentationPlugin />
                     <EscapeFocusPlugin />
-                    <LinkPlugin validateUrl={isValidUrl} />
+                    <LinkPlugin validateUrl={isValidUrl} attributes={linkAttributes} />
                     <Toolbar />
                 </Paper>
                 <Stack gap={4} mt={4}>

--- a/src/components/editable-text/config.ts
+++ b/src/components/editable-text/config.ts
@@ -1,5 +1,6 @@
 import { ListNode, ListItemNode } from '@lexical/list'
 import { LinkNode } from '@lexical/link'
+import type { LinkAttributes } from '@lexical/link'
 import type { Klass, LexicalNode } from 'lexical'
 
 export function isValidUrl(url: string): boolean {
@@ -11,7 +12,15 @@ export function isValidUrl(url: string): boolean {
     }
 }
 
+// Module-level so the object identity is stable: LinkPlugin lists `attributes`
+// in its effect deps, so an inline literal would re-register TOGGLE_LINK_COMMAND
+// on every render.
+export const linkAttributes: LinkAttributes = { target: '_blank', rel: 'noopener noreferrer' }
+
 export const lexicalTheme = {
+    // Lexical paragraphs would otherwise inherit the UA default margin-block: 1em,
+    // which reads as a blank line between paragraphs.
+    paragraph: 'editable-text-paragraph',
     text: {
         bold: 'editable-text-bold',
         italic: 'editable-text-italic',

--- a/src/components/editable-text/single-user-editor.tsx
+++ b/src/components/editable-text/single-user-editor.tsx
@@ -15,7 +15,7 @@ import type { EditorState } from 'lexical'
 
 import { isValidLexicalState } from '@/lib/lexical'
 import logger from '@/lib/logger'
-import { lexicalTheme, lexicalNodes, isValidUrl } from './config'
+import { lexicalTheme, lexicalNodes, isValidUrl, linkAttributes } from './config'
 import { Toolbar } from './toolbar'
 import { EscapeFocusPlugin } from './escape-focus-plugin'
 import { widgetBlurHandler } from '@/components/form-field'
@@ -148,7 +148,7 @@ export function SingleUserEditor({
                 <ListPlugin />
                 <TabIndentationPlugin />
                 <EscapeFocusPlugin />
-                <LinkPlugin validateUrl={isValidUrl} />
+                <LinkPlugin validateUrl={isValidUrl} attributes={linkAttributes} />
                 {onChange && <EditorChangePlugin onChange={onChange} />}
                 {children}
                 <Toolbar />

--- a/src/components/editable-text/toolbar.test.tsx
+++ b/src/components/editable-text/toolbar.test.tsx
@@ -1,0 +1,95 @@
+import { renderWithProviders, screen, act, waitFor, userEvent, describe, it, expect } from '@/tests/unit.helpers'
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import { $getRoot, $isElementNode, $isTextNode, type LexicalEditor } from 'lexical'
+import { SingleUserEditor } from './single-user-editor'
+
+function lexicalJson(text: string) {
+    return JSON.stringify({
+        root: {
+            children: [
+                {
+                    children: [{ detail: 0, format: 0, mode: 'normal', style: '', text, type: 'text', version: 1 }],
+                    direction: 'ltr',
+                    format: '',
+                    indent: 0,
+                    type: 'paragraph',
+                    version: 1,
+                },
+            ],
+            direction: 'ltr',
+            format: '',
+            indent: 0,
+            type: 'root',
+            version: 1,
+        },
+    })
+}
+
+// Captures the live Lexical editor so the test can drive real edits through the
+// editor's own API — jsdom can't dispatch the beforeinput events Lexical relies on.
+function CaptureEditor({ onReady }: { onReady: (editor: LexicalEditor) => void }) {
+    const [editor] = useLexicalComposerContext()
+    onReady(editor)
+    return null
+}
+
+async function renderEditorWithText(id: string, text: string) {
+    let editor: LexicalEditor | null = null
+    const { container } = renderWithProviders(
+        <SingleUserEditor id={id} initialValue={lexicalJson(text)} ariaLabel="Feedback">
+            <CaptureEditor onReady={(e) => (editor = e)} />
+        </SingleUserEditor>,
+    )
+
+    await waitFor(() => expect(editor).not.toBeNull())
+    return { container, editor: editor! }
+}
+
+// The toolbar reads the selection out of the editor state rather than the DOM, so
+// selecting programmatically is enough to stand in for a user drag.
+function selectAllText(editor: LexicalEditor) {
+    act(() => {
+        editor.update(() => {
+            const paragraph = $getRoot().getFirstChild()
+            if (!$isElementNode(paragraph)) return
+            const textNode = paragraph.getFirstChild()
+            if (!$isTextNode(textNode)) return
+            textNode.select(0, textNode.getTextContentSize())
+        })
+    })
+}
+
+async function insertLinkViaToolbar(url: string) {
+    const user = userEvent.setup()
+    await user.click(screen.getByLabelText('Link'))
+    const input = await screen.findByPlaceholderText('https://')
+    await user.clear(input)
+    await user.type(input, url)
+    await user.click(screen.getByLabelText('Apply link'))
+}
+
+describe('Toolbar link insertion', () => {
+    it('marks links to open in a new tab without leaking the referrer', async () => {
+        const { container, editor } = await renderEditorWithText('toolbar-1', 'hello world')
+        selectAllText(editor)
+
+        await insertLinkViaToolbar('https://example.com')
+
+        await waitFor(() => expect(container.querySelector('a')).not.toBeNull())
+        const anchor = container.querySelector('a')!
+        expect(anchor.getAttribute('href')).toBe('https://example.com')
+        expect(anchor.getAttribute('target')).toBe('_blank')
+        expect(anchor.getAttribute('rel')).toContain('noopener')
+    })
+
+    it('does not create a link for a URL that fails validation', async () => {
+        const { container, editor } = await renderEditorWithText('toolbar-2', 'hello world')
+        selectAllText(editor)
+
+        await insertLinkViaToolbar('javascript:alert(1)')
+
+        // The link editor closing is the signal that submitLink ran.
+        await waitFor(() => expect(screen.queryByPlaceholderText('https://')).toBeNull())
+        expect(container.querySelector('a')).toBeNull()
+    })
+})

--- a/src/components/readonly-lexical-content.test.tsx
+++ b/src/components/readonly-lexical-content.test.tsx
@@ -1,0 +1,74 @@
+import { renderWithProviders, fireEvent, waitFor, describe, it, expect, vi } from '@/tests/unit.helpers'
+import { ReadOnlyLexicalContent } from './readonly-lexical-content'
+
+function textNode(text: string) {
+    return { detail: 0, format: 0, mode: 'normal', style: '', text, type: 'text', version: 1 }
+}
+
+function paragraph(children: object[]) {
+    return { children, direction: 'ltr', format: '', indent: 0, type: 'paragraph', version: 1 }
+}
+
+function root(children: object[]) {
+    return JSON.stringify({ root: { children, direction: 'ltr', format: '', indent: 0, type: 'root', version: 1 } })
+}
+
+// Mirrors how links were persisted before target/rel were set on insertion.
+function legacyLinkState(url: string) {
+    return root([
+        paragraph([
+            {
+                children: [textNode('example')],
+                direction: 'ltr',
+                format: '',
+                indent: 0,
+                type: 'link',
+                version: 1,
+                rel: null,
+                target: null,
+                title: null,
+                url,
+            },
+        ]),
+    ])
+}
+
+describe('ReadOnlyLexicalContent', () => {
+    it('opens a link stored without a target in a new tab', async () => {
+        const open = vi.spyOn(window, 'open').mockReturnValue(null)
+        const { container } = renderWithProviders(
+            <ReadOnlyLexicalContent value={legacyLinkState('https://example.com')} />,
+        )
+
+        const anchor = await waitFor(() => {
+            const found = container.querySelector('a')
+            expect(found).not.toBeNull()
+            return found!
+        })
+        // Guards the premise: this is legacy content, so the fix cannot come from the attribute.
+        expect(anchor.getAttribute('target')).toBeNull()
+
+        fireEvent.click(anchor)
+
+        await waitFor(() => expect(open).toHaveBeenCalledWith('https://example.com', '_blank'))
+    })
+
+    it('renders paragraphs with the themed class that removes the default margin', async () => {
+        const { container } = renderWithProviders(
+            <ReadOnlyLexicalContent value={root([paragraph([textNode('first')]), paragraph([textNode('second')])])} />,
+        )
+
+        await waitFor(() => expect(container.querySelectorAll('p')).toHaveLength(2))
+        // happy-dom does not load globals.css, so assert the hook the stylesheet targets
+        // rather than a computed margin, which would be empty either way.
+        for (const p of container.querySelectorAll('p')) {
+            expect(p.classList.contains('editable-text-paragraph')).toBe(true)
+        }
+    })
+
+    it('renders nothing for a legacy empty-root state', () => {
+        const { container } = renderWithProviders(<ReadOnlyLexicalContent value={root([])} />)
+
+        expect(container.querySelector('p')).toBeNull()
+    })
+})

--- a/src/components/readonly-lexical-content.tsx
+++ b/src/components/readonly-lexical-content.tsx
@@ -4,6 +4,7 @@ import { LexicalComposer } from '@lexical/react/LexicalComposer'
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin'
 import { ContentEditable } from '@lexical/react/LexicalContentEditable'
 import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary'
+import { ClickableLinkPlugin } from '@lexical/react/LexicalClickableLinkPlugin'
 import { lexicalTheme, lexicalNodes } from '@/components/editable-text/config'
 import type { JsonValue } from '@/database/types'
 import { isValidLexicalState } from '@/lib/lexical'
@@ -36,6 +37,9 @@ export function ReadOnlyLexicalContent({ value }: { value: string | JsonValue })
                 placeholder={null}
                 ErrorBoundary={LexicalErrorBoundary}
             />
+            {/* newTab forces _blank even for links stored before target was set,
+                and preventing the default click keeps us from unloading the app. */}
+            <ClickableLinkPlugin newTab />
         </LexicalComposer>
     )
 }

--- a/tests/e2e.helpers.ts
+++ b/tests/e2e.helpers.ts
@@ -177,6 +177,20 @@ export async function fillLexicalField(page: Page, ariaLabel: string, text: stri
     await page.keyboard.type(text)
 }
 
+// Types `text` into a rich-text field and hyperlinks all of it through the editor
+// toolbar. The toolbar is scoped to the field's own editor because a page renders
+// one Lexical instance (and one toolbar) per rich-text field.
+export async function insertLexicalLink(page: Page, ariaLabel: string, text: string, url: string) {
+    const editor = page.locator(`.collaborative-editor-container:has([aria-label="${ariaLabel}"])`)
+    await editor.locator(`[aria-label="${ariaLabel}"]`).click()
+    await page.keyboard.type(text)
+    await page.keyboard.press('ControlOrMeta+a')
+
+    await editor.getByLabel('Link').click()
+    await editor.getByPlaceholder('https://').fill(url)
+    await editor.getByLabel('Apply link').click()
+}
+
 // Opens a context that restores `role`'s saved session from storageState (no
 // sign-in) and returns the context + page. The storageState file must exist (written
 // by globalSetup). Caller closes the context. This is the fast

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -4,6 +4,7 @@ import {
     visitAsRole,
     readTestSupportFile,
     fillLexicalField,
+    insertLexicalLink,
     goto,
     withRole,
     type Page,
@@ -30,6 +31,11 @@ import { execSync } from 'child_process'
 
 const RESEARCHER_DASHBOARD = '/openstax-lab/dashboard'
 const REVIEWER_DASHBOARD = '/openstax/dashboard'
+
+// OTTER-463: rich-text links must carry target="_blank" through submission so
+// neither researcher nor reviewer gets navigated off SafeInsights by a click.
+const PROPOSAL_LINK_TEXT = 'Prior study writeup'
+const PROPOSAL_LINK_URL = 'https://example.com/prior-study'
 
 // ============================================================================
 // Researcher: study creation (Step 1 + Step 2) — driven live by ONE test
@@ -66,7 +72,7 @@ async function navigateToProposeStudy(page: Page) {
     await expect(page.getByText('STEP 2')).toBeVisible()
 }
 
-async function fillAndSubmitProposal(page: Page, studyTitle: string) {
+async function fillAndSubmitProposal(page: Page, studyTitle: string, opts: { linkNotes?: boolean } = {}) {
     await page.getByLabel('Study Title').fill(studyTitle)
 
     await page.getByPlaceholder('Select dataset(s) of interest').click()
@@ -75,6 +81,13 @@ async function fillAndSubmitProposal(page: Page, studyTitle: string) {
     await fillLexicalField(page, 'Research question(s)', 'What is the impact of highlighting on student outcomes?')
     await fillLexicalField(page, 'Project summary', 'We analyze archival data to study highlighting behavior.')
     await fillLexicalField(page, 'Impact', 'This research will improve understanding of study habits.')
+
+    if (opts.linkNotes) {
+        await insertLexicalLink(page, 'Additional notes or requests', PROPOSAL_LINK_TEXT, PROPOSAL_LINK_URL)
+        // Confirm before submitting: an unmarked link here would navigate the
+        // researcher out of the app on click.
+        await expect(page.locator(`a[href="${PROPOSAL_LINK_URL}"]`)).toHaveAttribute('target', '_blank')
+    }
 
     const piSelect = page.getByRole('textbox', { name: 'Principal Investigator' })
     await piSelect.click()
@@ -415,7 +428,20 @@ test('Researcher submits a proposal', async ({ browser, studyFeatures }) => {
 
     await withRole(browser, 'researcher', async (page) => {
         await navigateToProposeStudy(page)
-        await fillAndSubmitProposal(page, studyTitle)
+        await fillAndSubmitProposal(page, studyTitle, { linkNotes: true })
+
+        // The read-only render of a submitted proposal is a separate Lexical mount, so
+        // assert the link survives there too and not just in the editor.
+        await visitAsRole(page, RESEARCHER_DASHBOARD)
+        const studyRow = page.getByRole('row').filter({ hasText: studyTitle }).filter({ hasNotText: 'DRAFT' })
+        await clickViewLink(page, studyRow)
+        await page.waitForURL(/\/submitted(\?.*)?$/)
+
+        const submittedLink = page.locator('[data-testid="proposal-body"]').getByRole('link', {
+            name: PROPOSAL_LINK_TEXT,
+        })
+        await expect(submittedLink).toHaveAttribute('href', PROPOSAL_LINK_URL)
+        await expect(submittedLink).toHaveAttribute('target', '_blank')
     })
 })
 

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -437,9 +437,13 @@ test('Researcher submits a proposal', async ({ browser, studyFeatures }) => {
         await clickViewLink(page, studyRow)
         await page.waitForURL(/\/submitted(\?.*)?$/)
 
-        const submittedLink = page.locator('[data-testid="proposal-body"]').getByRole('link', {
-            name: PROPOSAL_LINK_TEXT,
-        })
+        // This view mounts the proposal collapsed (initialExpanded={false}), so the body is
+        // display:none until the toggle is clicked.
+        await page.getByTestId('proposal-toggle-header').click()
+        const proposalBody = page.getByTestId('proposal-body')
+        await expect(proposalBody).toBeVisible()
+
+        const submittedLink = proposalBody.getByRole('link', { name: PROPOSAL_LINK_TEXT })
         await expect(submittedLink).toHaveAttribute('href', PROPOSAL_LINK_URL)
         await expect(submittedLink).toHaveAttribute('target', '_blank')
     })


### PR DESCRIPTION
Issue: [OTTER-463](https://openstax.atlassian.net/browse/OTTER-463).

This PR closes out the two remaining open comments. The original format controls (bold/italic/underline/link/bullet/numbered) were verified on QA and staging back in March, and indent/outdent landed in 93de454 — the rest of the ticket was already done.

| Comment | Resolution |
| --- | --- |
| Malar(Apr 8): "Could we make the `hyperlink` open the linked url in a new tab?" | Fixed here |
| Greg (Aug 3): "Request: remove double spacing between paragraphs" | Fixed here |

### Root causes

**Links opened in the same tab.** All three `LinkPlugin` mounts passed only `validateUrl`. In `@lexical/link`, `rel` falls back to `'noreferrer'` but `target` stays `undefined`, so `LinkNode.__target` remained `null` and `createDOM` emitted no `target` attribute. Separately, `ClickableLinkPlugin` was not mounted anywhere, so read-only views (`editable: false`) fell through to raw anchor navigation — that's the "opened from a submitted proposal" half of the report.

**Double paragraph spacing.** `lexicalTheme` had no `paragraph` key and no CSS in the repo targets `p`. Mantine's `baseline.css` resets only `body` margin, and there's no `TypographyStylesProvider`, so every `<p>` Lexical emits inherited the UA default `margin-block: 1em` (~16px). Against Mantine's ~24.8px line height that gap reads as a full blank line.

### Changes

- **`config.ts`** — added a module-level `linkAttributes` (`target: '_blank'`, `rel: 'noopener noreferrer'`) and a `paragraph: 'editable-text-paragraph'` theme key. `linkAttributes` is module-level on purpose: `LinkPlugin` lists `attributes` in its effect deps, so an inline literal would re-register `TOGGLE_LINK_COMMAND` every render.
- **`globals.css`** — `.editable-text-paragraph { margin: 0 }`.
- **`LinkPlugin` mounts** (`editable-text.tsx`, `single-user-editor.tsx`, `collaborative-editor.tsx`) — pass `attributes={linkAttributes}`. No toolbar change was needed: `registerLink` forwards plugin attributes to `$toggleLink` on the string-payload branch the toolbar already dispatches. This also covers paste-to-link.
- **`ClickableLinkPlugin`** — `newTab` in `readonly-lexical-content.tsx`, and `newTab disabled={isEditable}` in `editable-text.tsx`.

Two things worth calling out for review:

1. **`newTab` is what fixes existing content.** Links already in the DB have `target: null` in their serialized JSON, so the attribute change alone would only help links created from now on. `ClickableLinkPlugin newTab` forces `_blank` at click time regardless of the stored target.
2. **In edit mode a click places the caret rather than opening a tab** (`disabled={isEditable}`, matching the Lexical playground). A literal reading of the comment would be `newTab` everywhere, but that makes link text nearly uneditable — every click would launch a tab. Read-only renders (including the reviewer preview) do open in a new tab. Happy to flip this if reviewers disagree.

Because all four render paths share `lexicalTheme`, the spacing fix covers the editor and every read-only view without per-component edits. No node-registry change, so `SEED_NODES` in `services/editor/lexical-seed.ts` doesn't need mirroring, and no data migration is required — spacing was never persisted, only rendered.

The reported edit-mode "save as draft modal" symptom is stale: that modal was removed in f19258d and 8fee14a, and there's no `beforeunload`/router guard in the repo. Preventing the default click also means no unload either way.

### Manual verification checklist

- [ ] Edit mode: select text → Link → enter URL → Apply. Clicking the link places the caret; no navigation, no dialog.
- [ ] Submitted proposal (read-only): the link opens in a new tab and the SI tab stays put.
- [ ] **Legacy content**: open a proposal whose link predates this change and confirm it also opens in a new tab.
- [ ] Paragraph spacing: several paragraphs separated by single Enters render single-spaced in both the editor and the submitted view, including pre-existing stored content.


[OTTER-463]: https://openstax.atlassian.net/browse/OTTER-463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ