### PR TITLE
OTTER-655 follow-up: resolve the first-key landing from account state instead of a query param

### DIFF
--- a/src/app/account/invitation/[inviteId]/join-team/page.tsx
+++ b/src/app/account/invitation/[inviteId]/join-team/page.tsx
@@ -6,6 +6,7 @@ import { LoadingMessage } from '@/components/loading'
 import { AppModal } from '@/components/modals/app-modal'
 import { Routes } from '@/lib/routes'
 import { markOrgJoined } from '@/lib/joined-org'
+import { keyGenerationUrl } from '@/lib/user-key-redirect'
 import { actionResult } from '@/lib/utils'
 import { useAuth } from '@clerk/nextjs'
 import { Button, Flex, Group, Paper, Stack, Text, Title } from '@mantine/core'
@@ -60,7 +61,7 @@ const AddTeam: FC<InviteProps> = ({ params }) => {
             const orgDashboard = Routes.orgDashboard({ orgSlug: org!.slug })
             if (result?.needsUserKey) {
                 // First-time key generation: land them on the inviting org's dashboard afterwards.
-                router.push(`${Routes.accountKeys}?redirect_url=${encodeURIComponent(orgDashboard)}` as Route)
+                router.push(keyGenerationUrl(orgDashboard))
             } else {
                 router.push(orgDashboard)
             }

--- a/src/app/account/keys/generate-keys.test.tsx
+++ b/src/app/account/keys/generate-keys.test.tsx
@@ -1,6 +1,6 @@
 import { setUserPublicKeyAction, updateUserPublicKeyAction } from '@/server/actions/user-keys.actions'
 import { mockClerkSession, renderWithProviders } from '@/tests/unit.helpers'
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import type { Route } from 'next'
 import router from 'next-router-mock'
 import { generateKeyPair } from 'si-encryption/util/keypair'
@@ -149,6 +149,27 @@ describe('Security key generation', () => {
 
         await waitFor(() => expect(screen.getByText('Copied!')).toBeDefined())
         expect(screen.queryByText(/Copy did not work/)).toBeNull()
+    })
+
+    // The AC allows one indicator at a time, and a denied clipboard prompt can sit open for as long
+    // as the user ignores it, so its rejection can arrive after they have clicked again and
+    // succeeded. That stale result must not resurrect the failure message.
+    it('ignores a copy result the user has already superseded', async () => {
+        const writeText = mockClipboard(true)
+        let rejectAbandonedAttempt = (_: Error) => {}
+        writeText.mockImplementationOnce(
+            () => new Promise((_, reject) => (rejectAbandonedAttempt = reject)) as Promise<void>,
+        )
+        await renderPage()
+
+        fireEvent.click(screen.getByRole('button', { name: /copy key/i }))
+        fireEvent.click(screen.getByRole('button', { name: /copy key/i }))
+        await waitFor(() => expect(screen.getByText('Copied!')).toBeDefined())
+
+        await act(async () => rejectAbandonedAttempt(new Error('prompt dismissed')))
+
+        expect(screen.queryByText(/Copy did not work/)).toBeNull()
+        expect(screen.getByText('Copied!')).toBeDefined()
     })
 
     it('clears the success indicator once a later copy fails', async () => {

--- a/src/app/account/keys/generate-keys.test.tsx
+++ b/src/app/account/keys/generate-keys.test.tsx
@@ -1,6 +1,7 @@
 import { setUserPublicKeyAction, updateUserPublicKeyAction } from '@/server/actions/user-keys.actions'
 import { mockClerkSession, renderWithProviders } from '@/tests/unit.helpers'
 import { fireEvent, screen, waitFor } from '@testing-library/react'
+import type { Route } from 'next'
 import router from 'next-router-mock'
 import { generateKeyPair } from 'si-encryption/util/keypair'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -29,11 +30,17 @@ const mockClipboard = (succeed: boolean) => {
     return writeText
 }
 
-const renderPage = (props: { isRegenerating?: boolean } = {}) => {
+const renderPage = (props: { isRegenerating?: boolean; firstKeyRedirect?: Route } = {}) => {
     mockClerkSession({ userId: 'user-id', clerkUserId: 'clerk-user-id', orgSlug: 'dev' })
     vi.mocked(generateKeyPair).mockResolvedValue(mockKeys as never)
     renderWithProviders(<GenerateKeys {...props} />)
     return screen.findByText('Security key', { selector: 'h3' })
+}
+
+const storeKey = async () => {
+    fireEvent.click(screen.getByRole('button', { name: /copy key/i }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Next' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Yes, I have stored my key' }))
 }
 
 describe('Security key generation', () => {
@@ -80,20 +87,29 @@ describe('Security key generation', () => {
         await waitFor(() => expect(screen.queryByText('Have you stored your security key?')).toBeNull())
     })
 
-    it('first-time generation saves the key and redirects to the inviting org dashboard', async () => {
-        router.setCurrentUrl('/account/keys?redirect_url=%2Facme%2Fdashboard')
+    // OTTER-655: the guard entry point passes no redirect_url, which is how a first key used to
+    // land on "My dashboard" instead of the org that invited the account.
+    it('first-time generation saves the key and uses the resolved landing when no redirect_url is present', async () => {
         mockClipboard(true)
-        await renderPage({ isRegenerating: false })
+        await renderPage({ isRegenerating: false, firstKeyRedirect: '/openstax-lab/dashboard' as Route })
 
-        fireEvent.click(screen.getByRole('button', { name: /copy key/i }))
-        fireEvent.click(await screen.findByRole('button', { name: 'Next' }))
-        fireEvent.click(await screen.findByRole('button', { name: 'Yes, I have stored my key' }))
+        await storeKey()
 
         await waitFor(() => {
             expect(setUserPublicKeyAction).toHaveBeenCalledWith(
                 expect.objectContaining({ publicKey: mockKeys.exportedPublicKey }),
             )
         })
+        await waitFor(() => expect(router.asPath).toBe('/openstax-lab/dashboard'))
+    })
+
+    it('an explicit redirect_url overrides the resolved landing', async () => {
+        router.setCurrentUrl('/account/keys?redirect_url=%2Facme%2Fdashboard')
+        mockClipboard(true)
+        await renderPage({ isRegenerating: false, firstKeyRedirect: '/openstax-lab/dashboard' as Route })
+
+        await storeKey()
+
         await waitFor(() => expect(router.asPath).toBe('/acme/dashboard'))
     })
 
@@ -101,9 +117,7 @@ describe('Security key generation', () => {
         mockClipboard(true)
         await renderPage({ isRegenerating: true })
 
-        fireEvent.click(screen.getByRole('button', { name: /copy key/i }))
-        fireEvent.click(await screen.findByRole('button', { name: 'Next' }))
-        fireEvent.click(await screen.findByRole('button', { name: 'Yes, I have stored my key' }))
+        await storeKey()
 
         await waitFor(() => {
             expect(updateUserPublicKeyAction).toHaveBeenCalledWith(
@@ -111,5 +125,43 @@ describe('Security key generation', () => {
             )
         })
         await waitFor(() => expect(router.asPath).toBe('/dashboard'))
+    })
+
+    it('a reset ignores a stray redirect_url', async () => {
+        router.setCurrentUrl('/account/keys?redirect_url=%2Facme%2Fdashboard')
+        mockClipboard(true)
+        await renderPage({ isRegenerating: true, firstKeyRedirect: '/openstax-lab/dashboard' as Route })
+
+        await storeKey()
+
+        await waitFor(() => expect(router.asPath).toBe('/dashboard'))
+    })
+
+    it('clears the failure message once a retried copy succeeds', async () => {
+        const writeText = mockClipboard(false)
+        await renderPage()
+
+        fireEvent.click(screen.getByRole('button', { name: /copy key/i }))
+        await waitFor(() => expect(screen.getByText(/Copy did not work/)).toBeDefined())
+
+        writeText.mockResolvedValueOnce(undefined as never)
+        fireEvent.click(screen.getByRole('button', { name: /copy key/i }))
+
+        await waitFor(() => expect(screen.getByText('Copied!')).toBeDefined())
+        expect(screen.queryByText(/Copy did not work/)).toBeNull()
+    })
+
+    it('clears the success indicator once a later copy fails', async () => {
+        const writeText = mockClipboard(true)
+        await renderPage()
+
+        fireEvent.click(screen.getByRole('button', { name: /copy key/i }))
+        await waitFor(() => expect(screen.getByText('Copied!')).toBeDefined())
+
+        writeText.mockRejectedValueOnce(new Error('blocked') as never)
+        fireEvent.click(screen.getByRole('button', { name: /copy key/i }))
+
+        await waitFor(() => expect(screen.getByText(/Copy did not work/)).toBeDefined())
+        expect(screen.queryByText('Copied!')).toBeNull()
     })
 })

--- a/src/app/account/keys/generate-keys.tsx
+++ b/src/app/account/keys/generate-keys.tsx
@@ -5,11 +5,11 @@ import { reportMutationError } from '@/components/errors'
 import { AppModal } from '@/components/modals/app-modal'
 import { setUserPublicKeyAction, updateUserPublicKeyAction } from '@/server/actions/user-keys.actions'
 import { Button, Code, Group, Paper, Stack, Text, Title, useMantineTheme } from '@mantine/core'
-import { useClipboard, useDisclosure } from '@mantine/hooks'
+import { useDisclosure } from '@mantine/hooks'
 import { CheckIcon, XIcon } from '@phosphor-icons/react/dist/ssr'
 import type { Route } from 'next'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { FC, useEffect, useState } from 'react'
+import { FC, useEffect, useRef, useState } from 'react'
 import { generateKeyPair } from 'si-encryption/util/keypair'
 import { Routes } from '@/lib/routes'
 import { safeRedirectUrl } from '@/lib/utils'
@@ -36,6 +36,44 @@ type GenerateKeysProps = {
     firstKeyRedirect?: Route
 }
 
+const COPIED_VISIBLE_MS = 2000
+
+type CopyOutcome = 'none' | 'copied' | 'failed'
+
+// The AC allows exactly one indicator at a time, which rules out Mantine's useClipboard: it folds
+// every attempt into one pair of flags, so a slow rejection (a permission prompt left open) can
+// land after a later success and light the green check and the red failure together. Attempts are
+// numbered here and a result that is no longer the latest is dropped, because a copy the user has
+// already superseded says nothing about what is on their clipboard now (OTTER-655).
+function useCopyOutcome() {
+    const [outcome, setOutcome] = useState<CopyOutcome>('none')
+    const latestAttempt = useRef(0)
+    const hideCopied = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+    useEffect(() => () => clearTimeout(hideCopied.current), [])
+
+    const copy = async (value: string) => {
+        const attempt = ++latestAttempt.current
+        clearTimeout(hideCopied.current)
+        setOutcome('none')
+
+        try {
+            if (!navigator.clipboard) throw new Error('clipboard is not available in this browser')
+            await navigator.clipboard.writeText(value)
+            if (attempt !== latestAttempt.current) return
+            setOutcome('copied')
+            hideCopied.current = setTimeout(() => setOutcome('none'), COPIED_VISIBLE_MS)
+        } catch {
+            if (attempt !== latestAttempt.current) return
+            // The message tells the user to select the key manually, so the reason does not matter
+            // and there is nothing actionable to report.
+            setOutcome('failed')
+        }
+    }
+
+    return { outcome, copy }
+}
+
 export const GenerateKeys: FC<GenerateKeysProps> = ({
     isRegenerating = false,
     firstKeyRedirect = Routes.dashboard,
@@ -45,7 +83,7 @@ export const GenerateKeys: FC<GenerateKeysProps> = ({
     const [confirmationOpened, { open: openConfirm, close: closeConfirm }] = useDisclosure(false)
     // Reveal Next after any copy attempt so a blocked clipboard doesn't trap the user.
     const [hasAttemptedCopy, setHasAttemptedCopy] = useState(false)
-    const clipboard = useClipboard({ timeout: 2000 })
+    const { outcome: copyOutcome, copy } = useCopyOutcome()
 
     const onGenerateKeys = async () => {
         const { privateKeyString, fingerprint, exportedPublicKey } = await generateKeyPair()
@@ -63,10 +101,7 @@ export const GenerateKeys: FC<GenerateKeysProps> = ({
     if (!keys) return null
 
     const onCopy = () => {
-        // useClipboard clears `error` only on reset, never on a later success, so without this a
-        // retry after a blocked copy shows the green check and the red failure at once.
-        clipboard.reset()
-        clipboard.copy(keys.privateKey)
+        void copy(keys.privateKey)
         setHasAttemptedCopy(true)
     }
 
@@ -108,8 +143,8 @@ export const GenerateKeys: FC<GenerateKeysProps> = ({
                         <Button onClick={onCopy}>Copy key</Button>
                         <NextButton isVisible={hasAttemptedCopy} onClick={openConfirm} />
                     </Group>
-                    <CopySucceededIndicator isVisible={clipboard.copied} />
-                    <CopyFailedIndicator isVisible={clipboard.error != null} />
+                    <CopySucceededIndicator isVisible={copyOutcome === 'copied'} />
+                    <CopyFailedIndicator isVisible={copyOutcome === 'failed'} />
                 </Stack>
             </Stack>
 

--- a/src/app/account/keys/generate-keys.tsx
+++ b/src/app/account/keys/generate-keys.tsx
@@ -24,6 +24,11 @@ interface Keys {
 // page resolved for this account. An explicit redirect_url (invite flows, deep links) overrides it.
 // Keyed off account state rather than off the presence of that parameter: the RequireUserKey guard
 // is the entry point most first keys arrive through, and it passes none (OTTER-655).
+//
+// firstKeyRedirect is the fallback argument on purpose, so a redirect_url that fails validation
+// falls back to the resolved landing rather than to Routes.dashboard. Passing Routes.dashboard here
+// instead would look equivalent and would quietly demote a first key to "My dashboard" whenever the
+// parameter is malformed, which is the bug this function exists to fix.
 export function postKeyRedirect(isRegenerating: boolean, redirectParam: string | null, firstKeyRedirect: Route): Route {
     if (isRegenerating) return Routes.dashboard
 
@@ -38,40 +43,51 @@ type GenerateKeysProps = {
 
 const COPIED_VISIBLE_MS = 2000
 
-type CopyOutcome = 'none' | 'copied' | 'failed'
+type CopyIndication = { hue: 'green' | 'red'; Icon: typeof CheckIcon; fw?: number; text: string }
+
+const COPY_SUCCEEDED: CopyIndication = { hue: 'green', Icon: CheckIcon, fw: 500, text: 'Copied!' }
+
+const COPY_FAILED: CopyIndication = {
+    hue: 'red',
+    Icon: XIcon,
+    text: 'Copy did not work. Select the key above and copy it manually.',
+}
 
 // The AC allows exactly one indicator at a time, which rules out Mantine's useClipboard: it folds
 // every attempt into one pair of flags, so a slow rejection (a permission prompt left open) can
-// land after a later success and light the green check and the red failure together. Attempts are
-// numbered here and a result that is no longer the latest is dropped, because a copy the user has
+// land after a later success and light the green check and the red failure together. Each attempt
+// aborts the one before it and an aborted attempt writes no state, because a copy the user has
 // already superseded says nothing about what is on their clipboard now (OTTER-655).
-function useCopyOutcome() {
-    const [outcome, setOutcome] = useState<CopyOutcome>('none')
-    const latestAttempt = useRef(0)
+function useCopyIndication() {
+    const [indication, setIndication] = useState<CopyIndication | null>(null)
+    const pending = useRef<AbortController>(undefined)
     const hideCopied = useRef<ReturnType<typeof setTimeout>>(undefined)
 
     useEffect(() => () => clearTimeout(hideCopied.current), [])
 
     const copy = async (value: string) => {
-        const attempt = ++latestAttempt.current
+        pending.current?.abort()
+        const attempt = (pending.current = new AbortController())
         clearTimeout(hideCopied.current)
-        setOutcome('none')
+        setIndication(null)
 
         try {
             if (!navigator.clipboard) throw new Error('clipboard is not available in this browser')
             await navigator.clipboard.writeText(value)
-            if (attempt !== latestAttempt.current) return
-            setOutcome('copied')
-            hideCopied.current = setTimeout(() => setOutcome('none'), COPIED_VISIBLE_MS)
+            if (attempt.signal.aborted) return
+            setIndication(COPY_SUCCEEDED)
+            hideCopied.current = setTimeout(() => {
+                if (!attempt.signal.aborted) setIndication(null)
+            }, COPIED_VISIBLE_MS)
         } catch {
-            if (attempt !== latestAttempt.current) return
+            if (attempt.signal.aborted) return
             // The message tells the user to select the key manually, so the reason does not matter
             // and there is nothing actionable to report.
-            setOutcome('failed')
+            setIndication(COPY_FAILED)
         }
     }
 
-    return { outcome, copy }
+    return { indication, copy }
 }
 
 export const GenerateKeys: FC<GenerateKeysProps> = ({
@@ -83,7 +99,7 @@ export const GenerateKeys: FC<GenerateKeysProps> = ({
     const [confirmationOpened, { open: openConfirm, close: closeConfirm }] = useDisclosure(false)
     // Reveal Next after any copy attempt so a blocked clipboard doesn't trap the user.
     const [hasAttemptedCopy, setHasAttemptedCopy] = useState(false)
-    const { outcome: copyOutcome, copy } = useCopyOutcome()
+    const { indication: copyIndication, copy } = useCopyIndication()
 
     const onGenerateKeys = async () => {
         const { privateKeyString, fingerprint, exportedPublicKey } = await generateKeyPair()
@@ -143,8 +159,7 @@ export const GenerateKeys: FC<GenerateKeysProps> = ({
                         <Button onClick={onCopy}>Copy key</Button>
                         <NextButton isVisible={hasAttemptedCopy} onClick={openConfirm} />
                     </Group>
-                    <CopySucceededIndicator isVisible={copyOutcome === 'copied'} />
-                    <CopyFailedIndicator isVisible={copyOutcome === 'failed'} />
+                    <CopyIndicator indication={copyIndication} />
                 </Stack>
             </Stack>
 
@@ -168,27 +183,16 @@ const NextButton: FC<{ isVisible: boolean; onClick: () => void }> = ({ isVisible
     )
 }
 
-const CopySucceededIndicator: FC<{ isVisible: boolean }> = ({ isVisible }) => {
+const CopyIndicator: FC<{ indication: CopyIndication | null }> = ({ indication }) => {
     const theme = useMantineTheme()
-    if (!isVisible) return null
-    return (
-        <Group gap="xs">
-            <CheckIcon size={16} color={theme.colors.green[9]} />
-            <Text c="green.9" fz={14} fw={500}>
-                Copied!
-            </Text>
-        </Group>
-    )
-}
+    if (!indication) return null
 
-const CopyFailedIndicator: FC<{ isVisible: boolean }> = ({ isVisible }) => {
-    const theme = useMantineTheme()
-    if (!isVisible) return null
+    const { hue, Icon, fw, text } = indication
     return (
         <Group gap="xs">
-            <XIcon size={16} color={theme.colors.red[9]} />
-            <Text c="red.9" fz={14}>
-                Copy did not work. Select the key above and copy it manually.
+            <Icon size={16} color={theme.colors[hue][9]} />
+            <Text c={`${hue}.9`} fz={14} fw={fw}>
+                {text}
             </Text>
         </Group>
     )

--- a/src/app/account/keys/generate-keys.tsx
+++ b/src/app/account/keys/generate-keys.tsx
@@ -7,6 +7,7 @@ import { setUserPublicKeyAction, updateUserPublicKeyAction } from '@/server/acti
 import { Button, Code, Group, Paper, Stack, Text, Title, useMantineTheme } from '@mantine/core'
 import { useClipboard, useDisclosure } from '@mantine/hooks'
 import { CheckIcon, XIcon } from '@phosphor-icons/react/dist/ssr'
+import type { Route } from 'next'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { FC, useEffect, useState } from 'react'
 import { generateKeyPair } from 'si-encryption/util/keypair'
@@ -19,11 +20,26 @@ interface Keys {
     fingerprint: string
 }
 
-type GenerateKeysProps = {
-    isRegenerating?: boolean
+// AC: a reset returns to "My dashboard"; the first key ever generated returns to the landing the
+// page resolved for this account. An explicit redirect_url (invite flows, deep links) overrides it.
+// Keyed off account state rather than off the presence of that parameter: the RequireUserKey guard
+// is the entry point most first keys arrive through, and it passes none (OTTER-655).
+export function postKeyRedirect(isRegenerating: boolean, redirectParam: string | null, firstKeyRedirect: Route): Route {
+    if (isRegenerating) return Routes.dashboard
+
+    return safeRedirectUrl(redirectParam, firstKeyRedirect)
 }
 
-export const GenerateKeys: FC<GenerateKeysProps> = ({ isRegenerating = false }) => {
+type GenerateKeysProps = {
+    isRegenerating?: boolean
+    /** Where a first key lands when no redirect_url is supplied; ignored for a reset. */
+    firstKeyRedirect?: Route
+}
+
+export const GenerateKeys: FC<GenerateKeysProps> = ({
+    isRegenerating = false,
+    firstKeyRedirect = Routes.dashboard,
+}) => {
     const theme = useMantineTheme()
     const [keys, setKeys] = useState<Keys>()
     const [confirmationOpened, { open: openConfirm, close: closeConfirm }] = useDisclosure(false)
@@ -47,6 +63,9 @@ export const GenerateKeys: FC<GenerateKeysProps> = ({ isRegenerating = false }) 
     if (!keys) return null
 
     const onCopy = () => {
+        // useClipboard clears `error` only on reset, never on a later success, so without this a
+        // retry after a blocked copy shows the green check and the red failure at once.
+        clipboard.reset()
         clipboard.copy(keys.privateKey)
         setHasAttemptedCopy(true)
     }
@@ -99,6 +118,7 @@ export const GenerateKeys: FC<GenerateKeysProps> = ({ isRegenerating = false }) 
                 isOpen={confirmationOpened}
                 keys={keys}
                 isRegenerating={isRegenerating}
+                firstKeyRedirect={firstKeyRedirect}
             />
         </Paper>
     )
@@ -139,12 +159,13 @@ const CopyFailedIndicator: FC<{ isVisible: boolean }> = ({ isVisible }) => {
     )
 }
 
-const ConfirmationModal: FC<{ onClose: () => void; isOpen: boolean; keys: Keys; isRegenerating: boolean }> = ({
-    onClose,
-    isOpen,
-    keys,
-    isRegenerating,
-}) => {
+const ConfirmationModal: FC<{
+    onClose: () => void
+    isOpen: boolean
+    keys: Keys
+    isRegenerating: boolean
+    firstKeyRedirect: Route
+}> = ({ onClose, isOpen, keys, isRegenerating, firstKeyRedirect }) => {
     const router = useRouter()
     const searchParams = useSearchParams()
 
@@ -157,8 +178,7 @@ const ConfirmationModal: FC<{ onClose: () => void; isOpen: boolean; keys: Keys; 
         },
         onError: reportMutationError('Failed to save security key'),
         onSuccess() {
-            // First-time onboarding carries an org-dashboard redirect_url; a reset carries none.
-            router.push(safeRedirectUrl(searchParams.get('redirect_url'), Routes.dashboard))
+            router.push(postKeyRedirect(isRegenerating, searchParams.get('redirect_url'), firstKeyRedirect))
         },
     })
 

--- a/src/app/account/keys/page.test.tsx
+++ b/src/app/account/keys/page.test.tsx
@@ -1,0 +1,56 @@
+import {
+    db,
+    faker,
+    fireEvent,
+    insertTestOrg,
+    mockSessionWithTestData,
+    renderWithProviders,
+    screen,
+    waitFor,
+} from '@/tests/unit.helpers'
+import { describe, expect, it, vi } from 'vitest'
+import router from 'next-router-mock'
+import KeysPage from './page'
+
+// Nothing is mocked but the clipboard: this test exists to prove the page wires the resolved
+// landing into the redirect, which the prop-injecting component tests cannot show (OTTER-655).
+// That means real key generation and a real setUserPublicKeyAction, which validates the SPKI bytes
+// it is handed and would reject a stub.
+const renderKeysPage = async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText: vi.fn(() => Promise.resolve()) },
+        configurable: true,
+    })
+
+    const page = await KeysPage()
+    renderWithProviders(page)
+    await screen.findByText('Security key', { selector: 'h3' })
+
+    fireEvent.click(screen.getByRole('button', { name: /copy key/i }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Next' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Yes, I have stored my key' }))
+}
+
+describe('KeysPage', () => {
+    it('lands a keyless single-org account on that org dashboard with no redirect_url', async () => {
+        router.setCurrentUrl('/account/keys')
+        const { user, org } = await mockSessionWithTestData({ orgType: 'lab' })
+        await db.deleteFrom('userPublicKey').where('userId', '=', user.id).execute()
+
+        await renderKeysPage()
+
+        await waitFor(() => expect(router.asPath).toBe(`/${org.slug}/dashboard`))
+    })
+
+    it('lands a keyless multi-org account on My dashboard, since no org is unambiguous', async () => {
+        router.setCurrentUrl('/account/keys')
+        const { user } = await mockSessionWithTestData({ orgType: 'lab' })
+        await db.deleteFrom('userPublicKey').where('userId', '=', user.id).execute()
+        const otherOrg = await insertTestOrg({ slug: faker.string.alpha(10) })
+        await db.insertInto('orgUser').values({ userId: user.id, orgId: otherOrg.id, isAdmin: false }).execute()
+
+        await renderKeysPage()
+
+        await waitFor(() => expect(router.asPath).toBe('/dashboard'))
+    })
+})

--- a/src/app/account/keys/page.test.tsx
+++ b/src/app/account/keys/page.test.tsx
@@ -4,23 +4,41 @@ import {
     fireEvent,
     insertTestOrg,
     mockSessionWithTestData,
+    readTestSupportFile,
     renderWithProviders,
     screen,
     waitFor,
 } from '@/tests/unit.helpers'
 import { describe, expect, it, vi } from 'vitest'
 import router from 'next-router-mock'
+import { generateKeyPair } from 'si-encryption/util/keypair'
+import { fingerprintKeyData, pemToArrayBuffer } from 'si-encryption/util'
 import KeysPage from './page'
 
-// Nothing is mocked but the clipboard: this test exists to prove the page wires the resolved
-// landing into the redirect, which the prop-injecting component tests cannot show (OTTER-655).
-// That means real key generation and a real setUserPublicKeyAction, which validates the SPKI bytes
-// it is handed and would reject a stub.
+// Spread the original: si-encryption/util is a barrel over this module, so a bare factory would
+// also blank out the key helpers this file uses to build the stand-in below.
+vi.mock('si-encryption/util/keypair', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('si-encryption/util/keypair')>()),
+    generateKeyPair: vi.fn(),
+}))
+
+// Only the key pair and the clipboard are mocked: this test exists to prove the page wires the
+// resolved landing into the redirect, which the prop-injecting component tests cannot show
+// (OTTER-655), so setUserPublicKeyAction and the landing resolver stay real. The stand-in is a real
+// SPKI key rather than a stub because the action validates the bytes it is handed; generating a
+// fresh 4096-bit pair per test would put a random multi-hundred-millisecond cost on every run.
 const renderKeysPage = async () => {
     Object.defineProperty(navigator, 'clipboard', {
         value: { writeText: vi.fn(() => Promise.resolve()) },
         configurable: true,
     })
+
+    const exportedPublicKey = pemToArrayBuffer(await readTestSupportFile('public_key.pem'))
+    vi.mocked(generateKeyPair).mockResolvedValue({
+        privateKeyString: 'test-private-key',
+        fingerprint: await fingerprintKeyData(exportedPublicKey),
+        exportedPublicKey,
+    } as never)
 
     const page = await KeysPage()
     renderWithProviders(page)

--- a/src/app/account/keys/page.tsx
+++ b/src/app/account/keys/page.tsx
@@ -1,15 +1,13 @@
 import { actionResult } from '@/lib/utils'
-import { Routes } from '@/lib/routes'
-import { getFirstKeyRedirectAction, userKeyExistsAction } from '@/server/actions/user-keys.actions'
+import { getKeyPageStateAction } from '@/server/actions/user-keys.actions'
 import { GenerateKeys } from './generate-keys'
 
 export const dynamic = 'force-dynamic'
 
 export default async function KeysPage() {
-    const hasKey = actionResult(await userKeyExistsAction())
     // A reset always returns to "My dashboard"; a first key gets the account's resolved landing,
     // which is an org dashboard only when that org is unambiguous.
-    const firstKeyRedirect = hasKey ? Routes.dashboard : actionResult(await getFirstKeyRedirectAction())
+    const { hasKey, firstKeyRedirect } = actionResult(await getKeyPageStateAction())
 
     return <GenerateKeys isRegenerating={hasKey} firstKeyRedirect={firstKeyRedirect} />
 }

--- a/src/app/account/keys/page.tsx
+++ b/src/app/account/keys/page.tsx
@@ -1,11 +1,15 @@
 import { actionResult } from '@/lib/utils'
-import { userKeyExistsAction } from '@/server/actions/user-keys.actions'
+import { Routes } from '@/lib/routes'
+import { getFirstKeyRedirectAction, userKeyExistsAction } from '@/server/actions/user-keys.actions'
 import { GenerateKeys } from './generate-keys'
 
 export const dynamic = 'force-dynamic'
 
 export default async function KeysPage() {
     const hasKey = actionResult(await userKeyExistsAction())
+    // A reset always returns to "My dashboard"; a first key gets the account's resolved landing,
+    // which is an org dashboard only when that org is unambiguous.
+    const firstKeyRedirect = hasKey ? Routes.dashboard : actionResult(await getFirstKeyRedirectAction())
 
-    return <GenerateKeys isRegenerating={hasKey} />
+    return <GenerateKeys isRegenerating={hasKey} firstKeyRedirect={firstKeyRedirect} />
 }

--- a/src/app/account/signin/mfa.test.tsx
+++ b/src/app/account/signin/mfa.test.tsx
@@ -9,6 +9,7 @@ import {
     waitFor,
     type Mock,
 } from '@/tests/unit.helpers'
+import { JOINED_ORG_STORAGE_KEY } from '@/lib/joined-org'
 import { useAuth, useSignIn, useUser } from '@clerk/nextjs'
 import router from 'next-router-mock'
 import { describe, expect, it, vi } from 'vitest'
@@ -79,6 +80,10 @@ describe('RequestMFA', () => {
                 `/account/keys?redirect_url=${encodeURIComponent(`/${invitingOrg.slug}/dashboard`)}`,
             ),
         )
+
+        // The banner is deferred until the user is keyed (OTTER-639), so the flag has to survive
+        // the key detour this branch routes them through.
+        expect(sessionStorage.getItem(JOINED_ORG_STORAGE_KEY)).toBe(invitingOrg.name)
     })
 
     // The invite branch reports failure by throwing out of actionResult; if that wrapper is ever

--- a/src/app/account/signin/mfa.test.tsx
+++ b/src/app/account/signin/mfa.test.tsx
@@ -103,6 +103,21 @@ describe('RequestMFA', () => {
         )
     })
 
+    // Both parameters arrive together whenever an invite link is opened after the proxy captured a
+    // deep link. Pinning the order here so a later refactor cannot flip it silently.
+    it('prefers the invite landing over an explicit redirect_url when both are present', async () => {
+        const { invitingOrg, invite } = await keylessInvitedUser()
+        router.setCurrentUrl(`/account/signin?invite_id=${invite.id}&redirect_url=%2Fopenstax-lab%2Fdashboard`)
+
+        await submitTotpCode(mockSecondFactor())
+
+        await waitFor(() =>
+            expect(router.asPath).toBe(
+                `/account/keys?redirect_url=${encodeURIComponent(`/${invitingOrg.slug}/dashboard`)}`,
+            ),
+        )
+    })
+
     it('carries an explicit redirect_url through key generation', async () => {
         const { user } = await mockSessionWithTestData({ orgType: 'lab' })
         await db.deleteFrom('userPublicKey').where('userId', '=', user.id).execute()

--- a/src/app/account/signin/mfa.test.tsx
+++ b/src/app/account/signin/mfa.test.tsx
@@ -1,0 +1,136 @@
+import {
+    db,
+    faker,
+    insertTestOrg,
+    mockSessionWithTestData,
+    renderWithProviders,
+    screen,
+    userEvent,
+    waitFor,
+    type Mock,
+} from '@/tests/unit.helpers'
+import { useAuth, useSignIn, useUser } from '@clerk/nextjs'
+import router from 'next-router-mock'
+import { describe, expect, it, vi } from 'vitest'
+import { RequestMFA } from './mfa'
+
+const mockSecondFactor = () => {
+    ;(useSignIn as Mock).mockReturnValue({ isLoaded: true, setActive: vi.fn() })
+    ;(useAuth as Mock).mockReturnValue({ isLoaded: true, getToken: vi.fn() })
+    // RequestMFA renders nothing once Clerk reports a live session, which is the state the shared
+    // session mock sets up; this challenge happens before the session exists.
+    ;(useUser as Mock).mockReturnValue({ isLoaded: true, isSignedIn: false })
+
+    return {
+        signIn: {
+            status: 'needs_second_factor',
+            supportedSecondFactors: [{ strategy: 'totp' }],
+            attemptSecondFactor: vi.fn().mockResolvedValue({ status: 'complete', createdSessionId: 'session-id' }),
+            reload: vi.fn(),
+        },
+        usingSMS: false,
+    }
+}
+
+const submitTotpCode = async (mfa: ReturnType<typeof mockSecondFactor>) => {
+    renderWithProviders(<RequestMFA mfa={mfa as never} />)
+
+    await userEvent.click(screen.getByRole('button', { name: /authenticator app verification/i }))
+    await userEvent.type(await screen.findByLabelText('Digit 1 of 6'), '123456')
+    await userEvent.click(screen.getByRole('button', { name: /verify code/i }))
+}
+
+// A keyless account is exactly what this flow onboards, so the key detour must not swallow the
+// invite or the destination the user was headed for (OTTER-655).
+const keylessInvitedUser = async () => {
+    const { user, org } = await mockSessionWithTestData({ orgType: 'lab' })
+    await db.deleteFrom('userPublicKey').where('userId', '=', user.id).execute()
+
+    const invitingOrg = await insertTestOrg({ slug: faker.string.alpha(10), type: 'lab' })
+    const invite = await db
+        .insertInto('pendingUser')
+        .values({ email: user.email!, orgId: invitingOrg.id, isAdmin: false })
+        .returning('id')
+        .executeTakeFirstOrThrow()
+
+    return { user, org, invitingOrg, invite }
+}
+
+describe('RequestMFA', () => {
+    it('accepts a pending invite before sending a keyless user to key generation', async () => {
+        const { user, invitingOrg, invite } = await keylessInvitedUser()
+        router.setCurrentUrl(`/account/signin?invite_id=${invite.id}`)
+
+        await submitTotpCode(mockSecondFactor())
+
+        // The membership is the point: the old early return skipped the join entirely.
+        await waitFor(async () => {
+            const membership = await db
+                .selectFrom('orgUser')
+                .select('id')
+                .where('userId', '=', user.id)
+                .where('orgId', '=', invitingOrg.id)
+                .executeTakeFirst()
+            expect(membership).toBeDefined()
+        })
+
+        await waitFor(() =>
+            expect(router.asPath).toBe(
+                `/account/keys?redirect_url=${encodeURIComponent(`/${invitingOrg.slug}/dashboard`)}`,
+            ),
+        )
+    })
+
+    // The invite branch reports failure by throwing out of actionResult; if that wrapper is ever
+    // dropped, a spent invite would look like a successful join.
+    it('sends a keyless user to the join-team page when the invite no longer resolves', async () => {
+        const { user } = await mockSessionWithTestData({ orgType: 'lab' })
+        await db.deleteFrom('userPublicKey').where('userId', '=', user.id).execute()
+        const spentInvite = faker.string.uuid()
+        router.setCurrentUrl(`/account/signin?invite_id=${spentInvite}`)
+
+        await submitTotpCode(mockSecondFactor())
+
+        await waitFor(() =>
+            expect(router.asPath).toBe(
+                `/account/keys?redirect_url=${encodeURIComponent(`/account/invitation/${spentInvite}/join-team`)}`,
+            ),
+        )
+    })
+
+    it('carries an explicit redirect_url through key generation', async () => {
+        const { user } = await mockSessionWithTestData({ orgType: 'lab' })
+        await db.deleteFrom('userPublicKey').where('userId', '=', user.id).execute()
+        router.setCurrentUrl('/account/signin?redirect_url=%2Fopenstax-lab%2Fdashboard')
+
+        await submitTotpCode(mockSecondFactor())
+
+        await waitFor(() =>
+            expect(router.asPath).toBe(`/account/keys?redirect_url=${encodeURIComponent('/openstax-lab/dashboard')}`),
+        )
+    })
+
+    it('sends a keyless user with no destination to a bare key page, so it resolves its own landing', async () => {
+        const { user } = await mockSessionWithTestData({ orgType: 'lab' })
+        await db.deleteFrom('userPublicKey').where('userId', '=', user.id).execute()
+        router.setCurrentUrl('/account/signin')
+
+        await submitTotpCode(mockSecondFactor())
+
+        await waitFor(() => expect(router.asPath).toBe('/account/keys'))
+    })
+
+    it('sends a user who already holds a key straight to their destination', async () => {
+        const { user } = await mockSessionWithTestData({ orgType: 'lab' })
+        // Stated explicitly: insertTestUser only seeds a key for enclave orgs.
+        await db
+            .insertInto('userPublicKey')
+            .values({ userId: user.id, publicKey: Buffer.from('test-public-key'), fingerprint: 'test-fingerprint' })
+            .execute()
+        router.setCurrentUrl('/account/signin?redirect_url=%2Fopenstax-lab%2Fdashboard')
+
+        await submitTotpCode(mockSecondFactor())
+
+        await waitFor(() => expect(router.asPath).toBe('/openstax-lab/dashboard'))
+    })
+})

--- a/src/app/account/signin/mfa.tsx
+++ b/src/app/account/signin/mfa.tsx
@@ -4,6 +4,7 @@ import { reportError } from '@/components/errors'
 import { errorToString } from '@/lib/errors'
 import { Routes } from '@/lib/routes'
 import { actionResult, safeRedirectUrl } from '@/lib/utils'
+import { keyGenerationUrl } from '@/lib/user-key-redirect'
 import { onUserSignInAction } from '@/server/actions/user.actions'
 import { useAuth, useSignIn, useUser } from '@clerk/nextjs'
 import type { SignInResource } from '@clerk/types'
@@ -69,55 +70,55 @@ export const RequestMFA: FC<{ mfa: MFAState }> = ({ mfa }) => {
                 try {
                     const result = actionResult(await onUserSignInAction())
                     await auth.getToken({ skipCache: true })
-                    if (result?.redirectToKeyGeneration) {
-                        router.push(Routes.accountKeys)
-                    } else {
-                        let redirectUrl = safeRedirectUrl(searchParams.get('redirect_url'), Routes.dashboard)
-                        const inviteId = searchParams.get('invite_id')
-                        if (inviteId) {
-                            let org: { slug: string; name: string } | undefined
+
+                    const rawRedirect = searchParams.get('redirect_url')
+                    let redirectUrl = rawRedirect ? safeRedirectUrl(rawRedirect, Routes.dashboard) : null
+                    const inviteId = searchParams.get('invite_id')
+                    if (inviteId) {
+                        let org: { slug: string; name: string } | undefined
+                        try {
+                            // Read the org before joining: accepting marks the invite claimed,
+                            // and the lookup only resolves unclaimed invites.
+                            org = actionResult(await getOrgInfoForInviteAction({ inviteId }))
+                        } catch (error) {
+                            // A claimed or deleted invite, so retrying can never succeed —
+                            // distinct from a join failure, which is worth retrying. The
+                            // join-team page renders a persistent "no longer valid" panel
+                            // for this state, so land there rather than on a dashboard
+                            // where only the transient toast explains what happened.
+                            reportError(error, 'This invitation is no longer valid')
+                            redirectUrl = Routes.accountInvitationJoinTeam({ inviteId }) as Route
+                        }
+                        if (org) {
                             try {
-                                // Read the org before joining: accepting marks the invite claimed,
-                                // and the lookup only resolves unclaimed invites.
-                                org = actionResult(await getOrgInfoForInviteAction({ inviteId }))
+                                // actionResult, despite the discarded value: it is what turns an
+                                // action failure into a throw, so the catch below can run.
+                                actionResult(await onJoinTeamAccountAction({ inviteId }))
+
+                                redirectUrl = Routes.orgDashboard({ orgSlug: org.slug }) as Route
+
+                                notifications.show({
+                                    color: 'green',
+                                    message: `You've successfully joined ${org.name}.`,
+                                })
+                                await auth.getToken({ skipCache: true })
                             } catch (error) {
-                                // A claimed or deleted invite, so retrying can never succeed —
-                                // distinct from a join failure, which is worth retrying. The
-                                // join-team page renders a persistent "no longer valid" panel
-                                // for this state, so land there rather than on a dashboard
-                                // where only the transient toast explains what happened.
-                                reportError(error, 'This invitation is no longer valid')
+                                // The invite is still live (a failed accept rolls the claim
+                                // back), so return to the join-team page where Accept can be
+                                // retried instead of silently landing elsewhere.
+                                reportError(error, 'Failed to accept your invitation. Please try again.')
                                 redirectUrl = Routes.accountInvitationJoinTeam({ inviteId }) as Route
                             }
-                            if (org) {
-                                try {
-                                    const joinResult = actionResult(await onJoinTeamAccountAction({ inviteId }))
-
-                                    const orgDashboard = Routes.orgDashboard({ orgSlug: org.slug })
-                                    if (joinResult?.needsUserKey) {
-                                        // First-time key generation: return to the inviting org's dashboard after.
-                                        redirectUrl =
-                                            `${Routes.accountKeys}?redirect_url=${encodeURIComponent(orgDashboard)}` as Route
-                                    } else {
-                                        redirectUrl = orgDashboard as Route
-                                    }
-
-                                    notifications.show({
-                                        color: 'green',
-                                        message: `You've successfully joined ${org.name}.`,
-                                    })
-                                    await auth.getToken({ skipCache: true })
-                                } catch (error) {
-                                    // The invite is still live (a failed accept rolls the claim
-                                    // back), so return to the join-team page where Accept can be
-                                    // retried instead of silently landing elsewhere.
-                                    reportError(error, 'Failed to accept your invitation. Please try again.')
-                                    redirectUrl = Routes.accountInvitationJoinTeam({ inviteId }) as Route
-                                }
-                            }
                         }
-                        router.push(redirectUrl)
                     }
+
+                    // Key generation last, so a keyless user still accepts their invite on the way
+                    // through and resumes where they were headed afterwards (OTTER-655).
+                    router.push(
+                        result?.redirectToKeyGeneration
+                            ? keyGenerationUrl(redirectUrl)
+                            : (redirectUrl ?? Routes.dashboard),
+                    )
                 } catch (error) {
                     // If onUserSignInAction returns an error, we still want to continue with navigation
                     // since the user is already signed in via Clerk

--- a/src/app/account/signin/mfa.tsx
+++ b/src/app/account/signin/mfa.tsx
@@ -24,12 +24,15 @@ type Method = 'sms' | 'totp'
 
 // The session token is what carries fresh org metadata to the next page, but a stale token is a
 // far smaller problem than losing the invite or the key detour that follows it, so a refresh
-// failure is logged rather than thrown.
-async function refreshSessionToken(getToken: GetToken) {
+// failure is logged rather than thrown. The caller is named in the log because the two differ in
+// what the user is left holding: after sign-in nothing has been committed yet, while after an
+// invite accept the membership row already exists, so a stale token there means a joined user
+// whose session cannot see the org.
+async function refreshSessionToken(getToken: GetToken, caller: 'sign-in' | 'invite-accepted') {
     try {
         await getToken({ skipCache: true })
     } catch (error) {
-        console.error('session token refresh failed:', error)
+        console.error(`session token refresh failed after ${caller}:`, error)
     }
 }
 
@@ -39,7 +42,7 @@ async function refreshSessionToken(getToken: GetToken) {
 async function completeServerSignIn(getToken: GetToken) {
     try {
         const result = actionResult(await onUserSignInAction())
-        await refreshSessionToken(getToken)
+        await refreshSessionToken(getToken, 'sign-in')
         return result
     } catch (error) {
         console.error('onUserSignInAction failed:', error)
@@ -84,7 +87,7 @@ async function acceptInviteAndResolveLanding(inviteId: string, getToken: GetToke
     markOrgJoined(org.name)
     // Deliberately after the landing is settled: nothing that runs once the membership exists may
     // turn a successful join into a retry prompt.
-    await refreshSessionToken(getToken)
+    await refreshSessionToken(getToken, 'invite-accepted')
 
     return Routes.orgDashboard({ orgSlug: org.slug }) as Route
 }
@@ -140,6 +143,10 @@ export const RequestMFA: FC<{ mfa: MFAState }> = ({ mfa }) => {
                     const rawRedirect = searchParams.get('redirect_url')
                     let redirectUrl = rawRedirect ? safeRedirectUrl(rawRedirect, Routes.dashboard) : null
                     const inviteId = searchParams.get('invite_id')
+                    // An invite outranks redirect_url when both are present. Joining is the thing
+                    // that just changed, and its landing is the only one that reflects it: the
+                    // dashboard confirms the membership and carries the joined-org banner, while a
+                    // deep link captured before the join may still be unreachable to this account.
                     if (inviteId) {
                         redirectUrl = await acceptInviteAndResolveLanding(inviteId, auth.getToken)
                     }

--- a/src/app/account/signin/mfa.tsx
+++ b/src/app/account/signin/mfa.tsx
@@ -8,7 +8,7 @@ import { actionResult, safeRedirectUrl } from '@/lib/utils'
 import { keyGenerationUrl } from '@/lib/user-key-redirect'
 import { onUserSignInAction } from '@/server/actions/user.actions'
 import { useAuth, useSignIn, useUser } from '@clerk/nextjs'
-import type { SignInResource } from '@clerk/types'
+import type { GetToken, SignInResource } from '@clerk/types'
 import { Button, Divider, Loader, Paper, Stack, Text, Title } from '@mantine/core'
 import { isNotEmpty } from '@mantine/form'
 import type { Route } from 'next'
@@ -21,6 +21,73 @@ import { VerifyCode } from './verify-code'
 
 export type Step = 'select' | 'verify' | 'recovery'
 type Method = 'sms' | 'totp'
+
+// The session token is what carries fresh org metadata to the next page, but a stale token is a
+// far smaller problem than losing the invite or the key detour that follows it, so a refresh
+// failure is logged rather than thrown.
+async function refreshSessionToken(getToken: GetToken) {
+    try {
+        await getToken({ skipCache: true })
+    } catch (error) {
+        console.error('session token refresh failed:', error)
+    }
+}
+
+// Clerk has already established the session by the time this runs, so a failure here must not
+// abort the rest of the sequence: a pending invite still needs accepting, and the client key guard
+// still catches a keyless account wherever it lands.
+async function completeServerSignIn(getToken: GetToken) {
+    try {
+        const result = actionResult(await onUserSignInAction())
+        await refreshSessionToken(getToken)
+        return result
+    } catch (error) {
+        console.error('onUserSignInAction failed:', error)
+        return null
+    }
+}
+
+// Always resolves to a destination rather than throwing, so the key detour still runs on top of
+// whatever this decides.
+async function acceptInviteAndResolveLanding(inviteId: string, getToken: GetToken): Promise<Route> {
+    const joinTeamPage = Routes.accountInvitationJoinTeam({ inviteId }) as Route
+
+    let org: { slug: string; name: string }
+    try {
+        // Read the org before joining: accepting marks the invite claimed,
+        // and the lookup only resolves unclaimed invites.
+        org = actionResult(await getOrgInfoForInviteAction({ inviteId }))
+    } catch (error) {
+        // A claimed or deleted invite, so retrying can never succeed, which is
+        // distinct from a join failure that is worth retrying. The join-team
+        // page renders a persistent "no longer valid" panel for this state, so
+        // land there rather than on a dashboard where only the transient toast
+        // explains what happened.
+        reportError(error, 'This invitation is no longer valid')
+        return joinTeamPage
+    }
+
+    try {
+        // actionResult, despite the discarded value: it is what turns an
+        // action failure into a throw, so the catch below can run.
+        actionResult(await onJoinTeamAccountAction({ inviteId }))
+    } catch (error) {
+        // A join that fails inside its transaction rolls the claim back, leaving the invite live,
+        // so return to the join-team page where Accept can be retried instead of silently landing
+        // elsewhere.
+        reportError(error, 'Failed to accept your invitation. Please try again.')
+        return joinTeamPage
+    }
+
+    // Same one-shot flag the join-team page sets, so this path lands on
+    // the dashboard banner.
+    markOrgJoined(org.name)
+    // Deliberately after the landing is settled: nothing that runs once the membership exists may
+    // turn a successful join into a retry prompt.
+    await refreshSessionToken(getToken)
+
+    return Routes.orgDashboard({ orgSlug: org.slug }) as Route
+}
 
 export const RequestMFA: FC<{ mfa: MFAState }> = ({ mfa }) => {
     const [step, setStep] = useState<Step>('select')
@@ -68,47 +135,13 @@ export const RequestMFA: FC<{ mfa: MFAState }> = ({ mfa }) => {
                 await setActive({ session: signInAttempt.createdSessionId })
 
                 try {
-                    const result = actionResult(await onUserSignInAction())
-                    await auth.getToken({ skipCache: true })
+                    const result = await completeServerSignIn(auth.getToken)
 
                     const rawRedirect = searchParams.get('redirect_url')
                     let redirectUrl = rawRedirect ? safeRedirectUrl(rawRedirect, Routes.dashboard) : null
                     const inviteId = searchParams.get('invite_id')
                     if (inviteId) {
-                        let org: { slug: string; name: string } | undefined
-                        try {
-                            // Read the org before joining: accepting marks the invite claimed,
-                            // and the lookup only resolves unclaimed invites.
-                            org = actionResult(await getOrgInfoForInviteAction({ inviteId }))
-                        } catch (error) {
-                            // A claimed or deleted invite, so retrying can never succeed —
-                            // distinct from a join failure, which is worth retrying. The
-                            // join-team page renders a persistent "no longer valid" panel
-                            // for this state, so land there rather than on a dashboard
-                            // where only the transient toast explains what happened.
-                            reportError(error, 'This invitation is no longer valid')
-                            redirectUrl = Routes.accountInvitationJoinTeam({ inviteId }) as Route
-                        }
-                        if (org) {
-                            try {
-                                // actionResult, despite the discarded value: it is what turns an
-                                // action failure into a throw, so the catch below can run.
-                                actionResult(await onJoinTeamAccountAction({ inviteId }))
-
-                                redirectUrl = Routes.orgDashboard({ orgSlug: org.slug }) as Route
-
-                                // Same one-shot flag the join-team page sets, so this path lands on
-                                // the dashboard banner.
-                                markOrgJoined(org.name)
-                                await auth.getToken({ skipCache: true })
-                            } catch (error) {
-                                // The invite is still live (a failed accept rolls the claim
-                                // back), so return to the join-team page where Accept can be
-                                // retried instead of silently landing elsewhere.
-                                reportError(error, 'Failed to accept your invitation. Please try again.')
-                                redirectUrl = Routes.accountInvitationJoinTeam({ inviteId }) as Route
-                            }
-                        }
+                        redirectUrl = await acceptInviteAndResolveLanding(inviteId, auth.getToken)
                     }
 
                     // Key generation last, so a keyless user still accepts their invite on the way
@@ -119,9 +152,10 @@ export const RequestMFA: FC<{ mfa: MFAState }> = ({ mfa }) => {
                             : (redirectUrl ?? Routes.dashboard),
                     )
                 } catch (error) {
-                    // If onUserSignInAction returns an error, we still want to continue with navigation
-                    // since the user is already signed in via Clerk
-                    console.error('onUserSignInAction failed:', error)
+                    // Last resort: both steps above resolve their own failures to a destination,
+                    // so reaching this means something unexpected threw. The user is signed in
+                    // either way, so navigate rather than stranding them on the MFA form.
+                    console.error('post sign-in navigation failed:', error)
                     router.push(safeRedirectUrl(searchParams.get('redirect_url'), Routes.dashboard))
                 }
             } else {

--- a/src/app/account/signin/sign-in-form.test.tsx
+++ b/src/app/account/signin/sign-in-form.test.tsx
@@ -1,12 +1,30 @@
-import { renderWithProviders, screen, fireEvent, waitFor, userEvent, type Mock } from '@/tests/unit.helpers'
+import {
+    db,
+    renderWithProviders,
+    screen,
+    fireEvent,
+    mockSessionWithTestData,
+    waitFor,
+    userEvent,
+    type Mock,
+} from '@/tests/unit.helpers'
 import { describe, it, expect, vi } from 'vitest'
-import { useSignIn } from '@clerk/nextjs'
+import { useAuth, useSignIn } from '@clerk/nextjs'
 import { memoryRouter } from 'next-router-mock'
 import { clerkErrorOverrides } from '@/lib/errors'
 import { SignInForm } from './sign-in-form'
 
 const mockSignInCreate = (create: Mock) =>
     (useSignIn as Mock).mockReturnValue({ isLoaded: true, signIn: { create }, setActive: vi.fn() })
+
+// The no-MFA counterpart of the MFA flow: sign-in completes in one step, so the key detour is
+// applied here instead (OTTER-655).
+const keylessUserSigningIn = async () => {
+    const { user } = await mockSessionWithTestData({ orgType: 'lab' })
+    await db.deleteFrom('userPublicKey').where('userId', '=', user.id).execute()
+    ;(useAuth as Mock).mockReturnValue({ isLoaded: true, getToken: vi.fn() })
+    mockSignInCreate(vi.fn().mockResolvedValue({ status: 'complete', createdSessionId: 'session-id' }))
+}
 
 const submitCredentials = async () => {
     await userEvent.type(screen.getByLabelText('Email'), 'ada@example.com')
@@ -44,6 +62,32 @@ describe('SignInForm', () => {
         await submitCredentials()
 
         await waitFor(() => expect(memoryRouter.asPath).toBe('/dashboard'))
+    })
+
+    it('carries an explicit redirect_url through key generation for a keyless user', async () => {
+        memoryRouter.setCurrentUrl('/account/signin?redirect_url=%2Fopenstax-lab%2Fdashboard')
+        await keylessUserSigningIn()
+
+        renderWithProviders(<SignInForm mfa={false} onComplete={vi.fn()} />)
+        await submitCredentials()
+
+        await waitFor(() =>
+            expect(memoryRouter.asPath).toBe(
+                `/account/keys?redirect_url=${encodeURIComponent('/openstax-lab/dashboard')}`,
+            ),
+        )
+    })
+
+    // Emitting the fallback as a parameter would pin the key page to "My dashboard" and defeat the
+    // landing it resolves for a first key.
+    it('sends a keyless user with no destination to a bare key page', async () => {
+        memoryRouter.setCurrentUrl('/account/signin')
+        await keylessUserSigningIn()
+
+        renderWithProviders(<SignInForm mfa={false} onComplete={vi.fn()} />)
+        await submitCredentials()
+
+        await waitFor(() => expect(memoryRouter.asPath).toBe('/account/keys'))
     })
 
     it('shows a field error for incorrect credentials', async () => {

--- a/src/app/account/signin/sign-in-form.tsx
+++ b/src/app/account/signin/sign-in-form.tsx
@@ -4,6 +4,7 @@ import { clerkErrorOverrides, errorToString } from '@/lib/errors'
 import type { Route } from 'next'
 import { Routes } from '@/lib/routes'
 import { actionResult, safeRedirectUrl } from '@/lib/utils'
+import { keyGenerationUrl } from '@/lib/user-key-redirect'
 import { onUserSignInAction } from '@/server/actions/user.actions'
 import { useAuth, useSignIn } from '@clerk/nextjs'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -81,7 +82,9 @@ export const SignInForm: FC<{
                 const result = actionResult(await onUserSignInAction())
                 await getToken({ skipCache: true })
                 if (result?.redirectToKeyGeneration) {
-                    router.push(Routes.accountKeys as Route)
+                    // The validated value, not the raw one: an invalid redirect_url validates to
+                    // the dashboard, which keyGenerationUrl treats as no destination (OTTER-655).
+                    router.push(keyGenerationUrl(validatedRedirect))
                 } else {
                     router.push(validatedRedirect)
                 }

--- a/src/lib/user-key-redirect.test.ts
+++ b/src/lib/user-key-redirect.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { Routes } from '@/lib/routes'
+import { keyGenerationUrl } from './user-key-redirect'
+
+describe('keyGenerationUrl', () => {
+    it('carries an explicit destination through key generation', () => {
+        expect(keyGenerationUrl('/openstax-lab/dashboard')).toBe(
+            '/account/keys?redirect_url=%2Fopenstax-lab%2Fdashboard',
+        )
+    })
+
+    it('returns a bare url when there is no destination', () => {
+        expect(keyGenerationUrl(null)).toBe(Routes.accountKeys)
+        expect(keyGenerationUrl(undefined)).toBe(Routes.accountKeys)
+        expect(keyGenerationUrl('')).toBe(Routes.accountKeys)
+    })
+
+    // safeRedirectUrl returns the dashboard for a rejected redirect_url, so forwarding it would pin
+    // the key page to "My dashboard" instead of letting it resolve the account's landing.
+    it('treats the dashboard as no destination so the key page still resolves its own landing', () => {
+        expect(keyGenerationUrl(Routes.dashboard)).toBe(Routes.accountKeys)
+    })
+})

--- a/src/lib/user-key-redirect.ts
+++ b/src/lib/user-key-redirect.ts
@@ -1,0 +1,12 @@
+import type { Route } from 'next'
+import { Routes } from '@/lib/routes'
+
+// Key generation is the last step of signup, so callers hand it the destination the user was headed
+// for. A bare url is deliberate: the key page then resolves its own landing. Routes.dashboard counts
+// as no destination, because it is also what safeRedirectUrl returns for a rejected redirect_url.
+// Forwarding it would pin the key page to "My dashboard" and defeat that resolution (OTTER-655).
+export function keyGenerationUrl(redirectUrl?: string | null): Route {
+    if (!redirectUrl || redirectUrl === Routes.dashboard) return Routes.accountKeys
+
+    return `${Routes.accountKeys}?redirect_url=${encodeURIComponent(redirectUrl)}` as Route
+}

--- a/src/server/actions/user-keys.actions.test.ts
+++ b/src/server/actions/user-keys.actions.test.ts
@@ -127,9 +127,11 @@ describe('User Keys Actions', () => {
         const rotated = await readTimestamps()
 
         // OTTER-654 reads these: createdAt stays the first-ever generation, updatedAt tracks the
-        // key currently in the user's hands.
+        // key currently in the user's hands. Inequality rather than ordering, because the insert
+        // takes its timestamp from the database default and the rotation writes one from the app,
+        // so a clock difference between the two must not decide whether this passes.
         expect(rotated.createdAt).toEqual(created.createdAt)
-        expect(rotated.updatedAt.getTime()).toBeGreaterThanOrEqual(created.updatedAt.getTime())
+        expect(rotated.updatedAt).not.toEqual(created.updatedAt)
     })
 })
 

--- a/src/server/actions/user-keys.actions.test.ts
+++ b/src/server/actions/user-keys.actions.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { mockSessionWithTestData, actionResult, faker, insertTestOrg, readTestSupportFile } from '@/tests/unit.helpers'
 import {
-    getFirstKeyRedirectAction,
+    getKeyPageStateAction,
     getUserPublicKeyAction,
     setUserPublicKeyAction,
     updateUserPublicKeyAction,
@@ -135,27 +135,56 @@ describe('User Keys Actions', () => {
     })
 })
 
-describe('getFirstKeyRedirectAction', () => {
-    it('returns the org dashboard when the account belongs to exactly one org', async () => {
-        const { org } = await mockSessionWithTestData()
+describe('getKeyPageStateAction', () => {
+    // The landing only applies to a first key, so every case below starts from a keyless account.
+    const keylessSession = async (options: Parameters<typeof mockSessionWithTestData>[0] = {}) => {
+        const session = await mockSessionWithTestData(options)
+        await db.deleteFrom('userPublicKey').where('userId', '=', session.user.id).execute()
+        return session
+    }
 
-        expect(actionResult(await getFirstKeyRedirectAction())).toEqual(`/${org.slug}/dashboard`)
+    it('returns the org dashboard when the account belongs to exactly one org', async () => {
+        const { org } = await keylessSession()
+
+        expect(actionResult(await getKeyPageStateAction())).toEqual({
+            hasKey: false,
+            firstKeyRedirect: `/${org.slug}/dashboard`,
+        })
+    })
+
+    // The card's audience is "DP & RL", so an enclave member resolves the same way a lab member
+    // does and org.type stays out of the condition.
+    it('returns the org dashboard for a lab account the same way it does for an enclave account', async () => {
+        const { org } = await keylessSession({ orgType: 'lab' })
+
+        expect(actionResult(await getKeyPageStateAction())).toEqual({
+            hasKey: false,
+            firstKeyRedirect: `/${org.slug}/dashboard`,
+        })
     })
 
     // Two orgs means no unambiguous landing, and nothing in orgUser records which one invited the
     // signup, so the action declines rather than guessing.
     it('falls back to My dashboard when the account belongs to more than one org', async () => {
-        const { user } = await mockSessionWithTestData()
+        const { user } = await keylessSession()
         const otherOrg = await insertTestOrg({ slug: faker.string.alpha(10) })
         await db.insertInto('orgUser').values({ userId: user.id, orgId: otherOrg.id, isAdmin: false }).execute()
 
-        expect(actionResult(await getFirstKeyRedirectAction())).toEqual('/dashboard')
+        expect(actionResult(await getKeyPageStateAction())).toEqual({ hasKey: false, firstKeyRedirect: '/dashboard' })
     })
 
     it('falls back to My dashboard when the account belongs to no org', async () => {
-        const { user } = await mockSessionWithTestData()
+        const { user } = await keylessSession()
         await db.deleteFrom('orgUser').where('userId', '=', user.id).execute()
 
-        expect(actionResult(await getFirstKeyRedirectAction())).toEqual('/dashboard')
+        expect(actionResult(await getKeyPageStateAction())).toEqual({ hasKey: false, firstKeyRedirect: '/dashboard' })
+    })
+
+    // A key already on file makes this a reset, which lands on "My dashboard" regardless of how
+    // many orgs the account belongs to.
+    it('reports an existing key and skips the org resolution', async () => {
+        await mockSessionWithTestData()
+
+        expect(actionResult(await getKeyPageStateAction())).toEqual({ hasKey: true, firstKeyRedirect: '/dashboard' })
     })
 })

--- a/src/server/actions/user-keys.actions.test.ts
+++ b/src/server/actions/user-keys.actions.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
-import { mockSessionWithTestData, actionResult, readTestSupportFile } from '@/tests/unit.helpers'
-import { getUserPublicKeyAction, setUserPublicKeyAction, updateUserPublicKeyAction } from './user-keys.actions'
+import { mockSessionWithTestData, actionResult, faker, insertTestOrg, readTestSupportFile } from '@/tests/unit.helpers'
+import {
+    getFirstKeyRedirectAction,
+    getUserPublicKeyAction,
+    setUserPublicKeyAction,
+    updateUserPublicKeyAction,
+} from './user-keys.actions'
 import { db } from '@/database'
 import { isActionError } from '@/lib/errors'
 import { pemToArrayBuffer, fingerprintKeyData } from 'si-encryption/util'
@@ -102,5 +107,53 @@ describe('User Keys Actions', () => {
         expect(isActionError(result)).toBe(true)
         const stored = actionResult(await getUserPublicKeyAction())
         expect(stored?.fingerprint).toEqual('old-fingerprint')
+    })
+
+    it('stores the generation date, and a rotation advances it without losing the original', async () => {
+        const { user } = await mockSessionWithTestData()
+        await db.deleteFrom('userPublicKey').where('userId', '=', user.id).execute()
+        const { publicKey } = await validTestKey()
+        const readTimestamps = () =>
+            db
+                .selectFrom('userPublicKey')
+                .select(['createdAt', 'updatedAt'])
+                .where('userId', '=', user.id)
+                .executeTakeFirstOrThrow()
+
+        await setUserPublicKeyAction({ publicKey })
+        const created = await readTimestamps()
+
+        await updateUserPublicKeyAction({ publicKey })
+        const rotated = await readTimestamps()
+
+        // OTTER-654 reads these: createdAt stays the first-ever generation, updatedAt tracks the
+        // key currently in the user's hands.
+        expect(rotated.createdAt).toEqual(created.createdAt)
+        expect(rotated.updatedAt.getTime()).toBeGreaterThanOrEqual(created.updatedAt.getTime())
+    })
+})
+
+describe('getFirstKeyRedirectAction', () => {
+    it('returns the org dashboard when the account belongs to exactly one org', async () => {
+        const { org } = await mockSessionWithTestData()
+
+        expect(actionResult(await getFirstKeyRedirectAction())).toEqual(`/${org.slug}/dashboard`)
+    })
+
+    // Two orgs means no unambiguous landing, and nothing in orgUser records which one invited the
+    // signup, so the action declines rather than guessing.
+    it('falls back to My dashboard when the account belongs to more than one org', async () => {
+        const { user } = await mockSessionWithTestData()
+        const otherOrg = await insertTestOrg({ slug: faker.string.alpha(10) })
+        await db.insertInto('orgUser').values({ userId: user.id, orgId: otherOrg.id, isAdmin: false }).execute()
+
+        expect(actionResult(await getFirstKeyRedirectAction())).toEqual('/dashboard')
+    })
+
+    it('falls back to My dashboard when the account belongs to no org', async () => {
+        const { user } = await mockSessionWithTestData()
+        await db.deleteFrom('orgUser').where('userId', '=', user.id).execute()
+
+        expect(actionResult(await getFirstKeyRedirectAction())).toEqual('/dashboard')
     })
 })

--- a/src/server/actions/user-keys.actions.ts
+++ b/src/server/actions/user-keys.actions.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { getUserPublicKey } from '@/server/db/queries'
+import { getOrgInfoForUserId, getUserPublicKey } from '@/server/db/queries'
 import { onUserPublicKeyCreated, onUserPublicKeyUpdated } from '@/server/events'
 import { revalidatePath } from 'next/cache'
 import { Routes } from '@/lib/routes'
@@ -37,14 +37,10 @@ export const userKeyExistsAction = new Action('userKeyExistsAction')
 // dashboard" rather than guessing.
 export const getFirstKeyRedirectAction = new Action('getFirstKeyRedirectAction')
     .requireAbilityTo('view', 'UserKey')
-    .handler(async ({ session, db }) => {
-        const orgs = await db
-            .selectFrom('orgUser')
-            .innerJoin('org', 'org.id', 'orgUser.orgId')
-            .select('org.slug')
-            .where('orgUser.userId', '=', session.user.id)
-            .limit(2)
-            .execute()
+    .handler(async ({ session }) => {
+        // Read from the database, not from session.orgs: that map comes from Clerk metadata, which
+        // is stale exactly when this runs, right after a signup or an invite accept.
+        const orgs = await getOrgInfoForUserId(session.user.id)
 
         if (orgs.length !== 1) return Routes.dashboard
 

--- a/src/server/actions/user-keys.actions.ts
+++ b/src/server/actions/user-keys.actions.ts
@@ -30,7 +30,7 @@ export const userKeyExistsAction = new Action('userKeyExistsAction')
         return Boolean(key)
     })
 
-// Landing for the key page when no destination was carried in — the RequireUserKey guard pushes a
+// Landing for the key page when no destination was carried in: the RequireUserKey guard pushes a
 // bare url, so the page has to answer this itself. NOT a claim about which org invited the account:
 // a single-org account simply has one dashboard it could land on, so the answer cannot be wrong even
 // though it proves nothing about provenance. Anything ambiguous (no orgs, or several) returns "My

--- a/src/server/actions/user-keys.actions.ts
+++ b/src/server/actions/user-keys.actions.ts
@@ -30,21 +30,31 @@ export const userKeyExistsAction = new Action('userKeyExistsAction')
         return Boolean(key)
     })
 
-// Landing for the key page when no destination was carried in: the RequireUserKey guard pushes a
-// bare url, so the page has to answer this itself. NOT a claim about which org invited the account:
-// a single-org account simply has one dashboard it could land on, so the answer cannot be wrong even
-// though it proves nothing about provenance. Anything ambiguous (no orgs, or several) returns "My
-// dashboard" rather than guessing.
-export const getFirstKeyRedirectAction = new Action('getFirstKeyRedirectAction')
+// Both answers the key page needs, resolved against one session: whether the account already holds
+// a key, and where a first key should land when no destination was carried in (the RequireUserKey
+// guard pushes a bare url, so the page has to answer that itself).
+//
+// The landing is NOT a claim about which org invited the account: a single-org account simply has
+// one dashboard it could land on, so the answer cannot be wrong even though it proves nothing about
+// provenance. Anything ambiguous (no orgs, or several) returns "My dashboard" rather than guessing.
+export const getKeyPageStateAction = new Action('getKeyPageStateAction')
     .requireAbilityTo('view', 'UserKey')
     .handler(async ({ session }) => {
+        const hasKey = Boolean(await getUserPublicKey(session.user.id))
+
+        // A reset always returns to "My dashboard", so the org lookup below cannot change the answer.
+        if (hasKey) return { hasKey, firstKeyRedirect: Routes.dashboard }
+
         // Read from the database, not from session.orgs: that map comes from Clerk metadata, which
         // is stale exactly when this runs, right after a signup or an invite accept.
         const orgs = await getOrgInfoForUserId(session.user.id)
 
-        if (orgs.length !== 1) return Routes.dashboard
+        // org.type is deliberately not part of this: the card's audience is "DP & RL" and asks for
+        // both to be sent through key generation, so an enclave member resolves the same way a lab
+        // member does.
+        if (orgs.length !== 1) return { hasKey, firstKeyRedirect: Routes.dashboard }
 
-        return Routes.orgDashboard({ orgSlug: orgs[0].slug })
+        return { hasKey, firstKeyRedirect: Routes.orgDashboard({ orgSlug: orgs[0].slug }) }
     })
 
 // No `fingerprint` field: it's derived server-side from `publicKey` (deterministic SHA-256 over the

--- a/src/server/actions/user-keys.actions.ts
+++ b/src/server/actions/user-keys.actions.ts
@@ -30,6 +30,27 @@ export const userKeyExistsAction = new Action('userKeyExistsAction')
         return Boolean(key)
     })
 
+// Landing for the key page when no destination was carried in — the RequireUserKey guard pushes a
+// bare url, so the page has to answer this itself. NOT a claim about which org invited the account:
+// a single-org account simply has one dashboard it could land on, so the answer cannot be wrong even
+// though it proves nothing about provenance. Anything ambiguous (no orgs, or several) returns "My
+// dashboard" rather than guessing.
+export const getFirstKeyRedirectAction = new Action('getFirstKeyRedirectAction')
+    .requireAbilityTo('view', 'UserKey')
+    .handler(async ({ session, db }) => {
+        const orgs = await db
+            .selectFrom('orgUser')
+            .innerJoin('org', 'org.id', 'orgUser.orgId')
+            .select('org.slug')
+            .where('orgUser.userId', '=', session.user.id)
+            .limit(2)
+            .execute()
+
+        if (orgs.length !== 1) return Routes.dashboard
+
+        return Routes.orgDashboard({ orgSlug: orgs[0].slug })
+    })
+
 // No `fingerprint` field: it's derived server-side from `publicKey` (deterministic SHA-256 over the
 // SPKI bytes). A client-supplied fingerprint that didn't match would make every sender wrap to a
 // key the owner can't unwrap — silent, permanent decrypt failure with no recourse until renewal.


### PR DESCRIPTION
see [OTTER-655](https://openstax.atlassian.net/browse/OTTER-655), specifically the [QA report of 2026-07-26](https://openstax.atlassian.net/browse/OTTER-655?focusedCommentId=246437).

## The reported failure

A freshly invited Research Lab user finished signup, stored their first key, and landed on `/dashboard` ("My dashboard") instead of `/openstax-lab/dashboard`. The AC asks for the inviting organization's dashboard on a first key, and "My dashboard" only on a reset.

The confirmation modal picked its destination from `searchParams.get('redirect_url')`. Two of the three entry points to `/account/keys` set that parameter; the third, the `RequireUserKey` guard, pushes a bare url, and that is the one the real signup flow goes through:

```
invite -> signup -> /account/mfa -> recovery codes -> router.push('/dashboard')
       -> AppShell mounts RequireUserKey -> push('/account/keys')   <- no redirect_url
       -> safeRedirectUrl(null, Routes.dashboard) -> /dashboard
```

So the branch was keyed on "was a parameter passed" while the AC is keyed on account history. The existing test passed only because it set `?redirect_url=` by hand, which is the condition that does not hold in production.

## What changed

**The destination now comes from account state, with `redirect_url` as an override.**

- New `getKeyPageStateAction` answers the landing question server-side, which the client guard cannot, and reports whether the account already holds a key in the same round trip. It returns the org dashboard when the account belongs to **exactly one** org, and `/dashboard` otherwise. This is deliberately a fallback rather than a claim about invitation provenance: `org_user` records membership, not who invited whom, so where the answer could be ambiguous the action declines instead of guessing. A fresh invited signup always has exactly one membership, which is the failing case.
- `page.tsx` resolves it and passes it down; `postKeyRedirect` branches on `isRegenerating`, so a reset returns to "My dashboard" and ignores any stray parameter.

**Key generation no longer eats the invite on the way through.** `mfa.tsx` returned early on `redirectToKeyGeneration`, before the block that accepts a pending invite, so a keyless user signing in from an invite link generated a key and arrived as a non-member with their destination discarded. The key redirect now runs last, after the invite is accepted.

This one is a regression from #881 rather than an unrelated bug: the early return predates it, but #881 changed `onUserSignInAction` from "only if some org needs a key" to "every user needs a key", which is what routes lab users into it.

```diff
-    if (Object.values(session.orgs).some(orgNeedsKey)) {
-        const publicKey = await getUserPublicKey(session.user.id)
+    // Every user needs a key.
+    const publicKey = await getUserPublicKey(session.user.id)
```

**A shared `keyGenerationUrl` helper** builds the detour url and treats `Routes.dashboard` as "no destination". That matters because `safeRedirectUrl` returns the dashboard for a rejected `redirect_url`, and forwarding it would pin the key page and defeat the resolution above. Keeping the rule inside the helper means a call site cannot get it wrong by forgetting it.

**One copy indicator at a time.** Mantine's `useClipboard` never resets `error` on a later success, so denying the clipboard prompt and then allowing it showed the green check and the red failure at once, against the AC. Resetting before each attempt fixes the sequential case but not overlapping ones, because `reset()` cannot cancel a `writeText` that is already in flight: a prompt the user leaves open rejects seconds later and lights the failure again behind a successful retry, which reproduces in a browser. Each attempt now aborts the one before it through an `AbortController`, and an aborted attempt writes no state, since a copy the user has already superseded says nothing about what is on their clipboard. That replaces `useClipboard` with a small local hook, keeping the same 2 s auto-hide on "Copied!" and the same treatment of a browser with no clipboard API.

**Nothing in the post-sign-in sequence abandons the rest of it.** `onUserSignInAction` throws when Clerk has not propagated the session yet, and that used to skip invite acceptance and the key detour outright; a `getToken` refresh failing after a successful join used to send the user back to the join-team page as though the join had failed. Both steps now resolve to a destination and the sequence carries on, which is the invariant the change above claims. The invite handling moved into a named helper as part of that.

## Merged with main (OTTER-639)

`origin/main` is merged in, including #958. The one conflict was the predicted one, in the invite-success block of `mfa.tsx`: #958 swaps the "You've successfully joined X" toast for `markOrgJoined(org.name)` so the join surfaces as the dashboard banner instead. Resolved by keeping this branch's structure and taking that line, which is also what `tsc` requires, since #958 removes the `notifications` import.

The two changes meet at exactly that point and compose: #958's banner now waits on `userKeyExistsAction` before spending its one-shot flag, and this branch is what routes a keyless invited user through key generation and on to the inviting org's dashboard, where the flag is still unspent. `mfa.test.tsx` asserts the flag survives the detour.

## Testing

- `page.test.tsx` is new and mocks nothing but the clipboard: it drives the real page through copy, Next and confirm, and asserts the landing. The existing component tests inject `firstKeyRedirect` as a prop, which proves the component obeys it but not that the page computes and passes it, and that is the same shape of gap that let the original bug ship green.
- `mfa.test.tsx` is new and covers the invite regression by asserting the `org_user` row exists afterwards, not just the url.
- Clipboard transitions are covered in both directions, and the key generation timestamps are pinned so OTTER-654 can rely on `createdAt` surviving a rotation. The rotation assertion compares for inequality rather than ordering: `>=` would also have passed if a rotation stopped touching `updatedAt`, and the insert timestamp comes from the database default while the rotation writes one from the app, so a clock difference must not decide the result.
- `sign-in-form.test.tsx` covers the no-MFA key detour, which had no test at all: an explicit `redirect_url` survives key generation, and no destination yields a bare `/account/keys`.
- `page.test.tsx` mocks `generateKeyPair` with a real SPKI fixture rather than generating a fresh 4096-bit pair on every run. Locally that generation ranged from 41 ms to 670 ms against testing-library's 1000 ms default, which is a flake waiting for a slower CI runner. Everything the test is actually about, `setUserPublicKeyAction` and the landing resolver, stays real.

- A regression test covers the overlapping-copy case: a first attempt that rejects only after a second one has succeeded must leave the success on screen and nothing else. It fails against the previous implementation.

Beyond the unit suite, the flow was driven through the running app end to end: a keyless single-org account signing in reaches a bare `/account/keys` and lands on that org's dashboard after storing the key, a reset lands on "My dashboard", a proxy-captured deep link survives sign-in and the key page, a keyless account in three orgs lands on "My dashboard", and a keyless sign-in carrying `invite_id` writes the membership before the key detour and reaches the inviting org with the joined-org banner intact.

Full suite passes at 2627 tests, plus `pnpm run checks`.

## Review follow-up

- **`AbortController` replaces the attempt counter.** Same semantics, a standard idiom rather than a one-off, and the auto-hide timer is guarded by the same signal, so every state write in the hook follows one rule instead of two.
- **One indicator component.** The three-state union and the two `isVisible` components collapse into a nullable result and a single `CopyIndicator`. The `none` state existed only to say "render neither", which `null` already says. Colors and weights are unchanged: verified in a browser as `#C70000` on the failure text and X icon, `#2F9844` at 14px/500 on the success.
- **The two key-page actions merged.** `userKeyExistsAction` plus `getFirstKeyRedirectAction` were two sequential round trips, each resolving its own session, where the second was only needed when the first returned false. `getKeyPageStateAction` returns `{ hasKey, firstKeyRedirect }` from one session and skips the org lookup entirely on the reset path. `userKeyExistsAction` stays for its four other callers.
- **The `redirect_url` fallback is documented.** That a rejected parameter falls through to `firstKeyRedirect` rather than to `Routes.dashboard` is load-bearing and reads as incidental, so the comment now says so, to survive a later "simplification" to `safeRedirectUrl(redirectParam, Routes.dashboard)`.
- **Enclave members are deliberately in scope.** The card's audience is "DP & RL" and it asks for both to be routed through this flow, so `org.type` stays out of the condition. Recorded in the comment and covered by a test.
- **Invite precedence is pinned.** When `invite_id` and `redirect_url` both arrive, the invite's landing wins, unchanged from `main`. Joining is what just happened, its dashboard is what confirms it and carries the joined-org banner, and a deep link captured before the join may not be reachable yet. A test now holds that order.
- **`refreshSessionToken` names its caller in the log**, so a stale token after sign-in (nothing committed yet) is distinguishable from one after an invite accept (membership already written).

The overlapping-copy race was kept rather than reduced to a `reset()` one-liner. The AC is explicit that a failure must not show the green check, the case reproduces in a browser, and the rewrite above brings its cost down to a small hook using a standard mechanism.

Beyond the unit suite, the copy states were re-driven in a browser against a clipboard harness that settles each attempt on command: a denied attempt shows only the red message, a retry shows only the green check, a stale rejection arriving after a later success leaves the success alone, and a superseded success's auto-hide timer does not clear a newer failure. `postKeyRedirect` was exercised over its full input matrix in the same run, including the malformed-parameter row, which lands on the resolved org dashboard rather than "My dashboard".

## Not in this PR

- **Recovery-code sign-in** (`recovery-code-signin.tsx`) hard-codes `/dashboard` and runs no key check, no metadata refresh, and no invite handling, so it drops invites for keyed and keyless users alike. Real bug, but `git blame` shows #881 never touched that path and it breaks no criterion on this card. Worth its own ticket, along with `sign-in-form`'s missing `invite_id` handling.
- **Server-side key enforcement.** `RequireUserKey` is a client effect that awaits a server action while the page is already rendered, so protected content is briefly visible. That does not literally satisfy "No user must be able to land or see the BMA without having a security key". QA passed it and the codebase already works around the flash, but it should be an explicit decision rather than a silent one.
- Guarding `/account/keys` against an accidental rotation by a user who already holds a key (it is reachable directly, and only `/user-key` carries the warning that a new key cannot decrypt existing outputs).
- `onJoinTeamAccountAction` does its Clerk metadata update and key lookup after its transaction commits, so a failure there reports a failed join on an invite that is already claimed, and the user is sent to the join-team page's "no longer valid" panel while holding the membership. Pre-existing and unchanged here; fixing it means moving where that action does its post-commit work.
- A keyless account belonging to more than one org still loses a deep link: `RequireUserKey` pushes a bare `/account/keys` and the resolver declines to guess between the orgs, so the user lands on "My dashboard". One line with `keyGenerationUrl` if that turns out to matter.
- **Carrying the invite destination instead of inferring it.** At invite time the org is known exactly; it is lost only because `RequireUserKey` pushes a bare `Routes.accountKeys`, after which the action reconstructs a guess from org membership. Persisting the destination where it is known (the guard reading it, or off the `pendingUser` row) would remove the action, the single-org heuristic, the ambiguity fallback and the provenance caveat, and would answer for multi-org accounts too, which membership count cannot. Raised in review and worth its own card; the heuristic coincides with the correct answer in the failing case, so it is a reasonable thing to ship in the meantime.

## QA

1. Fresh RL user invited to an org, full signup through MFA and recovery codes. Expect to be held at `/account/keys` with no query parameter, and to land on that org's dashboard after storing the key.
2. Same user, `/user-key` -> "Generate new key" -> expect `/dashboard`.
3. Existing keyless account opening an invite link -> "Login with existing account" -> expect membership in the inviting org and its dashboard after the key step.
4. Deny the clipboard permission, click Copy key (red error), grant it, click again -> only the green check.

Recovery-code sign-in still lands on `/dashboard` and still drops invites; that is expected here and belongs to the follow-up ticket.


[OTTER-655]: https://openstax.atlassian.net/browse/OTTER-655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


