### PR TITLE
OTTER-675 follow-up: deliver the first submit click and let Tab leave the editor

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -149,6 +149,14 @@ const eslintConfig = [
                     name: '@tanstack/react-query',
                     message: 'Please import tanstack from @/common instead.',
                 },
+                {
+                    // It cancels the Tab keydown, which traps keyboard focus in the editor and
+                    // types a literal tab (WCAG 2.1.2). Lexical's own docs discourage it. Twice
+                    // now it has been copied into a new editor along with the rest of the plugin
+                    // list, so the ban is the guard. Indent / Outdent live on the toolbar.
+                    name: '@lexical/react/LexicalTabIndentationPlugin',
+                    message: 'Tab must move focus out of the editor. Use the toolbar Indent / Outdent buttons instead.',
+                },
             ],
             'no-console': ['error', { allow: ['warn', 'error'] }],
             '@typescript-eslint/no-unused-vars': [

--- a/src/components/editable-text.tsx
+++ b/src/components/editable-text.tsx
@@ -7,7 +7,6 @@ import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin'
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin'
 import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary'
 import { ListPlugin } from '@lexical/react/LexicalListPlugin'
-import { TabIndentationPlugin } from '@lexical/react/LexicalTabIndentationPlugin'
 import { LinkPlugin } from '@lexical/react/LexicalLinkPlugin'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import { $getRoot, EditorState, SerializedEditorState } from 'lexical'
@@ -186,7 +185,9 @@ export const EditableText: FC<EditableTextProps> = ({
                         />
                         <HistoryPlugin />
                         <ListPlugin />
-                        <TabIndentationPlugin />
+                        {/* No TabIndentationPlugin: it cancels the Tab keydown, so focus never
+                            leaves the editor and Tab types a literal tab instead. Indentation lives
+                            on the toolbar's Indent / Outdent buttons. */}
                         <EscapeFocusPlugin />
                         <LinkPlugin validateUrl={isValidUrl} />
                         <OnChangePlugin onChange={handleChange} ignoreSelectionChange />

--- a/src/components/editable-text.tsx
+++ b/src/components/editable-text.tsx
@@ -185,10 +185,7 @@ export const EditableText: FC<EditableTextProps> = ({
                         />
                         <HistoryPlugin />
                         <ListPlugin />
-                        {/* No TabIndentationPlugin: it cancels the Tab keydown, so focus never
-                            leaves the editor and Tab types a literal tab instead. Nothing is lost,
-                            because that plugin only indented inside a list, which the toolbar's
-                            Indent / Outdent buttons still do. */}
+                        {/* No TabIndentationPlugin: banned in eslint.config.mjs, which carries the why. */}
                         <EscapeFocusPlugin />
                         <LinkPlugin validateUrl={isValidUrl} />
                         <OnChangePlugin onChange={handleChange} ignoreSelectionChange />

--- a/src/components/editable-text.tsx
+++ b/src/components/editable-text.tsx
@@ -186,8 +186,9 @@ export const EditableText: FC<EditableTextProps> = ({
                         <HistoryPlugin />
                         <ListPlugin />
                         {/* No TabIndentationPlugin: it cancels the Tab keydown, so focus never
-                            leaves the editor and Tab types a literal tab instead. Indentation lives
-                            on the toolbar's Indent / Outdent buttons. */}
+                            leaves the editor and Tab types a literal tab instead. Nothing is lost,
+                            because that plugin only indented inside a list, which the toolbar's
+                            Indent / Outdent buttons still do. */}
                         <EscapeFocusPlugin />
                         <LinkPlugin validateUrl={isValidUrl} />
                         <OnChangePlugin onChange={handleChange} ignoreSelectionChange />

--- a/src/components/editable-text/collaborative-editor.tsx
+++ b/src/components/editable-text/collaborative-editor.tsx
@@ -413,8 +413,9 @@ export function CollaborativeEditor({
                     {onChange && <EditorChangePlugin onChange={onChange} />}
                     <ListPlugin />
                     {/* No TabIndentationPlugin: it cancels the Tab keydown, so focus never leaves
-                        the editor and Tab types a literal tab instead. Indentation lives on the
-                        toolbar's Indent / Outdent buttons, reachable by Tab themselves. */}
+                        the editor and Tab types a literal tab instead. Nothing is lost, because that
+                        plugin only indented inside a list, which the toolbar's Indent / Outdent
+                        buttons still do (they enable exactly there). */}
                     <EscapeFocusPlugin />
                     <LinkPlugin validateUrl={isValidUrl} />
                     <Toolbar />

--- a/src/components/editable-text/collaborative-editor.tsx
+++ b/src/components/editable-text/collaborative-editor.tsx
@@ -412,10 +412,7 @@ export function CollaborativeEditor({
                     />
                     {onChange && <EditorChangePlugin onChange={onChange} />}
                     <ListPlugin />
-                    {/* No TabIndentationPlugin: it cancels the Tab keydown, so focus never leaves
-                        the editor and Tab types a literal tab instead. Nothing is lost, because that
-                        plugin only indented inside a list, which the toolbar's Indent / Outdent
-                        buttons still do (they enable exactly there). */}
+                    {/* No TabIndentationPlugin: banned in eslint.config.mjs, which carries the why. */}
                     <EscapeFocusPlugin />
                     <LinkPlugin validateUrl={isValidUrl} />
                     <Toolbar />

--- a/src/components/editable-text/collaborative-editor.tsx
+++ b/src/components/editable-text/collaborative-editor.tsx
@@ -11,7 +11,6 @@ import { LexicalCollaboration } from '@lexical/react/LexicalCollaborationContext
 import { ListPlugin } from '@lexical/react/LexicalListPlugin'
 import { LinkPlugin } from '@lexical/react/LexicalLinkPlugin'
 import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary'
-import { TabIndentationPlugin } from '@lexical/react/LexicalTabIndentationPlugin'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import { HocuspocusProvider, HocuspocusProviderWebsocket } from '@hocuspocus/provider'
 import { Doc } from 'yjs'
@@ -413,7 +412,9 @@ export function CollaborativeEditor({
                     />
                     {onChange && <EditorChangePlugin onChange={onChange} />}
                     <ListPlugin />
-                    <TabIndentationPlugin />
+                    {/* No TabIndentationPlugin: it cancels the Tab keydown, so focus never leaves
+                        the editor and Tab types a literal tab instead. Indentation lives on the
+                        toolbar's Indent / Outdent buttons, reachable by Tab themselves. */}
                     <EscapeFocusPlugin />
                     <LinkPlugin validateUrl={isValidUrl} />
                     <Toolbar />

--- a/src/components/editable-text/single-user-editor.tsx
+++ b/src/components/editable-text/single-user-editor.tsx
@@ -145,10 +145,7 @@ export function SingleUserEditor({
                 />
                 <HistoryPlugin />
                 <ListPlugin />
-                {/* No TabIndentationPlugin: it cancels the Tab keydown, so focus never leaves the
-                    editor and Tab types a literal tab instead. Nothing is lost, because that plugin
-                    only indented inside a list, which the toolbar's Indent / Outdent buttons still
-                    do (they enable exactly there, and Tab can now reach them). */}
+                {/* No TabIndentationPlugin: banned in eslint.config.mjs, which carries the why. */}
                 <EscapeFocusPlugin />
                 <LinkPlugin validateUrl={isValidUrl} />
                 {onChange && <EditorChangePlugin onChange={onChange} />}

--- a/src/components/editable-text/single-user-editor.tsx
+++ b/src/components/editable-text/single-user-editor.tsx
@@ -9,7 +9,6 @@ import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin'
 import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary'
 import { ListPlugin } from '@lexical/react/LexicalListPlugin'
 import { LinkPlugin } from '@lexical/react/LexicalLinkPlugin'
-import { TabIndentationPlugin } from '@lexical/react/LexicalTabIndentationPlugin'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import type { EditorState } from 'lexical'
 
@@ -146,7 +145,9 @@ export function SingleUserEditor({
                 />
                 <HistoryPlugin />
                 <ListPlugin />
-                <TabIndentationPlugin />
+                {/* No TabIndentationPlugin: it cancels the Tab keydown, so focus never leaves the
+                    editor and Tab types a literal tab instead. Indentation lives on the toolbar's
+                    Indent / Outdent buttons, which are themselves reachable by Tab. */}
                 <EscapeFocusPlugin />
                 <LinkPlugin validateUrl={isValidUrl} />
                 {onChange && <EditorChangePlugin onChange={onChange} />}

--- a/src/components/editable-text/single-user-editor.tsx
+++ b/src/components/editable-text/single-user-editor.tsx
@@ -146,8 +146,9 @@ export function SingleUserEditor({
                 <HistoryPlugin />
                 <ListPlugin />
                 {/* No TabIndentationPlugin: it cancels the Tab keydown, so focus never leaves the
-                    editor and Tab types a literal tab instead. Indentation lives on the toolbar's
-                    Indent / Outdent buttons, which are themselves reachable by Tab. */}
+                    editor and Tab types a literal tab instead. Nothing is lost, because that plugin
+                    only indented inside a list, which the toolbar's Indent / Outdent buttons still
+                    do (they enable exactly there, and Tab can now reach them). */}
                 <EscapeFocusPlugin />
                 <LinkPlugin validateUrl={isValidUrl} />
                 {onChange && <EditorChangePlugin onChange={onChange} />}

--- a/src/components/study/outputs-decision-section.test.tsx
+++ b/src/components/study/outputs-decision-section.test.tsx
@@ -20,10 +20,8 @@ const renderSection = (overrides: Record<string, unknown> = {}) => {
         wordCount: 0,
         feedbackError: undefined,
         onFeedbackChange: vi.fn(),
-        onFeedbackBlur: vi.fn(),
         selected: null,
         onSelect: vi.fn(),
-        onDecisionBlur: vi.fn(),
         decisionError: undefined,
         ...overrides,
     }
@@ -138,23 +136,12 @@ describe('OutputsDecisionSection feedback field', () => {
         expect(items[1]).toHaveTextContent('If they do not, share the outputs along with your feedback.')
     })
 
-    // Guards against an accidental keyboard trap: an unresolved error must not pin the caret in
-    // the editor. Tabs until the radio is reached rather than assuming a fixed count, because the
-    // editor's formatting toolbar sits between the two and its size is not this test's business.
-    it('does not trap focus while an error is active', async () => {
-        renderSection({ feedbackError: 'Enter your feedback for Rice Lab before submitting.' })
-
-        const editor = await screen.findByLabelText('Decision feedback')
-        editor.focus()
-        expect(editor).toHaveFocus()
-
-        const firstRadio = screen.getByTestId('outputs-decision-share-outputs')
-        for (let i = 0; i < 12 && !firstRadio.matches(':focus'); i++) {
-            await userEvent.tab()
-        }
-
-        expect(firstRadio).toHaveFocus()
-    })
+    // The "focus is not trapped in the editor" AC row is covered in tests/study-flow.spec.ts, not
+    // here. jsdom cannot fail that assertion: Lexical's Tab handler returns early unless
+    // $getSelection() is a RangeSelection, and calling focus() on the contenteditable never
+    // establishes one, so the keydown is never cancelled and userEvent.tab() always moves focus.
+    // A version of this test lived here and passed for the whole time the real browser was
+    // trapping (OTTER-675).
 })
 
 describe('OutputsDecisionSection radio buttons', () => {

--- a/src/components/study/outputs-decision-section.tsx
+++ b/src/components/study/outputs-decision-section.tsx
@@ -6,7 +6,7 @@ import { InputError } from '@/components/errors'
 import { Editor } from '@/components/editable-text/editor'
 import { RequiredIndicator } from '@/components/required-indicator'
 import { WordCounter } from '@/components/word-counter'
-import { fieldDescribedBy, fieldDescriptionId, fieldErrorId, widgetBlurHandler } from '@/components/form-field'
+import { fieldDescribedBy, fieldDescriptionId, fieldErrorId } from '@/components/form-field'
 import { useYjsWebsocket } from '@/lib/realtime/yjs-websocket-context'
 import { outputsReviewFeedbackDocName } from '@/lib/collaboration-documents'
 import type { OutputsDecision } from '@/lib/outputs-review'
@@ -60,14 +60,13 @@ const RADIO_STYLES = { label: { fontWeight: 600, fontSize: 16 }, description: { 
 type DecisionRadioGroupProps = {
     value: OutputsDecision | null
     onChange: (next: OutputsDecision) => void
-    onBlur: () => void
     error: string | undefined
     labName: string
 }
 
 const descriptionId = (value: OutputsDecision) => `outputs-decision-${value}-description`
 
-const DecisionRadioGroup: FC<DecisionRadioGroupProps> = ({ value, onChange, onBlur, error, labName }) => {
+const DecisionRadioGroup: FC<DecisionRadioGroupProps> = ({ value, onChange, error, labName }) => {
     // Mantine's Radio renders a native <input type="radio">; Radio.Group gives them a shared
     // `name`, so mutual exclusivity and arrow-key navigation are the browser's, not simulated.
     //
@@ -104,8 +103,9 @@ const DecisionRadioGroup: FC<DecisionRadioGroupProps> = ({ value, onChange, onBl
         // document.getElementById would find nothing and the submit-time focus jump would silently
         // do nothing (see focusFirstInvalid).
         <Box id={DECISION_GROUP_ID}>
-            {/* Blur is a bubbled focusout, so moving between the two radios would validate a
-                still-empty group; widgetBlurHandler waits for focus to leave it (OTTER-647).
+            {/* No blur validation: the message renders above the options, so raising it as focus
+                leaves the group would push the navigation row down mid-click and cost the reviewer
+                the click that caused it (see useOutputsDecision).
                 The group's name is required by AT but is not drawn in the design, so the label is
                 visually hidden rather than dropped.
                 inputWrapperOrder moves the message above the options, where the design puts it;
@@ -113,7 +113,6 @@ const DecisionRadioGroup: FC<DecisionRadioGroupProps> = ({ value, onChange, onBl
             <Radio.Group
                 value={value ?? ''}
                 onChange={(next) => onChange(next as OutputsDecision)}
-                onBlur={widgetBlurHandler(onBlur)}
                 name="outputs-decision"
                 label={<VisuallyHidden>Sharing decision</VisuallyHidden>}
                 error={errorNode}
@@ -151,10 +150,8 @@ export type OutputsDecisionSectionProps = {
     wordCount: number
     feedbackError: string | undefined
     onFeedbackChange: (json: string) => void
-    onFeedbackBlur: () => void
     selected: OutputsDecision | null
     onSelect: (next: OutputsDecision) => void
-    onDecisionBlur: () => void
     decisionError: string | undefined
 }
 
@@ -166,10 +163,8 @@ export const OutputsDecisionSection: FC<OutputsDecisionSectionProps> = ({
     wordCount,
     feedbackError,
     onFeedbackChange,
-    onFeedbackBlur,
     selected,
     onSelect,
-    onDecisionBlur,
     decisionError,
 }) => {
     const websocketProvider = useYjsWebsocket()
@@ -192,7 +187,6 @@ export const OutputsDecisionSection: FC<OutputsDecisionSectionProps> = ({
                     websocketProvider={websocketProvider}
                     contentStyle={contentStyle}
                     onChange={onFeedbackChange}
-                    onBlur={onFeedbackBlur}
                     error={feedbackError}
                     ariaLabel="Decision feedback"
                     ariaRequired
@@ -204,13 +198,7 @@ export const OutputsDecisionSection: FC<OutputsDecisionSectionProps> = ({
                     footerRight={<FeedbackCounter wordCount={wordCount} maxWords={maxWords} />}
                 />
                 <FeedbackError error={feedbackError} />
-                <DecisionRadioGroup
-                    value={selected}
-                    onChange={onSelect}
-                    onBlur={onDecisionBlur}
-                    error={decisionError}
-                    labName={labName}
-                />
+                <DecisionRadioGroup value={selected} onChange={onSelect} error={decisionError} labName={labName} />
             </Stack>
         </Paper>
     )

--- a/src/components/study/outputs-review-panel.tsx
+++ b/src/components/study/outputs-review-panel.tsx
@@ -183,10 +183,8 @@ const ReviewBody: FC<ReviewBodyProps> = ({
                 wordCount={decision.wordCount}
                 feedbackError={decision.feedbackError}
                 onFeedbackChange={decision.onFeedbackChange}
-                onFeedbackBlur={decision.onFeedbackBlur}
                 selected={decision.selected}
                 onSelect={decision.onSelect}
-                onDecisionBlur={decision.onDecisionBlur}
                 decisionError={decision.decisionError}
             />
             <Group justify="space-between">

--- a/src/hooks/use-outputs-decision.test.tsx
+++ b/src/hooks/use-outputs-decision.test.tsx
@@ -1,10 +1,9 @@
 import { act, createTestQueryWrapper, describe, expect, faker, it, renderHook } from '@/tests/unit.helpers'
+import { lexicalJson } from '@/lib/lexical'
 import { ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS, OUTPUTS_DECISION_ERRORS } from '@/lib/outputs-review'
 import { useOutputsDecision } from './use-outputs-decision'
 
 const LAB = 'Rice Lab'
-
-const lexicalText = (text: string) => JSON.stringify({ root: { type: 'text', text } })
 
 const renderDecision = () =>
     renderHook(
@@ -34,7 +33,7 @@ describe('useOutputsDecision', () => {
     it('leaves an untouched empty form unflagged until a submit attempt', () => {
         const { result } = renderDecision()
 
-        act(() => result.current.onFeedbackChange(lexicalText('')))
+        act(() => result.current.onFeedbackChange(lexicalJson('')))
 
         expect(result.current.feedbackError).toBeUndefined()
         expect(result.current.decisionError).toBeUndefined()
@@ -55,7 +54,7 @@ describe('useOutputsDecision', () => {
 
         act(() =>
             result.current.onFeedbackChange(
-                lexicalText(
+                lexicalJson(
                     Array.from({ length: ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS + 1 }, (_, i) => `word${i}`).join(' '),
                 ),
             ),
@@ -76,7 +75,7 @@ describe('useOutputsDecision', () => {
         expect(result.current.decisionError).toBeUndefined()
         expect(result.current.feedbackError).toBe(OUTPUTS_DECISION_ERRORS.feedbackEmpty(LAB))
 
-        act(() => result.current.onFeedbackChange(lexicalText('Outputs look clean, no PII observed.')))
+        act(() => result.current.onFeedbackChange(lexicalJson('Outputs look clean, no PII observed.')))
 
         expect(result.current.feedbackError).toBeUndefined()
     })
@@ -85,7 +84,7 @@ describe('useOutputsDecision', () => {
         const { result } = renderDecision()
 
         act(() => result.current.attemptSubmit())
-        act(() => result.current.onFeedbackChange(lexicalText('Outputs look clean, no PII observed.')))
+        act(() => result.current.onFeedbackChange(lexicalJson('Outputs look clean, no PII observed.')))
         act(() => result.current.onSelect('share-feedback-only'))
         act(() => result.current.attemptSubmit())
 

--- a/src/hooks/use-outputs-decision.test.tsx
+++ b/src/hooks/use-outputs-decision.test.tsx
@@ -1,0 +1,94 @@
+import { act, createTestQueryWrapper, describe, expect, faker, it, renderHook } from '@/tests/unit.helpers'
+import { ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS, OUTPUTS_DECISION_ERRORS } from '@/lib/outputs-review'
+import { useOutputsDecision } from './use-outputs-decision'
+
+const LAB = 'Rice Lab'
+
+const lexicalText = (text: string) => JSON.stringify({ root: { type: 'text', text } })
+
+const renderDecision = () =>
+    renderHook(
+        () =>
+            useOutputsDecision({
+                orgSlug: 'openstax',
+                studyId: faker.string.uuid(),
+                jobId: faker.string.uuid(),
+                labName: LAB,
+                maxWords: ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS,
+                decryptedFiles: [],
+            }),
+        { wrapper: createTestQueryWrapper() },
+    )
+
+// OTTER-675: a failed submit must flag every unresolved field on the FIRST click. Flagging the
+// feedback field on blur instead moved the submit button between mousedown and mouseup, which cost
+// the click that caused it, so the reviewer saw one problem per click.
+describe('useOutputsDecision', () => {
+    it('opens with nothing flagged', () => {
+        const { result } = renderDecision()
+
+        expect(result.current.feedbackError).toBeUndefined()
+        expect(result.current.decisionError).toBeUndefined()
+    })
+
+    it('leaves an untouched empty form unflagged until a submit attempt', () => {
+        const { result } = renderDecision()
+
+        act(() => result.current.onFeedbackChange(lexicalText('')))
+
+        expect(result.current.feedbackError).toBeUndefined()
+        expect(result.current.decisionError).toBeUndefined()
+    })
+
+    it('flags both the feedback and the decision on a single failed submit', () => {
+        const { result } = renderDecision()
+
+        act(() => result.current.attemptSubmit())
+
+        expect(result.current.feedbackError).toBe(OUTPUTS_DECISION_ERRORS.feedbackEmpty(LAB))
+        expect(result.current.decisionError).toBe(OUTPUTS_DECISION_ERRORS.decisionMissing)
+        expect(result.current.confirming).toBeNull()
+    })
+
+    it('reports the over-limit error before any submit attempt', () => {
+        const { result } = renderDecision()
+
+        act(() =>
+            result.current.onFeedbackChange(
+                lexicalText(
+                    Array.from({ length: ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS + 1 }, (_, i) => `word${i}`).join(' '),
+                ),
+            ),
+        )
+
+        expect(result.current.feedbackError).toBe(
+            OUTPUTS_DECISION_ERRORS.feedbackTooLong(ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS),
+        )
+        expect(result.current.decisionError).toBeUndefined()
+    })
+
+    it('clears each message as its own field is resolved', () => {
+        const { result } = renderDecision()
+
+        act(() => result.current.attemptSubmit())
+        act(() => result.current.onSelect('share-outputs'))
+
+        expect(result.current.decisionError).toBeUndefined()
+        expect(result.current.feedbackError).toBe(OUTPUTS_DECISION_ERRORS.feedbackEmpty(LAB))
+
+        act(() => result.current.onFeedbackChange(lexicalText('Outputs look clean, no PII observed.')))
+
+        expect(result.current.feedbackError).toBeUndefined()
+    })
+
+    it('confirms once everything is resolved', () => {
+        const { result } = renderDecision()
+
+        act(() => result.current.attemptSubmit())
+        act(() => result.current.onFeedbackChange(lexicalText('Outputs look clean, no PII observed.')))
+        act(() => result.current.onSelect('share-feedback-only'))
+        act(() => result.current.attemptSubmit())
+
+        expect(result.current.confirming).toBe('share-feedback-only')
+    })
+})

--- a/src/hooks/use-outputs-decision.ts
+++ b/src/hooks/use-outputs-decision.ts
@@ -40,10 +40,16 @@ export function useOutputsDecision({
 
     const [feedback, setFeedback] = useState('')
     const [selected, setSelected] = useState<OutputsDecision | null>(null)
-    // Errors surface only after the user has left a field or pressed Submit; a pristine form
-    // must not open with everything flagged red.
-    const [showFeedbackError, setShowFeedbackError] = useState(false)
-    const [showDecisionError, setShowDecisionError] = useState(false)
+    // One flag for both fields, raised only by a submit attempt. A pristine form must not open
+    // with everything flagged red, and "still empty" is deliberately NOT raised on blur:
+    //
+    // rendering a message on blur inserts a line above the navigation row, and the blur that
+    // inserts it is the one caused by mousedown on "Submit decision" itself. The button moves
+    // ~21px between mousedown and mouseup, mouseup lands off it, and the browser fires click on
+    // an ancestor instead, so this hook never runs and the reviewer has to click twice. Flagging
+    // on submit alone is also what the AC asks for, and matches W3C ARIA guidance that a
+    // required field should not be marked invalid before the user has tried to submit.
+    const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false)
     // The decision the confirmation modal is confirming; null means closed. One nullable value
     // rather than an open flag beside the selection, so "open with nothing chosen" cannot be
     // represented and needs no guard.
@@ -54,15 +60,16 @@ export function useOutputsDecision({
     const isOverLimit = wordCount > maxWords
 
     // Over-limit is reported the moment it happens (the counter is already live, so a silent
-    // field would contradict it); emptiness waits for blur or a submit attempt.
+    // field would contradict it), and it appears while the user types, well before any click.
+    // Emptiness waits for a submit attempt.
     const resolveFeedbackError = () => {
         if (isOverLimit) return OUTPUTS_DECISION_ERRORS.feedbackTooLong(maxWords)
-        if (showFeedbackError && isEmpty) return OUTPUTS_DECISION_ERRORS.feedbackEmpty(labName)
+        if (hasAttemptedSubmit && isEmpty) return OUTPUTS_DECISION_ERRORS.feedbackEmpty(labName)
         return undefined
     }
 
     const feedbackError = resolveFeedbackError()
-    const decisionError = showDecisionError && selected === null ? OUTPUTS_DECISION_ERRORS.decisionMissing : undefined
+    const decisionError = hasAttemptedSubmit && selected === null ? OUTPUTS_DECISION_ERRORS.decisionMissing : undefined
 
     const { mutate: submit, isPending } = useMutation({
         mutationFn: async (decision: OutputsDecision) => {
@@ -97,8 +104,7 @@ export function useOutputsDecision({
     // full set on one click, even though focus can only land on one of them. focusFirstInvalid
     // returns the field it moved to, so its own scan doubles as the "is anything invalid" test.
     const attemptSubmit = useCallback(() => {
-        setShowFeedbackError(true)
-        setShowDecisionError(true)
+        setHasAttemptedSubmit(true)
 
         const invalid: Record<string, boolean> = {
             [FEEDBACK_INPUT_ID]: isEmpty || isOverLimit,
@@ -110,10 +116,9 @@ export function useOutputsDecision({
         setConfirming(selected)
     }, [isEmpty, isOverLimit, selected])
 
-    const onSelect = useCallback((next: OutputsDecision) => {
-        setSelected(next)
-        setShowDecisionError(false)
-    }, [])
+    // No error to clear: `decisionError` is derived from `selected`, so choosing an option drops
+    // the message on its own.
+    const onSelect = useCallback((next: OutputsDecision) => setSelected(next), [])
 
     // No null guard needed: the modal only exists while `confirming` holds a decision.
     const confirmSubmit = useCallback(() => {
@@ -123,12 +128,10 @@ export function useOutputsDecision({
     return {
         feedback,
         onFeedbackChange: setFeedback,
-        onFeedbackBlur: () => setShowFeedbackError(true),
         feedbackError,
         wordCount,
         selected,
         onSelect,
-        onDecisionBlur: () => setShowDecisionError(true),
         decisionError,
         confirming,
         closeModal: () => setConfirming(null),

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -401,8 +401,12 @@ async function reviewerSeesValidationOnBlankSubmit(page: Page): Promise<void> {
     await editor.fill(typed)
     await page.keyboard.press('Tab')
     await expect(editor).not.toBeFocused()
+    // textContent(), not toHaveText: the latter normalizes whitespace, so it would pass on the very
+    // tab character this asserts is absent.
     await expect(async () => {
-        expect(await editor.textContent()).toBe(typed)
+        const text = await editor.textContent()
+        expect(text).toContain(typed)
+        expect(text).not.toContain('\t')
     }).toPass()
 
     // Tabs until the radio is reached rather than assuming a count: the editor's formatting

--- a/tests/study-flow.spec.ts
+++ b/tests/study-flow.spec.ts
@@ -376,11 +376,43 @@ async function reviewerSharesOutputs(page: Page, feedback: string): Promise<void
 
 // OTTER-675: blank submit must flag both fields and open no modal.
 async function reviewerSeesValidationOnBlankSubmit(page: Page): Promise<void> {
-    await page.getByTestId('outputs-submit-decision').click()
+    const editor = page.getByLabel('Decision feedback')
+    const trigger = page.getByTestId('outputs-submit-decision')
+
+    // The caret starts inside the empty editor, which is where this used to break: raising the
+    // "enter your feedback" message as the editor lost focus inserted a line above the navigation
+    // row, so the button moved out from under the pointer between mousedown and mouseup, the click
+    // was never delivered, and only the field the blur had flagged was ever reported.
+    await editor.click()
+    await trigger.click()
 
     await expect(page.getByText(/Enter your feedback for .* before submitting\./)).toBeVisible()
     await expect(page.getByText('Select an option before submitting')).toBeVisible()
+    const options = page.locator('input[name="outputs-decision"]')
+    await expect(options.first()).toHaveAttribute('aria-invalid', 'true')
+    await expect(options.last()).toHaveAttribute('aria-invalid', 'true')
+    await expect(editor).toBeFocused()
     await expect(page.getByRole('dialog', { name: 'Submit your decision?' })).toBeHidden()
+
+    // Tab must move focus on rather than typing a tab character, and must keep going until it
+    // reaches the radios (WCAG 2.1.2). Checked here rather than in jsdom, where Lexical's Tab
+    // handler returns early for want of a range selection and the assertion cannot fail.
+    const typed = 'Checking the keyboard path.'
+    await editor.fill(typed)
+    await page.keyboard.press('Tab')
+    await expect(editor).not.toBeFocused()
+    await expect(async () => {
+        expect(await editor.textContent()).toBe(typed)
+    }).toPass()
+
+    // Tabs until the radio is reached rather than assuming a count: the editor's formatting
+    // toolbar sits between the two and its size is not this test's business.
+    const firstOption = page.getByTestId('outputs-decision-share-outputs')
+    const isFocused = () => firstOption.evaluate((el) => el === document.activeElement)
+    for (let i = 0; i < 12 && !(await isFocused()); i++) {
+        await page.keyboard.press('Tab')
+    }
+    await expect(firstOption).toBeFocused()
 }
 
 // The researcher's errored view is gated on a files decision existing (awaitingFilesDecisionOnError),


### PR DESCRIPTION
see [OTTER-675](https://openstax.atlassian.net/browse/OTTER-675), specifically the two failing rows in the Aug 05 QA verdict: a failed "Submit decision" flagged only one of two unresolved fields and moved no focus, and the Decision feedback field was a keyboard trap.

## 1. The first submit click was never delivered

Not a validation bug. `attemptSubmit` already flagged both fields and moved focus in one pass; the click never reached it.

Measured in Chromium against the real components, splitting `mousedown` from `mouseup` and re-measuring in between:

| measurement | value |
| --- | --- |
| Submit button `top` before `mousedown` | 881.17px |
| Submit button `top` after `mousedown`, before `mouseup` | 902.47px |
| shift | 21.30px |
| error slot height, before to after | 0px to 20.30px |
| pointer still over the button | false |
| `elementFromPoint` at the press coordinates | the page `DIV`, not the button |

`mousedown` on the button blurs the editor, the blur handler raises the "Enter your feedback" message synchronously, React flushes it before `mouseup`, and the button moves out from under the pointer. `mouseup` lands elsewhere, so the browser fires `click` on an ancestor. The one message on screen came from the blur, not from validation, which is why the radio group stayed unflagged and focus stayed on the button. The second click worked because the message was already in place.

Three controls were affected: "Submit decision", "Previous step" (same row, also confirmed swallowed, with the second click navigating fine), and the radio group's own blur, which raises its message above the options and moves the same row.

**Fix:** emptiness is flagged on a submit attempt only, never on blur. `showFeedbackError` and `showDecisionError` collapse into one `hasAttemptedSubmit` flag, and `onFeedbackBlur` / `onDecisionBlur` are gone from the hook and the section. Nothing can now be inserted during the mousedown-to-mouseup window, so all three paths are fixed by one change, and the hook holds less state than before.

This is also what the AC asks for: "Every empty required field is visually flagged ... at the moment of the failed click (not only on blur or initial typing)". The blur trigger was our own addition, not a review request. Further research on the pattern agrees: prefer validating on submit and avoid reflowing interactive targets, and W3C ARIA guidance is explicit that a required field should not be marked invalid before the user has tried to submit. `preventDefault` on the button's `mousedown`, or activating on `pointerdown`, were both considered and rejected as workarounds that change standard button behavior.

Unchanged deliberately: the over-limit message still appears live while typing, well before any click, so it is not a shift source. Reserving vertical space for the message would also have worked but changes spacing that has not been signed off, and it still shifts when a message wraps on a narrow viewport.

## 2. Tab was trapped in every Lexical editor

`TabIndentationPlugin` cancels the Tab keydown as soon as there is a range selection, then indents in a list or inserts a literal tab anywhere else. Measured: six Tabs and three Shift+Tabs never moved focus off `#outputs-decision-feedback`, the content gained nine tab characters, every Tab keydown reached document with `defaultPrevented: true`, and a 30-key traversal starting in the editor visited one element. Escape did release it, but nothing on screen says so, and WCAG 2.1.2 allows that escape hatch only if the user is advised of the method.

The plugin's own props do not help: `preventDefault()` runs before `$canIndent` is consulted. Lexical's docs discourage the plugin for exactly this reason and state that by default Tab follows the browser's focus order, which is what removing it restores. Nothing else in our stack cancels Tab (`@lexical/rich-text` registers the command only to reset capitalization and returns false).

**Fix:** removed from all three editor surfaces (single-user, collaborative, and the legacy `EditableText`). Nothing is lost: the plugin only indented inside a list, and in a paragraph it inserted a literal tab, which nobody wants in a feedback field. The list case still works through the toolbar's Indent / Outdent buttons, which enable (and so become focusable) exactly when the selection is in a list, and Tab can now reach them. `EscapeFocusPlugin` stays.

The plugin has been copied into a new editor twice along with the rest of the plugin list, so it is now banned via `no-restricted-imports` with a message pointing at the trap.

## Tests

- The unit test named for the trap row could not fail: Lexical's Tab handler returns early unless `$getSelection()` is a `RangeSelection`, and calling `focus()` on the contenteditable never establishes one in jsdom, so the keydown was never cancelled and `userEvent.tab()` always moved focus. It passed throughout the period the real browser was trapping. Removed, with a comment recording why and where the row is now covered.
- `tests/study-flow.spec.ts`: the blank-submit helper now clicks into the empty editor first, which is the precondition that used to break it, and asserts both messages, `aria-invalid="true"` on both radios, focus on the feedback field, and no modal, all from one click. It then asserts Tab moves focus off the editor without inserting a tab character and keeps going until it reaches the radios.
- New `src/hooks/use-outputs-decision.test.tsx`: pristine form unflagged, both fields flagged by a single `attemptSubmit`, over-limit reported without a submit attempt, each message clearing with its own field, and the modal confirming once everything is resolved.

## Not touched

The code review screen uses the same blur-validation pattern on its radio group, but its submit button is disabled while the form is invalid, so there is no click to lose, and OTTER-647 asked for that blur validation deliberately. Left alone.

Both copy deviations from the QA verdict ("Output files" versus "Outputs files", and the limit counted in words rather than characters) are unchanged and still waiting on PM sign-off.


[OTTER-675]: https://openstax.atlassian.net/browse/OTTER-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Verified in the browser

Same measurements as the diagnosis, re-run against these changes:

| check | before | after |
| --- | --- | --- |
| shift across `mousedown` on Submit | 21.30px | 1.00px, Mantine's own button press transform, and the pointer stays over the button |
| first click, caret in empty editor | feedback message only, `aria-invalid [null, null]`, focus stuck on the button | both messages, `["true", "true"]`, focus on the feedback field |
| first click on "Previous step" | URL unchanged | navigates |
| radio focused, nothing selected | focus stuck on the button | focus moves to the radio group |
| 12 Tabs from the editor | 1 stop, 9 tab characters inserted, every keydown cancelled | Bold, Italic, Underline, Link, Bullet list, Numbered list, radio, Previous step, Submit decision; 0 tab characters, no keydown cancelled |

Regressions checked and clean: pristine submit still flags both and focuses the editor, the over-limit message still appears live while typing with the radios untouched, the invalid to valid to modal cycle opens the modal with the right body copy, and toolbar Indent still produces nested `<ul>` markup.

CI is green, including e2e at `retries: 0` with 0 flaky, and the two tests that exercise the extended helper (`Successful results review`, `Error log review`) both pass. Those run the collaborative editor, so both editor implementations are covered.

## Regression audit

- `OutputsDecisionSection` / `useOutputsDecision` have two consumers, the errored screen and the available-outputs screen, both through `outputs-review-panel`. Typecheck confirms none was missed.
- `Editor`'s `onBlur` prop is still used by five other surfaces, so dropping this call site orphans nothing.
- Both `no-restricted-imports` entries were confirmed to fire independently, so the new one does not shadow the existing `@tanstack/react-query` ban.
- `TabNode` is registered by Lexical core rather than by the plugin, so feedback already saved containing tab characters still hydrates.
- No existing unit or e2e test asserted tab indentation.

## The same pattern elsewhere, deliberately out of scope

Expanding on "Not touched" above, since the audit went further than the code review screen. Both the code review and the proposal review screens validate their editor on blur, render the message in a zero-height slot, and sit above an enabled "Back" button, which is the same lost-click configuration. Their Submit is disabled while the form is invalid, so the reviewer is never blocked from learning what is missing, and the exposure is limited to a swallowed first click on "Back". It predates this branch, since clicking "Back" always blurred the editor, and freeing Tab does not worsen it because keyboard activation does not depend on hit testing. Worth its own card rather than widening this one, especially as OTTER-647 asked for that blur validation deliberately.


## Review follow-ups

- The new hook test builds its Lexical states with `lexicalJson` from `@/lib/lexical` rather than a local helper, so it runs on the same root / paragraph / text shape the editor actually produces instead of a bare text node at the root.
- The rationale for leaving `TabIndentationPlugin` out now lives only in the `no-restricted-imports` entry, which is what the person re-adding it will read. The three editor surfaces carry a one-line pointer to it instead of three copies of the same paragraph to keep in sync.

Re-verified in the browser after these changes, against the single-user editor surface:

| check | result |
| --- | --- |
| first click on Submit, caret in the empty editor | button shifts 1.00px (Mantine's press transform) and the pointer stays on it, both messages appear, `aria-invalid` is `["true", "true"]`, focus lands on the feedback field, no modal |
| first click on "Previous step", caret in the empty editor | navigates |
| Tab from the editor | Bold, Italic, Underline, Link, Bullet list, Numbered list, radio; 0 tab characters inserted |

Regressions clean: a pristine submit still flags both fields and focuses the editor, the over-limit message still appears live while typing ("Feedback exceeds the 300 word limit.") with the radios untouched, a valid form still opens the modal with the feedback-only copy, and toolbar Indent still produces nested `<ul>` markup.

Side effects checked: `widgetBlurHandler` and the `Editor` `onBlur` prop both keep other consumers, so neither is orphaned by the call sites this branch drops, and no test or code path referenced tab indentation.
