### PR TITLE
OTTER-724: bind researcher-profile lookup to the study

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.test.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { TextInput } from '@mantine/core'
 import { notifications } from '@mantine/notifications'
 import { memoryRouter } from 'next-router-mock'
@@ -94,15 +95,18 @@ const fullyValidExceptTitle: ProposalFormValues = {
 const VALID_NOTE = wordsString(60)
 
 // Test-only probe that primes the note form with a valid value so we can
-// isolate the title-gate behavior under test.
+// isolate the title-gate behavior under test. Runs in an effect — updating
+// form state during render triggers React's cross-component setState warning.
 const FormProbes = ({ titleOverride }: { titleOverride?: string }) => {
     const { form, noteForm } = useEditResubmit()
-    if (noteForm.values.resubmissionNote !== VALID_NOTE) {
-        noteForm.setFieldValue('resubmissionNote', VALID_NOTE)
-    }
-    if (titleOverride !== undefined && form.values.title !== titleOverride) {
-        form.setFieldValue('title', titleOverride)
-    }
+    useEffect(() => {
+        if (noteForm.values.resubmissionNote !== VALID_NOTE) {
+            noteForm.setFieldValue('resubmissionNote', VALID_NOTE)
+        }
+        if (titleOverride !== undefined && form.values.title !== titleOverride) {
+            form.setFieldValue('title', titleOverride)
+        }
+    })
     return null
 }
 
@@ -258,6 +262,29 @@ describe('EditResubmitFooter — save-on-navigate (OTTER-573)', () => {
         expect(after.title).toBe('Original title')
         // The rest of the flush still landed.
         expect(after.piName).toBe('PI Name')
+    })
+
+    // The preview's PI popover asks the server for the profile, and the server only serves ids
+    // the persisted study row names — opening the modal on unsaved form state would show
+    // "Profile not available" for a changed PI (OTTER-724).
+    it('flushes the draft to the study row before opening the reviewer preview', async () => {
+        const user = userEvent.setup()
+        const { researcher, study } = await setupChangeRequestedStudy('CHANGE-REQUESTED')
+
+        renderFooterForStudy(study.id, 'Original title', researcher.id)
+        await retypeTitle(user, 'Saved before preview')
+
+        await user.click(screen.getByRole('button', { name: 'View as reviewer' }))
+
+        await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument(), { timeout: 5000 })
+
+        const after = await db
+            .selectFrom('study')
+            .select(['title', 'piUserId'])
+            .where('id', '=', study.id)
+            .executeTakeFirstOrThrow()
+        expect(after.title).toBe('Saved before preview')
+        expect(after.piUserId).toBe(researcher.id)
     })
 
     it('reports the error and stays on the page when the flush fails', async () => {

--- a/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/edit-and-resubmit/footer.tsx
@@ -62,6 +62,15 @@ export const EditResubmitFooter: FC<EditResubmitFooterProps> = ({ researcherName
         resubmit()
     }
 
+    const handleOpenReviewer = async () => {
+        // Flush the form first: the preview's PI popover fetches the profile server-side, and
+        // the server only serves ids the persisted study row names — an unsaved piUserId would
+        // be denied and render as "Profile not available".
+        const saved = await saveDraft()
+        if (!saved) return
+        openReviewer()
+    }
+
     return (
         <>
             <Group mt="xs" justify="space-between" align="flex-start" w="100%">
@@ -77,7 +86,7 @@ export const EditResubmitFooter: FC<EditResubmitFooterProps> = ({ researcherName
                     Back
                 </Button>
                 <Group align="flex-start">
-                    <Button variant="outline" size="md" disabled={!hasContent || isBusy} onClick={openReviewer}>
+                    <Button variant="outline" size="md" disabled={!hasContent || isBusy} onClick={handleOpenReviewer}>
                         View as reviewer
                     </Button>
                     <Stack gap={4} align="flex-end">

--- a/src/app/[orgSlug]/study/[studyId]/proposal/footer.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/footer.test.tsx
@@ -155,6 +155,29 @@ describe('ProposalFooter save-on-navigate (OTTER-573)', () => {
         expect(study.title).toBe('Test draft')
     })
 
+    // The preview's PI popover asks the server for the profile, and the server only serves ids
+    // the persisted study row names — opening the modal on unsaved form state would show
+    // "Profile not available" for a freshly selected PI (OTTER-724).
+    it('flushes the draft to the study row before opening the reviewer preview', async () => {
+        const user = userEvent.setup()
+        const { studyId, user: researcher } = await createTestProposalDraft({ enclaveSlug: 'footer-preview-save' })
+
+        renderFooterForStudy(studyId, researcher.id)
+        await user.type(screen.getByLabelText('Study Title Probe'), 'Saved before preview')
+
+        await user.click(screen.getByRole('button', { name: 'View as reviewer' }))
+
+        await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument(), { timeout: 5000 })
+
+        const study = await db
+            .selectFrom('study')
+            .select(['title', 'piUserId'])
+            .where('id', '=', studyId)
+            .executeTakeFirstOrThrow()
+        expect(study.title).toBe('Saved before preview')
+        expect(study.piUserId).toBe(researcher.id)
+    })
+
     it('skips the flush and navigates when the form is pristine', async () => {
         const user = userEvent.setup()
         const { lab, studyId, user: researcher } = await createTestProposalDraft({ enclaveSlug: 'footer-nav-clean' })

--- a/src/app/[orgSlug]/study/[studyId]/proposal/footer.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/proposal/footer.tsx
@@ -50,6 +50,15 @@ export const ProposalFooter: FC<ProposalFooterProps> = ({ researcherName, resear
         router.push(Routes.studyEdit({ orgSlug, studyId }))
     }
 
+    const handleOpenReviewer = async () => {
+        // Flush the form first: the preview's PI popover fetches the profile server-side, and
+        // the server only serves ids the persisted study row names — an unsaved piUserId would
+        // be denied and render as "Profile not available".
+        const saved = await saveDraft()
+        if (!saved) return
+        openReviewer()
+    }
+
     return (
         <>
             <Group mt="xs" justify="space-between" align="flex-start" w="100%">
@@ -65,7 +74,7 @@ export const ProposalFooter: FC<ProposalFooterProps> = ({ researcherName, resear
                     Previous
                 </Button>
                 <Group align="flex-start">
-                    <Button variant="outline" size="md" disabled={!hasContent || isBusy} onClick={openReviewer}>
+                    <Button variant="outline" size="md" disabled={!hasContent || isBusy} onClick={handleOpenReviewer}>
                         View as reviewer
                     </Button>
                     <Stack gap={4} align="flex-end">

--- a/src/app/[orgSlug]/study/[studyId]/researcher-profile/page.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/researcher-profile/page.tsx
@@ -30,6 +30,8 @@ export default async function ResearcherProfilePage(props: {
     // membership — an SI admin can open this without belonging to either org. The URL slug tells
     // us which side we're on: the submitting org's slug means the researcher (lab) context, the
     // reviewing org's slug means the reviewer (enclave) context. This drives the Previous href.
+    // The ?userId param is untrusted; getResearcherProfileByUserIdAction rejects any id the study
+    // does not name, so a hand-edited URL yields the not-found panel below rather than someone's PII.
     const orgType = orgSlug === study.submittedByOrgSlug ? 'lab' : 'enclave'
 
     const profileData = await getResearcherProfileByUserIdAction({

--- a/src/components/researcher-profile-popover.test.tsx
+++ b/src/components/researcher-profile-popover.test.tsx
@@ -9,7 +9,8 @@ import {
     insertTestStudyJobData,
     insertTestResearcherProfile,
 } from '@/tests/unit.helpers'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import logger from '@/lib/logger'
 import { ResearcherProfilePopover } from './researcher-profile-popover'
 
 function ControlledPopover({ userId, studyId, orgSlug }: { userId: string; studyId: string; orgSlug: string }) {
@@ -72,10 +73,11 @@ describe('ResearcherProfilePopover', () => {
         expect(screen.queryByText('View full profile')).not.toBeInTheDocument()
     })
 
-    it('shows "Profile not available" when user does not exist', async () => {
+    it('shows "Profile not available" for a userId the study does not name', async () => {
         const { org, user } = await mockSessionWithTestData({ orgSlug: 'test-org', orgType: 'enclave' })
         const { study } = await insertTestStudyJobData({ org, researcherId: user.id })
 
+        vi.spyOn(logger, 'error').mockImplementation(() => undefined)
         await renderAndHover(faker.string.uuid(), study.id, 'test-org')
 
         await waitFor(() => {

--- a/src/hooks/use-researcher-popover-profile.ts
+++ b/src/hooks/use-researcher-popover-profile.ts
@@ -6,7 +6,9 @@ import { getResearcherProfileByUserIdAction } from '@/server/actions/researcher-
 
 export function useResearcherPopoverProfile(userId: string, studyId: string) {
     const query = useQuery({
-        queryKey: ['researcher-profile', userId],
+        // studyId is part of the key because the action authorizes per study: sharing one entry
+        // across studies would serve a result the current study never granted.
+        queryKey: ['researcher-profile', userId, studyId],
         queryFn: () => getResearcherProfileByUserIdAction({ userId, studyId }),
     })
 

--- a/src/server/actions/researcher-profile.actions.test.ts
+++ b/src/server/actions/researcher-profile.actions.test.ts
@@ -99,16 +99,69 @@ describe('researcher-profile.actions', () => {
             })
         })
 
-        it('returns null when user does not exist', async () => {
+        it('denies an unknown userId instead of confirming the account does not exist', async () => {
             const { org, user } = await mockSessionWithTestData({ isAdmin: true, orgType: 'enclave' })
             const { study } = await insertTestStudyJobData({ org, researcherId: user.id })
 
+            vi.spyOn(logger, 'error').mockImplementation(() => undefined)
             const result = await getResearcherProfileByUserIdAction({
                 userId: faker.string.uuid(),
                 studyId: study.id,
             })
 
-            expect(result).toBeNull()
+            expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+        })
+
+        it('denies a userId that is unrelated to the study', async () => {
+            const { org, user } = await mockSessionWithTestData({ isAdmin: true, orgType: 'enclave' })
+            const { study } = await insertTestStudyJobData({ org, researcherId: user.id })
+
+            const otherOrg = await insertTestOrg({ slug: faker.string.alpha(10), type: 'lab' })
+            const { user: unrelatedUser } = await insertTestUser({ org: otherOrg })
+            await insertTestResearcherProfile({
+                userId: unrelatedUser.id,
+                education: { institution: 'Stanford', degree: 'Ph.D.', fieldOfStudy: 'Physics' },
+            })
+
+            vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+            const result = await getResearcherProfileByUserIdAction({
+                userId: unrelatedUser.id,
+                studyId: study.id,
+            })
+
+            expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+        })
+
+        it('denies a member of the submitting org who is not named on the study', async () => {
+            const { org, user } = await mockSessionWithTestData({ isAdmin: true, orgType: 'enclave' })
+            const { study } = await insertTestStudyJobData({ org, researcherId: user.id })
+
+            const { user: labMate } = await insertTestUser({ org })
+
+            vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+            const result = await getResearcherProfileByUserIdAction({ userId: labMate.id, studyId: study.id })
+
+            expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+        })
+
+        it('allows the study principal investigator', async () => {
+            const { org, user } = await mockSessionWithTestData({ isAdmin: true, orgType: 'enclave' })
+            const { study } = await insertTestStudyJobData({ org, researcherId: user.id })
+
+            const { user: piUser } = await insertTestUser({ org })
+            await db.updateTable('study').set({ piUserId: piUser.id }).where('id', '=', study.id).execute()
+            await insertTestResearcherProfile({
+                userId: piUser.id,
+                education: { institution: 'Rice', degree: 'Ph.D.', fieldOfStudy: 'Statistics' },
+            })
+
+            const result = await getResearcherProfileByUserIdAction({ userId: piUser.id, studyId: study.id })
+
+            expect(isActionError(result)).toBe(false)
+            expect(result).toMatchObject({
+                user: { id: piUser.id, email: piUser.email },
+                profile: { educationInstitution: 'Rice' },
+            })
         })
 
         it('returns user with null profile when profile does not exist', async () => {

--- a/src/server/actions/researcher-profile.actions.test.ts
+++ b/src/server/actions/researcher-profile.actions.test.ts
@@ -103,13 +103,19 @@ describe('researcher-profile.actions', () => {
             const { org, user } = await mockSessionWithTestData({ isAdmin: true, orgType: 'enclave' })
             const { study } = await insertTestStudyJobData({ org, researcherId: user.id })
 
-            vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+            const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => undefined)
+            const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => undefined)
             const result = await getResearcherProfileByUserIdAction({
                 userId: faker.string.uuid(),
                 studyId: study.id,
             })
 
             expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+            // The denial must take the returned-value branch (logged at info), never the throwing
+            // branch (which logged at error and reached Sentry.captureException in action.ts's
+            // catch) — otherwise an attacker iterating user ids creates one Sentry issue per guess.
+            expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('is not associated with study'))
+            expect(errorSpy).not.toHaveBeenCalled()
         })
 
         it('denies a userId that is unrelated to the study', async () => {
@@ -123,7 +129,7 @@ describe('researcher-profile.actions', () => {
                 education: { institution: 'Stanford', degree: 'Ph.D.', fieldOfStudy: 'Physics' },
             })
 
-            vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+            vi.spyOn(logger, 'info').mockImplementation(() => undefined)
             const result = await getResearcherProfileByUserIdAction({
                 userId: unrelatedUser.id,
                 studyId: study.id,
@@ -138,7 +144,7 @@ describe('researcher-profile.actions', () => {
 
             const { user: labMate } = await insertTestUser({ org })
 
-            vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+            vi.spyOn(logger, 'info').mockImplementation(() => undefined)
             const result = await getResearcherProfileByUserIdAction({ userId: labMate.id, studyId: study.id })
 
             expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
@@ -193,6 +199,40 @@ describe('researcher-profile.actions', () => {
             vi.spyOn(logger, 'error').mockImplementation(() => undefined)
             const result = await getResearcherProfileByUserIdAction({ userId: user.id, studyId: study.id })
             expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+        })
+
+        it('does not tell a caller without study access whether a userId is named on the study', async () => {
+            const { org, user } = await mockSessionWithTestData({ isAdmin: true, orgType: 'enclave' })
+            const { study } = await insertTestStudyJobData({ org, researcherId: user.id })
+
+            const otherOrg = await insertTestOrg()
+            const { user: outsider } = await insertTestUser({ org: otherOrg })
+            mockClerkSession({
+                clerkUserId: outsider.clerkId,
+                orgSlug: otherOrg.slug,
+                userId: outsider.id,
+                orgId: otherOrg.id,
+            })
+
+            vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+            // A correct guess (the study's researcher) and a wrong guess must produce the same
+            // generic view-Study denial — a distinguishable "not associated" answer would let a
+            // caller with no study access confirm who a study's researcher or PI is.
+            const correctGuess = await getResearcherProfileByUserIdAction({ userId: user.id, studyId: study.id })
+            const wrongGuess = await getResearcherProfileByUserIdAction({
+                userId: faker.string.uuid(),
+                studyId: study.id,
+            })
+
+            for (const result of [correctGuess, wrongGuess]) {
+                expect(result).toEqual({
+                    error: { permission_denied: expect.stringContaining('cannot view Study') },
+                })
+                expect(JSON.stringify(result)).not.toContain('not associated')
+            }
+            // The denial message echoes the ability args, so it must never carry the study's
+            // real researcher/PI ids (the correct guess contains user.id only as caller input).
+            expect(JSON.stringify(wrongGuess)).not.toContain(user.id)
         })
     })
 })

--- a/src/server/actions/researcher-profile.actions.ts
+++ b/src/server/actions/researcher-profile.actions.ts
@@ -1,9 +1,10 @@
 'use server'
 
-import { Action, z } from '@/server/actions/action'
+import { Action, ActionFailure, z } from '@/server/actions/action'
 import { updateClerkUserName } from '@/server/clerk'
 import { positionSchema, educationSchema, personalInfoSchema, researchDetailsSchema } from '@/schema/researcher-profile'
 import { throwNotFound } from '@/lib/errors'
+import logger from '@/lib/logger'
 
 export const getResearcherProfileAction = new Action('getResearcherProfileAction')
     .middleware(async ({ session }) => ({ id: session?.user.id }))
@@ -157,12 +158,22 @@ export const updateResearchDetailsAction = new Action('updateResearchDetailsActi
 
 export const getResearcherProfileByUserIdAction = new Action('getResearcherProfileByUserIdAction')
     .params(z.object({ userId: z.string(), studyId: z.string() }))
-    .middleware(async ({ params: { studyId }, db }) => {
+    .middleware(async ({ params: { studyId, userId }, db }) => {
         const study = await db
             .selectFrom('study')
-            .select(['orgId', 'submittedByOrgId', 'status'])
+            .select(['orgId', 'submittedByOrgId', 'status', 'researcherId', 'piUserId'])
             .where('id', '=', studyId)
             .executeTakeFirstOrThrow(throwNotFound('Study'))
+
+        // The study's view ability says nothing about whose profile is being requested, so without
+        // this anyone able to view any single study could read every user's email and PII by
+        // editing the userId in the URL. Only the two people the study actually names are exposed.
+        if (userId !== study.researcherId && userId !== study.piUserId) {
+            const msg = `getResearcherProfileByUserIdAction: user ${userId} is not associated with study ${studyId}`
+            logger.error(msg)
+            throw new ActionFailure({ permission_denied: msg })
+        }
+
         return { orgId: study.orgId, submittedByOrgId: study.submittedByOrgId, status: study.status }
     })
     .requireAbilityTo('view', 'Study')

--- a/src/server/actions/researcher-profile.actions.ts
+++ b/src/server/actions/researcher-profile.actions.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { Action, ActionFailure, z } from '@/server/actions/action'
+import { Action, z } from '@/server/actions/action'
 import { updateClerkUserName } from '@/server/clerk'
 import { positionSchema, educationSchema, personalInfoSchema, researchDetailsSchema } from '@/schema/researcher-profile'
 import { throwNotFound } from '@/lib/errors'
@@ -158,26 +158,40 @@ export const updateResearchDetailsAction = new Action('updateResearchDetailsActi
 
 export const getResearcherProfileByUserIdAction = new Action('getResearcherProfileByUserIdAction')
     .params(z.object({ userId: z.string(), studyId: z.string() }))
-    .middleware(async ({ params: { studyId, userId }, db }) => {
+    .middleware(async ({ params: { studyId }, db }) => {
+        // Deliberately excludes researcherId/piUserId: everything returned here is merged into
+        // the CASL ability args, and requireAbilityTo echoes those args in its denial message —
+        // including them would leak the study's real researcher/PI ids to unauthorized callers.
         const study = await db
             .selectFrom('study')
-            .select(['orgId', 'submittedByOrgId', 'status', 'researcherId', 'piUserId'])
+            .select(['orgId', 'submittedByOrgId', 'status'])
+            .where('id', '=', studyId)
+            .executeTakeFirstOrThrow(throwNotFound('Study'))
+
+        return { orgId: study.orgId, submittedByOrgId: study.submittedByOrgId, status: study.status }
+    })
+    .requireAbilityTo('view', 'Study')
+    .handler(async ({ params: { userId, studyId }, db }) => {
+        const study = await db
+            .selectFrom('study')
+            .select(['researcherId', 'piUserId'])
             .where('id', '=', studyId)
             .executeTakeFirstOrThrow(throwNotFound('Study'))
 
         // The study's view ability says nothing about whose profile is being requested, so without
         // this anyone able to view any single study could read every user's email and PII by
         // editing the userId in the URL. Only the two people the study actually names are exposed.
+        // This must run after the view-Study check above: callers without access to the study get
+        // only the generic CASL denial, never a distinguishable "not associated" answer that would
+        // confirm whether an arbitrary user is the study's researcher or PI. The denial is returned
+        // rather than thrown so id enumeration cannot flood Sentry (only thrown errors are
+        // captured), and logged at info because warn/error console output is forwarded to Sentry.
         if (userId !== study.researcherId && userId !== study.piUserId) {
             const msg = `getResearcherProfileByUserIdAction: user ${userId} is not associated with study ${studyId}`
-            logger.error(msg)
-            throw new ActionFailure({ permission_denied: msg })
+            logger.info(msg)
+            return { error: { permission_denied: msg } }
         }
 
-        return { orgId: study.orgId, submittedByOrgId: study.submittedByOrgId, status: study.status }
-    })
-    .requireAbilityTo('view', 'Study')
-    .handler(async ({ params: { userId }, db }) => {
         const user = await db
             .selectFrom('user')
             .select(['id', 'firstName', 'lastName', 'email'])


### PR DESCRIPTION
Security finding MA-10: `getResearcherProfileByUserIdAction` accepted an arbitrary `userId` next to a `studyId` and only checked the caller's `view` ability on the study. Nothing linked the two, so anyone who could view any single study could read any user's email and profile PII (education, research interests, publication URLs) by editing the `userId` in the researcher-profile URL. Returning `null` for unknown ids also made it a userId-to-account oracle.

## Changes

- The action's middleware now rejects any `userId` the study does not name — `researcherId` or `piUserId` — before the ability check runs. Those are the only two profiles the popover and the full-profile page ever request, so no real use case changes.
- Keyed the popover's React Query cache on `studyId` as well as `userId`, so two studies asking about the same user can't share a cache entry and skip the per-study recheck.
- Tests for the hand-edited-URL denial, an unrelated org member, a same-org user not named on the study, and the legitimate researcher and PI paths.

https://openstax.atlassian.net/browse/OTTER-724