### PR TITLE
allow manual dismissal of error toasts

### DIFF
--- a/src/app/[orgSlug]/study/request/upload-study-job-code.test.ts
+++ b/src/app/[orgSlug]/study/request/upload-study-job-code.test.ts
@@ -23,10 +23,12 @@ describe('handleDuplicateUpload', () => {
         const mainFile = createFile('main.R')
         const duplicates = [createFile('main.R'), createFile('other.R')]
         expect(handleDuplicateUpload(mainFile, duplicates)).toBe(true)
-        expect(notificationsSpy).toHaveBeenCalledWith({
-            color: 'red',
-            title: 'Duplicate filename',
-            message: expect.stringContaining('main.R'),
-        })
+        expect(notificationsSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                color: 'red',
+                title: 'Duplicate filename',
+                message: expect.stringContaining('main.R'),
+            }),
+        )
     })
 })

--- a/src/app/account/mfa/sms/add-sms-mfa.tsx
+++ b/src/app/account/mfa/sms/add-sms-mfa.tsx
@@ -2,6 +2,7 @@
 
 import { InputError } from '@/components/errors'
 import { Link } from '@/components/links'
+import { ERROR_NOTIFICATION_OPTIONS } from '@/lib/constants'
 import { errorToString } from '@/lib/errors'
 import logger from '@/lib/logger'
 import { sleep } from '@/lib/utils'
@@ -130,7 +131,7 @@ export function AddSMSMFA() {
         if (!otpForm.isValid) return
 
         if (!phoneObj) {
-            notifications.show({ message: 'No phone number found', color: 'red' })
+            notifications.show({ ...ERROR_NOTIFICATION_OPTIONS, message: 'No phone number found' })
             return
         }
 

--- a/src/app/admin/safeinsights/agent-context.tsx
+++ b/src/app/admin/safeinsights/agent-context.tsx
@@ -2,6 +2,7 @@
 
 import { useForm, useMutation, useQuery, useQueryClient } from '@/common'
 import { CONTEXT_LABELS, CONTEXT_NAMES, ContextName } from '@/lib/agent-context'
+import { ERROR_NOTIFICATION_OPTIONS } from '@/lib/constants'
 import { errorToString } from '@/lib/errors'
 import { getAgentContextAction, writeAgentContextAction } from '@/server/actions/agent-context.actions'
 import { Stack, Title, Button, Textarea, Text, Group, Paper } from '@mantine/core'
@@ -31,10 +32,9 @@ function useAgentContextEditor({ name, orgId, initialContent }: ContextProps & {
         },
         onError: (error) => {
             notifications.show({
-                color: 'red',
+                ...ERROR_NOTIFICATION_OPTIONS,
                 title: 'Context save failed',
                 message: errorToString(error),
-                autoClose: false,
             })
         },
     })

--- a/src/components/dashboard/studies-table/delete-draft-button.tsx
+++ b/src/components/dashboard/studies-table/delete-draft-button.tsx
@@ -6,6 +6,7 @@ import { TrashIcon } from '@phosphor-icons/react/dist/ssr'
 import { useState } from 'react'
 import { useMutation, useQueryClient } from '@/common'
 import { AppModal } from '@/components/modals/app-modal'
+import { ERROR_NOTIFICATION_OPTIONS } from '@/lib/constants'
 import { softDeleteStudyAction } from '@/server/actions/study.actions'
 import { StudyRow } from './types'
 
@@ -32,9 +33,9 @@ function useDeleteDraft(study: StudyRow) {
         },
         onError: (error) => {
             notifications.show({
+                ...ERROR_NOTIFICATION_OPTIONS,
                 title: 'Failed to delete proposal draft',
                 message: error instanceof Error ? error.message : 'An unexpected error occurred. Please try again.',
-                color: 'red',
             })
         },
     })

