### PR TITLE
OTTER-668: address #922 review 

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.test.tsx
@@ -25,6 +25,7 @@ import type { FileType, StudyJobStatus } from '@/database/types'
 import { getStudyAction } from '@/server/actions/study.actions'
 import { fetchEncryptedJobFilesAction } from '@/server/actions/study-job.actions'
 import { latestJobForStudy } from '@/server/db/queries'
+import { rawStudyStateForStudy } from '@/server/db/study-state-query'
 import { setupStudyAction } from '@/tests/db-action.helpers'
 import { ReviewerOutputsAvailableScreen } from './reviewer-outputs-available-screen'
 import type { ScreenComponentProps } from './types'
@@ -73,26 +74,35 @@ async function seedArtifact(jobId: string, files: { name: string; content: strin
     }
 }
 
+const requireRawState = async (studyId: string) => {
+    const raw = await rawStudyStateForStudy(studyId)
+    if (!raw) throw new Error(`no raw study state for study ${studyId}`)
+    return raw
+}
+
 const setupAvailable = async (jobStatus: StudyJobStatus = 'RUN-COMPLETE') => {
     const { org, user } = await mockSessionWithTestData({ orgSlug: 'openstax', orgType: 'enclave' })
     const { study: dbStudy } = await insertTestStudyJobData({ org, researcherId: user.id, jobStatus })
     const study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
     const job = await latestJobForStudy(dbStudy.id)
+    const raw = await requireRawState(dbStudy.id)
     ;(useParams as Mock).mockReturnValue({ orgSlug: org.slug, studyId: study.id })
-    return { org, study, job }
+    return { org, study, job, raw }
 }
 
-const renderScreen = async (study: ScreenComponentProps['study'], orgSlug: string) =>
-    renderWithProviders(await ReviewerOutputsAvailableScreen({ study, orgSlug }))
+type ScreenInputs = Pick<ScreenComponentProps, 'study' | 'raw'>
+
+const renderScreen = async ({ study, raw }: ScreenInputs, orgSlug: string) =>
+    renderWithProviders(await ReviewerOutputsAvailableScreen({ study, raw, orgSlug }))
 
 // Like renderWithProviders, but with single-user editing on so the feedback editor (and the
 // word counter in its footer) renders synchronously instead of holding a collaborative skeleton.
