### PR TITLE
OTTER-724: invite acceptance — bearer-token invites, no privilege escalation

### DIFF
--- a/src/app/account/invitation/[inviteId]/create-account.action.test.ts
+++ b/src/app/account/invitation/[inviteId]/create-account.action.test.ts
@@ -43,6 +43,7 @@ describe('Create Account Actions', () => {
         client.mockResolvedValue({
             users: {
                 createUser: vi.fn(),
+                updateUser: vi.fn(async () => ({})),
                 updateUserMetadata: vi.fn(async () => ({})),
                 getUser: vi.fn(() => ({ publicMetadata: {} })),
                 getUserList: vi.fn(async () => ({
@@ -54,7 +55,8 @@ describe('Create Account Actions', () => {
                     ],
                 })),
             },
-            // Merge path adds the invite email to the existing Clerk account and auto-verifies it.
+            // Only the signup path touches these, to verify the address on a Clerk account it
+            // just created for the invitee.
             emailAddresses: {
                 createEmailAddress: vi.fn(async () => ({ id: faker.string.alpha(10) })),
                 updateEmailAddress: vi.fn(async () => ({})),
@@ -82,8 +84,28 @@ describe('Create Account Actions', () => {
 
         await onCreateAccountAction({ inviteId: invite.id, form })
 
-        const newUser = await db.selectFrom('user').where('email', '=', invite.email).executeTakeFirst()
-        expect(newUser).toBeDefined()
+        const newUser = await db
+            .selectFrom('user')
+            .select(['id', 'email'])
+            .where('email', '=', invite.email)
+            .executeTakeFirstOrThrow()
+
+        // The membership grant and the claim commit together, so the claimed-invite guard is
+        // self-enforcing rather than depending on a later client-side call.
+        const claimed = await db
+            .selectFrom('pendingUser')
+            .select(['claimedByUserId'])
+            .where('id', '=', invite.id)
+            .executeTakeFirstOrThrow()
+        expect(claimed.claimedByUserId).toBe(newUser.id)
+
+        const membership = await db
+            .selectFrom('orgUser')
+            .select(['isAdmin'])
+            .where('userId', '=', newUser.id)
+            .where('orgId', '=', org.id)
+            .executeTakeFirstOrThrow()
+        expect(membership.isAdmin).toBe(false)
     })
 
     it('onCreateAccountAction throws an error if invite not found', async () => {
@@ -167,31 +189,16 @@ describe('Create Account Actions', () => {
         expect(result).toEqual({ error: expect.objectContaining({ user: 'already has account' }) })
     })
 
-    // Signs in the given DB user and reports `verifiedEmails` as their verified Clerk addresses,
-    // which is what onJoinTeamAccountAction now authorizes against.
-    const signInAs = async (
-        user: { id: string; clerkId: string; email: string | null },
-        orgSlug: string,
-        verifiedEmails: string[] = [user.email!],
-    ) => {
+    // Signs in the given DB user. Invites are bearer credentials, so acceptance authorizes on
+    // the session alone — no Clerk email mocking is involved.
+    const signInAs = (user: { id: string; clerkId: string; email: string | null }, orgSlug: string) =>
         // Non-null: mockClerkSession only returns undefined for a null (signed-out) argument.
-        const mocks = mockClerkSession({
+        mockClerkSession({
             userId: user.id,
             clerkUserId: user.clerkId,
             email: user.email ?? undefined,
             orgSlug,
         })!
-
-        mocks.client.users.getUser = vi.fn(async () => ({
-            id: user.clerkId,
-            emailAddresses: verifiedEmails.map((emailAddress) => ({
-                emailAddress,
-                verification: { status: 'verified' },
-            })),
-        })) as unknown as typeof mocks.client.users.getUser
-
-        return mocks
-    }
 
     it('onJoinTeamAccountAction adds to existing user', async () => {
         const { user } = await insertTestUser({ org })
@@ -209,7 +216,7 @@ describe('Create Account Actions', () => {
             .returningAll()
             .executeTakeFirstOrThrow()
 
-        await signInAs(user, org.slug)
+        signInAs(user, org.slug)
 
         const result = actionResult(await onJoinTeamAccountAction({ inviteId: invite.id }))
         const userId = result.id
@@ -222,41 +229,19 @@ describe('Create Account Actions', () => {
                 expect.objectContaining({ orgId: newOrg.id }),
             ]),
         )
-    })
 
-    it('onJoinTeamAccountAction accepts an invite addressed to a secondary verified address', async () => {
-        // The merge case: the account signs in under its primary address but the invite was sent to
-        // another address it has already verified on the same Clerk account.
-        const { user } = await insertTestUser({ org })
-        const newOrg = await insertTestOrg({ slug: faker.string.alpha(10) })
-        const secondaryEmail = faker.internet.email({ provider: 'test.com' })
-
-        const invite = await db
-            .insertInto('pendingUser')
-            .values({
-                orgId: newOrg.id,
-                email: secondaryEmail,
-                isAdmin: false,
-                invitedByUserId: invitingUser.user.id,
-            })
-            .returningAll()
+        const claimed = await db
+            .selectFrom('pendingUser')
+            .select(['claimedByUserId'])
+            .where('id', '=', invite.id)
             .executeTakeFirstOrThrow()
-
-        await signInAs(user, org.slug, [user.email!, secondaryEmail])
-
-        const result = actionResult(await onJoinTeamAccountAction({ inviteId: invite.id }))
-        expect(result.id).toEqual(user.id)
-
-        const orgUsers = await db.selectFrom('orgUser').select('orgId').where('userId', '=', user.id).execute()
-        expect(orgUsers).toEqual(expect.arrayContaining([expect.objectContaining({ orgId: newOrg.id })]))
+        expect(claimed.claimedByUserId).toBe(user.id)
     })
 
-    it('onJoinTeamAccountAction refuses an invite the session has not verified', async () => {
-        vi.spyOn(logger, 'error').mockImplementation(() => undefined)
-
-        // The attacker's own signed-in account. The invite belongs to somebody else entirely; the
-        // pre-fix action would have granted membership based on a client-supplied email.
-        const { user: attacker } = await insertTestUser({ org })
+    it('onJoinTeamAccountAction attaches an invite addressed to another email to the accepting account', async () => {
+        // Invites are bearer credentials: whoever holds the link may accept, and the membership
+        // attaches to the accepting session's account — never to the invited address's account.
+        const { user } = await insertTestUser({ org })
         const targetOrg = await insertTestOrg({ slug: faker.string.alpha(10) })
 
         const invite = await db
@@ -264,31 +249,152 @@ describe('Create Account Actions', () => {
             .values({
                 orgId: targetOrg.id,
                 email: faker.internet.email({ provider: 'test.com' }),
+                isAdmin: false,
+                invitedByUserId: invitingUser.user.id,
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        const mocks = signInAs(user, org.slug)
+        // Accepting must never write the invited address onto the accepting Clerk account: a
+        // verified address is a sign-in / password-reset identifier (the old takeover primitive).
+        const emailWrites = { createEmailAddress: vi.fn(), updateEmailAddress: vi.fn() }
+        Object.assign(mocks.client, { emailAddresses: emailWrites })
+
+        const result = actionResult(await onJoinTeamAccountAction({ inviteId: invite.id }))
+        expect(result.id).toEqual(user.id)
+
+        const membership = await db
+            .selectFrom('orgUser')
+            .select(['userId', 'isAdmin'])
+            .where('orgId', '=', targetOrg.id)
+            .execute()
+        expect(membership).toEqual([{ userId: user.id, isAdmin: false }])
+
+        const claimed = await db
+            .selectFrom('pendingUser')
+            .select(['claimedByUserId'])
+            .where('id', '=', invite.id)
+            .executeTakeFirstOrThrow()
+        expect(claimed.claimedByUserId).toBe(user.id)
+
+        expect(emailWrites.createEmailAddress).not.toHaveBeenCalled()
+        expect(emailWrites.updateEmailAddress).not.toHaveBeenCalled()
+    })
+
+    it('onJoinTeamAccountAction grants exactly the role the invite row specifies', async () => {
+        // The no-escalation invariant: a non-admin invite can never yield an admin membership,
+        // and there is no caller-supplied input that can influence the granted role.
+        const { user } = await insertTestUser({ org })
+        const contributorOrg = await insertTestOrg({ slug: faker.string.alpha(10) })
+        const adminOrg = await insertTestOrg({ slug: faker.string.alpha(10) })
+
+        const contributorInvite = await db
+            .insertInto('pendingUser')
+            .values({
+                orgId: contributorOrg.id,
+                email: faker.internet.email({ provider: 'test.com' }),
+                isAdmin: false,
+                invitedByUserId: invitingUser.user.id,
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        const adminInvite = await db
+            .insertInto('pendingUser')
+            .values({
+                orgId: adminOrg.id,
+                email: faker.internet.email({ provider: 'test.com' }),
                 isAdmin: true,
                 invitedByUserId: invitingUser.user.id,
             })
             .returningAll()
             .executeTakeFirstOrThrow()
 
-        await signInAs(attacker, org.slug)
+        signInAs(user, org.slug)
 
-        const result = await onJoinTeamAccountAction({
-            inviteId: invite.id,
-            // Third-party identity claim that used to be honoured.
-            loggedInEmail: attacker.email!,
-        } as { inviteId: string })
+        // An injected isAdmin param is stripped by the schema, never honoured.
+        actionResult(
+            await onJoinTeamAccountAction({ inviteId: contributorInvite.id, isAdmin: true } as {
+                inviteId: string
+            }),
+        )
+        actionResult(await onJoinTeamAccountAction({ inviteId: adminInvite.id }))
 
-        expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+        const memberships = await db
+            .selectFrom('orgUser')
+            .select(['orgId', 'isAdmin'])
+            .where('userId', '=', user.id)
+            .execute()
+        expect(memberships).toEqual(
+            expect.arrayContaining([
+                { orgId: contributorOrg.id, isAdmin: false },
+                { orgId: adminOrg.id, isAdmin: true },
+            ]),
+        )
+    })
 
-        const orgUsers = await db.selectFrom('orgUser').select('orgId').where('userId', '=', attacker.id).execute()
-        expect(orgUsers).toEqual([expect.objectContaining({ orgId: org.id })])
+    it('onJoinTeamAccountAction promotes an existing member when the invite grants admin', async () => {
+        // Re-inviting an existing contributor as admin is the ordinary promote-by-invite path;
+        // consuming the invite without honouring its role would silently drop the promotion.
+        const { user } = await insertTestUser({ org })
 
-        const untouched = await db
+        const invite = await db
+            .insertInto('pendingUser')
+            .values({
+                orgId: org.id,
+                email: user.email!,
+                isAdmin: true,
+                invitedByUserId: invitingUser.user.id,
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        signInAs(user, org.slug)
+
+        actionResult(await onJoinTeamAccountAction({ inviteId: invite.id }))
+
+        const membership = await db
+            .selectFrom('orgUser')
+            .select(['isAdmin'])
+            .where('orgId', '=', org.id)
+            .where('userId', '=', user.id)
+            .executeTakeFirstOrThrow()
+        expect(membership.isAdmin).toBe(true)
+
+        const claimed = await db
             .selectFrom('pendingUser')
             .select(['claimedByUserId'])
             .where('id', '=', invite.id)
             .executeTakeFirstOrThrow()
-        expect(untouched.claimedByUserId).toBeNull()
+        expect(claimed.claimedByUserId).toBe(user.id)
+    })
+
+    it('onJoinTeamAccountAction never demotes an existing admin via a contributor invite', async () => {
+        const { user } = await insertTestUser({ org, isAdmin: true })
+
+        const invite = await db
+            .insertInto('pendingUser')
+            .values({
+                orgId: org.id,
+                email: user.email!,
+                isAdmin: false,
+                invitedByUserId: invitingUser.user.id,
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        signInAs(user, org.slug)
+
+        actionResult(await onJoinTeamAccountAction({ inviteId: invite.id }))
+
+        const membership = await db
+            .selectFrom('orgUser')
+            .select(['isAdmin'])
+            .where('orgId', '=', org.id)
+            .where('userId', '=', user.id)
+            .executeTakeFirstOrThrow()
+        expect(membership.isAdmin).toBe(true)
     })
 
     it('onJoinTeamAccountAction refuses an unauthenticated caller', async () => {
@@ -329,7 +435,7 @@ describe('Create Account Actions', () => {
             .returningAll()
             .executeTakeFirstOrThrow()
 
-        await signInAs(user, org.slug)
+        signInAs(user, org.slug)
 
         const result = await onJoinTeamAccountAction({ inviteId: invite.id })
 
@@ -355,7 +461,7 @@ describe('Create Account Actions', () => {
             .returningAll()
             .executeTakeFirstOrThrow()
 
-        await signInAs(user, labOrg.slug)
+        signInAs(user, labOrg.slug)
 
         const result = actionResult(await onJoinTeamAccountAction({ inviteId: invite.id }))
         expect(result.needsUserKey).toBe(true)
@@ -377,7 +483,7 @@ describe('Create Account Actions', () => {
             .returningAll()
             .executeTakeFirstOrThrow()
 
-        await signInAs(user, org.slug)
+        signInAs(user, org.slug)
 
         const result = actionResult(await onJoinTeamAccountAction({ inviteId: invite.id }))
         expect(result.needsUserKey).toBe(false)
@@ -402,34 +508,13 @@ describe('Create Account Actions', () => {
             .returningAll()
             .executeTakeFirstOrThrow()
 
-        await signInAs(user, existingLabOrg.slug)
+        signInAs(user, existingLabOrg.slug)
 
         const result = actionResult(await onJoinTeamAccountAction({ inviteId: invite.id }))
         expect(result.needsUserKey).toBe(true)
     })
 
-    // Sets the Clerk emails reported for the currently-signed-in user, which is how the revoke
-    // action recognises an invitee declining their own invite.
-    const mockCallerEmails = (emails: string[]) => {
-        const client = clerkClient as unknown as Mock
-        client.mockResolvedValue({
-            users: {
-                createUser: vi.fn(),
-                updateUserMetadata: vi.fn(async () => ({})),
-                getUser: vi.fn(async () => ({
-                    publicMetadata: {},
-                    emailAddresses: emails.map((emailAddress) => ({ emailAddress })),
-                })),
-                getUserList: vi.fn(async () => ({ totalCount: 0, data: [] })),
-            },
-            emailAddresses: {
-                createEmailAddress: vi.fn(async () => ({ id: faker.string.alpha(10) })),
-                updateEmailAddress: vi.fn(async () => ({})),
-            },
-        })
-    }
-
-    const insertInvite = async (opts: { orgId?: string; email?: string } = {}) =>
+    const insertInvite = async (opts: { orgId?: string; email?: string; claimedByUserId?: string } = {}) =>
         await db
             .insertInto('pendingUser')
             .values({
@@ -437,6 +522,7 @@ describe('Create Account Actions', () => {
                 email: opts.email ?? faker.internet.email({ provider: 'test.com' }).toLowerCase(),
                 isAdmin: false,
                 invitedByUserId: invitingUser.user.id,
+                claimedByUserId: opts.claimedByUserId ?? null,
             })
             .returningAll()
             .executeTakeFirstOrThrow()
@@ -446,7 +532,6 @@ describe('Create Account Actions', () => {
 
     it('onRevokeInviteAction lets an org admin revoke an invite', async () => {
         await mockSessionWithTestData({ orgSlug: org.slug, isAdmin: true })
-        mockCallerEmails([faker.internet.email({ provider: 'test.com' })])
 
         const invite = await insertInvite()
 
@@ -455,24 +540,20 @@ describe('Create Account Actions', () => {
         expect(await findInvite(invite.id)).toBeFalsy()
     })
 
-    it('onRevokeInviteAction lets the invitee decline their own invite', async () => {
+    it('onRevokeInviteAction lets any authenticated holder of the link decline an unclaimed invite', async () => {
+        // Bearer design: possession of the invite id is the same credential that authorizes
+        // accepting the invite, so it also authorizes declining it — no email match involved.
         await mockSessionWithTestData({ orgSlug: org.slug, isAdmin: false })
 
-        const inviteEmail = faker.internet.email({ provider: 'test.com' }).toLowerCase()
-        const invite = await insertInvite({ email: inviteEmail })
-
-        // Matched case-insensitively across all Clerk addresses, mirroring the join-team UI.
-        mockCallerEmails([faker.internet.email({ provider: 'test.com' }), inviteEmail.toUpperCase()])
+        const invite = await insertInvite()
 
         await onRevokeInviteAction({ inviteId: invite.id })
 
         expect(await findInvite(invite.id)).toBeFalsy()
     })
 
-    it('onRevokeInviteAction rejects a non-admin revoking someone else’s invite', async () => {
+    it('onRevokeInviteAction refuses an unauthenticated caller', async () => {
         vi.spyOn(logger, 'error').mockImplementation(() => undefined)
-        await mockSessionWithTestData({ orgSlug: org.slug, isAdmin: false })
-        mockCallerEmails([faker.internet.email({ provider: 'test.com' })])
 
         const invite = await insertInvite()
 
@@ -482,13 +563,36 @@ describe('Create Account Actions', () => {
         expect(await findInvite(invite.id)).toBeTruthy()
     })
 
-    it('onRevokeInviteAction rejects an admin of a different org', async () => {
+    it('onRevokeInviteAction lets an org admin remove a claimed invite', async () => {
+        const { user } = await mockSessionWithTestData({ orgSlug: org.slug, isAdmin: true })
+
+        const invite = await insertInvite({ claimedByUserId: user.id })
+
+        await onRevokeInviteAction({ inviteId: invite.id })
+
+        expect(await findInvite(invite.id)).toBeFalsy()
+    })
+
+    it('onRevokeInviteAction refuses a non-admin deleting a claimed invite', async () => {
+        // A claimed invite is a spent bearer token: possession of the id no longer authorizes
+        // anything, so only an org admin may remove the row.
+        vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+        await mockSessionWithTestData({ orgSlug: org.slug, isAdmin: false })
+
+        const invite = await insertInvite({ claimedByUserId: invitingUser.user.id })
+
+        const result = await onRevokeInviteAction({ inviteId: invite.id })
+
+        expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+        expect(await findInvite(invite.id)).toBeTruthy()
+    })
+
+    it('onRevokeInviteAction refuses an admin of a different org deleting a claimed invite', async () => {
         vi.spyOn(logger, 'error').mockImplementation(() => undefined)
         await mockSessionWithTestData({ isAdmin: true })
-        mockCallerEmails([faker.internet.email({ provider: 'test.com' })])
 
         // Invite belongs to `org`, which the caller does not administer.
-        const invite = await insertInvite()
+        const invite = await insertInvite({ claimedByUserId: invitingUser.user.id })
 
         const result = await onRevokeInviteAction({ inviteId: invite.id })
 
@@ -519,6 +623,34 @@ describe('Create Account Actions', () => {
             .executeTakeFirst()
 
         expect(updatedInvite?.claimedByUserId).toBe(user.id)
+    })
+
+    it('onPendingUserLoginAction is a no-op success when the same user already claimed the invite', async () => {
+        // The signup page calls this after sign-in, by which point onCreateAccountAction has
+        // already claimed the invite for the same user in-transaction.
+        const { user } = await mockSessionWithTestData({ orgSlug: org.slug })
+
+        const invite = await db
+            .insertInto('pendingUser')
+            .values({
+                orgId: org.id,
+                email: faker.internet.email({ provider: 'test.com' }),
+                isAdmin: false,
+                invitedByUserId: invitingUser.user.id,
+                claimedByUserId: user.id,
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        const result = await onPendingUserLoginAction({ inviteId: invite.id })
+        expect(result).toBeUndefined()
+
+        const unchanged = await db
+            .selectFrom('pendingUser')
+            .select(['claimedByUserId'])
+            .where('id', '=', invite.id)
+            .executeTakeFirstOrThrow()
+        expect(unchanged.claimedByUserId).toBe(user.id)
     })
 
     it('onPendingUserLoginAction cannot re-claim an invite another user already claimed', async () => {

--- a/src/app/account/invitation/[inviteId]/create-account.action.test.ts
+++ b/src/app/account/invitation/[inviteId]/create-account.action.test.ts
@@ -1,5 +1,12 @@
 import { db } from '@/database'
-import { actionResult, faker, insertTestOrg, insertTestUser, mockSessionWithTestData } from '@/tests/unit.helpers'
+import {
+    actionResult,
+    faker,
+    insertTestOrg,
+    insertTestUser,
+    mockClerkSession,
+    mockSessionWithTestData,
+} from '@/tests/unit.helpers'
 import { auth as clerkAuth, clerkClient } from '@clerk/nextjs/server'
 import { v7 } from 'uuid'
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
@@ -60,7 +67,6 @@ describe('Create Account Actions', () => {
             firstName: 'Test',
             lastName: 'User',
             password: 'password',
-            confirmPassword: 'password',
         }
 
         const invite = await db
@@ -85,7 +91,6 @@ describe('Create Account Actions', () => {
             firstName: 'Test',
             lastName: 'User',
             password: 'password',
-            confirmPassword: 'password',
         }
 
         const result = await onCreateAccountAction({ inviteId: v7(), form })
@@ -128,7 +133,6 @@ describe('Create Account Actions', () => {
             firstName: 'Test',
             lastName: 'User',
             password: 'hunter2',
-            confirmPassword: 'hunter2',
         }
 
         const result = await onCreateAccountAction({ inviteId: invite.id, form })
@@ -158,11 +162,36 @@ describe('Create Account Actions', () => {
             firstName: 'Test',
             lastName: 'User',
             password: 'password',
-            confirmPassword: 'password',
         }
         const result = await onCreateAccountAction({ inviteId: invite.id, form })
         expect(result).toEqual({ error: expect.objectContaining({ user: 'already has account' }) })
     })
+
+    // Signs in the given DB user and reports `verifiedEmails` as their verified Clerk addresses,
+    // which is what onJoinTeamAccountAction now authorizes against.
+    const signInAs = async (
+        user: { id: string; clerkId: string; email: string | null },
+        orgSlug: string,
+        verifiedEmails: string[] = [user.email!],
+    ) => {
+        // Non-null: mockClerkSession only returns undefined for a null (signed-out) argument.
+        const mocks = mockClerkSession({
+            userId: user.id,
+            clerkUserId: user.clerkId,
+            email: user.email ?? undefined,
+            orgSlug,
+        })!
+
+        mocks.client.users.getUser = vi.fn(async () => ({
+            id: user.clerkId,
+            emailAddresses: verifiedEmails.map((emailAddress) => ({
+                emailAddress,
+                verification: { status: 'verified' },
+            })),
+        })) as unknown as typeof mocks.client.users.getUser
+
+        return mocks
+    }
 
     it('onJoinTeamAccountAction adds to existing user', async () => {
         const { user } = await insertTestUser({ org })
@@ -180,6 +209,8 @@ describe('Create Account Actions', () => {
             .returningAll()
             .executeTakeFirstOrThrow()
 
+        await signInAs(user, org.slug)
+
         const result = actionResult(await onJoinTeamAccountAction({ inviteId: invite.id }))
         const userId = result.id
         expect(userId).toEqual(user.id)
@@ -191,6 +222,120 @@ describe('Create Account Actions', () => {
                 expect.objectContaining({ orgId: newOrg.id }),
             ]),
         )
+    })
+
+    it('onJoinTeamAccountAction accepts an invite addressed to a secondary verified address', async () => {
+        // The merge case: the account signs in under its primary address but the invite was sent to
+        // another address it has already verified on the same Clerk account.
+        const { user } = await insertTestUser({ org })
+        const newOrg = await insertTestOrg({ slug: faker.string.alpha(10) })
+        const secondaryEmail = faker.internet.email({ provider: 'test.com' })
+
+        const invite = await db
+            .insertInto('pendingUser')
+            .values({
+                orgId: newOrg.id,
+                email: secondaryEmail,
+                isAdmin: false,
+                invitedByUserId: invitingUser.user.id,
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        await signInAs(user, org.slug, [user.email!, secondaryEmail])
+
+        const result = actionResult(await onJoinTeamAccountAction({ inviteId: invite.id }))
+        expect(result.id).toEqual(user.id)
+
+        const orgUsers = await db.selectFrom('orgUser').select('orgId').where('userId', '=', user.id).execute()
+        expect(orgUsers).toEqual(expect.arrayContaining([expect.objectContaining({ orgId: newOrg.id })]))
+    })
+
+    it('onJoinTeamAccountAction refuses an invite the session has not verified', async () => {
+        vi.spyOn(logger, 'error').mockImplementation(() => undefined)
+
+        // The attacker's own signed-in account. The invite belongs to somebody else entirely; the
+        // pre-fix action would have granted membership based on a client-supplied email.
+        const { user: attacker } = await insertTestUser({ org })
+        const targetOrg = await insertTestOrg({ slug: faker.string.alpha(10) })
+
+        const invite = await db
+            .insertInto('pendingUser')
+            .values({
+                orgId: targetOrg.id,
+                email: faker.internet.email({ provider: 'test.com' }),
+                isAdmin: true,
+                invitedByUserId: invitingUser.user.id,
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        await signInAs(attacker, org.slug)
+
+        const result = await onJoinTeamAccountAction({
+            inviteId: invite.id,
+            // Third-party identity claim that used to be honoured.
+            loggedInEmail: attacker.email!,
+        } as { inviteId: string })
+
+        expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+
+        const orgUsers = await db.selectFrom('orgUser').select('orgId').where('userId', '=', attacker.id).execute()
+        expect(orgUsers).toEqual([expect.objectContaining({ orgId: org.id })])
+
+        const untouched = await db
+            .selectFrom('pendingUser')
+            .select(['claimedByUserId'])
+            .where('id', '=', invite.id)
+            .executeTakeFirstOrThrow()
+        expect(untouched.claimedByUserId).toBeNull()
+    })
+
+    it('onJoinTeamAccountAction refuses an unauthenticated caller', async () => {
+        const { user } = await insertTestUser({ org })
+        const newOrg = await insertTestOrg({ slug: faker.string.alpha(10) })
+
+        const invite = await db
+            .insertInto('pendingUser')
+            .values({
+                orgId: newOrg.id,
+                email: user.email!,
+                isAdmin: false,
+                invitedByUserId: invitingUser.user.id,
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        const result = await onJoinTeamAccountAction({ inviteId: invite.id })
+
+        expect(result).toEqual({ error: expect.objectContaining({ permission_denied: expect.any(String) }) })
+        const orgUsers = await db.selectFrom('orgUser').select('orgId').where('userId', '=', user.id).execute()
+        expect(orgUsers).toEqual([expect.objectContaining({ orgId: org.id })])
+    })
+
+    it('onJoinTeamAccountAction refuses an already-claimed invite', async () => {
+        const { user } = await insertTestUser({ org })
+        const newOrg = await insertTestOrg({ slug: faker.string.alpha(10) })
+
+        const invite = await db
+            .insertInto('pendingUser')
+            .values({
+                orgId: newOrg.id,
+                email: user.email!,
+                isAdmin: false,
+                invitedByUserId: invitingUser.user.id,
+                claimedByUserId: invitingUser.user.id,
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        await signInAs(user, org.slug)
+
+        const result = await onJoinTeamAccountAction({ inviteId: invite.id })
+
+        expect(result).toEqual({ error: expect.objectContaining({ invite: 'not found' }) })
+        const orgUsers = await db.selectFrom('orgUser').select('orgId').where('userId', '=', user.id).execute()
+        expect(orgUsers).toEqual([expect.objectContaining({ orgId: org.id })])
     })
 
     it('onJoinTeamAccountAction returns needsUserKey true for enclave org without existing key', async () => {
@@ -209,6 +354,8 @@ describe('Create Account Actions', () => {
             })
             .returningAll()
             .executeTakeFirstOrThrow()
+
+        await signInAs(user, labOrg.slug)
 
         const result = actionResult(await onJoinTeamAccountAction({ inviteId: invite.id }))
         expect(result.needsUserKey).toBe(true)
@@ -229,6 +376,8 @@ describe('Create Account Actions', () => {
             })
             .returningAll()
             .executeTakeFirstOrThrow()
+
+        await signInAs(user, org.slug)
 
         const result = actionResult(await onJoinTeamAccountAction({ inviteId: invite.id }))
         expect(result.needsUserKey).toBe(false)
@@ -253,55 +402,9 @@ describe('Create Account Actions', () => {
             .returningAll()
             .executeTakeFirstOrThrow()
 
+        await signInAs(user, existingLabOrg.slug)
+
         const result = actionResult(await onJoinTeamAccountAction({ inviteId: invite.id }))
-        expect(result.needsUserKey).toBe(true)
-    })
-
-    it('onJoinTeamAccountAction merges a second email into a key-holding account without re-prompting', async () => {
-        // Existing enclave-org account already holds a key. It accepts an invite addressed to a
-        // DIFFERENT email (the merge case) while logged in under its own email.
-        const { user } = await insertTestUser({ org })
-        const newOrg = await insertTestOrg({ slug: faker.string.alpha(10) })
-
-        const invite = await db
-            .insertInto('pendingUser')
-            .values({
-                orgId: newOrg.id,
-                email: faker.internet.email({ provider: 'test.com' }),
-                isAdmin: false,
-                invitedByUserId: invitingUser.user.id,
-            })
-            .returningAll()
-            .executeTakeFirstOrThrow()
-
-        const result = actionResult(await onJoinTeamAccountAction({ inviteId: invite.id, loggedInEmail: user.email! }))
-
-        // Same account (not the invite email), and the combined key status suppresses the prompt.
-        expect(result.id).toEqual(user.id)
-        expect(result.needsUserKey).toBe(false)
-    })
-
-    it('onJoinTeamAccountAction merging into a keyless account reflects combined status and prompts once', async () => {
-        // Account seeded via a lab org → keyless. Merging a second email must re-evaluate key status
-        // at the account level immediately (no re-login) and still prompt for a key.
-        const labOrg = await insertTestOrg({ slug: faker.string.alpha(10), type: 'lab' })
-        const { user } = await insertTestUser({ org: labOrg })
-        const newOrg = await insertTestOrg({ slug: faker.string.alpha(10) })
-
-        const invite = await db
-            .insertInto('pendingUser')
-            .values({
-                orgId: newOrg.id,
-                email: faker.internet.email({ provider: 'test.com' }),
-                isAdmin: false,
-                invitedByUserId: invitingUser.user.id,
-            })
-            .returningAll()
-            .executeTakeFirstOrThrow()
-
-        const result = actionResult(await onJoinTeamAccountAction({ inviteId: invite.id, loggedInEmail: user.email! }))
-
-        expect(result.id).toEqual(user.id)
         expect(result.needsUserKey).toBe(true)
     })
 
@@ -418,6 +521,33 @@ describe('Create Account Actions', () => {
         expect(updatedInvite?.claimedByUserId).toBe(user.id)
     })
 
+    it('onPendingUserLoginAction cannot re-claim an invite another user already claimed', async () => {
+        await mockSessionWithTestData({ orgSlug: org.slug })
+
+        const invite = await db
+            .insertInto('pendingUser')
+            .values({
+                orgId: org.id,
+                email: faker.internet.email({ provider: 'test.com' }),
+                isAdmin: false,
+                invitedByUserId: invitingUser.user.id,
+                claimedByUserId: invitingUser.user.id,
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        const result = await onPendingUserLoginAction({ inviteId: invite.id })
+
+        expect(result).toEqual({ error: expect.objectContaining({ invite: 'not found' }) })
+
+        const unchanged = await db
+            .selectFrom('pendingUser')
+            .select(['claimedByUserId'])
+            .where('id', '=', invite.id)
+            .executeTakeFirstOrThrow()
+        expect(unchanged.claimedByUserId).toBe(invitingUser.user.id)
+    })
+
     it('getOrgInfoForInviteAction returns org information for valid invite', async () => {
         const invite = await db
             .insertInto('pendingUser')
@@ -443,5 +573,45 @@ describe('Create Account Actions', () => {
     it('getOrgInfoForInviteAction throws error for invalid invite', async () => {
         const result = await getOrgInfoForInviteAction({ inviteId: v7() })
         expect(result).toEqual({ error: expect.stringContaining('no result') })
+    })
+
+    it('getOrgInfoForInviteAction discloses nothing for an already-claimed invite', async () => {
+        const invite = await db
+            .insertInto('pendingUser')
+            .values({
+                orgId: org.id,
+                email: faker.internet.email({ provider: 'test.com' }),
+                isAdmin: false,
+                invitedByUserId: invitingUser.user.id,
+                claimedByUserId: invitingUser.user.id,
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        const result = await getOrgInfoForInviteAction({ inviteId: invite.id })
+        expect(result).toEqual({ error: expect.stringContaining('no result') })
+    })
+
+    it('onCreateAccountAction refuses an already-claimed invite', async () => {
+        const invite = await db
+            .insertInto('pendingUser')
+            .values({
+                orgId: org.id,
+                email: faker.internet.email({ provider: 'test.com' }),
+                isAdmin: false,
+                invitedByUserId: invitingUser.user.id,
+                claimedByUserId: invitingUser.user.id,
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow()
+
+        const result = await onCreateAccountAction({
+            inviteId: invite.id,
+            form: { firstName: 'Test', lastName: 'User', password: 'password' },
+        })
+
+        expect(result).toEqual({ error: expect.objectContaining({ invite: 'not found' }) })
+        const created = await db.selectFrom('user').where('email', '=', invite.email).executeTakeFirst()
+        expect(created).toBeUndefined()
     })
 })

--- a/src/app/account/invitation/[inviteId]/create-account.action.ts
+++ b/src/app/account/invitation/[inviteId]/create-account.action.ts
@@ -8,9 +8,11 @@ import { extractClerkCodeAndMessage, isClerkApiError } from '@/lib/errors'
 import { toRecord } from '@/lib/permissions'
 import { clerkClient } from '@clerk/nextjs/server'
 
-// `claim PendingUser` is unconditioned in permissions.ts, so it grants every signed-in user the
-// verb on every invite. The `claimedByUserId is null` guard is what stops one user burning an
-// invite that belongs to (or was already accepted by) somebody else.
+// Invites are bearer credentials by design: holding the invite id is what authorizes acting on
+// it, so `claim PendingUser` is unconditioned in permissions.ts. The `claimedByUserId` guard is
+// what stops one user burning an invite somebody else already accepted; re-claiming by the same
+// user is a no-op success because onCreateAccountAction claims in-transaction and this action
+// runs again from the signup page after sign-in.
 export const onPendingUserLoginAction = new Action('onPendingUserLoginAction')
     .params(z.object({ inviteId: z.string() }))
     .requireAbilityTo('claim', 'PendingUser')
@@ -19,7 +21,7 @@ export const onPendingUserLoginAction = new Action('onPendingUserLoginAction')
             .updateTable('pendingUser')
             .set({ claimedByUserId: session.user.id })
             .where('id', '=', inviteId)
-            .where('claimedByUserId', 'is', null)
+            .where((eb) => eb.or([eb('claimedByUserId', 'is', null), eb('claimedByUserId', '=', session.user.id)]))
             // returning() so an update that matched nothing yields no row and raises, rather than
             // an UpdateResult that looks like success regardless of how many rows were touched.
             .returning('id')
@@ -56,9 +58,12 @@ export const getOrgInfoForInviteAction = new Action('getOrgInfoForInviteAction')
     })
 
 // Two legitimate callers with different rights: an org admin revoking an invite, and the invitee
-// declining it. The invitee may not be a member of the org at all, so no single ability rule covers
-// both — authorization is an explicit either/or below. Previously this action had no check of any
-// kind, letting any caller delete any invite by id.
+// declining it. Invites are bearer credentials — holding the id is the same credential that
+// authorizes accepting one, and declining is strictly weaker, so possession authorizes declining
+// an unclaimed invite. (The previous email-match check was weaker than it looked: Clerk reports
+// unverified addresses, so anyone could add the invitee's address to their own account unverified
+// and delete their invites.) Claimed invites are spent bearer tokens; only an org admin may still
+// remove those rows.
 export const onRevokeInviteAction = new Action('onRevokeInviteAction')
     .params(
         z.object({
@@ -74,52 +79,27 @@ export const onRevokeInviteAction = new Action('onRevokeInviteAction')
 
         const invite = await db
             .selectFrom('pendingUser')
-            .select(['id', 'orgId', 'email'])
+            .select(['id', 'orgId', 'claimedByUserId'])
             .where('id', '=', inviteId)
             .executeTakeFirstOrThrow(() => new ActionFailure({ invite: 'not found' }))
 
         const isOrgAdmin = session.ability.can('revoke', toRecord('PendingUser', { orgId: invite.orgId }))
+        const isBearerOfUnclaimedInvite = invite.claimedByUserId === null
 
-        // The invitee is identified by email rather than claimedByUserId, which is only set on the
-        // signup path and stays null when an existing user opens the invite (join-team page).
-        // Checked against all Clerk addresses so merged/secondary emails match, as the UI does.
-        const isInvitee = await callerOwnsEmail(session.user.clerkUserId, invite.email)
-
-        if (!isOrgAdmin && !isInvitee) {
+        if (!isOrgAdmin && !isBearerOfUnclaimedInvite) {
             throw new ActionFailure({ permission_denied: 'cannot revoke this invite' })
         }
 
         await db.deleteFrom('pendingUser').where('id', '=', invite.id).executeTakeFirstOrThrow()
     })
 
-const callerEmails = async (clerkUserId: string) => {
-    const clerk = await clerkClient()
-    const clerkUser = await clerk.users.getUser(clerkUserId)
-    return clerkUser.emailAddresses
-}
-
-const callerOwnsEmail = async (clerkUserId: string, email: string) => {
-    const emails = await callerEmails(clerkUserId)
-    return emails.some((ea) => ea.emailAddress.toLowerCase() === email.toLowerCase())
-}
-
-// Clerk returns unverified addresses too, and anyone can add an arbitrary address to their own
-// account. Only a verified address proves the caller controls that mailbox, which is the whole
-// basis for accepting an invite addressed to it.
-const callerOwnsVerifiedEmail = async (clerkUserId: string, email: string) => {
-    const emails = await callerEmails(clerkUserId)
-    return emails.some(
-        (ea) => ea.emailAddress.toLowerCase() === email.toLowerCase() && ea.verification?.status === 'verified',
-    )
-}
-
-// Accepting an invite grants org membership (possibly as admin), so the acting identity must come
-// from the session, never from a parameter. The previous version took a `loggedInEmail` param and
-// granted membership to whichever account owned it, then created and force-verified the invite
-// email on that account — an unauthenticated account-takeover primitive (OTTER-724 / MA-9).
-//
-// There is no ability rule to gate this on: the invitee is by definition not yet a member of the
-// inviting org, so authorization is "the session already owns the invited address", checked below.
+// Invites are bearer credentials by design: any authenticated user holding the link may accept it,
+// and the membership attaches to the accepting session's account — a user opening an invite
+// addressed to another email joins under their own identity. The invariant enforced here is no
+// privilege escalation: the acting identity comes from the session, never from a parameter (the
+// pre-fix version took a `loggedInEmail` param and granted membership to whichever account owned
+// it, unauthenticated — OTTER-724 / MA-9), the granted role comes only from the invite row, and
+// nothing writes or verifies email addresses on any Clerk account.
 export const onJoinTeamAccountAction = new Action('onJoinTeamAccountAction')
     .params(
         z.object({
@@ -130,17 +110,6 @@ export const onJoinTeamAccountAction = new Action('onJoinTeamAccountAction')
     .handler(async function ({ params: { inviteId }, db, session }) {
         // Without requireAbilityTo the handler is reached with a null session, so require one here.
         if (!session) {
-            throw new ActionFailure({ permission_denied: 'cannot accept this invite' })
-        }
-
-        const invite = await db
-            .selectFrom('pendingUser')
-            .selectAll('pendingUser')
-            .where('id', '=', inviteId)
-            .where('claimedByUserId', 'is', null)
-            .executeTakeFirstOrThrow(() => new ActionFailure({ invite: 'not found' }))
-
-        if (!(await callerOwnsVerifiedEmail(session.user.clerkUserId, invite.email))) {
             throw new ActionFailure({ permission_denied: 'cannot accept this invite' })
         }
 
@@ -155,19 +124,40 @@ export const onJoinTeamAccountAction = new Action('onJoinTeamAccountAction')
         }
 
         const siUser = await db.transaction().execute(async (trx) => {
+            // Claim first, atomically: `claimedByUserId is null` plus returning() makes concurrent
+            // accepts race on this row — the loser matches nothing and fails here instead of
+            // reporting success — and a failure below rolls the claim back with the membership.
+            const invite = await trx
+                .updateTable('pendingUser')
+                .set({ claimedByUserId: user.id })
+                .where('id', '=', inviteId)
+                .where('claimedByUserId', 'is', null)
+                .returning(['orgId', 'isAdmin'])
+                .executeTakeFirstOrThrow(() => new ActionFailure({ invite: 'not found' }))
+
             const orgUser = await trx
                 .selectFrom('orgUser')
                 .where('orgId', '=', invite.orgId)
                 .where('userId', '=', user.id)
-                .select(['id'])
+                .select(['id', 'isAdmin'])
                 .executeTakeFirst()
 
-            // If the user is already a member, we simply return the user so the
-            // rest of the handler can continue (marking the invite as claimed, etc.).
+            // Already a member: the invite is still consumed so it leaves pending lists, and its
+            // role is honoured as a grant — an admin re-invite of an existing contributor is the
+            // ordinary promote-by-invite path. Never a downgrade: a contributor invite to an
+            // existing admin is not a demotion; role removal has its own admin-only flow.
             if (orgUser) {
+                if (invite.isAdmin && !orgUser.isAdmin) {
+                    await trx
+                        .updateTable('orgUser')
+                        .set({ isAdmin: true })
+                        .where('id', '=', orgUser.id)
+                        .executeTakeFirstOrThrow()
+                }
                 return user
             }
 
+            // isAdmin comes from the invite row alone; no caller-supplied input can raise it.
             await trx
                 .insertInto('orgUser')
                 .values({
@@ -183,14 +173,6 @@ export const onJoinTeamAccountAction = new Action('onJoinTeamAccountAction')
 
         await updateClerkUserMetadata(siUser.id)
         onUserAcceptInvite(siUser.id)
-
-        // mark invite as claimed by this user so it no longer shows in pending lists
-        await db
-            .updateTable('pendingUser')
-            .set({ claimedByUserId: siUser.id })
-            .where('id', '=', inviteId)
-            .where('claimedByUserId', 'is', null)
-            .executeTakeFirst()
 
         // Checked here too because the client RequireUserKey guard reads Clerk useUser() metadata,
         // which can be stale right after this server-side update.
@@ -299,6 +281,8 @@ export const onCreateAccountAction = new Action('onCreateAccountAction')
                 throw new ActionFailure({ team: 'already a member' })
             }
 
+            // isAdmin comes from the invite row alone; the caller-supplied form carries only
+            // name and password, so it cannot influence the granted role.
             await trx
                 .insertInto('orgUser')
                 .values({
@@ -308,6 +292,19 @@ export const onCreateAccountAction = new Action('onCreateAccountAction')
                 })
                 .returning('id')
                 .executeTakeFirstOrThrow()
+
+            // Claim in the same transaction as the membership grant so the claimed-invite guard is
+            // self-enforcing, rather than relying on the signup page to call
+            // onPendingUserLoginAction after sign-in (unchecked, and skipped if sign-in fails or
+            // the tab closes). The unclaimed filter plus returning() also makes the claim atomic
+            // against a concurrent redemption of the same invite.
+            await trx
+                .updateTable('pendingUser')
+                .set({ claimedByUserId: user.id })
+                .where('id', '=', inviteId)
+                .where('claimedByUserId', 'is', null)
+                .returning('id')
+                .executeTakeFirstOrThrow(() => new ActionFailure({ invite: 'not found' }))
 
             return user
         })

--- a/src/app/account/invitation/[inviteId]/create-account.action.ts
+++ b/src/app/account/invitation/[inviteId]/create-account.action.ts
@@ -8,6 +8,9 @@ import { extractClerkCodeAndMessage, isClerkApiError } from '@/lib/errors'
 import { toRecord } from '@/lib/permissions'
 import { clerkClient } from '@clerk/nextjs/server'
 
+// `claim PendingUser` is unconditioned in permissions.ts, so it grants every signed-in user the
+// verb on every invite. The `claimedByUserId is null` guard is what stops one user burning an
+// invite that belongs to (or was already accepted by) somebody else.
 export const onPendingUserLoginAction = new Action('onPendingUserLoginAction')
     .params(z.object({ inviteId: z.string() }))
     .requireAbilityTo('claim', 'PendingUser')
@@ -16,9 +19,17 @@ export const onPendingUserLoginAction = new Action('onPendingUserLoginAction')
             .updateTable('pendingUser')
             .set({ claimedByUserId: session.user.id })
             .where('id', '=', inviteId)
-            .executeTakeFirstOrThrow()
+            .where('claimedByUserId', 'is', null)
+            // returning() so an update that matched nothing yields no row and raises, rather than
+            // an UpdateResult that looks like success regardless of how many rows were touched.
+            .returning('id')
+            .executeTakeFirstOrThrow(() => new ActionFailure({ invite: 'not found' }))
     })
 
+// Deliberately callable without a session: the invite link is opened before the recipient has an
+// account, and the signup page needs the org name and invited email to render. Exposure is limited
+// by the query rather than by an ability rule — only an unclaimed invite resolves, so a link that
+// has already been accepted stops disclosing the invitee's email and the inviting user's name.
 export const getOrgInfoForInviteAction = new Action('getOrgInfoForInviteAction')
     .params(
         z.object({
@@ -40,6 +51,7 @@ export const getOrgInfoForInviteAction = new Action('getOrgInfoForInviteAction')
                 'invitingUser.lastName as invitingUserLastName',
             ])
             .where('pendingUser.id', '=', inviteId)
+            .where('pendingUser.claimedByUserId', 'is', null)
             .executeTakeFirstOrThrow()
     })
 
@@ -80,47 +92,63 @@ export const onRevokeInviteAction = new Action('onRevokeInviteAction')
         await db.deleteFrom('pendingUser').where('id', '=', invite.id).executeTakeFirstOrThrow()
     })
 
-const callerOwnsEmail = async (clerkUserId: string, email: string) => {
+const callerEmails = async (clerkUserId: string) => {
     const clerk = await clerkClient()
     const clerkUser = await clerk.users.getUser(clerkUserId)
-    return clerkUser.emailAddresses.some((ea) => ea.emailAddress.toLowerCase() === email.toLowerCase())
+    return clerkUser.emailAddresses
 }
 
+const callerOwnsEmail = async (clerkUserId: string, email: string) => {
+    const emails = await callerEmails(clerkUserId)
+    return emails.some((ea) => ea.emailAddress.toLowerCase() === email.toLowerCase())
+}
+
+// Clerk returns unverified addresses too, and anyone can add an arbitrary address to their own
+// account. Only a verified address proves the caller controls that mailbox, which is the whole
+// basis for accepting an invite addressed to it.
+const callerOwnsVerifiedEmail = async (clerkUserId: string, email: string) => {
+    const emails = await callerEmails(clerkUserId)
+    return emails.some(
+        (ea) => ea.emailAddress.toLowerCase() === email.toLowerCase() && ea.verification?.status === 'verified',
+    )
+}
+
+// Accepting an invite grants org membership (possibly as admin), so the acting identity must come
+// from the session, never from a parameter. The previous version took a `loggedInEmail` param and
+// granted membership to whichever account owned it, then created and force-verified the invite
+// email on that account — an unauthenticated account-takeover primitive (OTTER-724 / MA-9).
+//
+// There is no ability rule to gate this on: the invitee is by definition not yet a member of the
+// inviting org, so authorization is "the session already owns the invited address", checked below.
 export const onJoinTeamAccountAction = new Action('onJoinTeamAccountAction')
     .params(
         z.object({
             inviteId: z.string(),
-            loggedInEmail: z.string().optional(), // provide if merging team invite to existing user account
         }),
     )
 
-    .handler(async function ({ params: { inviteId, loggedInEmail }, db }) {
+    .handler(async function ({ params: { inviteId }, db, session }) {
+        // Without requireAbilityTo the handler is reached with a null session, so require one here.
+        if (!session) {
+            throw new ActionFailure({ permission_denied: 'cannot accept this invite' })
+        }
+
         const invite = await db
             .selectFrom('pendingUser')
             .selectAll('pendingUser')
             .where('id', '=', inviteId)
+            .where('claimedByUserId', 'is', null)
             .executeTakeFirstOrThrow(() => new ActionFailure({ invite: 'not found' }))
 
-        let user = await db
+        if (!(await callerOwnsVerifiedEmail(session.user.clerkUserId, invite.email))) {
+            throw new ActionFailure({ permission_denied: 'cannot accept this invite' })
+        }
+
+        const user = await db
             .selectFrom('user')
             .select(['id', 'email', 'clerkId'])
-            .where('email', '=', loggedInEmail ? loggedInEmail : invite.email)
+            .where('id', '=', session.user.id)
             .executeTakeFirst()
-
-        // If user not found by email, check if email belongs to any existing Clerk user (handles merged emails)
-        if (!user) {
-            const clerk = await clerkClient()
-            const clerkUsers = await clerk.users.getUserList({ emailAddress: [invite.email] })
-
-            if (clerkUsers.data.length > 0) {
-                // Check if this Clerk user has a corresponding user in the DB
-                user = await db
-                    .selectFrom('user')
-                    .select(['id', 'email', 'clerkId'])
-                    .where('clerkId', '=', clerkUsers.data[0].id)
-                    .executeTakeFirst()
-            }
-        }
 
         if (!user) {
             throw new ActionFailure({ user: 'does not exist' })
@@ -135,8 +163,7 @@ export const onJoinTeamAccountAction = new Action('onJoinTeamAccountAction')
                 .executeTakeFirst()
 
             // If the user is already a member, we simply return the user so the
-            // rest of the handler can continue (adding the invite email to the
-            // account, marking the invite as claimed, etc.).
+            // rest of the handler can continue (marking the invite as claimed, etc.).
             if (orgUser) {
                 return user
             }
@@ -153,19 +180,6 @@ export const onJoinTeamAccountAction = new Action('onJoinTeamAccountAction')
 
             return user
         })
-
-        if (loggedInEmail) {
-            // add the invite email to the existing user's email addresses in clerk
-            const clerk = await clerkClient()
-
-            const emailAddress = await clerk.emailAddresses.createEmailAddress({
-                userId: user.clerkId,
-                emailAddress: invite.email,
-            })
-
-            // auto-verify email (the user has already followed the email invite link)
-            await clerk.emailAddresses.updateEmailAddress(emailAddress.id, { verified: true })
-        }
 
         await updateClerkUserMetadata(siUser.id)
         onUserAcceptInvite(siUser.id)
@@ -193,16 +207,19 @@ export const onCreateAccountAction = new Action('onCreateAccountAction')
                 firstName: z.string(),
                 lastName: z.string(),
                 password: z.string(),
-                confirmPassword: z.string(),
             }),
         }),
     )
 
     .handler(async function ({ params: { inviteId, form }, db }) {
+        // Unauthenticated by necessity — this is what creates the account the invite is for — so
+        // the invite id is the only credential. A claimed invite is spent and must not create a
+        // second account or re-grant membership.
         const invite = await db
             .selectFrom('pendingUser')
             .selectAll('pendingUser')
             .where('id', '=', inviteId)
+            .where('claimedByUserId', 'is', null)
             .executeTakeFirstOrThrow(() => new ActionFailure({ invite: 'not found' }))
 
         const clerk = await clerkClient()

--- a/src/app/account/invitation/[inviteId]/invalid-invite-panel.tsx
+++ b/src/app/account/invitation/[inviteId]/invalid-invite-panel.tsx
@@ -1,0 +1,20 @@
+import { ButtonLink } from '@/components/links'
+import { Routes } from '@/lib/routes'
+import { Flex, Paper, Text, Title } from '@mantine/core'
+
+export const InvalidInvitePanel = () => (
+    <Paper bg="white" p="xxl" radius="sm" w={600} my={{ base: '1rem', lg: 0 }}>
+        <Flex direction="column" maw={500} mx="auto" pb="xxl" gap="md">
+            <Title order={3} ta="center" c="red.8">
+                This invitation is no longer valid
+            </Title>
+            <Text size="md">
+                It may have already been accepted or expired. If you think this is a mistake, contact the person who
+                invited you for a new invitation.
+            </Text>
+            <ButtonLink variant="filled" size="lg" href={Routes.dashboard} fullWidth>
+                Go to your dashboard
+            </ButtonLink>
+        </Flex>
+    </Paper>
+)

--- a/src/app/account/invitation/[inviteId]/join-team/page.tsx
+++ b/src/app/account/invitation/[inviteId]/join-team/page.tsx
@@ -7,12 +7,13 @@ import { AppModal } from '@/components/modals/app-modal'
 import { Routes } from '@/lib/routes'
 import { markOrgJoined } from '@/lib/joined-org'
 import { actionResult } from '@/lib/utils'
-import { useAuth, useUser } from '@clerk/nextjs'
+import { useAuth } from '@clerk/nextjs'
 import { Button, Flex, Group, Paper, Stack, Text, Title } from '@mantine/core'
 import type { Route } from 'next'
 import { useRouter } from 'next/navigation'
 import { FC, use, useState } from 'react'
 import { getOrgInfoForInviteAction, onJoinTeamAccountAction, onRevokeInviteAction } from '../create-account.action'
+import { InvalidInvitePanel } from '../invalid-invite-panel'
 
 type InviteProps = {
     params: Promise<{ inviteId: string }>
@@ -29,20 +30,19 @@ type ConfirmationModalProps = {
 const AddTeam: FC<InviteProps> = ({ params }) => {
     const { inviteId } = use(params)
     const router = useRouter()
-    const { user } = useUser()
     const auth = useAuth()
     const [isDisabled, setIsDisabled] = useState<boolean>(false)
     const [confirmOpen, setConfirmOpen] = useState(false)
     const [isSkipping, setIsSkipping] = useState(false)
 
-    const { data: org, isLoading } = useQuery({
+    const {
+        data: org,
+        isLoading,
+        isError,
+    } = useQuery({
         queryKey: ['orgInfoForInvite', inviteId],
         queryFn: () => getOrgInfoForInviteAction({ inviteId }),
     })
-
-    // Check if logged-in user's email matches the invite email (handles both primary and merged emails)
-    const userEmails = user?.emailAddresses?.map((ea) => ea.emailAddress.toLowerCase()) || []
-    const emailMismatch = user && org && !userEmails.includes(org.email.toLowerCase())
 
     const { mutate: joinTeam, isPending: isJoining } = useMutation({
         mutationFn: async () => actionResult(await onJoinTeamAccountAction({ inviteId })),
@@ -78,32 +78,16 @@ const AddTeam: FC<InviteProps> = ({ params }) => {
         onError: reportMutationError('Unable to decline invitation'),
     })
 
-    if (isLoading || !org || !user) {
+    // A claimed or deleted invite no longer resolves; without this the page would show the
+    // loading spinner forever (org stays undefined after the query errors).
+    if (isError) {
+        return <InvalidInvitePanel />
+    }
+
+    if (isLoading || !org) {
         return (
             <Paper bg="white" p="xxl" radius="sm" w={600} my={{ base: '1rem', lg: 0 }}>
                 <LoadingMessage message="Loading account invitation" />
-            </Paper>
-        )
-    }
-
-    if (emailMismatch) {
-        return (
-            <Paper bg="white" p="xxl" radius="sm" w={600} my={{ base: '1rem', lg: 0 }}>
-                <Flex direction="column" maw={500} mx="auto" pb="xxl" gap="md">
-                    <Title order={3} ta="center" mb="md" c="red.8">
-                        Email Mismatch
-                    </Title>
-                    <Text size="md">
-                        The email address you are logged in with does not match the email address in the invitation.
-                    </Text>
-                    <Text size="md">
-                        Please sign in with the correct account or contact the person who sent the invitation for a new
-                        invite.
-                    </Text>
-                    <Button variant="filled" size="lg" onClick={() => router.push(Routes.accountSignin)} mt="md">
-                        Sign in
-                    </Button>
-                </Flex>
             </Paper>
         )
     }

--- a/src/app/account/invitation/[inviteId]/page.tsx
+++ b/src/app/account/invitation/[inviteId]/page.tsx
@@ -2,6 +2,7 @@ import { db } from '@/database'
 import { sessionFromClerk } from '@/server/clerk'
 import { redirect, RedirectType } from 'next/navigation'
 import { SignOutPanel } from './signout-panel'
+import { InvalidInvitePanel } from './invalid-invite-panel'
 import { Routes } from '@/lib/routes'
 import { clerkClient } from '@clerk/nextjs/server'
 import { ButtonLink } from '@/components/links'
@@ -123,20 +124,3 @@ export default async function AcceptInvitePage({ params }: { params: Promise<{ i
         </Paper>
     )
 }
-
-const InvalidInvitePanel = () => (
-    <Paper bg="white" p="xxl" radius="sm" w={600} my={{ base: '1rem', lg: 0 }}>
-        <Flex direction="column" maw={500} mx="auto" pb="xxl" gap="md">
-            <Title order={3} ta="center" c="red.8">
-                This invitation is no longer valid
-            </Title>
-            <Text size="md">
-                It may have already been accepted or expired. If you think this is a mistake, contact the person who
-                invited you for a new invitation.
-            </Text>
-            <ButtonLink variant="filled" size="lg" href={Routes.dashboard} fullWidth>
-                Go to your dashboard
-            </ButtonLink>
-        </Flex>
-    </Paper>
-)

--- a/src/app/account/invitation/[inviteId]/signup/page.tsx
+++ b/src/app/account/invitation/[inviteId]/signup/page.tsx
@@ -11,6 +11,7 @@ import { TermsCheckbox } from '@/components/terms-checkbox'
 import { useRouter } from 'next/navigation'
 import { FC, use, useState } from 'react'
 import { getOrgInfoForInviteAction, onCreateAccountAction, onPendingUserLoginAction } from '../create-account.action'
+import { InvalidInvitePanel } from '../invalid-invite-panel'
 import { Routes } from '@/lib/routes'
 import { markOrgJoined } from '@/lib/joined-org'
 
@@ -244,10 +245,18 @@ const SignupAccountPanel: FC<InviteProps> = ({ params }) => {
     const { inviteId } = use(params)
     const { isLoaded: isLoadedAuth, isSignedIn } = useAuth()
 
-    const { data, isLoading: isLoadingData } = useQuery({
+    const {
+        data,
+        isLoading: isLoadingData,
+        isError,
+    } = useQuery({
         queryKey: ['orgInfoForInvite', inviteId],
         queryFn: () => getOrgInfoForInviteAction({ inviteId }),
     })
+
+    // A claimed or deleted invite no longer resolves; without this the page would show the
+    // loading spinner forever (data stays undefined after the query errors).
+    if (isError) return <InvalidInvitePanel />
 
     if (!isLoadedAuth || isLoadingData || !data) return <LoadingMessage message="Loading" />
 

--- a/src/app/account/invitation/[inviteId]/signup/page.tsx
+++ b/src/app/account/invitation/[inviteId]/signup/page.tsx
@@ -71,8 +71,10 @@ const SetupAccountForm: FC<InviteData> = ({ inviteId, email, orgName }) => {
     const { requirementsDescription } = usePasswordRequirements(form.values.password, passwordTouched)
 
     const { mutate: createAccount, isPending: isCreating } = useMutation({
-        mutationFn: ({ termsAccepted: _termsAccepted, ...form }: FormValues) =>
-            onCreateAccountAction({ inviteId, form }),
+        // confirmPassword and termsAccepted are client-side concerns; the action's schema has
+        // neither, so only the fields it actually uses are sent.
+        mutationFn: ({ firstName, lastName, password }: FormValues) =>
+            onCreateAccountAction({ inviteId, form: { firstName, lastName, password } }),
         onError: handleMutationErrorsWithForm(form),
         async onSuccess(_, vals) {
             if (!signIn || !setActive) {

--- a/src/app/account/signin/mfa.tsx
+++ b/src/app/account/signin/mfa.tsx
@@ -75,14 +75,11 @@ export const RequestMFA: FC<{ mfa: MFAState }> = ({ mfa }) => {
                         const inviteId = searchParams.get('invite_id')
                         if (inviteId) {
                             try {
-                                const joinResult = actionResult(
-                                    await onJoinTeamAccountAction({
-                                        inviteId,
-                                        loggedInEmail: signInAttempt?.identifier || undefined,
-                                    }),
-                                )
+                                // Read the org before joining: accepting marks the invite claimed,
+                                // and the lookup only resolves unclaimed invites.
+                                const { slug, name } = actionResult(await getOrgInfoForInviteAction({ inviteId }))
+                                const joinResult = actionResult(await onJoinTeamAccountAction({ inviteId }))
 
-                                const { slug } = actionResult(await getOrgInfoForInviteAction({ inviteId }))
                                 const orgDashboard = Routes.orgDashboard({ orgSlug: slug })
                                 if (joinResult?.needsUserKey) {
                                     // First-time key generation: return to the inviting org's dashboard after.
@@ -92,16 +89,15 @@ export const RequestMFA: FC<{ mfa: MFAState }> = ({ mfa }) => {
                                     redirectUrl = orgDashboard as Route
                                 }
 
-                                const email = signInAttempt?.identifier || 'your account'
                                 notifications.show({
                                     color: 'green',
-                                    message: `You've successfully linked your SafeInsights accounts under ${email}.`,
+                                    message: `You've successfully joined ${name}.`,
                                 })
                                 await auth.getToken({ skipCache: true })
                             } catch {
                                 notifications.show({
                                     color: 'red',
-                                    message: `Failed to link your SafeInsights accounts. Please try again.`,
+                                    message: `Failed to accept your invitation. Please try again.`,
                                 })
                             }
                         }

--- a/src/app/account/signin/mfa.tsx
+++ b/src/app/account/signin/mfa.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useForm, useMutation } from '@/common'
+import { reportError } from '@/components/errors'
 import { errorToString } from '@/lib/errors'
 import { Routes } from '@/lib/routes'
 import { actionResult, safeRedirectUrl } from '@/lib/utils'
@@ -74,31 +75,45 @@ export const RequestMFA: FC<{ mfa: MFAState }> = ({ mfa }) => {
                         let redirectUrl = safeRedirectUrl(searchParams.get('redirect_url'), Routes.dashboard)
                         const inviteId = searchParams.get('invite_id')
                         if (inviteId) {
+                            let org: { slug: string; name: string } | undefined
                             try {
                                 // Read the org before joining: accepting marks the invite claimed,
                                 // and the lookup only resolves unclaimed invites.
-                                const { slug, name } = actionResult(await getOrgInfoForInviteAction({ inviteId }))
-                                const joinResult = actionResult(await onJoinTeamAccountAction({ inviteId }))
+                                org = actionResult(await getOrgInfoForInviteAction({ inviteId }))
+                            } catch (error) {
+                                // A claimed or deleted invite, so retrying can never succeed —
+                                // distinct from a join failure, which is worth retrying. The
+                                // join-team page renders a persistent "no longer valid" panel
+                                // for this state, so land there rather than on a dashboard
+                                // where only the transient toast explains what happened.
+                                reportError(error, 'This invitation is no longer valid')
+                                redirectUrl = Routes.accountInvitationJoinTeam({ inviteId }) as Route
+                            }
+                            if (org) {
+                                try {
+                                    const joinResult = actionResult(await onJoinTeamAccountAction({ inviteId }))
 
-                                const orgDashboard = Routes.orgDashboard({ orgSlug: slug })
-                                if (joinResult?.needsUserKey) {
-                                    // First-time key generation: return to the inviting org's dashboard after.
-                                    redirectUrl =
-                                        `${Routes.accountKeys}?redirect_url=${encodeURIComponent(orgDashboard)}` as Route
-                                } else {
-                                    redirectUrl = orgDashboard as Route
+                                    const orgDashboard = Routes.orgDashboard({ orgSlug: org.slug })
+                                    if (joinResult?.needsUserKey) {
+                                        // First-time key generation: return to the inviting org's dashboard after.
+                                        redirectUrl =
+                                            `${Routes.accountKeys}?redirect_url=${encodeURIComponent(orgDashboard)}` as Route
+                                    } else {
+                                        redirectUrl = orgDashboard as Route
+                                    }
+
+                                    notifications.show({
+                                        color: 'green',
+                                        message: `You've successfully joined ${org.name}.`,
+                                    })
+                                    await auth.getToken({ skipCache: true })
+                                } catch (error) {
+                                    // The invite is still live (a failed accept rolls the claim
+                                    // back), so return to the join-team page where Accept can be
+                                    // retried instead of silently landing elsewhere.
+                                    reportError(error, 'Failed to accept your invitation. Please try again.')
+                                    redirectUrl = Routes.accountInvitationJoinTeam({ inviteId }) as Route
                                 }
-
-                                notifications.show({
-                                    color: 'green',
-                                    message: `You've successfully joined ${name}.`,
-                                })
-                                await auth.getToken({ skipCache: true })
-                            } catch {
-                                notifications.show({
-                                    color: 'red',
-                                    message: `Failed to accept your invitation. Please try again.`,
-                                })
                             }
                         }
                         router.push(redirectUrl)


### PR DESCRIPTION
Fixes MA-9 from the OTTER-724 security review: https://openstax.atlassian.net/browse/OTTER-724

Stacks on #939 — please merge that first.

Scope changed after review — design decision recorded in [this discussion](https://github.com/safeinsights/management-app/pull/949#issuecomment-5207647379): invites are **bearer tokens by design**. Any authenticated user holding the link may accept it, and the membership attaches to *their own* account — including an invite addressed to a different email. The verified-email binding originally implemented here was deliberately reverted. The invariant this PR enforces is **no privilege escalation**:

- the acting identity is `session.user.id`, never a client-supplied `loggedInEmail` (the original bug let an unauthenticated caller grant any account membership — and admin — in any org from an invite id)
- the granted role comes only from the invite row; no caller-supplied input can influence it
- accepting never writes or verifies an email on any Clerk account (the old flow force-verified the invited address on the acceptor — an account-takeover primitive)

Also from review:

- invite claiming is atomic and transactional in `onJoinTeamAccountAction` and `onCreateAccountAction` (unclaimed filter + `returning()`), so the claimed-invite guard is self-enforcing; `onPendingUserLoginAction` is idempotent per-user
- revoke-by-invitee keys off invite-id possession (consistent with the bearer design, and strictly weaker than accepting) instead of unverified Clerk email match; claimed invites are admin-only to remove
- an admin re-invite of an existing contributor promotes them rather than consuming the invite with the role silently dropped
- claimed invites render an "invitation is no longer valid" panel on the join-team and signup pages instead of an infinite spinner; the MFA sign-in path distinguishes "no longer valid" from "join failed", reports via `reportError`, and lands on the join-team page

### Deliberately deferred

The unauthenticated half of `onCreateAccountAction` (review summary item 4): it still creates and force-verifies the invitee's Clerk account from the invite id alone, so a leaked id lets an attacker pre-create that account. The right fix is Clerk's ticket-strategy invitations; deferred as a follow-up rather than changed silently here.

Invite expiry is also still unenforced (`pendingUser` has no `expiresAt`) — needs a migration and a product decision.
