### PR TITLE
Fix two sources of unit-test flakiness from colliding faker fixture data

### DIFF
--- a/src/app/[orgSlug]/dashboard/page.test.tsx
+++ b/src/app/[orgSlug]/dashboard/page.test.tsx
@@ -1,7 +1,7 @@
 import { Org } from '@/schema/org'
 import { getOrgFromSlugAction } from '@/server/actions/org.actions'
 import { fetchStudiesForOrgAction } from '@/server/actions/study.actions'
-import { renderWithProviders, testEmail } from '@/tests/unit.helpers'
+import { renderWithProviders } from '@/tests/unit.helpers'
 import { useUser } from '@clerk/nextjs'
 import { UseUserReturn } from '@clerk/types'
 import { faker } from '@faker-js/faker'
@@ -24,7 +24,7 @@ const mockOrg: Org = {
     id: faker.string.uuid(),
     slug: 'test-org',
     name: faker.company.name(),
-    email: testEmail(),
+    email: faker.internet.email({ provider: 'test.com' }),
     type: 'enclave',
     settings: { publicKey: 'fake-key' },
     description: null,

--- a/src/app/[orgSlug]/dashboard/page.test.tsx
+++ b/src/app/[orgSlug]/dashboard/page.test.tsx
@@ -1,7 +1,7 @@
 import { Org } from '@/schema/org'
 import { getOrgFromSlugAction } from '@/server/actions/org.actions'
 import { fetchStudiesForOrgAction } from '@/server/actions/study.actions'
-import { renderWithProviders } from '@/tests/unit.helpers'
+import { renderWithProviders, testEmail } from '@/tests/unit.helpers'
 import { useUser } from '@clerk/nextjs'
 import { UseUserReturn } from '@clerk/types'
 import { faker } from '@faker-js/faker'
@@ -24,7 +24,7 @@ const mockOrg: Org = {
     id: faker.string.uuid(),
     slug: 'test-org',
     name: faker.company.name(),
-    email: faker.internet.email({ provider: 'test.com' }),
+    email: testEmail(),
     type: 'enclave',
     settings: { publicKey: 'fake-key' },
     description: null,

--- a/src/app/account/invitation/[inviteId]/create-account.action.test.ts
+++ b/src/app/account/invitation/[inviteId]/create-account.action.test.ts
@@ -6,6 +6,7 @@ import {
     insertTestUser,
     mockClerkSession,
     mockSessionWithTestData,
+    testEmail,
 } from '@/tests/unit.helpers'
 import { auth as clerkAuth, clerkClient } from '@clerk/nextjs/server'
 import { v7 } from 'uuid'
@@ -75,7 +76,7 @@ describe('Create Account Actions', () => {
             .insertInto('pendingUser')
             .values({
                 orgId: org.id,
-                email: faker.internet.email({ provider: 'test.com' }),
+                email: testEmail(),
                 isAdmin: false,
                 invitedByUserId: invitingUser.user.id,
             })
@@ -144,7 +145,7 @@ describe('Create Account Actions', () => {
             .insertInto('pendingUser')
             .values({
                 orgId: org.id,
-                email: faker.internet.email({ provider: 'test.com' }),
+                email: testEmail(),
                 isAdmin: false,
                 invitedByUserId: invitingUser.user.id,
             })
@@ -248,7 +249,7 @@ describe('Create Account Actions', () => {
             .insertInto('pendingUser')
             .values({
                 orgId: targetOrg.id,
-                email: faker.internet.email({ provider: 'test.com' }),
+                email: testEmail(),
                 isAdmin: false,
                 invitedByUserId: invitingUser.user.id,
             })
@@ -293,7 +294,7 @@ describe('Create Account Actions', () => {
             .insertInto('pendingUser')
             .values({
                 orgId: contributorOrg.id,
-                email: faker.internet.email({ provider: 'test.com' }),
+                email: testEmail(),
                 isAdmin: false,
                 invitedByUserId: invitingUser.user.id,
             })
@@ -304,7 +305,7 @@ describe('Create Account Actions', () => {
             .insertInto('pendingUser')
             .values({
                 orgId: adminOrg.id,
-                email: faker.internet.email({ provider: 'test.com' }),
+                email: testEmail(),
                 isAdmin: true,
                 invitedByUserId: invitingUser.user.id,
             })
@@ -519,7 +520,7 @@ describe('Create Account Actions', () => {
             .insertInto('pendingUser')
             .values({
                 orgId: opts.orgId ?? org.id,
-                email: opts.email ?? faker.internet.email({ provider: 'test.com' }).toLowerCase(),
+                email: opts.email ?? testEmail().toLowerCase(),
                 isAdmin: false,
                 invitedByUserId: invitingUser.user.id,
                 claimedByUserId: opts.claimedByUserId ?? null,
@@ -607,7 +608,7 @@ describe('Create Account Actions', () => {
             .insertInto('pendingUser')
             .values({
                 orgId: org.id,
-                email: faker.internet.email({ provider: 'test.com' }),
+                email: testEmail(),
                 isAdmin: false,
                 invitedByUserId: invitingUser.user.id,
             })
@@ -634,7 +635,7 @@ describe('Create Account Actions', () => {
             .insertInto('pendingUser')
             .values({
                 orgId: org.id,
-                email: faker.internet.email({ provider: 'test.com' }),
+                email: testEmail(),
                 isAdmin: false,
                 invitedByUserId: invitingUser.user.id,
                 claimedByUserId: user.id,
@@ -660,7 +661,7 @@ describe('Create Account Actions', () => {
             .insertInto('pendingUser')
             .values({
                 orgId: org.id,
-                email: faker.internet.email({ provider: 'test.com' }),
+                email: testEmail(),
                 isAdmin: false,
                 invitedByUserId: invitingUser.user.id,
                 claimedByUserId: invitingUser.user.id,
@@ -685,7 +686,7 @@ describe('Create Account Actions', () => {
             .insertInto('pendingUser')
             .values({
                 orgId: org.id,
-                email: faker.internet.email({ provider: 'test.com' }),
+                email: testEmail(),
                 isAdmin: false,
                 invitedByUserId: invitingUser.user.id,
             })
@@ -712,7 +713,7 @@ describe('Create Account Actions', () => {
             .insertInto('pendingUser')
             .values({
                 orgId: org.id,
-                email: faker.internet.email({ provider: 'test.com' }),
+                email: testEmail(),
                 isAdmin: false,
                 invitedByUserId: invitingUser.user.id,
                 claimedByUserId: invitingUser.user.id,
@@ -729,7 +730,7 @@ describe('Create Account Actions', () => {
             .insertInto('pendingUser')
             .values({
                 orgId: org.id,
-                email: faker.internet.email({ provider: 'test.com' }),
+                email: testEmail(),
                 isAdmin: false,
                 invitedByUserId: invitingUser.user.id,
                 claimedByUserId: invitingUser.user.id,

--- a/src/components/researcher-profile/personal-info-section.test.tsx
+++ b/src/components/researcher-profile/personal-info-section.test.tsx
@@ -13,6 +13,13 @@ import { PersonalInfoSection } from './personal-info-section'
 import { notifications } from '@mantine/notifications'
 
 describe('PersonalInfoSection', () => {
+    // usePersonalInfoSection deliberately closes edit mode without calling the action when the
+    // form is pristine (see 'should close edit mode without API call when no changes are made').
+    // The seeded user gets a faker-random name, so typing a hardcoded literal stops exercising
+    // the save at all on the runs where faker happens to emit that same name. Deriving the edit
+    // from the seeded value keeps the form dirty whatever faker produced.
+    const editOf = (seededName: string) => `${seededName}Edited`
+
     it('should display user data in view mode', async () => {
         const { user } = await mockSessionWithTestData({ orgType: 'lab' })
 
@@ -68,11 +75,13 @@ describe('PersonalInfoSection', () => {
 
         const firstNameInput = screen.getByPlaceholderText('Enter your first name')
         const lastNameInput = screen.getByPlaceholderText('Enter your last name')
+        const newFirstName = editOf(user.firstName)
+        const newLastName = editOf(user.lastName!)
 
         await userEvents.clear(firstNameInput)
         await userEvents.clear(lastNameInput)
-        await userEvents.type(firstNameInput, 'Jane')
-        await userEvents.type(lastNameInput, 'Smith')
+        await userEvents.type(firstNameInput, newFirstName)
+        await userEvents.type(lastNameInput, newLastName)
 
         const saveButton = screen.getByRole('button', { name: /save changes/i })
         await userEvents.click(saveButton)
@@ -89,8 +98,8 @@ describe('PersonalInfoSection', () => {
             .where('id', '=', user.id)
             .executeTakeFirstOrThrow()
 
-        expect(updated.firstName).toBe('Jane')
-        expect(updated.lastName).toBe('Smith')
+        expect(updated.firstName).toBe(newFirstName)
+        expect(updated.lastName).toBe(newLastName)
     })
 
     it('should show error notification on save failure', async () => {
@@ -113,7 +122,7 @@ describe('PersonalInfoSection', () => {
 
         const firstNameInput = screen.getByPlaceholderText('Enter your first name')
         await userEvents.clear(firstNameInput)
-        await userEvents.type(firstNameInput, 'Jane')
+        await userEvents.type(firstNameInput, editOf(user.firstName))
 
         const saveButton = screen.getByRole('button', { name: /save changes/i })
         await userEvents.click(saveButton)

--- a/src/server/user-sync.test.ts
+++ b/src/server/user-sync.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { db, insertTestOrg, insertTestUser, faker } from '@/tests/unit.helpers'
+import { db, insertTestOrg, insertTestUser, faker, testEmail } from '@/tests/unit.helpers'
 
 const mockProdEnv = vi.hoisted(() => ({ value: false }))
 
@@ -22,7 +22,7 @@ describe('syncUserToDatabase', () => {
             clerkId: faker.string.alpha(10),
             firstName: 'Test',
             lastName: 'User',
-            email: faker.internet.email({ provider: 'test.com' }),
+            email: testEmail(),
         }
 
         const result = await db.transaction().execute(async (trx) => {
@@ -45,7 +45,7 @@ describe('syncUserToDatabase', () => {
             clerkId: faker.string.alpha(10),
             firstName: 'Test',
             lastName: 'User',
-            email: faker.internet.email({ provider: 'test.com' }),
+            email: testEmail(),
             metadataUserId: faker.string.uuid(),
         }
 
@@ -196,7 +196,7 @@ describe('syncUserToDatabaseWithConflictResolution', () => {
             clerkId: faker.string.alpha(10),
             firstName: 'New',
             lastName: 'User',
-            email: faker.internet.email({ provider: 'test.com' }),
+            email: testEmail(),
         }
 
         await syncUserToDatabaseWithConflictResolution(attrs, onConflictResolved)

--- a/tests/unit.helpers.tsx
+++ b/tests/unit.helpers.tsx
@@ -141,6 +141,24 @@ export * from './common.helpers'
 
 export const BLANK_UUID = '00000000-0000-0000-0000-000000000000'
 
+// faker.internet.email() draws its local part from the shared name pools plus a small numeric
+// suffix, a space narrow enough that a full run (thousands of users) hands out the same address
+// twice and user_email_lower_unique rejects the second insert, surfacing as a duplicate-key error
+// in whichever unrelated test lost the race. The appended discriminator removes the draw from the
+// equation: the counter separates addresses within a worker, the token separates workers without
+// depending on how vitest pools them (faker is unseeded, so each worker draws its own).
+//
+// faker's casing is preserved, so callers still get the mixed-case addresses they got before.
+// Tests that need two records to share an address must pass it explicitly rather than hoping for
+// a collision.
+let emailSequence = 0
+const emailWorkerToken = faker.string.alphanumeric({ length: 6, casing: 'lower' })
+
+export const testEmail = (provider = 'test.com') => {
+    const [localPart] = faker.internet.email({ provider }).split('@')
+    return `${localPart}-${emailWorkerToken}${++emailSequence}@${provider}`
+}
+
 export const insertTestStudyData = async ({
     org,
     researcherId,
@@ -265,7 +283,7 @@ export const insertTestUser = async ({
             clerkId: faker.string.alpha(10),
             firstName: faker.person.firstName(),
             lastName: faker.person.lastName(),
-            email: email ?? faker.internet.email({ provider: 'test.com' }),
+            email: email ?? testEmail(),
         })
         .returningAll()
         .executeTakeFirstOrThrow()
@@ -583,7 +601,7 @@ export const mockClerkSession = (values: MockSession | null) => {
         teams: null,
         orgs,
     }
-    const mockEmail = values.email || faker.internet.email({ provider: 'test.com' })
+    const mockEmail = values.email || testEmail()
     const userProperties = {
         id: values.clerkUserId,
         banned: false,

--- a/tests/unit.helpers.tsx
+++ b/tests/unit.helpers.tsx
@@ -141,12 +141,16 @@ export * from './common.helpers'
 
 export const BLANK_UUID = '00000000-0000-0000-0000-000000000000'
 
-// faker.internet.email() draws its local part from the shared name pools plus a small numeric
-// suffix, a space narrow enough that a full run (thousands of users) hands out the same address
-// twice and user_email_lower_unique rejects the second insert, surfacing as a duplicate-key error
-// in whichever unrelated test lost the race. The appended discriminator removes the draw from the
-// equation: the counter separates addresses within a worker, the token separates workers without
-// depending on how vitest pools them (faker is unseeded, so each worker draws its own).
+// Generates a throwaway address for a user row. faker.internet.email() draws its local part from
+// the shared name pools plus a small numeric suffix, an effective space of roughly 1.9M addresses,
+// narrow enough that a full run repeats one and user_email_lower_unique rejects the second insert,
+// surfacing as a duplicate-key error in whichever unrelated test lost the race.
+//
+// The counter makes addresses unique within a worker outright. Across workers and across runs the
+// token carries it: a repeat would need the same token, the same local part and the same sequence
+// number, which is not impossible but is far below the rate of any other flake in the suite. The
+// token rather than a worker id keeps this independent of how vitest pools tests (faker is
+// unseeded, so each worker draws its own).
 //
 // faker's casing is preserved, so callers still get the mixed-case addresses they got before.
 // Tests that need two records to share an address must pass it explicitly rather than hoping for


### PR DESCRIPTION
Two independent sources of unit-test flakiness, both caused by faker handing out the same fixture value twice. Each is fixed at the generator that produced the collision, not at the assertion that noticed it.

## How often these broke a run

| Flake | Chance of breaking a given full-suite run |
| --- | --- |
| Duplicate generated email address | **~10 to 14%**, and rising as the test DB accumulates rows |
| Colliding first name in the personal-info save | **~0.06%** (about 1 run in 1,700) |
| **Either** | **~10 to 14%** |

The email one is the big one, and it gets worse over time rather than staying put: against the 198 leftover rows currently in the unit-test database it is ~10 to 14% per run, reaching roughly 53% at 1,000 leftovers and 78% at 2,000.

The name figure is a direct measurement. The email figure is a modelled estimate from measured inputs, and the range reflects one input that is bounded rather than counted exactly; the model and its limits are set out below. Both are stated to two significant figures at most because the inputs do not support more.

## 1. Duplicate generated email addresses (~10 to 14%)

A full-suite run failed with:

```
duplicate key value violates unique constraint "user_email_lower_unique"
Key (lower(email))=(peggy90@test.com) already exists.
```

`faker.internet.email()` draws its local part from the shared name pools plus a small numeric suffix. Counting colliding pairs across a single sample of 600,000 draws puts the generator's effective address space at **1,899,332** distinct addresses, which is small relative to how many users the suite creates.

Two further measurements pin down the rest:

- A full run inserts **1,436 rows into `user`**, counted from `pg_stat_user_tables.n_tup_ins` before and after a run.
- The unit-test database currently holds **198 committed users** with `@test.com` addresses, dating back across several days, so rows are escaping the per-test transaction rollback and accumulating from run to run.

Those two facts together are what break a run. Each test rolls back in its own transaction, so a duplicate drawn by two *different* tests never conflicts, and two colliding inserts in different workers merely make one wait for the other's rollback. What does fail is a fresh draw landing on one of the already-committed leftovers, which is a birthday calculation against a fixed set:

```text
1 - (1 - 198/1,899,332) ^ D
    D = 1436  ->  13.9%
    D = 1000  ->   9.9%
```

Hence the ~10 to 14% range rather than a single figure. `D` is the number of *generated* addresses per run, and the 1,436 measured inserts are an upper bound on it: some of those rows carry an explicitly passed, QA-prefixed, or deliberately reused address rather than a fresh draw. The 198 retained addresses are likewise not a guaranteed-unbiased sample of the generator. So this is an order-of-magnitude estimate from measured inputs, not a precise run-failure probability. What it does establish is the scale, roughly one run in eight, and the direction: the rate climbs with the leftover count, to about 53% at 1,000 leftovers and 78% at 2,000.

The observed failure is exactly that mechanism, not a within-run coincidence. `Peggy90@test.com` was already sitting in the database, committed on 2026-08-04, when a run two days later drew the same address:

```
      email       |          created_at
------------------+-------------------------------
 Peggy90@test.com | 2026-08-04 20:21:30.393511+00
```

A single `testEmail()` helper in `tests/unit.helpers.tsx` now appends a discriminator, so uniqueness is a property of the generator rather than of the draw:

```ts
export const testEmail = (provider = 'test.com') => {
    const [localPart] = faker.internet.email({ provider }).split('@')
    return `${localPart}-${emailWorkerToken}${++emailSequence}@${provider}`
}
```

The counter makes addresses unique within a worker outright. Across workers, and across a run and every earlier run's leftovers, the token carries it: a repeat needs the same token *and* the same local part *and* the same sequence number. That is not literally guaranteed, but it sits far below the rate of any other flake in the suite, so the accumulated rows stop mattering in practice. Using the token rather than a worker id keeps this independent of how vitest pools tests (faker is unseeded, so each worker draws its own).

Drawing 3,000 addresses produced a duplicate in **91.3%** of trials (±1.4 at 95% confidence, 1,500 trials) with the old generator and **0%** with this one. That measurement agrees with the 90.6% the space estimate above predicts, which is the cross-check that the two numbers are consistent.

The change is one central fix plus defensive conversions:

- **Central:** `insertTestUser()` in `tests/unit.helpers.tsx` is the generator behind the overwhelming majority of user rows, and is what the observed failure came through.
- **Also user rows:** the Clerk session mock in the same file, and the invitation addresses in `create-account.action.test.ts`, which become `user` rows once an invite is accepted, plus the three fresh addresses in `user-sync.test.ts`.

That is 17 call sites. faker's own casing is preserved, so callers receive the same mixed-case shape they did before.

Two things were deliberately left alone:

- Tests that *intend* two records to share an address. They pass one explicitly or reuse an existing row's email, as the email-conflict cases in `user-sync.test.ts` do, so changing the generator does not weaken them.
- Org addresses, in `edit-org-form.test.tsx` and `dashboard/page.test.tsx`. Both are in-memory fixtures in render-only tests, and org email has no unique index. `testEmail()` is deliberately scoped to user rows so the reason to use it stays unambiguous.

### This is collision prevention, not test isolation repair

Worth being explicit about the boundary. Rows escaping the per-test rollback is the amplifier that made a duplicate address fatal, and this PR does not fix it. Unique addresses mean the leaked rows can no longer collide with anything, so this particular failure is gone, but leaked state remains capable of causing other trouble and deserves its own card.

What is known about it, so that card starts from evidence rather than a guess:

- The leak is real and steady, at **5 to 10 `user` rows per full run** (counted across five runs).
- Every leaked row carries `first_name = 'Mocked'`, `last_name = 'User'`. That is the fixture identity from the Clerk `users.getUser` mock, not from `insertTestUser`, which uses faker names. So these rows are written by the session-sync path (`src/server/session.ts` reading the mocked Clerk user, then `syncUserToDatabaseWithConflictResolution`), at roughly one row per worker, and not by the fixture helpers this PR touches.
- **Teardown ordering is not the cause.** The obvious hypothesis is that `afterEach` in `tests/vitest.setup.ts` rolls the transaction back before `cleanup()` and the QueryClient reset, letting late work commit outside it. That was tested directly: unmounting, resetting the query clients, and draining deferred callbacks in a loop all *before* the rollback left the leak unchanged at 5, 10, 6 and 9 rows against a baseline of 9. The reordering was therefore reverted rather than carried here as an unverified change to global test setup.

`./bin/docker-test --clean` clears the accumulated rows today.

## 2. Colliding first name in the personal-info save (~0.06% per run)

`PersonalInfoSection > should show error notification on save failure` failed with:

```
AssertionError: expected "vi.fn()" to be called with arguments: [ ObjectContaining{…} ]
Number of calls: 0
```

`usePersonalInfoSection` deliberately closes edit mode without calling the action when the form is pristine:

```ts
if (!form.isDirty()) {
    setIsEditing(false)
    return
}
```

The test cleared the first-name field and typed the literal `Jane`, while the seeded user's name comes from `faker.person.firstName()`. On the runs where faker emitted that same name, clearing and retyping it left the form pristine, so the save was never attempted, no notification was shown, and the assertion reported zero calls.

Measured over 5 million draws, `faker.person.firstName()` returned `Jane` once every **1,676 calls**, or 0.060%. That is more often than the flat 3,186-name pool suggests, because faker picks a sex first and then draws from a weighted combination of the sex-specific and generic pools, so `Jane` competes against a smaller list than the raw total implies. The figure is empirical, and a dataset-derived calculation lands nearby at about 1 in 1,632; either way the headline is ~0.06%. The test creates one user per run, so that is also the per-run failure rate.

The failure DOM showed exactly that state: the section back in view mode, first name `Jane`, last name still the untouched seeded surname.

Both halves arrived together in #506 ([OTTER-389](https://openstax.atlassian.net/browse/OTTER-389)): the test typing the literal, and the `!form.isDirty()` short-circuit that turned the collision into a failure.

The edit is now derived from whatever was seeded, so the form is dirty regardless of the draw:

```ts
const editOf = (seededName: string) => `${seededName}Edited`
```

The assertion is unchanged, so `Save failed` still has to be reached through a real save attempt. No retry, no inline timeout, no weakened expectation.

The sibling `should save name changes and show success notification` test carried the same assumption and is fixed the same way. It needed both `Jane` and `Smith` to collide, which measures at roughly 1 in 800,000 runs, so it was never going to be seen in practice, but it is the same defect.

## How the flakiness evolved

Neither flake came from a single wrong change. Both are intersections that only became reachable once separate, individually reasonable changes met.

The name collision assembled over about a week, entirely inside #506. The hook came first. The test then typed `Jane` into the first-name field, at a point where that was simply a value with nothing to collide against. The `!form.isDirty()` short-circuit arrived next, and it is a correct optimization: there is no reason to call the action when nothing changed, and it has its own test asserting exactly that. Last, the profile tests moved onto real database fixtures, which seed names through `faker.person.firstName()`. Only with all three in place does the literal have something to collide with, and only then does a collision mean the test quietly stops exercising a save while still appearing to assert one. Every step is defensible on its own; the defect lives in the coupling between the short-circuit and the randomized seeding, which is not visible in any of the individual diffs.

The email collision assembled the same way over a much longer period. `faker.internet.email({ provider: 'test.com' })` has been the ordinary way to fabricate a throwaway address across many suites, and for as long as a repeat was harmless, it was fine. Two later changes made repeats fatal. `user_email_lower_unique` (migration `1766441147000_unique_user_email.ts`) turned a duplicate address into a hard error, and rows escaping the per-test rollback gave each run a growing set of committed addresses to collide against. The generator itself never changed. What changed was the cost of a repeat and the number of chances to hit one, which is why this surfaced long after the call sites were written, why it lands on an arbitrary unrelated test, and why its failure rate climbs with every run rather than holding steady.

## Verification

- The name collision was reproduced deterministically by forcing the seeded first name to `Jane`, which failed on the same line with the same DOM as the intermittent failure, then confirmed fixed by re-running that same forced collision against the change.
- Collision rates and the address-space estimate were measured directly with the trial counts quoted above; insert and leak counts came from `pg_stat_user_tables` and row counts taken either side of a run.
- Full unit suite run repeatedly after the change, green every time (261 files, 2,544 tests), plus `pnpm run checks`.


[OTTER-389]: https://openstax.atlassian.net/browse/OTTER-389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