--- a/src/components/errors.test.tsx
+++ b/src/components/errors.test.tsx
@@ -108,11 +108,13 @@ describe('reportError', () => {
     it('calls notifications.show with the default title and error message', () => {
         const errorMsg = 'Test error'
         reportError(errorMsg)
-        expect(notificationsShowSpy).toHaveBeenCalledWith({
-            color: 'red',
-            title: 'An error occurred',
-            message: expect.stringMatching(new RegExp(`${errorMsg}\\nReference: [a-f0-9]{32}`)),
-        })
+        expect(notificationsShowSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                color: 'red',
+                title: 'An error occurred',
+                message: expect.stringMatching(new RegExp(`${errorMsg}\\nReference: [a-f0-9]{32}`)),
+            }),
+        )
     })
 
     it('calls notifications.show with a custom title if provided', () => {
@@ -120,11 +122,20 @@ describe('reportError', () => {
         const customTitle = 'Custom Title'
         reportError(errorInstance, customTitle)
         const errorString = errorInstance.toString()
-        expect(notificationsShowSpy).toHaveBeenCalledWith({
-            color: 'red',
-            title: customTitle,
-            message: expect.stringMatching(new RegExp(`${errorString}\\nReference: [a-f0-9]{32}`)),
-        })
+        expect(notificationsShowSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                color: 'red',
+                title: customTitle,
+                message: expect.stringMatching(new RegExp(`${errorString}\\nReference: [a-f0-9]{32}`)),
+            }),
+        )
+    })
+
+    it('shows error toasts that persist until manually dismissed', () => {
+        reportError('Test error')
+        expect(notificationsShowSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ autoClose: false, withCloseButton: true }),
+        )
     })
 })
 

--- a/src/components/errors.tsx
+++ b/src/components/errors.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { ERROR_NOTIFICATION_OPTIONS } from '@/lib/constants'
 import { errorToString, extractActionFailure } from '@/lib/errors'
 import { Alert, AlertProps, Group, Text, useMantineTheme } from '@mantine/core'
 import { notifications } from '@mantine/notifications'
