### PR TITLE
OTTER-724: scope org configuration reads and whitelist org updates

### DIFF
--- a/src/app/[orgSlug]/admin/settings/code-envs.actions.test.ts
+++ b/src/app/[orgSlug]/admin/settings/code-envs.actions.test.ts
@@ -12,6 +12,7 @@ import {
     deleteOrgCodeEnvAction,
     fetchCodeEnvHistoryAction,
     fetchOrgCodeEnvsAction,
+    fetchStarterCodeAction,
     updateOrgCodeEnvAction,
 } from './code-envs.actions'
 import { db } from '@/database'
@@ -1067,6 +1068,75 @@ describe('Code Environment audit logging', () => {
         const { org } = await mockSessionWithTestData({ isAdmin: true })
 
         const result = await fetchCodeEnvHistoryAction({ orgSlug: org.slug, codeEnvId: otherEnv.id })
+        expect(isActionError(result)).toBe(true)
+    })
+
+    // fetchOrgCodeEnvsAction selectAll's the row, which carries settings.environment — plaintext
+    // env-var pairs, commonly credentials. It used to sit on the unconditioned `view Org`, so any
+    // authenticated user could read any org's. It is now `view OrgConfig` (OTTER-724 / MA-6).
+    describe('fetchOrgCodeEnvsAction scoping', () => {
+        const insertOrgWithSecret = async (slug: string) => {
+            const org = await insertTestOrg({ slug })
+            await insertTestCodeEnv({
+                orgId: org.id,
+                language: 'R',
+                environment: [{ name: 'DB_PASSWORD', value: 'super-secret-value' }],
+            })
+            return org
+        }
+
+        it('denies a non-admin member of the same org', async () => {
+            const { org } = await mockSessionWithTestData({ isAdmin: false })
+            await insertTestCodeEnv({
+                orgId: org.id,
+                language: 'R',
+                environment: [{ name: 'DB_PASSWORD', value: 'super-secret-value' }],
+            })
+
+            const result = await fetchOrgCodeEnvsAction({ orgSlug: org.slug })
+            expect(isActionError(result)).toBe(true)
+            expect(JSON.stringify(result)).not.toContain('super-secret-value')
+        })
+
+        it('denies an admin of a different org', async () => {
+            const otherOrg = await insertOrgWithSecret('other-org-code-env-scope')
+            await mockSessionWithTestData({ isAdmin: true })
+
+            const result = await fetchOrgCodeEnvsAction({ orgSlug: otherOrg.slug })
+            expect(isActionError(result)).toBe(true)
+            expect(JSON.stringify(result)).not.toContain('super-secret-value')
+        })
+
+        // An unknown slug leaves orgId absent from the CASL subject, so the `$in` must fail CLOSED.
+        it('denies an unknown org slug', async () => {
+            await mockSessionWithTestData({ isAdmin: true })
+
+            const result = await fetchOrgCodeEnvsAction({ orgSlug: 'no-such-org-slug' })
+            expect(isActionError(result)).toBe(true)
+        })
+
+        it('allows an SI admin', async () => {
+            const otherOrg = await insertOrgWithSecret('si-admin-readable-code-env')
+            await mockSessionWithTestData({ isSiAdmin: true })
+
+            const result = actionResult(await fetchOrgCodeEnvsAction({ orgSlug: otherOrg.slug }))
+            expect(result).toHaveLength(1)
+        })
+    })
+
+    it('fetchStarterCodeAction denies a non-admin member of the org', async () => {
+        const { org } = await mockSessionWithTestData({ isAdmin: false })
+        const codeEnv = await insertTestCodeEnv({
+            orgId: org.id,
+            language: 'R',
+            starterCodeFileNames: ['starter.R'],
+        })
+
+        const result = await fetchStarterCodeAction({
+            orgSlug: org.slug,
+            codeEnvId: codeEnv.id,
+            fileName: 'starter.R',
+        })
         expect(isActionError(result)).toBe(true)
     })
 })

--- a/src/app/[orgSlug]/admin/settings/code-envs.actions.ts
+++ b/src/app/[orgSlug]/admin/settings/code-envs.actions.ts
@@ -355,10 +355,12 @@ const fetchOrgCodeEnvsSchema = z.object({
     orgSlug: z.string(),
 })
 
