### PR TITLE
OTTER-639: fix invite banner not showing on new user signups

### DIFF
--- a/src/app/account/signin/mfa.tsx
+++ b/src/app/account/signin/mfa.tsx
@@ -2,6 +2,7 @@
 import { useForm, useMutation } from '@/common'
 import { reportError } from '@/components/errors'
 import { errorToString } from '@/lib/errors'
+import { markOrgJoined } from '@/lib/joined-org'
 import { Routes } from '@/lib/routes'
 import { actionResult, safeRedirectUrl } from '@/lib/utils'
 import { onUserSignInAction } from '@/server/actions/user.actions'
@@ -9,7 +10,6 @@ import { useAuth, useSignIn, useUser } from '@clerk/nextjs'
 import type { SignInResource } from '@clerk/types'
 import { Button, Divider, Loader, Paper, Stack, Text, Title } from '@mantine/core'
 import { isNotEmpty } from '@mantine/form'
-import { notifications } from '@mantine/notifications'
 import type { Route } from 'next'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { FC, useState } from 'react'
@@ -102,10 +102,9 @@ export const RequestMFA: FC<{ mfa: MFAState }> = ({ mfa }) => {
                                         redirectUrl = orgDashboard as Route
                                     }
 
-                                    notifications.show({
-                                        color: 'green',
-                                        message: `You've successfully joined ${org.name}.`,
-                                    })
+                                    // Same one-shot flag the join-team page sets, so this path lands on
+                                    // the dashboard banner.
+                                    markOrgJoined(org.name)
                                     await auth.getToken({ skipCache: true })
                                 } catch (error) {
                                     // The invite is still live (a failed accept rolls the claim

--- a/src/components/dashboard/joined-org-banner.test.tsx
+++ b/src/components/dashboard/joined-org-banner.test.tsx
@@ -1,45 +1,68 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { renderWithProviders, waitFor, userEvent } from '@/tests/unit.helpers'
+import {
+    actionResult,
+    db,
+    mockSessionWithTestData,
+    renderWithProviders,
+    waitFor,
+    userEvent,
+} from '@/tests/unit.helpers'
 import { JOINED_ORG_STORAGE_KEY } from '@/lib/joined-org'
-import { JoinedOrgBanner, REVEAL_DELAY_MS } from './joined-org-banner'
+import { userKeyExistsAction } from '@/server/actions/user-keys.actions'
+import { JoinedOrgBanner } from './joined-org-banner'
 
-const REVEAL_TIMEOUT = REVEAL_DELAY_MS + 2000
+// insertTestUser only seeds a public key for enclave orgs, so orgType picks the user's key state:
+// 'enclave' is keyed, 'lab' is the keyless user RequireUserKey bounces to key setup.
+const KEYED = 'enclave'
+const KEYLESS = 'lab'
 
 describe('JoinedOrgBanner', () => {
     beforeEach(() => sessionStorage.clear())
 
-    it('renders nothing when no org was just joined', () => {
+    it('renders nothing when no org was just joined', async () => {
+        await mockSessionWithTestData({ orgType: KEYED })
         const { queryByTestId } = renderWithProviders(<JoinedOrgBanner />)
+
         expect(queryByTestId('joined-org-banner')).toBeNull()
     })
 
-    it('reveals the banner after the delay and clears the flag', async () => {
+    it('reveals the banner and clears the flag once the user is keyed', async () => {
+        await mockSessionWithTestData({ orgType: KEYED })
         sessionStorage.setItem(JOINED_ORG_STORAGE_KEY, 'ASU Research Lab')
         const { getByTestId } = renderWithProviders(<JoinedOrgBanner />)
 
-        await waitFor(() => expect(getByTestId('joined-org-banner')).toHaveTextContent('ASU Research Lab'), {
-            timeout: REVEAL_TIMEOUT,
-        })
+        await waitFor(() => expect(getByTestId('joined-org-banner')).toHaveTextContent('ASU Research Lab'))
         expect(sessionStorage.getItem(JOINED_ORG_STORAGE_KEY)).toBeNull()
     })
 
-    it('keeps the flag when unmounted before the delay (transient dashboard mount)', async () => {
+    // OTTER-639: the transient mount must not spend the flag, however long the key check takes.
+    it('keeps the flag for a keyless user awaiting key setup, then reveals on the real landing', async () => {
+        const { user } = await mockSessionWithTestData({ orgType: KEYLESS })
         sessionStorage.setItem(JOINED_ORG_STORAGE_KEY, 'ASU Research Lab')
-        const { unmount, queryByTestId } = renderWithProviders(<JoinedOrgBanner />)
 
-        unmount()
-        // Wait past the delay to prove the cancelled timer never fires.
-        await new Promise((resolve) => setTimeout(resolve, REVEAL_TIMEOUT))
-
-        expect(queryByTestId('joined-org-banner')).toBeNull()
+        const transient = renderWithProviders(<JoinedOrgBanner />)
+        // The component awaits this same check before it can reveal, so awaiting it here means an
+        // intact flag below is the settled result rather than a snapshot taken too early.
+        expect(actionResult(await userKeyExistsAction())).toBe(false)
         expect(sessionStorage.getItem(JOINED_ORG_STORAGE_KEY)).toBe('ASU Research Lab')
+        expect(transient.queryByTestId('joined-org-banner')).toBeNull()
+        transient.unmount()
+
+        await db
+            .insertInto('userPublicKey')
+            .values({ userId: user.id, publicKey: Buffer.from('testPublicKey1'), fingerprint: 'testFingerprint1' })
+            .executeTakeFirstOrThrow()
+
+        const { getByTestId } = renderWithProviders(<JoinedOrgBanner />)
+        await waitFor(() => expect(getByTestId('joined-org-banner')).toHaveTextContent('ASU Research Lab'))
     })
 
     it('dismisses when the close button is clicked', async () => {
+        await mockSessionWithTestData({ orgType: KEYED })
         sessionStorage.setItem(JOINED_ORG_STORAGE_KEY, 'ASU Research Lab')
         const { getByTestId, queryByTestId } = renderWithProviders(<JoinedOrgBanner />)
 
-        await waitFor(() => expect(getByTestId('joined-org-banner')).toBeInTheDocument(), { timeout: REVEAL_TIMEOUT })
+        await waitFor(() => expect(getByTestId('joined-org-banner')).toBeInTheDocument())
         await userEvent.click(getByTestId('joined-org-banner').querySelector('button')!)
         await waitFor(() => expect(queryByTestId('joined-org-banner')).toBeNull())
     })

--- a/src/components/dashboard/joined-org-banner.tsx
+++ b/src/components/dashboard/joined-org-banner.tsx
@@ -18,9 +18,10 @@ export function JoinedOrgBanner() {
         const joined = sessionStorage.getItem(JOINED_ORG_STORAGE_KEY)
         if (!joined) return
 
+        let cancelled = false
         const revealOnceKeyed = async () => {
             const hasKey = actionResult(await userKeyExistsAction())
-            if (!hasKey) return
+            if (!hasKey || cancelled) return
 
             sessionStorage.removeItem(JOINED_ORG_STORAGE_KEY)
             setOrgName(joined)
@@ -28,6 +29,9 @@ export function JoinedOrgBanner() {
         // Anything short of a definite key — not yet keyed, or a check that threw — leaves the flag
         // in place for the dashboard the user actually lands on.
         revealOnceKeyed().catch(() => {})
+        return () => {
+            cancelled = true
+        }
     }, [])
 
     if (!orgName) return null

--- a/src/components/dashboard/joined-org-banner.tsx
+++ b/src/components/dashboard/joined-org-banner.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { JOINED_ORG_STORAGE_KEY } from '@/lib/joined-org'
+import { actionResult } from '@/lib/utils'
 import { userKeyExistsAction } from '@/server/actions/user-keys.actions'
 import { Alert, Text, useMantineTheme } from '@mantine/core'
 import { CheckCircleIcon } from '@phosphor-icons/react'
@@ -18,13 +19,13 @@ export function JoinedOrgBanner() {
         if (!joined) return
 
         const revealOnceKeyed = async () => {
-            const hasKey = await userKeyExistsAction()
-            if (hasKey !== true) return
+            const hasKey = actionResult(await userKeyExistsAction())
+            if (!hasKey) return
 
             sessionStorage.removeItem(JOINED_ORG_STORAGE_KEY)
             setOrgName(joined)
         }
-        // Anything short of a definite key — not yet keyed, or a check that failed — leaves the flag
+        // Anything short of a definite key — not yet keyed, or a check that threw — leaves the flag
         // in place for the dashboard the user actually lands on.
         revealOnceKeyed().catch(() => {})
     }, [])

--- a/src/components/dashboard/joined-org-banner.tsx
+++ b/src/components/dashboard/joined-org-banner.tsx
@@ -1,28 +1,32 @@
 'use client'
 
 import { JOINED_ORG_STORAGE_KEY } from '@/lib/joined-org'
+import { userKeyExistsAction } from '@/server/actions/user-keys.actions'
 import { Alert, Text, useMantineTheme } from '@mantine/core'
 import { CheckCircleIcon } from '@phosphor-icons/react'
 import { useEffect, useState } from 'react'
-
-// Defer the reveal so a keyless user's transient dashboard mount (before RequireUserKey redirects to
-// key setup) unmounts first and cancels the timer, leaving the flag intact for the real landing.
-export const REVEAL_DELAY_MS = 500
 
 export function JoinedOrgBanner() {
     const theme = useMantineTheme()
     const [orgName, setOrgName] = useState<string | null>(null)
 
+    // A keyless user mounts the dashboard transiently before RequireUserKey redirects them to key setup,
+    // so wait on that same key check before spending the one-shot flag — otherwise the banner is consumed
+    // on a screen the user is being moved off of. A fixed delay raced that redirect and lost (OTTER-639).
     useEffect(() => {
         const joined = sessionStorage.getItem(JOINED_ORG_STORAGE_KEY)
         if (!joined) return
 
-        const timer = setTimeout(() => {
+        const revealOnceKeyed = async () => {
+            const hasKey = await userKeyExistsAction()
+            if (hasKey !== true) return
+
             sessionStorage.removeItem(JOINED_ORG_STORAGE_KEY)
             setOrgName(joined)
-        }, REVEAL_DELAY_MS)
-
-        return () => clearTimeout(timer)
+        }
+        // Anything short of a definite key — not yet keyed, or a check that failed — leaves the flag
+        // in place for the dashboard the user actually lands on.
+        revealOnceKeyed().catch(() => {})
     }, [])
 
     if (!orgName) return null


### PR DESCRIPTION
## Summary

Fixes [OTTER-639](https://openstax.atlassian.net/browse/OTTER-639) — the "You have been added to {org}" confirmation banner was not shown to new users joining an organization.

Follow-up to #899, which QA rejected on Staging: the banner worked for an existing user joining a new org, but never appeared for a newly-invited user creating an account. This PR fixes that race and a second path that never set the flag at all.

## Problem 1 — the reveal raced a redirect and lost

`JoinedOrgBanner` revealed itself on a 500ms `setTimeout`, and that same timer also cleared the one-shot `si:joined-org` flag. The delay existed so that a keyless user's *transient* dashboard mount — the one that happens before `RequireUserKey` redirects them to key setup — would unmount and cancel the timer, preserving the flag for the real landing.

That transient mount lasts exactly as long as an async `userKeyExistsAction` round-trip, so its duration is network-bound: under 500ms locally, over it on Staging. When the timer won, the flag was spent on a dashboard the user was already being redirected away from, and the banner never appeared on the one they landed on.

Raising the delay would only widen the window, so the timer is gone. The banner now waits on the key check itself — the same signal that decides the redirect, unwrapped with `actionResult` exactly as `RequireUserKey` does when making the identical call — and reveals only once that check confirms a key. Both failure modes are now deterministic rather than probabilistic:

- not yet keyed (`!hasKey`) → never consumes the flag
- a check that throws (an `ActionError`, e.g. a session that has not resolved yet) → never consumes the flag

This also removes the 500ms lag for users who already have a key.

**Why only new users hit this:** the existing-user path (`join-team`) routes to `/account/keys?redirect_url=<orgDashboard>` when a key is needed, so the dashboard is never mounted while keyless. The new-user path goes signup → MFA → `/dashboard` → `RequireUserKey` → key setup, which is what creates the transient mount.

## Problem 2 — a third join path never set the flag

`signin/mfa.tsx` also accepts invitations (`onJoinTeamAccountAction`) and pushes the user to the joined org's dashboard, but it still showed the old toast instead of calling `markOrgJoined`. #899 replaced that toast with the banner everywhere else and missed this call site.

The path is reached when the invited email matches no existing account: the invite page offers "Login with existing account", which is the only thing that sets `?invite_id=`, and the join runs in the MFA success handler. That's the account-linking case — invited at one address, signing in with an account under another.


[OTTER-639]: https://openstax.atlassian.net/browse/OTTER-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