-const renderScreenSingleUser = async (study: ScreenComponentProps['study'], orgSlug: string) =>
+const renderScreenSingleUser = async ({ study, raw }: ScreenInputs, orgSlug: string) =>
     render(
         <QueryClientProvider client={createTestQueryClient()}>
             <MantineProvider theme={theme}>
                 <YjsWebsocketProvider singleUserEditing>
-                    <ModalsProvider>{await ReviewerOutputsAvailableScreen({ study, orgSlug })}</ModalsProvider>
+                    <ModalsProvider>{await ReviewerOutputsAvailableScreen({ study, raw, orgSlug })}</ModalsProvider>
                 </YjsWebsocketProvider>
             </MantineProvider>
         </QueryClientProvider>,
@@ -114,8 +124,8 @@ describe('ReviewerOutputsAvailableScreen before decryption', () => {
     })
 
     it('renders the shared page and section headers', async () => {
-        const { org, study } = await setupAvailable()
-        await renderScreen(study, org.slug)
+        const { org, study, raw } = await setupAvailable()
+        await renderScreen({ study, raw }, org.slug)
 
         expect(screen.getByRole('heading', { level: 1, name: 'Secondary analysis study' })).toBeInTheDocument()
         expect(screen.getByTestId('proposal-section-header')).toHaveTextContent('STEP 3')
@@ -123,8 +133,8 @@ describe('ReviewerOutputsAvailableScreen before decryption', () => {
     })
 
     it('shows the outputs-available banner with the run-complete date, addressed to the lab', async () => {
-        const { org, study } = await setupAvailable()
-        await renderScreen(study, org.slug)
+        const { org, study, raw } = await setupAvailable()
+        await renderScreen({ study, raw }, org.slug)
 
         // The RUN-COMPLETE status row was just inserted, so the surfaced date is today.
         const alert = screen.getByTestId('status-alert')
@@ -137,8 +147,8 @@ describe('ReviewerOutputsAvailableScreen before decryption', () => {
     // The two-part gate: RUN-COMPLETE alone must not surface the outputs. Only a validated key
     // does, which is why this screen is a client phase flip and not a route.
     it('asks for the security key and hides the review view until a key validates', async () => {
-        const { org, study } = await setupAvailable()
-        await renderScreen(study, org.slug)
+        const { org, study, raw } = await setupAvailable()
+        await renderScreen({ study, raw }, org.slug)
 
         expect(screen.getByRole('heading', { name: /security key/i })).toBeInTheDocument()
         expect(screen.queryByTestId('outputs-files-section')).toBeNull()
@@ -150,11 +160,11 @@ describe('ReviewerOutputsAvailableScreen before decryption', () => {
     // owned by security-key-form.test.tsx — the same form instance this screen embeds. Screen-level
     // gating is proven here by the wrong-key path below, which anchors on a visible error.
     it('keeps the outputs hidden when the key is wrong', async () => {
-        const { org, study, job } = await setupAvailable()
+        const { org, study, job, raw } = await setupAvailable()
         vi.mocked(fetchEncryptedJobFilesAction).mockResolvedValue([
             await seedArtifact(job.id, [{ name: 'results.csv', content: 'a,b\n1,2' }]),
         ])
-        await renderScreen(study, org.slug)
+        await renderScreen({ study, raw }, org.slug)
         await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
 
         fireEvent.change(screen.getByRole('textbox'), { target: { value: 'not-a-real-key' } })
@@ -165,8 +175,8 @@ describe('ReviewerOutputsAvailableScreen before decryption', () => {
     })
 
     it('links Previous step to the read-only code page for this study', async () => {
-        const { org, study } = await setupAvailable()
-        await renderScreen(study, org.slug)
+        const { org, study, raw } = await setupAvailable()
+        await renderScreen({ study, raw }, org.slug)
 
         expect(screen.getByRole('link', { name: /previous step/i })).toHaveAttribute(
             'href',
@@ -180,14 +190,15 @@ describe('ReviewerOutputsAvailableScreen before decryption', () => {
     // here — they pin the guards, not a reviewer-visible state.
     it('shows a not-found alert when the study has no submitted job', async () => {
         const { org, study } = await setupStudyAction({ orgSlug: 'openstax', orgType: 'enclave', createJob: false })
+        const raw = await requireRawState(study.id)
         ;(useParams as Mock).mockReturnValue({ orgSlug: org.slug, studyId: study.id })
-        await renderScreen(study, org.slug)
+        await renderScreen({ study, raw }, org.slug)
         expect(screen.getByText('No submission found')).toBeInTheDocument()
     })
 
     it('shows a not-found alert when the job has not completed a run', async () => {
-        const { org, study } = await setupAvailable('JOB-RUNNING')
-        await renderScreen(study, org.slug)
+        const { org, study, raw } = await setupAvailable('JOB-RUNNING')
+        await renderScreen({ study, raw }, org.slug)
         expect(screen.getByText('Outputs not found')).toBeInTheDocument()
     })
 })
@@ -201,9 +212,9 @@ describe('ReviewerOutputsAvailableScreen after decryption', () => {
         files: { name: string; content: string }[],
         doRender: typeof renderScreen = renderScreen,
     ) => {
-        const { org, study, job } = await setupAvailable()
+        const { org, study, job, raw } = await setupAvailable()
         vi.mocked(fetchEncryptedJobFilesAction).mockResolvedValue([await seedArtifact(job.id, files)])
-        await doRender(study, org.slug)
+        await doRender({ study, raw }, org.slug)
         await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
         await unlock()
         await waitFor(() => expect(screen.getByTestId('outputs-files-section')).toBeInTheDocument())

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.test.tsx
@@ -16,7 +16,9 @@ import {
     readTestSupportFile,
     render,
     renderWithProviders,
+    requireRawState,
     screen,
+    type ScreenInputs,
     waitFor,
 } from '@/tests/unit.helpers'
 import { YjsWebsocketProvider } from '@/lib/realtime/yjs-websocket-context'
@@ -25,10 +27,8 @@ import type { FileType, StudyJobStatus } from '@/database/types'
 import { getStudyAction } from '@/server/actions/study.actions'
 import { fetchEncryptedJobFilesAction } from '@/server/actions/study-job.actions'
 import { latestJobForStudy } from '@/server/db/queries'
-import { rawStudyStateForStudy } from '@/server/db/study-state-query'
 import { setupStudyAction } from '@/tests/db-action.helpers'
 import { ReviewerOutputsAvailableScreen } from './reviewer-outputs-available-screen'
-import type { ScreenComponentProps } from './types'
 
 vi.mock('@/server/actions/study-job.actions', async () => {
     const actual = await vi.importActual<typeof import('@/server/actions/study-job.actions')>(
@@ -74,12 +74,6 @@ async function seedArtifact(jobId: string, files: { name: string; content: strin
     }
 }
 
-const requireRawState = async (studyId: string) => {
-    const raw = await rawStudyStateForStudy(studyId)
-    if (!raw) throw new Error(`no raw study state for study ${studyId}`)
-    return raw
-}
-
 const setupAvailable = async (jobStatus: StudyJobStatus = 'RUN-COMPLETE') => {
     const { org, user } = await mockSessionWithTestData({ orgSlug: 'openstax', orgType: 'enclave' })
     const { study: dbStudy } = await insertTestStudyJobData({ org, researcherId: user.id, jobStatus })
@@ -89,8 +83,6 @@ const setupAvailable = async (jobStatus: StudyJobStatus = 'RUN-COMPLETE') => {
     ;(useParams as Mock).mockReturnValue({ orgSlug: org.slug, studyId: study.id })
     return { org, study, job, raw }
 }
-
-type ScreenInputs = Pick<ScreenComponentProps, 'study' | 'raw'>
 
 const renderScreen = async ({ study, raw }: ScreenInputs, orgSlug: string) =>
     renderWithProviders(await ReviewerOutputsAvailableScreen({ study, raw, orgSlug }))
@@ -198,6 +190,17 @@ describe('ReviewerOutputsAvailableScreen before decryption', () => {
 
     it('shows a not-found alert when the job has not completed a run', async () => {
         const { org, study, raw } = await setupAvailable('JOB-RUNNING')
+        await renderScreen({ study, raw }, org.slug)
+        expect(screen.getByText('Outputs not found')).toBeInTheDocument()
+    })
+
+    // Pins the behavioral edge of the resultsDisplayStatus guard: a decided run (RUN-COMPLETE plus
+    // a later FILES-APPROVED) routes to reviewer-study-results, so this screen must refuse it. The
+    // old timestamp guard would have rendered the panel because a RUN-COMPLETE row still exists.
+    it('shows a not-found alert when the run already has a files decision', async () => {
+        const { org, study, job } = await setupAvailable()
+        await db.insertInto('jobStatusChange').values({ studyJobId: job.id, status: 'FILES-APPROVED' }).execute()
+        const raw = await requireRawState(study.id)
         await renderScreen({ study, raw }, org.slug)
         expect(screen.getByText('Outputs not found')).toBeInTheDocument()
     })

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-available-screen.tsx
@@ -5,25 +5,21 @@ import { ReviewBeforeSharingBanner } from '@/components/study/review-before-shar
 import { StatusAlert, STATUS_ALERT_VARIANT } from '@/components/study/status-alert'
 import { COMPLETED_OUTPUTS_FEEDBACK_MAX_WORDS } from '@/lib/outputs-review'
 import { Routes } from '@/lib/routes'
+import { latestStatusAt } from '@/lib/study-job-status'
+import { projectStudyState } from '@/lib/study-screen'
 import { latestSubmittedJobForStudy } from '@/server/db/queries'
 import type { ScreenComponentProps } from './types'
 
-// statusChanges arrive newest-first (see latestJobForStudyQuery ordering), so `find` picks the
-// most recent RUN-COMPLETE — the moment the outputs became available for review.
-function availableTimestamp(
-    statusChanges: ReadonlyArray<{ status: string; createdAt: Date | string }>,
-): Date | string | null {
-    return statusChanges.find((c) => c.status === 'RUN-COMPLETE')?.createdAt ?? null
+const AvailableBanner = ({ availableAt, labName }: { availableAt: Date | string | null; labName: string }) => {
+    // The date is display-only, so a payload job missing RUN-COMPLETE degrades to an undated
+    // banner rather than blocking a review the state machine already routed here.
+    const availableOn = availableAt ? ` • ${dayjs(availableAt).format('MMM DD, YYYY')}` : ''
+    return (
+        <StatusAlert variant={STATUS_ALERT_VARIANT.action} title={`Outputs are available for review${availableOn}`}>
+            Enter your security key to decrypt the outputs, review them, and then share with {labName}.
+        </StatusAlert>
+    )
 }
-
-const AvailableBanner = ({ availableAt, labName }: { availableAt: Date | string; labName: string }) => (
-    <StatusAlert
-        variant={STATUS_ALERT_VARIANT.action}
-        title={`Outputs are available for review • ${dayjs(availableAt).format('MMM DD, YYYY')}`}
-    >
-        Enter your security key to decrypt the outputs, review them, and then share with {labName}.
-    </StatusAlert>
-)
 
 // OTTER-676: same two-phase panel as the errored screen (OTTER-675) — the security key gate,
 // then the decrypted outputs table, feedback and sharing decision. Only the locked banner copy
@@ -31,18 +27,19 @@ const AvailableBanner = ({ availableAt, labName }: { availableAt: Date | string;
 // which the server derives independently from the job's own status history).
 export async function ReviewerOutputsAvailableScreen({
     study,
+    raw,
     orgSlug,
-}: Pick<ScreenComponentProps, 'study' | 'orgSlug'>) {
-    // Both not-found branches below are defensive: reviewer-screen-rules (rule 1b) routes here
-    // only when a RUN-COMPLETE landed with no files decision, so a routed render always has a
-    // submitted job with a completed run. They guard direct renders, not a reachable state.
+}: Pick<ScreenComponentProps, 'study' | 'raw' | 'orgSlug'>) {
     const job = await latestSubmittedJobForStudy(study.id)
     if (!job) {
         return <AlertNotFound title="No submission found" message="This study has no submitted code to review." />
     }
 
-    const availableAt = availableTimestamp(job.statusChanges)
-    if (!availableAt) {
+    // Guards the same fact rule 1b routes on (reviewer-screen-rules), so routing and rendering
+    // cannot disagree about whether outputs are available (#922 review). The query above supplies
+    // only the panel's job payload.
+    const state = projectStudyState(raw)
+    if (state.resultsDisplayStatus !== 'RUN-COMPLETE') {
         return (
             <AlertNotFound
                 title="Outputs not found"
@@ -52,6 +49,7 @@ export async function ReviewerOutputsAvailableScreen({
     }
 
     const labName = study.submittingLabName ?? study.submittedByOrgSlug
+    const availableAt = latestStatusAt(job.statusChanges, 'RUN-COMPLETE')
 
     return (
         <OutputsReviewPanel

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.test.tsx
@@ -17,6 +17,7 @@ import type { FileType, StudyJobStatus } from '@/database/types'
 import { getStudyAction } from '@/server/actions/study.actions'
 import { fetchEncryptedJobFilesAction } from '@/server/actions/study-job.actions'
 import { latestJobForStudy } from '@/server/db/queries'
+import { rawStudyStateForStudy } from '@/server/db/study-state-query'
 import { ReviewerOutputsErroredScreen } from './reviewer-outputs-errored-screen'
 import type { ScreenComponentProps } from './types'
 
@@ -61,17 +62,26 @@ async function seedArtifact(jobId: string, files: { name: string; content: strin
     }
 }
 
+const requireRawState = async (studyId: string) => {
+    const raw = await rawStudyStateForStudy(studyId)
+    if (!raw) throw new Error(`no raw study state for study ${studyId}`)
+    return raw
+}
+
 const setupErrored = async (jobStatus: StudyJobStatus = 'JOB-ERRORED') => {
     const { org, user } = await mockSessionWithTestData({ orgSlug: 'openstax', orgType: 'enclave' })
     const { study: dbStudy } = await insertTestStudyJobData({ org, researcherId: user.id, jobStatus })
     const study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
     const job = await latestJobForStudy(dbStudy.id)
+    const raw = await requireRawState(dbStudy.id)
     ;(useParams as Mock).mockReturnValue({ orgSlug: org.slug, studyId: study.id })
-    return { org, study, job }
+    return { org, study, job, raw }
 }
 
-const renderScreen = async (study: ScreenComponentProps['study'], orgSlug: string) =>
-    renderWithProviders(await ReviewerOutputsErroredScreen({ study, orgSlug }))
+type ScreenInputs = Pick<ScreenComponentProps, 'study' | 'raw'>
+
+const renderScreen = async ({ study, raw }: ScreenInputs, orgSlug: string) =>
+    renderWithProviders(await ReviewerOutputsErroredScreen({ study, raw, orgSlug }))
 
 const unlock = async () => {
     fireEvent.change(screen.getByRole('textbox'), { target: { value: await readTestSupportFile('private_key.pem') } })
@@ -84,8 +94,8 @@ describe('ReviewerOutputsErroredScreen before decryption', () => {
     })
 
     it('renders the shared page and section headers', async () => {
-        const { org, study } = await setupErrored()
-        await renderScreen(study, org.slug)
+        const { org, study, raw } = await setupErrored()
+        await renderScreen({ study, raw }, org.slug)
 
         expect(screen.getByRole('heading', { level: 1, name: 'Secondary analysis study' })).toBeInTheDocument()
         expect(screen.getByTestId('proposal-section-header')).toHaveTextContent('STEP 3')
@@ -93,8 +103,8 @@ describe('ReviewerOutputsErroredScreen before decryption', () => {
     })
 
     it('asks for the security key rather than showing the review view', async () => {
-        const { org, study } = await setupErrored()
-        await renderScreen(study, org.slug)
+        const { org, study, raw } = await setupErrored()
+        await renderScreen({ study, raw }, org.slug)
 
         expect(screen.getByRole('heading', { name: /security key/i })).toBeInTheDocument()
         expect(screen.getByTestId('status-alert')).toHaveTextContent('Code errored')
@@ -103,8 +113,8 @@ describe('ReviewerOutputsErroredScreen before decryption', () => {
     // The two-part gate: JOB-ERRORED alone must not surface the outputs. Only a validated key
     // does, which is why this screen is a client phase flip and not a route.
     it('hides the outputs table, decision section and submit until a key validates', async () => {
-        const { org, study } = await setupErrored()
-        await renderScreen(study, org.slug)
+        const { org, study, raw } = await setupErrored()
+        await renderScreen({ study, raw }, org.slug)
 
         expect(screen.queryByTestId('outputs-files-section')).toBeNull()
         expect(screen.queryByTestId('outputs-decision-section')).toBeNull()
@@ -112,11 +122,11 @@ describe('ReviewerOutputsErroredScreen before decryption', () => {
     })
 
     it('keeps the outputs hidden when the key is wrong', async () => {
-        const { org, study, job } = await setupErrored()
+        const { org, study, job, raw } = await setupErrored()
         vi.mocked(fetchEncryptedJobFilesAction).mockResolvedValue([
             await seedArtifact(job.id, [{ name: 'run.log', content: 'boom' }], 'ENCRYPTED-CODE-RUN-LOG'),
         ])
-        await renderScreen(study, org.slug)
+        await renderScreen({ study, raw }, org.slug)
         await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
 
         fireEvent.change(screen.getByRole('textbox'), { target: { value: 'not-a-real-key' } })
@@ -131,8 +141,8 @@ describe('ReviewerOutputsErroredScreen before decryption', () => {
     // The default mock serves no artifacts, which is a legitimate state (no registered reviewer
     // key, or a failed fetch). A well-formed key must not unlock the review view against nothing.
     it('does not unlock the review view when there are no artifacts to decrypt', async () => {
-        const { org, study } = await setupErrored()
-        await renderScreen(study, org.slug)
+        const { org, study, raw } = await setupErrored()
+        await renderScreen({ study, raw }, org.slug)
         await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
 
         await unlock()
@@ -143,8 +153,8 @@ describe('ReviewerOutputsErroredScreen before decryption', () => {
     })
 
     it('links Previous step to the read-only code page for this study', async () => {
-        const { org, study } = await setupErrored()
-        await renderScreen(study, org.slug)
+        const { org, study, raw } = await setupErrored()
+        await renderScreen({ study, raw }, org.slug)
 
         expect(screen.getByRole('link', { name: /previous step/i })).toHaveAttribute(
             'href',
@@ -153,8 +163,8 @@ describe('ReviewerOutputsErroredScreen before decryption', () => {
     })
 
     it('reports a missing error status rather than rendering the screen', async () => {
-        const { org, study } = await setupErrored('JOB-RUNNING')
-        await renderScreen(study, org.slug)
+        const { org, study, raw } = await setupErrored('JOB-RUNNING')
+        await renderScreen({ study, raw }, org.slug)
 
         expect(screen.getByText('No error found')).toBeInTheDocument()
     })
@@ -166,11 +176,11 @@ describe('ReviewerOutputsErroredScreen after decryption', () => {
     })
 
     const setupDecrypted = async (files: { name: string; content: string }[]) => {
-        const { org, study, job } = await setupErrored()
+        const { org, study, job, raw } = await setupErrored()
         vi.mocked(fetchEncryptedJobFilesAction).mockResolvedValue([
             await seedArtifact(job.id, files, 'ENCRYPTED-CODE-RUN-LOG'),
         ])
-        await renderScreen(study, org.slug)
+        await renderScreen({ study, raw }, org.slug)
         await waitFor(() => expect(vi.mocked(fetchEncryptedJobFilesAction)).toHaveBeenCalled())
         await unlock()
         await waitFor(() => expect(screen.getByTestId('outputs-files-section')).toBeInTheDocument())

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.test.tsx
@@ -10,16 +10,16 @@ import {
     mockSessionWithTestData,
     readTestSupportFile,
     renderWithProviders,
+    requireRawState,
     screen,
+    type ScreenInputs,
     waitFor,
 } from '@/tests/unit.helpers'
 import type { FileType, StudyJobStatus } from '@/database/types'
 import { getStudyAction } from '@/server/actions/study.actions'
 import { fetchEncryptedJobFilesAction } from '@/server/actions/study-job.actions'
 import { latestJobForStudy } from '@/server/db/queries'
-import { rawStudyStateForStudy } from '@/server/db/study-state-query'
 import { ReviewerOutputsErroredScreen } from './reviewer-outputs-errored-screen'
-import type { ScreenComponentProps } from './types'
 
 vi.mock('@/server/actions/study-job.actions', async () => {
     const actual = await vi.importActual<typeof import('@/server/actions/study-job.actions')>(
@@ -62,12 +62,6 @@ async function seedArtifact(jobId: string, files: { name: string; content: strin
     }
 }
 
-const requireRawState = async (studyId: string) => {
-    const raw = await rawStudyStateForStudy(studyId)
-    if (!raw) throw new Error(`no raw study state for study ${studyId}`)
-    return raw
-}
-
 const setupErrored = async (jobStatus: StudyJobStatus = 'JOB-ERRORED') => {
     const { org, user } = await mockSessionWithTestData({ orgSlug: 'openstax', orgType: 'enclave' })
     const { study: dbStudy } = await insertTestStudyJobData({ org, researcherId: user.id, jobStatus })
@@ -77,8 +71,6 @@ const setupErrored = async (jobStatus: StudyJobStatus = 'JOB-ERRORED') => {
     ;(useParams as Mock).mockReturnValue({ orgSlug: org.slug, studyId: study.id })
     return { org, study, job, raw }
 }
-
-type ScreenInputs = Pick<ScreenComponentProps, 'study' | 'raw'>
 
 const renderScreen = async ({ study, raw }: ScreenInputs, orgSlug: string) =>
     renderWithProviders(await ReviewerOutputsErroredScreen({ study, raw, orgSlug }))
@@ -164,6 +156,19 @@ describe('ReviewerOutputsErroredScreen before decryption', () => {
 
     it('reports a missing error status rather than rendering the screen', async () => {
         const { org, study, raw } = await setupErrored('JOB-RUNNING')
+        await renderScreen({ study, raw }, org.slug)
+
+        expect(screen.getByText('No error found')).toBeInTheDocument()
+    })
+
+    // Pins the behavioral edge of the awaitingFilesDecisionOnError guard: a decided errored run
+    // (JOB-ERRORED plus FILES-APPROVED) routes to reviewer-study-results, so this screen must
+    // refuse it. The old timestamp guard would have rendered the panel because a JOB-ERRORED row
+    // still exists.
+    it('shows a not-found alert when the errored run already has a files decision', async () => {
+        const { org, study, job } = await setupErrored()
+        await db.insertInto('jobStatusChange').values({ studyJobId: job.id, status: 'FILES-APPROVED' }).execute()
+        const raw = await requireRawState(study.id)
         await renderScreen({ study, raw }, org.slug)
 
         expect(screen.getByText('No error found')).toBeInTheDocument()

--- a/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/reviewer-outputs-errored-screen.tsx
@@ -5,37 +5,41 @@ import { ReviewBeforeSharingBanner } from '@/components/study/review-before-shar
 import { StatusAlert, STATUS_ALERT_VARIANT } from '@/components/study/status-alert'
 import { ERRORED_OUTPUTS_FEEDBACK_MAX_WORDS } from '@/lib/outputs-review'
 import { Routes } from '@/lib/routes'
+import { latestStatusAt } from '@/lib/study-job-status'
+import { awaitingFilesDecisionOnError, projectStudyState } from '@/lib/study-screen'
 import { latestSubmittedJobForStudy } from '@/server/db/queries'
 import type { ScreenComponentProps } from './types'
 
-const ErroredBanner = ({ erroredAt }: { erroredAt: Date | string }) => (
-    <StatusAlert
-        variant={STATUS_ALERT_VARIANT.action}
-        title={`Code errored • ${dayjs(erroredAt).format('MMM DD, YYYY')}`}
-    >
-        Enter your security key below to access the outputs and see what went wrong.
-    </StatusAlert>
-)
+const ErroredBanner = ({ erroredAt }: { erroredAt: Date | string | null }) => {
+    // The date is display-only, so a payload job missing JOB-ERRORED degrades to an undated
+    // banner rather than blocking the triage the state machine already routed here.
+    const erroredOn = erroredAt ? ` • ${dayjs(erroredAt).format('MMM DD, YYYY')}` : ''
+    return (
+        <StatusAlert variant={STATUS_ALERT_VARIANT.action} title={`Code errored${erroredOn}`}>
+            Enter your security key below to access the outputs and see what went wrong.
+        </StatusAlert>
+    )
+}
 
 export async function ReviewerOutputsErroredScreen({
     study,
+    raw,
     orgSlug,
-}: Pick<ScreenComponentProps, 'study' | 'orgSlug'>) {
-    // Uses the same "latest submitted job" anchor as the state machine's latestJob()
-    // so the job here always matches the one that set state.resultsErrored.
-    // The not-found guards below are unreachable via normal routing but protect against
-    // direct URL navigation that bypasses the state machine.
+}: Pick<ScreenComponentProps, 'study' | 'raw' | 'orgSlug'>) {
     const job = await latestSubmittedJobForStudy(study.id)
     if (!job) {
         return <AlertNotFound title="No submission found" message="This study has no submitted code to review." />
     }
 
-    const erroredAt = job.statusChanges.find((c) => c.status === 'JOB-ERRORED')?.createdAt ?? null
-    if (!erroredAt) {
+    // Guards the same predicate rule 1a routes on (reviewer-screen-rules), so routing and rendering
+    // cannot disagree about whether an error awaits triage (#922 review). The query above supplies
+    // only the panel's job payload.
+    if (!awaitingFilesDecisionOnError(projectStudyState(raw))) {
         return <AlertNotFound title="No error found" message="This study has not encountered an error." />
     }
 
     const labName = study.submittingLabName ?? study.submittedByOrgSlug
+    const erroredAt = latestStatusAt(job.statusChanges, 'JOB-ERRORED')
 
     return (
         <OutputsReviewPanel

--- a/src/lib/study-job-status.test.ts
+++ b/src/lib/study-job-status.test.ts
@@ -3,6 +3,7 @@ import type { StudyJobStatus } from '@/database/types'
 import {
     currentExecutionStage,
     latestCodeChangeIsSubmission,
+    latestStatusAt,
     latestSubmittedJobHasLiveCodeDecision,
 } from './study-job-status'
 
@@ -143,5 +144,62 @@ describe('currentExecutionStage', () => {
                 { status: 'JOB-RUNNING', createdAt: '2026-07-20T11:00:00Z' },
             ]),
         ).toEqual({ status: 'JOB-RUNNING', startedAt: '2026-07-20T11:00:00Z' })
+    })
+})
+
+describe('latestStatusAt', () => {
+    it('returns null when the status never occurred', () => {
+        expect(latestStatusAt([], 'RUN-COMPLETE')).toBeNull()
+        expect(latestStatusAt([{ status: 'JOB-RUNNING', createdAt: new Date() }], 'RUN-COMPLETE')).toBeNull()
+    })
+
+    it('returns the timestamp of the requested status', () => {
+        const completedAt = new Date('2026-07-20T12:00:00Z')
+        expect(
+            latestStatusAt(
+                [
+                    { status: 'JOB-RUNNING', createdAt: new Date('2026-07-20T10:00:00Z') },
+                    { status: 'RUN-COMPLETE', createdAt: completedAt },
+                ],
+                'RUN-COMPLETE',
+            ),
+        ).toBe(completedAt)
+    })
+
+    // Selection is by timestamp, not array position, so a caller's query ordering (newest-first,
+    // oldest-first, or tied-and-arbitrary) cannot change which occurrence dates the display.
+    it('picks the most recent occurrence regardless of array order', () => {
+        const rerunAt = new Date('2026-07-21T09:00:00Z')
+        const firstRunAt = new Date('2026-07-20T12:00:00Z')
+        expect(
+            latestStatusAt(
+                [
+                    { status: 'RUN-COMPLETE', createdAt: rerunAt },
+                    { status: 'RUN-COMPLETE', createdAt: firstRunAt },
+                ],
+                'RUN-COMPLETE',
+            ),
+        ).toBe(rerunAt)
+        expect(
+            latestStatusAt(
+                [
+                    { status: 'RUN-COMPLETE', createdAt: firstRunAt },
+                    { status: 'RUN-COMPLETE', createdAt: rerunAt },
+                ],
+                'RUN-COMPLETE',
+            ),
+        ).toBe(rerunAt)
+    })
+
+    it('accepts ISO string timestamps', () => {
+        expect(
+            latestStatusAt(
+                [
+                    { status: 'RUN-COMPLETE', createdAt: '2026-07-20T12:00:00Z' },
+                    { status: 'RUN-COMPLETE', createdAt: '2026-07-21T09:00:00Z' },
+                ],
+                'RUN-COMPLETE',
+            ),
+        ).toBe('2026-07-21T09:00:00Z')
     })
 })

--- a/src/lib/study-job-status.ts
+++ b/src/lib/study-job-status.ts
@@ -37,6 +37,20 @@ export function currentExecutionStage(
     return { status: latest.status, startedAt: latest.createdAt }
 }
 
+// The most recent time `status` was recorded on the job, or null if it never was. Selected by
+// timestamp, not array position: statusChanges ordering differs by query, and rows written in one
+// transaction tie on createdAt (see latestSubmittedJobHasLiveCodeDecision), so callers must not
+// inherit a hidden ordering contract. Ties are irrelevant to its one job: dating a status for display.
+export function latestStatusAt(
+    statusChanges: ReadonlyArray<{ status: StudyJobStatus; createdAt: Date | string }>,
+    status: StudyJobStatus,
+): Date | string | null {
+    const matches = statusChanges.filter((c) => c.status === status)
+    if (matches.length === 0) return null
+    const latest = matches.reduce((a, b) => (new Date(b.createdAt) > new Date(a.createdAt) ? b : a))
+    return latest.createdAt
+}
+
 // Code submitted and awaiting a review decision.
 export const CODE_UNDER_REVIEW_JOB_STATUSES: readonly StudyJobStatus[] = ['CODE-SUBMITTED', 'CODE-SCANNED']
 

--- a/src/lib/study-screen/resolve.test.ts
+++ b/src/lib/study-screen/resolve.test.ts
@@ -187,9 +187,13 @@ describe('resolveScreen (reviewer)', () => {
         ).toBe('reviewer-study-results')
     })
     it('undecided results → reviewer-outputs-available (decrypt-before-review, OTTER-668)', () => {
-        expect(resolveScreen('reviewer', state({ hasResults: true, codeDecision: 'CODE-APPROVED' }), ctx).screen).toBe(
-            'reviewer-outputs-available',
-        )
+        expect(
+            resolveScreen(
+                'reviewer',
+                state({ hasResults: true, resultsDisplayStatus: 'RUN-COMPLETE', codeDecision: 'CODE-APPROVED' }),
+                ctx,
+            ).screen,
+        ).toBe('reviewer-outputs-available')
     })
     it('pending review → reviewer-proposal-review', () => {
         expect(resolveScreen('reviewer', state({ status: 'PENDING-REVIEW', isDraft: false }), ctx).screen).toBe(

--- a/src/lib/study-screen/reviewer-screen-rules.ts
+++ b/src/lib/study-screen/reviewer-screen-rules.ts
@@ -12,16 +12,16 @@ export const REVIEWER_SCREEN_RULES = [
 
     // 1b. Run completed, no files decision yet ("results pending review") → outputs-available view
     //     (OTTER-668). The reviewer enters their security key to decrypt the outputs before making
-    //     a files decision. Sits below 1a so an errored run keeps the errored view even when a
-    //     RUN-COMPLETE also landed.
-    [
-        'reviewer-outputs-available',
-        { when: (s) => s.hasResults && !s.resultsApproved && !s.resultsRejected && !s.resultsErrored },
-    ],
+    //     a files decision. Keyed on resultsDisplayStatus so the result-status priority stays owned
+    //     by the state machine (approved/rejected/errored all out-rank RUN-COMPLETE there) instead
+    //     of being re-derived here, and so routing reads the same fact the screen's own guard
+    //     checks (#922 review).
+    ['reviewer-outputs-available', { when: (s) => s.resultsDisplayStatus === 'RUN-COMPLETE' }],
 
-    // 1c. Results exist → results-only Study Details (OTTER-538). Out-ranks the code decision
-    //     (CODE-APPROVED is always present once results land), mirroring legacy
-    //     `decisionMade = hasLiveCodeDecision && !hasResultsStatus`.
+    // 1c. Results exist and a files decision was recorded → results-only Study Details (OTTER-538).
+    //     1a/1b claim the undecided results states above, so only decided results reach this rule.
+    //     Out-ranks the code decision (CODE-APPROVED is always present once results land), mirroring
+    //     legacy `decisionMade = hasLiveCodeDecision && !hasResultsStatus`.
     ['reviewer-study-results', { when: (s) => s.hasResults }],
 
     // 2. Code approved and executing in the enclave, no results yet → the "Secondary

--- a/tests/unit.helpers.tsx
+++ b/tests/unit.helpers.tsx
@@ -4,6 +4,7 @@ import type { AuditRecordType, Json, Language, StudyJobStatus, StudyStatus } fro
 import { CLERK_ADMIN_ORG_SLUG, UserOrgRoles } from '@/lib/types'
 import { Org } from '@/schema/org'
 import { latestJobForStudy } from '@/server/db/queries'
+import { rawStudyStateForStudy } from '@/server/db/study-state-query'
 import { findOrCreateOrgMembership } from '@/server/mutations'
 import { onSaveDraftStudyAction } from '@/server/actions/study-request'
 import { actionResult } from '@/lib/utils'
@@ -25,6 +26,7 @@ import { useParams } from 'next/navigation'
 import os from 'os'
 import path from 'path'
 import type { StudyRow } from '@/components/dashboard/studies-table/types'
+import type { ScreenComponentProps } from '@/app/[orgSlug]/study/[studyId]/_screens/types'
 
 import { ReactElement, ReactNode } from 'react'
 import { expect, Mock, vi } from 'vitest'
@@ -140,6 +142,17 @@ export function renderWithProviders(ui: ReactElement, options?: Parameters<typeo
 export * from './common.helpers'
 
 export const BLANK_UUID = '00000000-0000-0000-0000-000000000000'
+
+// Screen components take the raw study state their rules routed on (see render-screen.tsx).
+// Screen tests fetch it here and pass the same { study, raw } pick the screens declare, so
+// each screen test file isn't re-declaring the fetch-or-throw and the Pick.
+export type ScreenInputs = Pick<ScreenComponentProps, 'study' | 'raw'>
+
+export const requireRawState = async (studyId: string) => {
+    const raw = await rawStudyStateForStudy(studyId)
+    if (!raw) throw new Error(`no raw study state for study ${studyId}`)
+    return raw
+}
 
 export const insertTestStudyData = async ({
     org,


### PR DESCRIPTION
## Summary

#922 was auto-closed as merged when #928 (stacked on the OTTER-668 branch) landed, which mechanically bypassed the pending changes-requested review. This picks up the review items that weren't already addressed on the OTTER-676 branch:

- **One routing fact.** Rule 1b now keys on `resultsDisplayStatus === 'RUN-COMPLETE'` instead of re-deriving the result-status priority from four booleans, and both outputs screens guard on the same projected state (`projectStudyState(raw)`) their rules route on. Routing and rendering read one fact, so the "stranded on Outputs not found" divergence can't occur; `latestSubmittedJobForStudy` now supplies only the panel's job payload. The errored screen's anchoring comment is gone because the code no longer needs it.
- **Shared, typed timestamp helper.** The per-screen timestamp finders are replaced by `latestStatusAt(statusChanges, status)` in `study-job-status.ts`, typed to `StudyJobStatus` (a `'RUN_COMPLETE'` typo now fails to compile) and selected by timestamp rather than array position, so it carries no hidden ordering contract. The banner date degrades to an undated banner rather than a dead end if the payload job lacks the status row.
- **1c comment.** Reworded to say what the rule actually catches now that 1a/1b claim the undecided results states.

Review notes:

- `resolve.test.ts`'s undecided-results fixture now sets `resultsDisplayStatus: 'RUN-COMPLETE'` — hand-built states must carry the fact the rule keys on, the same coherence argument as the review.
- The remaining #922 item (the silent #921 revert) never reached main: merging main into OTTER-676 re-resolved it, and rule 1a still uses `awaitingFilesDecisionOnError`. No change needed.
- The e2e selector scoping and the researcher errored-view e2e leg were already fixed on OTTER-676 before it merged.

Validation: `pnpm run checks` clean (typecheck, eslint, prettier, validate-actions); 166 unit tests pass across the touched areas (study-screen suite, study-job-status, both outputs screen suites) against a real Postgres 16.