### PR TITLE
OTTER-649 follow-up: add an indeterminate scan status so an unscanned result is not a finding

### DIFF
--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
@@ -489,6 +489,24 @@ describe('SubmittedCodeSection — Security scan log', () => {
         expect(row.querySelector('[data-icon="warning"]')).not.toBeNull()
     })
 
+    // The third outcome: the scan reported, but not a verdict. It must not read as either a clean
+    // bill of health or a vulnerability finding (OTTER-649).
+    it('shows Trivy "Needs review" with a warning icon, and no finding, when the result is indeterminate', async () => {
+        const fixture = await setupBaseFixture()
+        await renderSection(fixture, scanResult('INDETERMINATE', 'PASSED'))
+        const row = screen.getByTestId('security-scan-trivy')
+        expect(row).toHaveTextContent('Needs review')
+        expect(row).not.toHaveTextContent('Vulnerabilities found')
+        expect(row).not.toHaveTextContent('No vulnerabilities found')
+        expect(row.querySelector('[data-icon="warning"]')).not.toBeNull()
+    })
+
+    it('still offers the log download when a tool result is indeterminate', async () => {
+        const fixture = await setupBaseFixture()
+        await renderSection(fixture, scanResult('INDETERMINATE', 'PASSED'))
+        expect(screen.getByTestId('security-scan-log-download')).toHaveTextContent('Download')
+    })
+
     it('shows a download link to the plaintext scan log when a log file is present', async () => {
         const fixture = await setupBaseFixture()
         await renderSection(fixture, scanResult('PASSED', 'PASSED'))

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.test.tsx
@@ -465,12 +465,14 @@ describe('SubmittedCodeSection — Security scan log', () => {
         expect(row.querySelector('[data-icon="warning"]')).toBeNull()
     })
 
-    it('shows Trivy "Vulnerabilities found" with a warning icon when it failed', async () => {
+    it('shows Trivy "Vulnerabilities found" with a red warning icon when it failed', async () => {
         const fixture = await setupBaseFixture()
         await renderSection(fixture, scanResult('FAILED', 'PASSED'))
         const row = screen.getByTestId('security-scan-trivy')
         expect(row).toHaveTextContent('Vulnerabilities found')
-        expect(row.querySelector('[data-icon="warning"]')).not.toBeNull()
+        const icon = row.querySelector('[data-icon="warning"]')
+        expect(icon).not.toBeNull()
+        expect(icon?.outerHTML).toContain('red')
     })
 
     it('shows SonarQube "Passed" with no warning icon when it passed', async () => {
@@ -505,6 +507,16 @@ describe('SubmittedCodeSection — Security scan log', () => {
         const fixture = await setupBaseFixture()
         await renderSection(fixture, scanResult('INDETERMINATE', 'PASSED'))
         expect(screen.getByTestId('security-scan-log-download')).toHaveTextContent('Download')
+    })
+
+    // An indeterminate result must not look like a reported problem, so it deliberately does not get
+    // the red icon a real finding gets.
+    it('does not give the indeterminate row the red icon used for a finding', async () => {
+        const fixture = await setupBaseFixture()
+        await renderSection(fixture, scanResult('INDETERMINATE', 'PASSED'))
+        const icon = screen.getByTestId('security-scan-trivy').querySelector('[data-icon="warning"]')
+        expect(icon).not.toBeNull()
+        expect(icon?.outerHTML).not.toContain('red')
     })
 
     it('shows a download link to the plaintext scan log when a log file is present', async () => {

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.tsx
@@ -50,11 +50,29 @@ function DatasetPills({ names }: { names: string[] }) {
     )
 }
 
+type ScanStatusLabels = Record<ScanToolStatus, string>
+
+// "Needs review" is the card's own phrasing for the case where we cannot state an outcome with
+// confidence. Trivy reaches it two ways: it examined nothing (no analyzer for R, no lockfile to
+// read), or it produced no report at all. Neither is a finding and neither is a clean bill of
+// health. Pending UX sign-off on whether those two should read differently to a Data Partner.
+const TRIVY_LABELS: ScanStatusLabels = {
+    PASSED: 'No vulnerabilities found',
+    FAILED: 'Vulnerabilities found',
+    INDETERMINATE: 'Needs review',
+}
+
+// SonarQube has no third label: a failing gate and an unresolvable one both need the same human look.
+const SONARQUBE_LABELS: ScanStatusLabels = {
+    PASSED: 'Passed',
+    FAILED: 'Needs review',
+    INDETERMINATE: 'Needs review',
+}
+
 type ScanRowProps = {
     label: string
     status: ScanToolStatus | null
-    passedLabel: string
-    failedLabel: string
+    labels: ScanStatusLabels
     testId: string
 }
 
@@ -63,19 +81,11 @@ function ScanWarningIcon({ isVisible }: { isVisible: boolean }) {
     return <WarningCircle size={20} color="var(--mantine-color-red-9)" data-icon="warning" aria-hidden="true" />
 }
 
-// A tool's result: plain text when it passed, a warning icon plus the failure
-// phrasing when it failed, and a neutral pending note while the scan has not
-// reported (status null). Deliberately no "pass" icon, and never a fabricated
-// pass/fail when the status is unknown; we only flag what needs a human (OTTER-649).
-function ScanRowValue({
-    status,
-    passedLabel,
-    failedLabel,
-}: {
-    status: ScanToolStatus | null
-    passedLabel: string
-    failedLabel: string
-}) {
+// A tool's result: plain text when it passed, a warning icon plus the relevant phrasing when it did
+// not, and a neutral pending note while the scan has not reported (status null). Deliberately no
+// "pass" icon, and never a fabricated pass/fail when the status is unknown; we only flag what needs
+// a human (OTTER-649).
+function ScanRowValue({ status, labels }: { status: ScanToolStatus | null; labels: ScanStatusLabels }) {
     if (status === null) {
         return (
             <Text size="sm" c="dimmed">
@@ -88,17 +98,17 @@ function ScanRowValue({
         <Group gap={4} wrap="nowrap" align="center">
             <ScanWarningIcon isVisible={!passed} />
             <Text size="sm" fw={600}>
-                {passed ? passedLabel : failedLabel}
+                {labels[status]}
             </Text>
         </Group>
     )
 }
 
-function ScanRow({ label, status, passedLabel, failedLabel, testId }: ScanRowProps) {
+function ScanRow({ label, status, labels, testId }: ScanRowProps) {
     return (
         <Group gap="xs" wrap="nowrap" align="center" data-testid={testId}>
             <Text size="sm">{label}</Text>
-            <ScanRowValue status={status} passedLabel={passedLabel} failedLabel={failedLabel} />
+            <ScanRowValue status={status} labels={labels} />
         </Group>
     )
 }
@@ -130,15 +140,13 @@ function ScanLogBody({ scan }: { scan: JobScanResult }) {
             <ScanRow
                 label="Trivy Filesystem Scan:"
                 status={scan.trivy}
-                passedLabel="No vulnerabilities found"
-                failedLabel="Vulnerabilities found"
+                labels={TRIVY_LABELS}
                 testId="security-scan-trivy"
             />
             <ScanRow
                 label="SonarQube Quality Gate:"
                 status={scan.sonarqube}
-                passedLabel="Passed"
-                failedLabel="Needs review"
+                labels={SONARQUBE_LABELS}
                 testId="security-scan-sonarqube"
             />
         </Stack>

--- a/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/review/submitted-code-section.tsx
@@ -69,6 +69,15 @@ const SONARQUBE_LABELS: ScanStatusLabels = {
     INDETERMINATE: 'Needs review',
 }
 
+// A passed row carries no icon at all. The other two are visually distinct on purpose: red reads as
+// a reported problem, and an indeterminate result is not one. Amber reuses the "action needed"
+// pairing the design system already applies to WarningCircle (see StatusAlert's action variant)
+// rather than introducing a new treatment. Provisional along with the labels above.
+const SCAN_ICON_COLORS: Partial<Record<ScanToolStatus, string>> = {
+    FAILED: 'var(--mantine-color-red-9)',
+    INDETERMINATE: 'var(--mantine-color-yellow-10)',
+}
+
 type ScanRowProps = {
     label: string
     status: ScanToolStatus | null
@@ -76,9 +85,9 @@ type ScanRowProps = {
     testId: string
 }
 
-function ScanWarningIcon({ isVisible }: { isVisible: boolean }) {
-    if (!isVisible) return null
-    return <WarningCircle size={20} color="var(--mantine-color-red-9)" data-icon="warning" aria-hidden="true" />
+function ScanWarningIcon({ color }: { color?: string }) {
+    if (!color) return null
+    return <WarningCircle size={20} color={color} data-icon="warning" aria-hidden="true" />
 }
 
 // A tool's result: plain text when it passed, a warning icon plus the relevant phrasing when it did
@@ -93,10 +102,9 @@ function ScanRowValue({ status, labels }: { status: ScanToolStatus | null; label
             </Text>
         )
     }
-    const passed = status === 'PASSED'
     return (
         <Group gap={4} wrap="nowrap" align="center">
-            <ScanWarningIcon isVisible={!passed} />
+            <ScanWarningIcon color={SCAN_ICON_COLORS[status]} />
             <Text size="sm" fw={600}>
                 {labels[status]}
             </Text>

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -583,17 +583,20 @@ export type JobScanResult = {
 // lines. Only the two explicit verdicts are honored; "nothing scanned", "scan did not complete", the
 // pre-OTTER-649 "no results", and anything unrecognized are all indeterminate. Treating unrecognized
 // text as FAILED is what surfaced a scan that never ran as a vulnerability finding on QA.
-const TRIVY_VERDICTS: Record<string, ScanToolStatus> = {
-    'no vulnerabilities found': 'PASSED',
-    'vulnerabilities found': 'FAILED',
-}
+// A Map, not an object literal: the phrase comes from a file, and an object lookup would resolve
+// inherited keys like "constructor" to a truthy non-status value.
+const TRIVY_VERDICTS = new Map<string, ScanToolStatus>([
+    ['no vulnerabilities found', 'PASSED'],
+    ['vulnerabilities found', 'FAILED'],
+])
 
 export function parseTrivyStatus(log: string): ScanToolStatus {
     const phrase = log
         .match(/trivy (?:filesystem|image) scan:[ \t]*(.*)/i)?.[1]
         ?.trim()
         .toLowerCase()
-    if (phrase && TRIVY_VERDICTS[phrase]) return TRIVY_VERDICTS[phrase]
+    const verdict = phrase && TRIVY_VERDICTS.get(phrase)
+    if (verdict) return verdict
     // Logs written before the scanner emitted a status phrase headed their findings with
     // "<label> Results" and listed vulnerabilities beneath it. Keep reading those as findings so
     // already-stored logs do not lose their verdict.

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -563,7 +563,12 @@ export type StudyReviewWithMeta = {
 // Trivy and SonarQube report independently. Per OTTER-649 we cannot say with
 // confidence that a scan "failed"; we only assert PASSED when the log carries an
 // explicit clean signal and otherwise surface the result for human review.
-export type ScanToolStatus = 'PASSED' | 'FAILED'
+//
+// INDETERMINATE is the third outcome the original two-state model could not express: the scan
+// reported, but not a verdict. Trivy has no analyzer for R, so a successful scan of an R submission
+// examines nothing, and a scan that never ran produces no report at all. Neither clears the code and
+// neither is a finding, so both go to a human instead of being forced into PASSED or FAILED.
+export type ScanToolStatus = 'PASSED' | 'FAILED' | 'INDETERMINATE'
 
 export type JobScanResult = {
     // null when the scan hasn't reported yet (no readable plaintext log).
@@ -573,14 +578,33 @@ export type JobScanResult = {
     logFile: { id: string; name: string; path: string } | null
 }
 
-// Trivy passes only on the explicit clean line the scanner emits; anything else
-// (findings, "no results", or an unrecognized log) is flagged for review.
-export function parseTrivyStatus(log: string): ScanToolStatus {
-    return /trivy (?:filesystem|image) scan:\s*no vulnerabilities found/i.test(log) ? 'PASSED' : 'FAILED'
+// The scanner leads its Trivy section with a single status phrase (iac codebuild/scripts/common.ts,
+// trivyPlaintextLog), so we read that rather than inferring a verdict from the shape of the detail
+// lines. Only the two explicit verdicts are honored; "nothing scanned", "scan did not complete", the
+// pre-OTTER-649 "no results", and anything unrecognized are all indeterminate. Treating unrecognized
+// text as FAILED is what surfaced a scan that never ran as a vulnerability finding on QA.
+const TRIVY_VERDICTS: Record<string, ScanToolStatus> = {
+    'no vulnerabilities found': 'PASSED',
+    'vulnerabilities found': 'FAILED',
 }
 
-// SonarQube passes only when its quality gate reports OK. Any other gate status,
-// or a missing SonarQube section (skipped/unavailable), needs human review.
+export function parseTrivyStatus(log: string): ScanToolStatus {
+    const phrase = log
+        .match(/trivy (?:filesystem|image) scan:[ \t]*(.*)/i)?.[1]
+        ?.trim()
+        .toLowerCase()
+    if (phrase && TRIVY_VERDICTS[phrase]) return TRIVY_VERDICTS[phrase]
+    // Logs written before the scanner emitted a status phrase headed their findings with
+    // "<label> Results" and listed vulnerabilities beneath it. Keep reading those as findings so
+    // already-stored logs do not lose their verdict.
+    if (/trivy (?:filesystem|image) scan results/i.test(log)) return 'FAILED'
+    return 'INDETERMINATE'
+}
+
+// SonarQube passes only when its quality gate reports OK. Every other case (a failing gate, a gate
+// we could not resolve for this analysis, a timed-out or absent analysis) means the same thing to a
+// reviewer and to this card: it needs human review. The card is explicit that we can confirm a
+// SonarQube pass but never a SonarQube failure, so there is deliberately no third state here.
 export function parseSonarqubeStatus(log: string): ScanToolStatus {
     const match = log.match(/sonarqube quality gate:\s*(\S+)/i)
     return match?.[1]?.toUpperCase() === 'OK' ? 'PASSED' : 'FAILED'

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -590,17 +590,26 @@ const TRIVY_VERDICTS = new Map<string, ScanToolStatus>([
     ['vulnerabilities found', 'FAILED'],
 ])
 
+const TRIVY_STATUS_LINE = /^trivy (?:filesystem|image) scan:/i
+const TRIVY_LEGACY_FINDINGS_HEADER = /^trivy (?:filesystem|image) scan results$/i
+
+// Both patterns are anchored to a whole trimmed line, and the legacy header is only consulted when
+// there is no status line at all. Matching anywhere in the log would let the scan's own detail lines
+// decide the verdict: a scanned file path or a CVE title containing "Trivy Filesystem Scan Results"
+// would turn an indeterminate result into a reported finding.
 export function parseTrivyStatus(log: string): ScanToolStatus {
-    const phrase = log
-        .match(/trivy (?:filesystem|image) scan:[ \t]*(.*)/i)?.[1]
-        ?.trim()
-        .toLowerCase()
-    const verdict = phrase && TRIVY_VERDICTS.get(phrase)
-    if (verdict) return verdict
-    // Logs written before the scanner emitted a status phrase headed their findings with
-    // "<label> Results" and listed vulnerabilities beneath it. Keep reading those as findings so
-    // already-stored logs do not lose their verdict.
-    if (/trivy (?:filesystem|image) scan results/i.test(log)) return 'FAILED'
+    const lines = log.split('\n').map((line) => line.trim())
+
+    const statusLine = lines.find((line) => TRIVY_STATUS_LINE.test(line))
+    if (statusLine) {
+        const phrase = statusLine.replace(TRIVY_STATUS_LINE, '').trim().toLowerCase()
+        return TRIVY_VERDICTS.get(phrase) ?? 'INDETERMINATE'
+    }
+
+    // Logs written before the scanner emitted a status phrase headed their findings with the label
+    // followed by "Results" on a line of its own. Keep reading those as findings so already-stored
+    // logs do not lose their verdict.
+    if (lines.some((line) => TRIVY_LEGACY_FINDINGS_HEADER.test(line))) return 'FAILED'
     return 'INDETERMINATE'
 }
 

--- a/src/server/db/scan-log.test.ts
+++ b/src/server/db/scan-log.test.ts
@@ -9,12 +9,38 @@ import { jobScanResultForJob, parseTrivyStatus, parseSonarqubeStatus } from './q
 // the Trivy section comes first, then an optional SonarQube section.
 const TRIVY_CLEAN = 'Trivy Filesystem Scan: no vulnerabilities found'
 const TRIVY_FINDINGS = [
+    'Trivy Filesystem Scan: vulnerabilities found',
+    'Target: package-lock.json',
+    '  HIGH CVE-2024-1234 lodash 4.17.0 (fix: 4.17.21) - Prototype pollution',
+].join('\n')
+// Logs stored before the scanner emitted a status phrase headed their findings this way.
+const TRIVY_LEGACY_FINDINGS = [
     'Trivy Filesystem Scan Results',
     'Target: package-lock.json',
     '  HIGH CVE-2024-1234 lodash 4.17.0 (fix: 4.17.21) - Prototype pollution',
 ].join('\n')
 const SONAR_OK = 'SonarQube Quality Gate: OK'
 const SONAR_ERROR = ['SonarQube Quality Gate: ERROR', '  new_coverage: ERROR'].join('\n')
+
+// Verbatim from QA (job 019fd838-f3da-73c8-afe2-1c72c9142161, 2026-08-06): the scanner aborted before
+// Trivy ran, and its failure handler still posted this as a completed scan. The old parser read it as
+// a vulnerability finding, which is the defect this card was reopened for.
+const QA_ABORTED_SCAN_LOG = [
+    'Trivy Filesystem Scan: no results',
+    '',
+    'SonarQube Quality Gate: OK',
+    '  new_violations: OK',
+].join('\n')
+
+// Verbatim from the last successful QA scan (job 019eadb3-6cc5-7b1c-8da1-5f925b4a50e6, 2026-06-09).
+// Trivy ran but had nothing to analyze: the submission was a single .R file and Trivy has no R
+// analyzer, so its SBOM held zero components and its summary reported the target as "not scanned".
+const QA_SUCCESSFUL_SCAN_LOG = [
+    'Trivy Filesystem Scan: no vulnerabilities found',
+    '',
+    'SonarQube Quality Gate: OK',
+    '  new_violations: OK',
+].join('\n')
 
 describe('parseTrivyStatus', () => {
     it('passes on the explicit clean line', () => {
@@ -25,12 +51,36 @@ describe('parseTrivyStatus', () => {
         expect(parseTrivyStatus(`${TRIVY_FINDINGS}\n\n${SONAR_OK}`)).toBe('FAILED')
     })
 
-    it('fails on "no results" (scanner produced no output) rather than claiming a pass', () => {
-        expect(parseTrivyStatus('Trivy Filesystem Scan: no results')).toBe('FAILED')
+    it('still reads findings from logs stored before the status phrase existed', () => {
+        expect(parseTrivyStatus(`${TRIVY_LEGACY_FINDINGS}\n\n${SONAR_OK}`)).toBe('FAILED')
+    })
+
+    it('is indeterminate when Trivy had nothing it could analyze', () => {
+        expect(parseTrivyStatus('Trivy Filesystem Scan: nothing scanned')).toBe('INDETERMINATE')
+    })
+
+    it('is indeterminate when the scan never produced a report', () => {
+        expect(parseTrivyStatus('Trivy Filesystem Scan: scan did not complete')).toBe('INDETERMINATE')
+    })
+
+    it('does not read the legacy "no results" as a vulnerability finding', () => {
+        expect(parseTrivyStatus(QA_ABORTED_SCAN_LOG)).toBe('INDETERMINATE')
+    })
+
+    it('is indeterminate for an unrecognized log rather than claiming a finding', () => {
+        expect(parseTrivyStatus('something else entirely')).toBe('INDETERMINATE')
     })
 
     it('also recognizes the image-scan label', () => {
         expect(parseTrivyStatus('Trivy Image Scan: no vulnerabilities found')).toBe('PASSED')
+    })
+
+    it('matches the status phrase case-insensitively', () => {
+        expect(parseTrivyStatus('trivy filesystem scan: NO VULNERABILITIES FOUND')).toBe('PASSED')
+    })
+
+    it('reads the last successful QA scan as a pass', () => {
+        expect(parseTrivyStatus(QA_SUCCESSFUL_SCAN_LOG)).toBe('PASSED')
     })
 })
 
@@ -45,6 +95,10 @@ describe('parseSonarqubeStatus', () => {
 
     it('needs review when the SonarQube section is absent (skipped/unavailable)', () => {
         expect(parseSonarqubeStatus(TRIVY_CLEAN)).toBe('FAILED')
+    })
+
+    it('needs review when no analysis could be resolved for this build', () => {
+        expect(parseSonarqubeStatus(`${TRIVY_CLEAN}\n\nSonarQube Quality Gate: not available`)).toBe('FAILED')
     })
 
     // The scanner (iac fetchSonarQualityGate) can emit these non-OK statuses; all mean "needs review".

--- a/src/server/db/scan-log.test.ts
+++ b/src/server/db/scan-log.test.ts
@@ -71,6 +71,22 @@ describe('parseTrivyStatus', () => {
         expect(parseTrivyStatus('something else entirely')).toBe('INDETERMINATE')
     })
 
+    // The status line decides the verdict. Detail lines carry scanned file paths and upstream CVE
+    // titles, so text appearing there must never be able to promote a result to a finding.
+    it('ignores the legacy findings header when a status line is present', () => {
+        const log = [
+            'Trivy Filesystem Scan: nothing scanned',
+            'Target: Trivy Filesystem Scan Results',
+            '',
+            SONAR_OK,
+        ].join('\n')
+        expect(parseTrivyStatus(log)).toBe('INDETERMINATE')
+    })
+
+    it('does not treat the legacy header appearing mid-line as a findings header', () => {
+        expect(parseTrivyStatus('Target: docs/Trivy Filesystem Scan Results.txt')).toBe('INDETERMINATE')
+    })
+
     it('also recognizes the image-scan label', () => {
         expect(parseTrivyStatus('Trivy Image Scan: no vulnerabilities found')).toBe('PASSED')
     })


### PR DESCRIPTION
see [OTTER-649](https://openstax.atlassian.net/browse/OTTER-649)

Pairs with safeinsights/iac#215. **This PR must reach an environment before that one** (see Deploy order below).

## Why

QA showed `Trivy Filesystem Scan: (!) Vulnerabilities found` on a scan that had never run. The downloaded log said:

```
Trivy Filesystem Scan: no results

SonarQube Quality Gate: OK
  new_violations: OK
```

The root cause is in the CodeBuild scanner and is fixed in the iac PR. This side is the other half: the reviewer UI could only express two outcomes, so a log that reported no verdict had to become either a pass or a finding. `parseTrivyStatus` accepted one exact clean phrase and mapped everything else, including `no results` and any unrecognized text, to `FAILED`.

That answers the question left open in the card's comments. There is a third outcome, and it is not rare. Trivy has no analyzer for R, so a *successful* scan of a typical submission examines nothing: the last good QA scan (job `019eadb3-6cc5-7b1c-8da1-5f925b4a50e6`) produced a Trivy report with no `Results` key, an SBOM with zero components, and a summary reporting its only target as not scanned. A scan that clears nothing is not the same as a scan that finds nothing.

## Changes

- `ScanToolStatus` gains `INDETERMINATE`: the scan reported, but not a verdict. `null` keeps its existing meaning of "has not reported yet" and still drives "Scan in progress…".
- `parseTrivyStatus` reads the single status phrase the scanner now leads its section with, rather than inferring a verdict from the shape of the detail lines. Only `no vulnerabilities found` and `vulnerabilities found` are honored. `nothing scanned`, `scan did not complete`, the legacy `no results`, and anything unrecognized are indeterminate. A fallback still reads the older `Trivy Filesystem Scan Results` findings header as a finding so logs already stored do not lose their verdict.
- Both patterns are matched against whole trimmed lines, and the legacy header is only consulted when there is no status line at all, so nothing appearing in the detail lines (a scanned file path, an upstream CVE title) can promote a result to a finding.
- `ScanRowValue` takes a per-status label map instead of a passed/failed pair. Copy lives in `TRIVY_LABELS` and `SONARQUBE_LABELS`.
- The indeterminate icon is amber (`yellow-10`) rather than the red used for a real finding, reusing the "action needed" pairing the design system already applies to `WarningCircle` in `StatusAlert`. A passed row still carries no icon at all.
- Tests cover all four Trivy markers, the legacy findings header, line-scoping against detail-line text, the new SonarQube `not available` marker, and the indeterminate row's text and icon color. Two fixtures are pinned verbatim to real QA logs: the 82-byte aborted-scan log behind the reported defect, and the 96-byte log from the last successful scan.

## Copy is provisional

The indeterminate state reads **"Needs review"**, taken from the card's own overview ("we should indicate whether it passed or whether it needs human review"). There is no Figma frame for this state, so both the label and the amber icon treatment are placeholders pending UX. The label is a single string in `TRIVY_LABELS` and the color a single entry in `SCAN_ICON_COLORS`; changing either touches no logic.

Two Trivy cases collapse into it: Trivy examined nothing, and Trivy produced no report. Neither is a finding and neither is a clean result. Whether a Data Partner should be able to tell those apart is a UX question; a separate label would need a second Figma frame for a distinction they probably cannot act on differently.

## Not changed, deliberately

- `parseSonarqubeStatus`. Its existing "anything but OK needs review" behavior is already correct for the scanner's new `not available` marker, and the card is explicit that we can confirm a SonarQube pass but never a SonarQube failure. So SonarQube keeps two states, and `SONARQUBE_LABELS` maps failed and indeterminate to the same text.
- The download rule. `logFile != null` shows Download, which already matches the logs-present and logs-absent Figma pairs, and a log explaining that a scan did not complete is still worth downloading.

## Deploy order

This PR is safe in either order on its own: new markers map to the new state and existing phrases keep their meaning, so it reads both old and new logs correctly. The iac PR is not, because its new Trivy markers would fall through this repo's old parser and render as "Vulnerabilities found", which is the defect being fixed. So this ships first.

## Verification

- `pnpm run checks` passes (typecheck, eslint, prettier, action validation).
- Full unit suite passes: 264 files, 2578 tests.
- All eleven scan states were rendered locally and checked against the acceptance criteria and the Figma frames: no icon in the panel title, the two tool rows always present and in order, Trivy pass/fail wording with the exclamation icon only on the fail, SonarQube pass/needs-review wording likewise, and Download shown only when a log file exists. States 1 to 8 match Figma nodes 4905-6027, 5199-94, 4905-14275, 5109-6072, 4905-14412, 5199-106, 4905-14349 and 5199-130 respectively. The two indeterminate states and the not-yet-reported state have no frame yet.

Full end-to-end verification against a real scan still needs a dev/QA stack deploy of the iac side, since the scanner scripts only re-sync when the stack changeset executes and a PR preview skips it.

[OTTER-649]: https://openstax.atlassian.net/browse/OTTER-649