+// `selectAll('orgCodeEnv')` includes settings.environment — plaintext env-var name/value pairs,
+// commonly credentials — plus scan results, so this is admin-console data, not public catalog data.
 export const fetchOrgCodeEnvsAction = new Action('fetchOrgCodeEnvsAction')
     .params(fetchOrgCodeEnvsSchema)
     .middleware(orgIdFromSlug)
-    .requireAbilityTo('view', 'Org')
+    .requireAbilityTo('view', 'OrgConfig')
     .handler(async ({ orgId, db }) => {
         return await db
             .selectFrom('orgCodeEnv')
@@ -549,10 +551,12 @@ const fetchStarterCodeSchema = z.object({
     fileName: z.string(),
 })
 
+// Returns S3 file contents. Note this is the admin console's editor view; the researcher-facing
+// starter-code download is getStarterCodeUrlAction, which stays cross-org on `view Orgs`.
 export const fetchStarterCodeAction = new Action('fetchStarterCodeAction')
     .params(fetchStarterCodeSchema)
     .middleware(codeEnvFromOrgAndId)
-    .requireAbilityTo('view', 'Org')
+    .requireAbilityTo('view', 'OrgConfig')
     .handler(async ({ codeEnv, params: { fileName } }) => {
         if (!codeEnv.starterCodeFileNames.includes(fileName)) {
             throw new Error(`Starter code file "${fileName}" not found`)

--- a/src/app/[orgSlug]/admin/settings/data-sources.actions.test.ts
+++ b/src/app/[orgSlug]/admin/settings/data-sources.actions.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
-import { mockSessionWithTestData, actionResult, insertTestCodeEnv, insertTestDataSource } from '@/tests/unit.helpers'
+import {
+    mockSessionWithTestData,
+    actionResult,
+    insertTestCodeEnv,
+    insertTestDataSource,
+    insertTestOrg,
+} from '@/tests/unit.helpers'
 import {
     createOrgDataSourceAction,
     deleteOrgDataSourceAction,
@@ -265,5 +271,24 @@ describe('Data Source Actions', () => {
 
         const stillExists = await db.selectFrom('orgCodeEnv').where('id', '=', codeEnv1.id).executeTakeFirst()
         expect(stillExists).toBeDefined()
+    })
+
+    // Pins the flow that made `view Org` unconditioned in the first place (97c118b1): on the
+    // study-proposal page a lab researcher picks a dataset from an ENCLAVE org they do not belong
+    // to. OTTER-724 moved the credential-bearing reads off `view Org`; this one must stay put.
+    it('stays readable cross-org: proposal dataset picker (97c118b1)', async () => {
+        const enclaveOrg = await insertTestOrg({ slug: 'unrelated-enclave-catalog', type: 'enclave' })
+        await insertTestDataSource({
+            orgId: enclaveOrg.id,
+            name: 'Advertised Enclave Dataset',
+            description: 'Listed in the proposal dataset picker',
+        })
+
+        await mockSessionWithTestData({ orgType: 'lab', isAdmin: false })
+
+        const result = actionResult(await fetchOrgDataSourcesAction({ orgSlug: enclaveOrg.slug }))
+        expect(result).toEqual(
+            expect.arrayContaining([expect.objectContaining({ name: 'Advertised Enclave Dataset' })]),
+        )
     })
 })

--- a/src/app/[orgSlug]/admin/settings/data-sources.actions.ts
+++ b/src/app/[orgSlug]/admin/settings/data-sources.actions.ts
@@ -19,6 +19,10 @@ const fetchOrgDataSourcesSchema = z.object({
     orgSlug: z.string(),
 })
 
+// Stays on the unconditioned `view Org` on purpose: the study-proposal dataset picker needs a lab
+// researcher to list an enclave org's datasets (97c118b1). The selected columns are therefore
+// catalog-level only — keep it that way, and route any new field carrying configuration or secrets
+// through `view OrgConfig` instead (OTTER-724 / MA-6).
 export const fetchOrgDataSourcesAction = new Action('fetchOrgDataSourcesAction')
     .params(fetchOrgDataSourcesSchema)
     .middleware(orgIdFromSlug)

--- a/src/app/[orgSlug]/admin/settings/organization-settings-display.tsx
+++ b/src/app/[orgSlug]/admin/settings/organization-settings-display.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { Text, Grid, Stack, Flex, Title, Button, Divider } from '@mantine/core'
-import { type Org } from '@/schema/org'
+import { type PublicOrg } from '@/schema/org'
 
 interface OrganizationSettingsDisplayProps {
-    org: Org
+    org: PublicOrg
     onStartEdit: () => void
 }
 

--- a/src/app/[orgSlug]/admin/settings/organization-settings-edit.tsx
+++ b/src/app/[orgSlug]/admin/settings/organization-settings-edit.tsx
@@ -6,7 +6,7 @@ import { useForm, zodResolver, useMutation } from '@/common'
 import { notifications } from '@mantine/notifications'
 import { FormFieldLabel } from '@/components/form-field-label'
 import { z } from 'zod'
-import { type Org } from '@/schema/org'
+import { type PublicOrg } from '@/schema/org'
 import { updateOrgSettingsAction } from '@/server/actions/org.actions'
 import { handleMutationErrorsWithForm, InputError } from '@/components/errors'
 
@@ -30,7 +30,7 @@ export const settingsFormSchema = z.object({
 export type SettingsFormValues = z.infer<typeof settingsFormSchema>
 
 interface OrganizationSettingsEditProps {
-    org: Org
+    org: PublicOrg
     onSaveSuccess: () => void
     onCancel: () => void
 }

--- a/src/app/[orgSlug]/admin/settings/organization-settings-manager.tsx
+++ b/src/app/[orgSlug]/admin/settings/organization-settings-manager.tsx
@@ -4,10 +4,10 @@ import { Paper } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { OrganizationSettingsEdit } from './organization-settings-edit'
 import { OrganizationSettingsDisplay } from './organization-settings-display'
-import { type Org } from '@/schema/org'
+import { type PublicOrg } from '@/schema/org'
 
 interface OrganizationSettingsManagerProps {
-    org: Org
+    org: PublicOrg
 }
 
 export function OrganizationSettingsManager({ org }: OrganizationSettingsManagerProps) {

--- a/src/app/[orgSlug]/admin/team/admin-users.actions.test.ts
+++ b/src/app/[orgSlug]/admin/team/admin-users.actions.test.ts
@@ -1,6 +1,6 @@
 import { db } from '@/database'
 import { sendInviteEmail } from '@/server/mailer'
-import { actionResult, mockSessionWithTestData } from '@/tests/unit.helpers'
+import { actionResult, insertTestOrg, mockSessionWithTestData } from '@/tests/unit.helpers'
 import { clerkClient } from '@clerk/nextjs/server'
 import { Mock, describe, expect, it, vi } from 'vitest'
 import { getPendingUsersAction, orgAdminInviteUserAction, reInviteUserAction } from './admin-users.actions'
@@ -125,6 +125,34 @@ describe('Admin Users Actions', () => {
 
         const pendingUsersResult = actionResult(await getPendingUsersAction({ orgSlug: org.slug }))
         expect(pendingUsersResult).toHaveLength(origCount + 2)
+    })
+
+    // Each row's `id` IS the live invite token, so a leak lets an outsider claim a seat in the org.
+    // Used to sit on the unconditioned `view Org`; now on `invite User` (OTTER-724 / MA-6).
+    it('getPendingUsersAction denies a non-admin member of the org', async () => {
+        const { org } = await mockSessionWithTestData({ isAdmin: false })
+        await db
+            .insertInto('pendingUser')
+            .values({ orgId: org.id, email: 'member-cannot-see@test.com', isAdmin: false })
+            .execute()
+
+        const result = await getPendingUsersAction({ orgSlug: org.slug })
+        expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+        expect(JSON.stringify(result)).not.toContain('member-cannot-see@test.com')
+    })
+
+    it('getPendingUsersAction denies an admin of another org', async () => {
+        const otherOrg = await insertTestOrg({ slug: 'other-org-pending-invites' })
+        await db
+            .insertInto('pendingUser')
+            .values({ orgId: otherOrg.id, email: 'other-org-invitee@test.com', isAdmin: false })
+            .execute()
+
+        await mockSessionWithTestData({ isAdmin: true })
+
+        const result = await getPendingUsersAction({ orgSlug: otherOrg.slug })
+        expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+        expect(JSON.stringify(result)).not.toContain('other-org-invitee@test.com')
     })
 
     it('reInviteUserAction re-invites a user', async () => {

--- a/src/app/[orgSlug]/admin/team/admin-users.actions.ts
+++ b/src/app/[orgSlug]/admin/team/admin-users.actions.ts
@@ -79,7 +79,10 @@ export const getPendingUsersAction = new Action('getPendingUsersAction')
             .executeTakeFirstOrThrow()
         return { orgId: org.orgId }
     })
-    .requireAbilityTo('view', 'Org')
+    // `pendingUser.id` IS the live invite token, so this returns claimable invites plus invitee
+    // emails. Gated on the same verb as its siblings above/below rather than a read verb, since
+    // reading the outstanding invites is part of administering them (OTTER-724 / MA-6).
+    .requireAbilityTo('invite', 'User')
     .handler(async ({ params: { orgSlug }, db }) => {
         return await db
             .selectFrom('pendingUser')

--- a/src/lib/permission-types.ts
+++ b/src/lib/permission-types.ts
@@ -64,6 +64,11 @@ type Abilities =
     // name was misleading. Route + UI copy: /user-key (Routes.userKey), "Security key".
     | Ability<'UserKey', 'view' | 'update', object>
     | Ability<'Org', 'view' | 'update' | 'create' | 'delete', { orgId?: UUID; orgSlug?: string }>
+    // Split out from 'Org' because `view Org` must stay cross-org for the public catalog (a lab
+    // researcher picks datasets from an enclave they don't belong to). Configuration reads —
+    // code-env settings, starter code — carry secrets and belong to that org's admins only
+    // (OTTER-724 / MA-6).
+    | Ability<'OrgConfig', 'view', { orgId?: UUID; orgSlug?: string }>
     | Ability<'OrgMembers', 'view', { orgId?: UUID; orgSlug?: string }>
     | Ability<'Orgs', 'view', object>
     | Ability<'MFA', 'reset', object>

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -62,9 +62,19 @@ export function defineAbilityFor(session: UserSession) {
     permit('view', 'OrgStudies', { orgType: 'lab', orgId: { $in: usersResearcherOrgIds } })
 
     permit('view', 'OrgMembers', { orgId: { $in: usersOrgIds } })
-    // in the future we may narrow this, but right now
-    // researchers need to be able to view enclave orgs to create studies
+
+    // Deliberately unconditioned, and it must stay that way: a lab researcher composing a study
+    // proposal has to read enclave orgs they do not belong to in order to pick a dataset (97c118b1).
+    // The narrowing therefore lives in the ACTIONS, not here — an action gated on `view Org` may
+    // only return catalog-level data (identity + advertised datasets) that we are content to show
+    // any authenticated user. Anything carrying an org's configuration or secrets belongs on
+    // `view OrgConfig` below (OTTER-724 / MA-6).
     permit('view', 'Org')
+
+    // Org configuration reads: code-env settings (plaintext env vars, commonly credentials),
+    // scan results, and starter code contents. Scoped to admins of that org; SI admins pick it up
+    // via ('manage','all').
+    permit('view', 'OrgConfig', { orgId: { $in: usersAdminOrgIds } })
 
     // Enclave (Data Organization) reviewers may only view SUBMITTED studies/jobs. Unsubmitted drafts
     // (proposal content + uploaded code) stay private to the submitting Research Lab, which retains

--- a/src/schema/org.ts
+++ b/src/schema/org.ts
@@ -65,4 +65,8 @@ export const getNewOrg = (type: 'enclave' | 'lab' = 'enclave'): NewOrg => {
 
 export type Org = Selectable<DefinedOrg>
 
+// The subset of an org any authenticated user may read (getOrgFromSlugAction). Deliberately
+// excludes `settings` — which holds an enclave's publicKey — and `email` (OTTER-724 / MA-6).
+export type PublicOrg = Pick<Org, 'id' | 'slug' | 'name' | 'type' | 'description'>
+
 export type NewOrg = Omit<Org, 'id' | 'createdAt' | 'updatedAt'> & { createdAt?: never; updatedAt?: never }

--- a/src/server/actions/action.ts
+++ b/src/server/actions/action.ts
@@ -99,6 +99,12 @@ export class Action<
                 throw new ActionFailure({ user: `is not logged in when calling ${this.actionName}` })
             }
 
+            // Every middleware return value lands in the CASL subject here, and the subject is
+            // stringified into the permission_denied message below — which is returned to the
+            // caller we just refused. Middleware must therefore return only identifiers that are
+            // safe to hand someone who has no right to the record: ids and slugs, never a whole
+            // row and never secrets (OTTER-724 / MA-6). Read the sensitive columns in the HANDLER,
+            // which only runs after the check passes.
             const abilityArgs = { ...ctx.params, ...omit(ctx, ['session', 'db']) }
             const abilitySubject = toRecord(String(subject), abilityArgs)
 

--- a/src/server/actions/org.actions.test.ts
+++ b/src/server/actions/org.actions.test.ts
@@ -12,7 +12,9 @@ import {
 import { type Org } from '@/schema/org'
 import {
     deleteOrgAction,
+    fetchAdminOrgsWithStatsAction,
     getOrgFromSlugAction,
+    updateOrgAction,
     getUsersForOrgAction,
     fetchUsersOrgsAction,
     insertOrgAction,
@@ -21,6 +23,7 @@ import {
     getLanguagesForOrgAction,
 } from './org.actions'
 import logger from '@/lib/logger'
+import { isActionError } from '@/lib/errors'
 
 vi.mock('@/server/aws', async (importOriginal) => {
     const actual = await importOriginal<typeof import('@/server/aws')>()
@@ -85,12 +88,96 @@ describe('Org Actions', () => {
     describe('getOrgFromSlug', () => {
         it('returns org when found', async () => {
             const result = actionResult(await getOrgFromSlugAction({ orgSlug: newOrg.slug }))
-            expect(result).toMatchObject(newOrg)
+            expect(result).toMatchObject({ slug: newOrg.slug, name: newOrg.name, type: newOrg.type })
         })
 
-        it('throws when org not found', async () => {
+        // Sits on the unconditioned `view Org`, so every authenticated user reaches it. It must
+        // therefore never carry the enclave's publicKey or the org's contact email (MA-6).
+        it('omits settings and email from the org it returns', async () => {
+            const result = actionResult(await getOrgFromSlugAction({ orgSlug: newOrg.slug }))
+            expect(result).not.toHaveProperty('settings')
+            expect(result).not.toHaveProperty('email')
+            expect(JSON.stringify(result)).not.toContain(newOrg.settings.publicKey)
+            expect(JSON.stringify(result)).not.toContain(newOrg.email)
+        })
+
+        // The row is now read in the handler, so an unknown slug errors there rather than
+        // returning the whole row through the middleware. Either way the response must carry
+        // none of the org's secrets (MA-6).
+        it('leaks neither publicKey nor email when the org is not found', async () => {
+            vi.spyOn(logger, 'error').mockImplementation(() => undefined)
             const result = await getOrgFromSlugAction({ orgSlug: 'non-existent' })
-            expect(result).toEqual({ error: expect.stringContaining('no result') })
+            expect(isActionError(result)).toBe(true)
+            expect(JSON.stringify(result)).not.toContain(newOrg.settings.publicKey)
+            expect(JSON.stringify(result)).not.toContain(newOrg.email)
+        })
+
+        // Same for a plain org admin. `view Org` is unconditioned by design (the dataset picker),
+        // so this errors in the handler rather than at the ability check — the point of the test
+        // is the response body, not which layer refused.
+        it('leaks nothing for a non-SI-admin when the org is not found', async () => {
+            await mockSessionWithTestData({ isAdmin: true })
+            vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+
+            const result = await getOrgFromSlugAction({ orgSlug: 'non-existent' })
+            expect(isActionError(result)).toBe(true)
+            expect(JSON.stringify(result)).not.toContain(newOrg.settings.publicKey)
+            expect(JSON.stringify(result)).not.toContain(newOrg.email)
+        })
+    })
+
+    describe('fetchAdminOrgsWithStatsAction', () => {
+        // Returns every org's email and settings; its SI-admin-console callers have no layout
+        // gate, so this action's own check is the only thing standing in the way (MA-6).
+        it('denies an org admin who is not an SI admin', async () => {
+            await mockSessionWithTestData({ isAdmin: true })
+            vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+
+            const result = await fetchAdminOrgsWithStatsAction()
+            expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+            expect(JSON.stringify(result)).not.toContain(newOrg.settings.publicKey)
+        })
+
+        it('allows an SI admin', async () => {
+            await mockSessionWithTestData({ isSiAdmin: true })
+            const result = actionResult(await fetchAdminOrgsWithStatsAction())
+            expect(result).toEqual(expect.arrayContaining([expect.objectContaining({ slug: newOrg.slug })]))
+        })
+    })
+
+    describe('updateOrgAction', () => {
+        // updateOrgSchema is built from the CREATE schemas, so it accepts type, slug and
+        // settings.publicKey — the RS256 key verifying that enclave's M2M API tokens. An org admin
+        // must not reach this path at all (MA-5).
+        it('denies an org admin changing type, slug, or settings.publicKey', async () => {
+            const target = await db
+                .selectFrom('org')
+                .selectAll('org')
+                .where('slug', '=', newOrg.slug)
+                .executeTakeFirstOrThrow()
+
+            await mockSessionWithTestData({ orgSlug: newOrg.slug, isAdmin: true })
+            vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+
+            const result = await updateOrgAction({
+                id: target.id,
+                slug: 'attacker-controlled-slug',
+                name: target.name,
+                email: 'attacker@example.com',
+                type: 'enclave',
+                settings: { publicKey: 'attacker-supplied-public-key' },
+            })
+
+            expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+
+            const unchanged = await db
+                .selectFrom('org')
+                .selectAll('org')
+                .where('id', '=', target.id)
+                .executeTakeFirstOrThrow()
+            expect(unchanged.slug).toBe(newOrg.slug)
+            expect(unchanged.type).toBe('enclave')
+            expect(unchanged.settings).toEqual(target.settings)
         })
     })
 
@@ -290,6 +377,22 @@ describe('Org Actions', () => {
         it('rejects an empty orgSlug with a validation error', async () => {
             const result = await getLanguagesForOrgAction({ orgSlug: '' })
             expect(result).toEqual({ error: expect.stringContaining('Validation error') })
+        })
+
+        // Deliberately cross-org: a lab researcher starting a proposal browses enclaves they do
+        // not belong to and downloads their starter code. OTTER-724 narrowed the neighbouring
+        // config reads, so pin that this catalog pair stayed open.
+        it('stays readable cross-org for a lab researcher', async () => {
+            const enclaveOrg = await insertTestOrg({ slug: faker.string.alpha(10), type: 'enclave' })
+            await insertTestCodeEnv({ orgId: enclaveOrg.id, language: 'R', isTesting: false })
+
+            await mockSessionWithTestData({ orgType: 'lab', isAdmin: false })
+
+            const orgs = actionResult(await getStudyCapableEnclaveOrgsAction())
+            expect(orgs).toEqual(expect.arrayContaining([expect.objectContaining({ slug: enclaveOrg.slug })]))
+
+            const langs = actionResult(await getLanguagesForOrgAction({ orgSlug: enclaveOrg.slug }))
+            expect(langs.languages).toEqual(expect.arrayContaining([expect.objectContaining({ value: 'R' })]))
         })
     })
 })

--- a/src/server/actions/org.actions.ts
+++ b/src/server/actions/org.actions.ts
@@ -1,16 +1,22 @@
 'use server'
 
 import { ActionSuccessType } from '@/lib/types'
-import { orgSchema, updateOrgSchema } from '@/schema/org'
+import { orgSchema, updateOrgSchema, type PublicOrg } from '@/schema/org'
 import { revalidatePath } from 'next/cache'
 import { orgIdFromSlug } from '../db/queries'
 import { Action, z } from './action'
 import { Language } from '@/database/types'
 
+// Mass-assignment path: updateOrgSchema is a discriminated union of the CREATE schemas, so it
+// carries `type`, `slug`, `email` and `settings`. `settings.publicKey` is the RS256 key that
+// verifies an enclave's M2M API bearer tokens — an org admin who could overwrite it would forge
+// API JWTs as that enclave, and flipping `type` lab->enclave grants reviewer abilities. So this is
+// gated on ('manage','all') rather than the org-admin-scoped ('update','Org'). Its only caller is
+// the SI-admin console (EditOrgForm), which already required SI staff. Org admins edit their own
+// org through updateOrgSettingsAction below, which whitelists name + description (OTTER-724 / MA-5).
 export const updateOrgAction = new Action('updateOrgAction', { performsMutations: true })
     .params(updateOrgSchema)
-    .middleware(async ({ params: { id } }) => ({ orgId: id })) // translate params for requireAbility below
-    .requireAbilityTo('update', 'Org')
+    .requireAbilityTo('manage', 'all')
     .handler(async ({ params: { id, ...update }, db }) => {
         return await db.updateTable('org').set(update).where('id', '=', id).returningAll().executeTakeFirstOrThrow()
     })
@@ -21,13 +27,6 @@ export const insertOrgAction = new Action('insertOrgAction')
     .requireAbilityTo('create', 'Org')
     .handler(async ({ db, params: org }) => {
         return await db.insertInto('org').values(org).returningAll().executeTakeFirstOrThrow()
-    })
-
-export const getOrgFromIdAction = new Action('getOrgFromIdAction')
-    .params(z.object({ orgId: z.string() }))
-    .requireAbilityTo('view', 'Org')
-    .handler(async ({ db, params: { orgId } }) => {
-        return await db.selectFrom('org').selectAll('org').where('id', '=', orgId).executeTakeFirst()
     })
 
 export const fetchUsersOrgsAction = new Action('fetchUsersOrgsAction')
@@ -41,8 +40,11 @@ export const fetchUsersOrgsAction = new Action('fetchUsersOrgsAction')
             .execute()
     })
 
+// Returns EVERY org's email and settings (including enclave publicKeys). Its only callers live in
+// the SI-admin console, whose layout applies no admin gate, so this check is the sole gate
+// (OTTER-724 / MA-6).
 export const fetchAdminOrgsWithStatsAction = new Action('fetchAdminOrgsWithStatsAction')
-    .requireAbilityTo('view', 'Orgs')
+    .requireAbilityTo('manage', 'all')
     .handler(async ({ db }) => {
         return await db
             .selectFrom('org')
@@ -71,6 +73,8 @@ export const deleteOrgAction = new Action('deleteOrgAction')
     .requireAbilityTo('delete', 'Org')
     .handler(async ({ db, params: { orgId } }) => db.deleteFrom('org').where('id', '=', orgId).execute())
 
+// Cross-org by design: a lab researcher picks the enclave to submit to, so this must list enclaves
+// the caller does not belong to. Selects catalog columns only — keep it that way (OTTER-724 / MA-6).
 export const getStudyCapableEnclaveOrgsAction = new Action('getStudyCapableEnclaveOrgsAction')
     .requireAbilityTo('view', 'Orgs')
     .handler(async ({ db }) => {
@@ -99,6 +103,8 @@ type LanguageOption = {
     commandLines: Record<string, string>
 }
 
+// Cross-org by design, like getStudyCapableEnclaveOrgsAction: after choosing an enclave, the
+// researcher needs its languages and starter-code downloads to begin a proposal (OTTER-724 / MA-6).
 export const getLanguagesForOrgAction = new Action('getLanguagesForOrgAction')
     .requireAbilityTo('view', 'Orgs')
     .params(z.object({ orgSlug: z.string().min(1) }))
@@ -149,6 +155,9 @@ export const getLanguagesForOrgAction = new Action('getLanguagesForOrgAction')
         }
     })
 
+// Cross-org starter-code download is the intended researcher flow, so this stays on `view Orgs`.
+// The admin console's editor view of the same files is fetchStarterCodeAction, which is scoped to
+// that org's admins via `view OrgConfig` (OTTER-724 / MA-6).
 export const getStarterCodeUrlAction = new Action('getStarterCodeUrlAction')
     .requireAbilityTo('view', 'Orgs')
     .params(z.object({ orgSlug: z.string(), language: z.string() }))
@@ -183,18 +192,29 @@ export const getStarterCodeUrlAction = new Action('getStarterCodeUrlAction')
         return { starterCodeUrls }
     })
 
+// Sits on the unconditioned `view Org`, so the row read happens in the HANDLER and is narrowed to
+// PublicOrg. It previously selected the whole row in MIDDLEWARE, which both handed `settings`
+// (an enclave's publicKey) and `email` to any authenticated caller and echoed them back inside the
+// permission_denied message to a caller who was refused (OTTER-724 / MA-6).
 export const getOrgFromSlugAction = new Action('getOrgFromSlugAction')
     .params(z.object({ orgSlug: z.string() }))
-    .middleware(async ({ db, params: { orgSlug } }) => {
-        const org = await db.selectFrom('org').selectAll('org').where('slug', '=', orgSlug).executeTakeFirstOrThrow()
-        return { org, orgId: org.id }
-    })
+    .middleware(orgIdFromSlug)
     .requireAbilityTo('view', 'Org')
-    .handler(async ({ org }) => org)
+    .handler(
+        async ({ db, orgId }): Promise<PublicOrg> =>
+            await db
+                .selectFrom('org')
+                .select(['id', 'slug', 'name', 'type', 'description'])
+                .where('id', '=', orgId)
+                .executeTakeFirstOrThrow(),
+    )
 
 export type OrgUserReturn = ActionSuccessType<typeof getUsersForOrgAction>[number]
 
-export const updateOrgSettingsAction = new Action('updateOrgSettingsAction')
+// The org-admin-scoped update path. The field list here is the whitelist: it is the reason
+// ('update','Org') can safely be granted to every org admin, so keep `type`, `slug`, `email` and
+// `settings` out of it — those belong to updateOrgAction's SI-admin path (OTTER-724 / MA-5).
+export const updateOrgSettingsAction = new Action('updateOrgSettingsAction', { performsMutations: true })
     .params(
         z.object({
             orgSlug: z.string(),

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -312,6 +312,10 @@ export const getUserById = async (userId: string) => {
     return await Action.db.selectFrom('user').selectAll('user').where('id', '=', userId).executeTakeFirstOrThrow()
 }
 
+// executeTakeFirst, NOT ...OrThrow, on purpose: an unknown slug must leave `orgId` ABSENT from the
+// CASL subject so the mongo `$in` conditions fail CLOSED (deny). Throwing here would instead
+// distinguish "no such org" from "not yours" for the caller, and switching to OrThrow would make
+// every rule built on this middleware depend on an exception for its safety.
 export const orgIdFromSlug = async ({ db, params: { orgSlug } }: { db: DBExecutor; params: { orgSlug: string } }) =>
     await db.selectFrom('org').select(['id as orgId', 'type as orgType']).where('slug', '=', orgSlug).executeTakeFirst()
 


### PR DESCRIPTION
https://openstax.atlassian.net/browse/OTTER-724

Stacks on #939 — review that one first; this branch is based on it, not main.

**MA-6 — cross-tenant org reads.** `permit('view','Org')` is unconditioned, so every authenticated user passed it for any org. It has to stay that way for the study-proposal dataset picker (97c118b1), so the narrowing moves into the actions:

- New `view OrgConfig` subject scoped to admins of that org. `fetchOrgCodeEnvsAction` (its `selectAll` carries `settings.environment` — plaintext env-var pairs, commonly credentials) and `fetchStarterCodeAction` move onto it.
- `getPendingUsersAction` → `invite User`, matching its two siblings in the same file. Its rows expose `pendingUser.id`, which is the live invite token.
- `getOrgFromSlugAction` read the whole row in *middleware*, which both handed `settings.publicKey` and `email` to any authenticated caller and echoed them back inside the `permission_denied` message returned to a refused one. Now uses `orgIdFromSlug` and selects a narrow `PublicOrg` in the handler.
- `fetchAdminOrgsWithStatsAction` returns every org's email and settings; its SI-admin-console callers have no layout gate, so it now requires `manage all`.
- `getOrgFromIdAction` deleted — no call sites, no middleware, `selectAll` on a client-supplied orgId.

**MA-5 — org mass-assignment.** `updateOrgAction` spread the full `updateOrgSchema` into `.set()`. That union extends the CREATE schemas, so it carries `type`, `slug`, `email` and `settings` — including `settings.publicKey`, the RS256 key verifying an enclave's M2M API bearer tokens. An org admin could overwrite it and forge API JWTs as that enclave, or flip `type` lab→enclave to gain reviewer abilities. Its only caller is the SI-admin console's `EditOrgForm`, so it now requires `manage all`; org admins keep `updateOrgSettingsAction`, which already whitelists name + description (and now runs in a transaction like its sibling).

The deliberately cross-org reads are commented so they aren't "fixed" later, and there are regression tests pinning them — the dataset-picker flow is preserved, as are cross-org enclave browsing and starter-code download for lab researchers.