### PR TITLE
Show the deployed infrastructure version and editor release on /about

### DIFF
--- a/src/app/about/page.test.tsx
+++ b/src/app/about/page.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '@/tests/unit.helpers'
+import AboutPage from './page'
+
+const linkFor = (label: string) => screen.getByText(label).closest('a')
+
+describe('AboutPage deployed versions', () => {
+    const ORIGINAL_ENV = process.env
+
+    beforeEach(() => {
+        process.env = { ...ORIGINAL_ENV }
+    })
+
+    afterEach(() => {
+        process.env = ORIGINAL_ENV
+    })
+
+    it('links the infrastructure commit to the iac repo, not the app repo', () => {
+        process.env.IAC_VERSION = '37cfdea'
+        renderWithProviders(<AboutPage />)
+
+        expect(linkFor('37cfdea')).toHaveAttribute('href', 'https://github.com/safeinsights/iac/commit/37cfdea')
+    })
+
+    it('shows a decorated git describe value as text, since it is not a linkable ref', () => {
+        process.env.IAC_VERSION = '37cfdea-dirty'
+        renderWithProviders(<AboutPage />)
+
+        expect(screen.getByText('37cfdea-dirty')).toBeDefined()
+        expect(linkFor('37cfdea-dirty')).toBeNull()
+    })
+
+    it('shows the unknown sentinel as text when git was unavailable at synth', () => {
+        process.env.IAC_VERSION = 'unknown'
+        renderWithProviders(<AboutPage />)
+
+        expect(linkFor('unknown')).toBeNull()
+    })
+
+    it('links the editor release to the app repo it was built from', () => {
+        process.env.EDITOR_RELEASE_SHA = 'a3f4f84'
+        renderWithProviders(<AboutPage />)
+
+        expect(linkFor('a3f4f84')).toHaveAttribute(
+            'href',
+            'https://github.com/safeinsights/management-app/commit/a3f4f84',
+        )
+    })
+
+    it('reports both as not deployed when the infrastructure has not supplied them', () => {
+        delete process.env.IAC_VERSION
+        delete process.env.EDITOR_RELEASE_SHA
+        renderWithProviders(<AboutPage />)
+
+        expect(screen.getAllByText('not deployed').length).toBeGreaterThanOrEqual(2)
+    })
+})

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -15,6 +15,15 @@ const Stat = ({ title, value }: { title: string; value: React.ReactNode }) => (
     </>
 )
 
+const GithubLink = ({ repo, path, label }: { repo: string; path: string; label: string }) => (
+    <a href={`https://github.com/safeinsights/${repo}/${path}`} target="_blank" rel="noopener noreferrer">
+        <Flex gap="md" align={'center'}>
+            <span>{label}</span>
+            <EyeIcon />
+        </Flex>
+    </a>
+)
+
 const TagLink = () => {
     const tag = process.env.RELEASE_TAG
     const sha = process.env.RELEASE_SHA
@@ -23,14 +32,37 @@ const TagLink = () => {
     }
     const path = tag ? `releases/tag/${tag}` : `commit/${sha}`
 
-    return (
-        <a href={`https://github.com/safeinsights/management-app/${path}`} target="_blank" rel="noopener noreferrer">
-            <Flex gap="md" align={'center'}>
-                <span>{tag || sha}</span>
-                <EyeIcon />
-            </Flex>
-        </a>
-    )
+    return <GithubLink repo="management-app" path={path} label={tag || sha || ''} />
+}
+
+// The commit of the infrastructure repo that deployed this environment. Advances only on an infra
+// deploy, so it intentionally lags the application release above.
+const IacVersionLink = () => {
+    const version = process.env.IAC_VERSION
+    if (!version) {
+        return 'not deployed'
+    }
+    // `git describe --always --dirty` emits a bare short SHA today, but grows a `-N-g<sha>` suffix
+    // once the repo carries tags, a `-dirty` suffix when deployed from a modified working copy, and
+    // the literal 'unknown' when git was unavailable at synth. Link the commit only for a plain
+    // SHA — the decorated forms are not valid refs, so a link would 404.
+    if (!/^[0-9a-f]{7,40}$/.test(version)) {
+        return version
+    }
+
+    return <GithubLink repo="iac" path={`commit/${version}`} label={version} />
+}
+
+// Which release built the editor image this environment is serving. Diverges from the release above
+// whenever the editor was unchanged: its image is tagged by a content hash, so an untouched editor
+// keeps serving the image an earlier release built.
+const EditorReleaseLink = () => {
+    const sha = process.env.EDITOR_RELEASE_SHA
+    if (!sha) {
+        return 'not deployed'
+    }
+
+    return <GithubLink repo="management-app" path={`commit/${sha}`} label={sha} />
 }
 
 export default function AboutPage() {
@@ -38,6 +70,14 @@ export default function AboutPage() {
         <Paper bg="#d3d3d3" shadow="none" p={10} mt={30} radius="sm" miw={500} maw={800} mx="auto">
             <Card withBorder radius="md" padding="xl" bg="var(--mantine-color-body)">
                 <Stat title="Release" value={<TagLink />} />
+
+                <Divider my="md" />
+
+                <Stat title="Editor Release" value={<EditorReleaseLink />} />
+
+                <Divider my="md" />
+
+                <Stat title="Infrastructure" value={<IacVersionLink />} />
 
                 <Divider my="md" />
 


### PR DESCRIPTION
Adds two rows to `/about`: which infrastructure commit deployed this environment, and which release built the editor image it is actually serving.

Pairs with safeinsights/iac#217, which supplies both as Lambda environment variables. Until that merges and an environment is deployed, both render as `not deployed` — this PR is safe to merge first.

## `Infrastructure` (`IAC_VERSION`)

The commit of the iac repo behind the running infrastructure. It advances only on an infra deploy, so it intentionally lags the application release.

The value comes from `git describe --always --dirty`, so it is usually a bare short SHA but can carry a `-N-g<sha>` or `-dirty` suffix, or the literal `unknown` when git was unavailable at synth. Only a plain SHA is linked — the decorated forms are not valid refs and the link would 404. It points at the **iac** repo, not this one.

## `Editor Release` (`EDITOR_RELEASE_SHA`)

Which release built the editor image being served. This diverges from the application release whenever the editor was unchanged: the editor image is tagged by a content hash of its build inputs, so an untouched editor keeps serving the image an earlier release built. That divergence is the reason this is worth displaying separately.

## Notes

- The repeated anchor markup is extracted into `GithubLink` rather than copied a third time.
- Adds `src/app/about/page.test.tsx` — the page had no tests. Five cases, including that each value links to the correct repo.
- `/about` is in `ANON_ROUTES`, so this is publicly visible. Both values are public git SHAs, so nothing sensitive is exposed.