@@ -11,7 +12,7 @@ import { difference } from 'remeda'
 export const reportError = (error: unknown, title = 'An error occurred') => {
     const eventId = captureException(error)
     notifications.show({
-        color: 'red',
+        ...ERROR_NOTIFICATION_OPTIONS,
         title,
         message: eventId ? `${errorToString(error)}\nReference: ${eventId}` : errorToString(error),
     })

--- a/src/components/study/file-drop-overlay.tsx
+++ b/src/components/study/file-drop-overlay.tsx
@@ -5,6 +5,7 @@ import { Anchor, Box, Paper, Stack, Text, ThemeIcon } from '@mantine/core'
 import { Dropzone, type FileWithPath } from '@mantine/dropzone'
 import { notifications } from '@mantine/notifications'
 import { FileArrowUpIcon } from '@phosphor-icons/react/dist/ssr'
+import { ERROR_NOTIFICATION_OPTIONS } from '@/lib/constants'
 import { ACCEPTED_FILE_TYPES, ACCEPTED_FILE_FORMATS_TEXT } from '@/lib/types'
 
 const ACCEPTED_EXTENSIONS = new Set(
@@ -110,7 +111,7 @@ export function FileDropOverlay({
 
         if (rejected.length > 0) {
             notifications.show({
-                color: 'red',
+                ...ERROR_NOTIFICATION_OPTIONS,
                 title: 'Unsupported file type',
                 message: `${rejected.map((f) => f.name).join(', ')} — ${ACCEPTED_FILE_FORMATS_TEXT}`,
             })

--- a/src/contexts/edit-resubmit/hooks/use-resubmit-proposal.ts
+++ b/src/contexts/edit-resubmit/hooks/use-resubmit-proposal.ts
@@ -5,6 +5,7 @@ import { type UseFormReturnType } from '@mantine/form'
 import { useMutation } from '@/common'
 import { resubmitProposalAction } from '@/server/actions/study-request'
 import { actionResult } from '@/lib/utils'
+import { ERROR_NOTIFICATION_OPTIONS } from '@/lib/constants'
 import { Routes } from '@/lib/routes'
 import { type ProposalFormValues } from '@/app/[orgSlug]/study/[studyId]/proposal/schema'
 import { type ResubmitNoteValue } from '@/app/[orgSlug]/study/[studyId]/edit-and-resubmit/schema'
@@ -53,9 +54,9 @@ export function useResubmitProposal({ studyId, form, noteForm, yjsForm, tabSessi
         },
         onError: (error) => {
             notifications.show({
+                ...ERROR_NOTIFICATION_OPTIONS,
                 title: 'Failed to resubmit proposal',
                 message: error instanceof Error ? error.message : 'An unexpected error occurred. Please try again.',
-                color: 'red',
             })
         },
     })

--- a/src/contexts/study-request/hooks/use-save-draft.ts
+++ b/src/contexts/study-request/hooks/use-save-draft.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import { notifications } from '@mantine/notifications'
 import { useMutation, useQueryClient } from '@/common'
 import { actionResult } from '@/lib/utils'
+import { ERROR_NOTIFICATION_OPTIONS } from '@/lib/constants'
 import { errorToString } from '@/lib/errors'
 import { onSaveDraftStudyAction, onUpdateDraftStudyAction } from '@/server/actions/study-request'
 import type { StudyProposalFormValues, MutationOptions } from '../study-request-types'
@@ -61,7 +62,7 @@ export function useSaveDraft({ studyId, submittingOrgSlug, onStudyCreated }: Use
         },
         onError: (error) => {
             notifications.show({
-                color: 'red',
+                ...ERROR_NOTIFICATION_OPTIONS,
                 title: 'Failed to save draft',
                 message: `${errorToString(error)}\nPlease contact support.`,
             })

--- a/src/hooks/file-upload.tsx
+++ b/src/hooks/file-upload.tsx
@@ -1,3 +1,4 @@
+import { ERROR_NOTIFICATION_OPTIONS } from '@/lib/constants'
 import { notifications } from '@mantine/notifications'
 import { FileDocIcon, FilePdfIcon, FileTextIcon, UploadSimpleIcon } from '@phosphor-icons/react/dist/ssr'
 import { useMantineTheme } from '@mantine/core'
@@ -12,7 +13,7 @@ export const handleDuplicateUpload = (mainFile: File | null, additionalFiles: Fi
 
     if (duplicateFound) {
         notifications.show({
-            color: 'red',
+            ...ERROR_NOTIFICATION_OPTIONS,
             title: 'Duplicate filename',
             message: `The file name "${mainFile.name}" has already been uploaded. Please choose a different file name or remove the existing one before continuing.`,
         })

--- a/src/hooks/use-education-section.ts
+++ b/src/hooks/use-education-section.ts
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useMutation, useForm, zodResolver } from '@/common'
 import { notifications } from '@mantine/notifications'
+import { ERROR_NOTIFICATION_OPTIONS } from '@/lib/constants'
 import { updateEducationAction } from '@/server/actions/researcher-profile.actions'
 import { educationSchema, type EducationValues } from '@/schema/researcher-profile'
 import type { ResearcherProfileData } from '@/hooks/use-researcher-profile'
@@ -59,7 +60,7 @@ export function useEducationSection(data: ResearcherProfileData | null, refetch:
             notifications.show({ title: 'Saved', message: 'Education updated', color: 'green' })
         },
         onError: (error) => {
-            notifications.show({ title: 'Save failed', message: String(error), color: 'red' })
+            notifications.show({ ...ERROR_NOTIFICATION_OPTIONS, title: 'Save failed', message: String(error) })
         },
     })
 

--- a/src/hooks/use-encrypted-files-panel.ts
+++ b/src/hooks/use-encrypted-files-panel.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@/common'
 import { useDecryptFiles } from '@/hooks/use-decrypt-files'
+import { ERROR_NOTIFICATION_OPTIONS } from '@/lib/constants'
 import { isEncryptedArtifact, logLabel } from '@/lib/file-type-helpers'
 import type { JobFile, JobFileInfo } from '@/lib/types'
 import { fetchEncryptedJobFilesAction, fetchSharedFileIdsAction } from '@/server/actions/study-job.actions'
@@ -128,7 +129,7 @@ export function useEncryptedFilesPanel({ job, onFilesApproved, isReviewer }: Opt
         (values) => decrypt(values.privateKey),
         (errors) => {
             if (errors.privateKey) {
-                notifications.show({ message: 'Invalid private key', color: 'red' })
+                notifications.show({ ...ERROR_NOTIFICATION_OPTIONS, message: 'Invalid private key' })
             }
         },
     )

--- a/src/hooks/use-ide-files.ts
+++ b/src/hooks/use-ide-files.ts
@@ -3,6 +3,7 @@ import { notifications } from '@mantine/notifications'
 import { useCallback, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { Routes } from '@/lib/routes'
+import { ERROR_NOTIFICATION_OPTIONS } from '@/lib/constants'
 import { reportMutationError } from '@/components/errors'
 import { useWorkspaceLauncher } from './use-workspace-launcher'
 import { useWorkspaceFiles, type WorkspaceFileInfo } from './use-workspace-files'
@@ -225,7 +226,7 @@ export function useIDEFiles({ studyId, onSubmitSuccess }: UseIDEFilesOptions) {
     const submitDirectly = useCallback(() => {
         if (!canSubmit) {
             notifications.show({
-                color: 'red',
+                ...ERROR_NOTIFICATION_OPTIONS,
                 title: 'Cannot proceed',
                 message: 'Please add files and select a main file first.',
             })

--- a/src/hooks/use-personal-info-section.ts
+++ b/src/hooks/use-personal-info-section.ts
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useMutation, useForm, zodResolver } from '@/common'
 import { notifications } from '@mantine/notifications'
+import { ERROR_NOTIFICATION_OPTIONS } from '@/lib/constants'
 import { updatePersonalInfoAction } from '@/server/actions/researcher-profile.actions'
 import { personalInfoSchema, type PersonalInfoValues } from '@/schema/researcher-profile'
 import type { ResearcherProfileData } from '@/hooks/use-researcher-profile'
@@ -51,7 +52,7 @@ export function usePersonalInfoSection(data: ResearcherProfileData | null, refet
             notifications.show({ title: 'Saved', message: 'Personal information updated', color: 'green' })
         },
         onError: (error) => {
-            notifications.show({ title: 'Save failed', message: String(error), color: 'red' })
+            notifications.show({ ...ERROR_NOTIFICATION_OPTIONS, title: 'Save failed', message: String(error) })
         },
     })
 

--- a/src/hooks/use-positions-section.ts
+++ b/src/hooks/use-positions-section.ts
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useMutation, useForm, zodResolver } from '@/common'
 import { notifications } from '@mantine/notifications'
+import { ERROR_NOTIFICATION_OPTIONS } from '@/lib/constants'
 import { updatePositionsAction } from '@/server/actions/researcher-profile.actions'
 import { positionsSchema, type PositionsValues, type PositionValues } from '@/schema/researcher-profile'
 import type { ResearcherProfileData } from '@/hooks/use-researcher-profile'
@@ -60,7 +61,7 @@ export function usePositionsSection(data: ResearcherProfileData | null, refetch:
             notifications.show({ title: 'Saved', message: 'Current institutional information updated', color: 'green' })
         },
         onError: (error) => {
-            notifications.show({ title: 'Save failed', message: String(error), color: 'red' })
+            notifications.show({ ...ERROR_NOTIFICATION_OPTIONS, title: 'Save failed', message: String(error) })
         },
     })
 

--- a/src/hooks/use-research-details-section.ts
+++ b/src/hooks/use-research-details-section.ts
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useMutation, useForm, zodResolver } from '@/common'
 import { notifications } from '@mantine/notifications'
+import { ERROR_NOTIFICATION_OPTIONS } from '@/lib/constants'
 import { updateResearchDetailsAction } from '@/server/actions/researcher-profile.actions'
 import { researchDetailsSchema, type ResearchDetailsValues } from '@/schema/researcher-profile'
 import type { ResearcherProfileData } from '@/hooks/use-researcher-profile'
@@ -63,7 +64,7 @@ export function useResearchDetailsSection(data: ResearcherProfileData | null, re
             notifications.show({ title: 'Saved', message: 'Research details updated', color: 'green' })
         },
         onError: (error) => {
-            notifications.show({ title: 'Save failed', message: String(error), color: 'red' })
+            notifications.show({ ...ERROR_NOTIFICATION_OPTIONS, title: 'Save failed', message: String(error) })
         },
     })
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -29,3 +29,11 @@ export const APP_SHELL = {
 
 // 8 seconds
 export const NOTIFICATION_DISPLAY_MS = 8000
+
+// Error toasts persist until dismissed so users can read the message and copy the
+// Sentry reference id before it disappears.
+export const ERROR_NOTIFICATION_OPTIONS = {
+    color: 'red',
+    autoClose: false,
+    withCloseButton: true,
+} as const


### PR DESCRIPTION
Issue: [OTTER-665](https://openstax.atlassian.net/browse/OTTER-665) (Error toasts should stay visible until manually dismissed)

### Problem

Every notification inherits an 8-second auto-close from the two global `<Notifications>` mounts (`NOTIFICATION_DISPLAY_MS`). Error toasts inherit it too, which is a problem: `reportError` appends a Sentry event id (`\nReference: ${eventId}`) that users are asked to quote when reporting a bug, and 8 seconds isn't enough time to read a failure message and copy a 32-character id before it vanishes.

### Solution

Added a shared constant in `src/lib/constants.ts`:

```ts
// Error toasts persist until dismissed so users can read the message and copy the
// Sentry reference id before it disappears.
export const ERROR_NOTIFICATION_OPTIONS = {
    color: 'red',
    autoClose: false,
    withCloseButton: true,
} as const
```

and spread it into every red toast in the app — one source of truth instead of per-site literals.

**`reportError`** (`src/components/errors.tsx`) covers the whole `reportError` / `reportMutationError` / `handleMutationErrorsWithForm` family (~35 call sites) with no signature change.

**13 direct call sites** bypassed `reportError` and would otherwise still auto-dismiss:

| Area | File |
| --- | --- |
| Researcher profile "Save failed" | `use-personal-info-section.ts`, `use-positions-section.ts`, `use-education-section.ts`, `use-research-details-section.ts` |
| Study request / resubmit | `use-save-draft.ts`, `use-resubmit-proposal.ts`, `use-ide-files.ts` |
| Files | `use-encrypted-files-panel.ts`, `file-upload.tsx`, `file-drop-overlay.tsx` |
| Dashboard / admin / auth | `delete-draft-button.tsx`, `agent-context.tsx`, `add-sms-mfa.tsx` |

`agent-context.tsx` already had a one-off `autoClose: false`; it now uses the shared constant.

### Scope notes

- Success/info toasts are unchanged — they keep the 8s `NOTIFICATION_DISPLAY_MS` default. `NOTIFICATION_DISPLAY_MS` itself was not touched.
- `withCloseButton: true` is redundant with Mantine 8's per-notification default, but is set explicitly so the sticky-toast contract is self-documenting and survives a future theme default change.
- Left alone: the yellow "Popup blocked" toast (`use-workspace-launcher.tsx`) and the session-expired toasts (`activity-context.tsx`), which already opt out of auto-close for their own reasons and shouldn't adopt red styling.
- Excluded: three `color: 'red'` hits in `code-envs-view.tsx`, `code-env-history-view.tsx`, and `proposal-submitted.tsx` — these are Badge/status config maps, not notifications.

### Testing

- Added a regression test in `errors.test.tsx` asserting error toasts are shown with `autoClose: false` and `withCloseButton: true`, so a future refactor can't silently restore auto-dismiss.
- Loosened exact-object `toHaveBeenCalledWith` assertions to `expect.objectContaining` in `errors.test.tsx` and `upload-study-job-code.test.ts` — they asserted on the full notification payload and would break on any added default.

[OTTER-665]: https://openstax.atlassian.net/browse/OTTER-665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