### PR TITLE
OTTER-572 follow-up: resume Step 2 drafts whose edits only reached the collaborative document

### DIFF
--- a/docs/study-screens-logic.md
+++ b/docs/study-screens-logic.md
@@ -116,6 +116,11 @@ correctly reads "under review again." Counting handles both shapes and is permut
 - `displayStatus` — highest-priority **present** status (see `DISPLAY_STATUS_PRIORITY`), with
   stale code decisions dropped on a fresh resubmission; falls back to the study status.
 - `submissionRound` — count of jobs that ever carried a `CODE-SUBMITTED` (the one cross-job fact).
+- `hasStep2Progress` = the DRAFT reached Step 2 of the proposal wizard, from **either** persistence
+  layer: a written Step 2 column (`draftHasStep2Progress`) or an existing Step 2 collaborative
+  document (`hasStep2CollabDoc`, see `server/db/step2-collab-doc.ts`). Both are needed because
+  collaborative Step 2 autosaves into Yjs and flushes the columns only on Previous / View as
+  reviewer / Submit, so the columns alone under-report progress (OTTER-572).
 
 ---
 
@@ -207,12 +212,17 @@ share a `guardExecutionStage` helper for their common precondition checks.
 
 | #   | When                                                                                       | Link             | Label                     |
 | --- | ------------------------------------------------------------------------------------------ | ---------------- | ------------------------- |
-| 1   | `isDraft`                                                                                  | `studyEdit`      | `Edit` (+ `delete-draft`) |
-| 2   | `APPROVED && hasAnyJob && !hasSubmittedCode`                                               | `studyCode`      | `View`                    |
-| 3   | `hasAnyJob`                                                                                | `studyView`      | `View`                    |
-| 4   | `APPROVED && researcherAgreementsAcked`                                                    | `studyCode`      | `View`                    |
-| 5   | post-submission status, no job (`PENDING-REVIEW`/`APPROVED`/`REJECTED`/`CHANGE-REQUESTED`) | `studySubmitted` | `View`                    |
-| 6   | fallback                                                                                   | `studyView`      | `View`                    |
+| 1   | `isDraft && hasStep2Progress`                                                              | `studyProposal`  | `Edit` (+ `delete-draft`) |
+| 2   | `isDraft`                                                                                  | `studyEdit`      | `Edit` (+ `delete-draft`) |
+| 3   | `APPROVED && hasAnyJob && !hasSubmittedCode`                                               | `studyCode`      | `View`                    |
+| 4   | `hasAnyJob`                                                                                | `studyView`      | `View`                    |
+| 5   | `APPROVED && researcherAgreementsAcked`                                                    | `studyCode`      | `View`                    |
+| 6   | post-submission status, no job (`PENDING-REVIEW`/`APPROVED`/`REJECTED`/`CHANGE-REQUESTED`) | `studySubmitted` | `View`                    |
+| 7   | fallback                                                                                   | `studyView`      | `View`                    |
+
+Rule 1 is the draft-resume rule (OTTER-572): a draft left on Step 2 reopens on Step 2, and only a
+draft that never got there lands on the Step 1 data-partner picker. `/edit` itself stays
+redirect-free so Step 2's Previous button remains a working escape hatch.
 
 ---
 

--- a/src/components/dashboard/studies-table/dashboard-raw-state.test.ts
+++ b/src/components/dashboard/studies-table/dashboard-raw-state.test.ts
@@ -22,6 +22,7 @@ const row = (overrides: Partial<StudyRow>): StudyRow => ({
     projectSummary: null,
     impact: null,
     additionalNotes: null,
+    hasStep2CollabDoc: false,
     ...overrides,
 })
 
@@ -35,6 +36,11 @@ describe('dashboardRawStateFromRow', () => {
     it('maps researcherAgreementsAckedAt', () => {
         const state = projectStudyState(dashboardRawStateFromRow(row({ researcherAgreementsAckedAt: new Date() })))
         expect(state.researcherAgreementsAcked).toBe(true)
+    })
+    it('maps hasStep2CollabDoc into Step 2 progress', () => {
+        expect(projectStudyState(dashboardRawStateFromRow(row({ status: 'DRAFT' }))).hasStep2Progress).toBe(false)
+        const state = projectStudyState(dashboardRawStateFromRow(row({ status: 'DRAFT', hasStep2CollabDoc: true })))
+        expect(state.hasStep2Progress).toBe(true)
     })
     it('no job activity → empty jobs', () => {
         const state = projectStudyState(dashboardRawStateFromRow(row({ jobStatusChanges: [] })))

--- a/src/components/dashboard/studies-table/dashboard-raw-state.ts
+++ b/src/components/dashboard/studies-table/dashboard-raw-state.ts
@@ -23,13 +23,15 @@ export function dashboardRawStateFromRow(study: StudyRow): RawStudyState {
         reviewerAgreementsAckedAt: null,
         proposalResubmissionNoteDraft: null,
         codeResubmissionNoteDraft: null,
-        // Step 2 fields drive hasStep2Progress so a reopened DRAFT resumes on the right step (OTTER-572).
+        // Step 2 fields and the collaborative document drive hasStep2Progress so a reopened DRAFT resumes
+        // on the right step (OTTER-572). The document covers the edits no flush wrote to the columns.
         piUserId: study.piUserId,
         datasets: study.datasets,
         researchQuestions: study.researchQuestions,
         projectSummary: study.projectSummary,
         impact: study.impact,
         additionalNotes: study.additionalNotes,
+        hasStep2CollabDoc: !!study.hasStep2CollabDoc,
         jobs: hasActivity
             ? [{ id: '0', statusChanges: study.jobStatusChanges.map((c) => ({ status: c.status })) }]
             : [],

--- a/src/components/dashboard/studies-table/studies-table-view.stories.tsx
+++ b/src/components/dashboard/studies-table/studies-table-view.stories.tsx
@@ -32,6 +32,7 @@ const study = (o: Partial<StudyRowType> = {}): StudyRowType => ({
     projectSummary: null,
     impact: null,
     additionalNotes: null,
+    hasStep2CollabDoc: false,
     orgName: 'Mars University',
     orgSlug: 'mars-university',
     reviewingEnclaveName: 'Mars University Data Partner',

--- a/src/components/dashboard/studies-table/study-action-link.test.tsx
+++ b/src/components/dashboard/studies-table/study-action-link.test.tsx
@@ -70,6 +70,24 @@ describe('StudyActionLink', () => {
             expect(link.getAttribute('href')).toBe(`/${ORG_SLUG}/study/${STUDY_ID}/proposal`)
         })
 
+        // OTTER-572 follow-up: collaborative Step 2 edits live in Yjs, so a draft left on Step 2 without
+        // an explicit flush has no Step 2 columns at all and must still reopen on the proposal editor.
+        it('links a DRAFT with only a Step 2 collaborative document to the proposal editor', () => {
+            const study = mockStudyRow({ status: 'DRAFT' as StudyStatus, hasStep2CollabDoc: true })
+            renderWithProviders(
+                <StudyActionLink
+                    study={study}
+                    audience="researcher"
+                    scope="user"
+                    orgSlug={ORG_SLUG}
+                    isHighlighted={false}
+                />,
+            )
+
+            const link = screen.getByRole('link', { name: /edit draft study/i })
+            expect(link.getAttribute('href')).toBe(`/${ORG_SLUG}/study/${STUDY_ID}/proposal`)
+        })
+
         it('links to submitted page for PENDING-REVIEW studies without job activity', () => {
             const study = mockStudyRow({ status: 'PENDING-REVIEW' as StudyStatus, jobStatusChanges: [] })
             renderWithProviders(

--- a/src/components/dashboard/studies-table/study-row.stories.tsx
+++ b/src/components/dashboard/studies-table/study-row.stories.tsx
@@ -31,6 +31,7 @@ const study = (o: Partial<StudyRowType> = {}): StudyRowType => ({
     projectSummary: null,
     impact: null,
     additionalNotes: null,
+    hasStep2CollabDoc: false,
     orgName: 'Mars University',
     orgSlug: 'mars-university',
     reviewingEnclaveName: 'Mars University Data Partner',

--- a/src/components/dashboard/studies-table/study-row.test.tsx
+++ b/src/components/dashboard/studies-table/study-row.test.tsx
@@ -25,6 +25,7 @@ const baseStudy: StudyRowType = {
     projectSummary: null,
     impact: null,
     additionalNotes: null,
+    hasStep2CollabDoc: false,
     orgName: 'Test Org',
     orgSlug: 'test-org',
 }

--- a/src/components/dashboard/studies-table/types.ts
+++ b/src/components/dashboard/studies-table/types.ts
@@ -25,6 +25,8 @@ export type StudyRow = {
     projectSummary: Json | null
     impact: Json | null
     additionalNotes: Json | null
+    // Same purpose, for the Step 2 edits that live only in Yjs because no flush wrote the columns above.
+    hasStep2CollabDoc: boolean
     // Org actions return these
     reviewingEnclaveName?: string
     submittingLabName?: string

--- a/src/hooks/use-study-status.ts
+++ b/src/hooks/use-study-status.ts
@@ -32,6 +32,7 @@ export const useStudyStatus = ({ studyStatus, audience, jobStatusChanges }: UseS
         projectSummary: null,
         impact: null,
         additionalNotes: null,
+        hasStep2CollabDoc: false,
         jobs: jobStatusChanges.length ? [{ id: '0', statusChanges: jobStatusChanges }] : [],
     })
     return resolvePillStatus(audience, state)

--- a/src/lib/collaboration-documents.ts
+++ b/src/lib/collaboration-documents.ts
@@ -27,7 +27,11 @@ const SLUG_TO_FIELD: Record<string, ProposalTextFieldKey> = Object.fromEntries(
     Object.entries(FIELD_TO_SLUG).map(([key, slug]) => [slug, key as ProposalTextFieldKey]),
 )
 
-export const proposalFieldsDocName = (studyId: string) => `${PROPOSAL_PREFIX}${studyId}-fields`
+// Exported so SQL that builds the name from a study id column (see hasStep2CollabDocSql) reuses
+// this convention instead of re-spelling it.
+export const PROPOSAL_FIELDS_SUFFIX = '-fields'
+
+export const proposalFieldsDocName = (studyId: string) => `${PROPOSAL_PREFIX}${studyId}${PROPOSAL_FIELDS_SUFFIX}`
 
 // Y.Map name for the collab fields inside the proposal-fields doc. Shared so
 // the client hook and editor service agree on the key.

--- a/src/lib/study-screen/eligibility.test.ts
+++ b/src/lib/study-screen/eligibility.test.ts
@@ -22,6 +22,7 @@ const stateFor = (jobs: RawJob[]): RawStudyState => ({
     projectSummary: null,
     impact: null,
     additionalNotes: null,
+    hasStep2CollabDoc: false,
     jobs,
 })
 

--- a/src/lib/study-screen/state.shuffle.test.ts
+++ b/src/lib/study-screen/state.shuffle.test.ts
@@ -32,6 +32,7 @@ const base = (jobs: RawJob[]): RawStudyState => ({
     projectSummary: null,
     impact: null,
     additionalNotes: null,
+    hasStep2CollabDoc: false,
     jobs,
 })
 

--- a/src/lib/study-screen/state.test.ts
+++ b/src/lib/study-screen/state.test.ts
@@ -21,6 +21,7 @@ const raw = (overrides: Partial<RawStudyState> = {}): RawStudyState => ({
     projectSummary: null,
     impact: null,
     additionalNotes: null,
+    hasStep2CollabDoc: false,
     jobs: [],
     ...overrides,
 })
@@ -213,5 +214,12 @@ describe('projectStudyState', () => {
         expect(projectStudyState(raw({ status: 'DRAFT', researchQuestions: { q: 1 } })).hasStep2Progress).toBe(true)
         // empty datasets array is not progress
         expect(projectStudyState(raw({ status: 'DRAFT', datasets: [] })).hasStep2Progress).toBe(false)
+    })
+
+    // OTTER-572 follow-up: in collaborative mode Step 2 autosaves into Yjs and leaves every column
+    // empty until an explicit flush, so the document alone has to count as progress.
+    it('hasStep2Progress: true from the collaborative document with every Step 2 column empty', () => {
+        const s = projectStudyState(raw({ status: 'DRAFT', hasStep2CollabDoc: true }))
+        expect(s.hasStep2Progress).toBe(true)
     })
 })

--- a/src/lib/study-screen/state.ts
+++ b/src/lib/study-screen/state.ts
@@ -118,7 +118,7 @@ export function projectStudyState(raw: RawStudyState): StudyState {
     return {
         status: raw.status,
         isDraft: raw.status === 'DRAFT',
-        hasStep2Progress: draftHasStep2Progress(raw),
+        hasStep2Progress: draftHasStep2Progress(raw) || raw.hasStep2CollabDoc,
         researcherAgreementsAcked: !!raw.researcherAgreementsAckedAt,
         reviewerAgreementsAcked: !!raw.reviewerAgreementsAckedAt,
         hasAnyJob: raw.jobs.length > 0,

--- a/src/lib/study-screen/state.types.ts
+++ b/src/lib/study-screen/state.types.ts
@@ -14,6 +14,10 @@ export type RawJob = {
 // Step 2 of the proposal wizard is the first time any of these columns is written (Step 1 saves only
 // data partner + language + title + piName + doc paths). Any one being non-empty means the draft reached
 // Step 2 — see draftHasStep2Progress / projectStudyState's hasStep2Progress.
+//
+// These columns are the whole story only in single-user mode. In collaborative mode Step 2 autosaves into
+// Yjs and flushes the columns just on Previous / View as reviewer / Submit, so hasStep2CollabDoc below
+// carries the rest of the signal.
 export type DraftStep2Fields = {
     piUserId: string | null
     datasets: string[] | null
@@ -31,6 +35,9 @@ export type RawStudyState = {
     reviewerAgreementsAckedAt: Date | null
     proposalResubmissionNoteDraft: string | null
     codeResubmissionNoteDraft: string | null
+    // The study's Step 2 collaborative document exists, i.e. the draft reached Step 2 even if no flush
+    // ever wrote the DraftStep2Fields columns (OTTER-572). See hasStep2CollabDocSql.
+    hasStep2CollabDoc: boolean
     jobs: ReadonlyArray<RawJob>
 } & DraftStep2Fields
 
@@ -39,8 +46,9 @@ export type RawStudyState = {
 export type StudyState = {
     status: StudyStatus
     isDraft: boolean
-    // A DRAFT that has reached Step 2 of the proposal wizard. Routes a "resume draft" entry to the
-    // step the researcher last left off (OTTER-572) instead of always landing on the Step 1 picker.
+    // A DRAFT that has reached Step 2 of the proposal wizard, from either persistence layer: the flushed
+    // columns (DraftStep2Fields) or the collaborative document (hasStep2CollabDoc). Routes a "resume draft"
+    // entry to the step the researcher last left off (OTTER-572) instead of always landing on Step 1.
     hasStep2Progress: boolean
     researcherAgreementsAcked: boolean
     reviewerAgreementsAcked: boolean

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -34,6 +34,9 @@ import {
 import { finalizeStudySubmissionAction } from './study-request'
 import { purgeReviewFeedbackYjsDocBeforeAt } from '@/server/db/yjs-cleanup'
 import { lexicalJson } from '@/lib/lexical'
+import { proposalFieldsDocName } from '@/lib/collaboration-documents'
+import { projectStudyState } from '@/lib/study-screen'
+import { dashboardRawStateFromRow } from '@/components/dashboard/studies-table/dashboard-raw-state'
 
 vi.mock('@/server/mailgun', () => ({
     deliver: vi.fn(),
@@ -585,6 +588,33 @@ describe('Study Actions', () => {
                 .executeTakeFirstOrThrow()
             expect(row.status).toBe('PENDING-REVIEW')
         })
+    })
+
+    // OTTER-572: a draft whose Step 2 edits only ever reached Yjs must still be reported as having Step 2
+    // progress, so the dashboard resumes it on the proposal editor instead of the Step 1 picker.
+    it('reports hasStep2CollabDoc for a DRAFT whose Step 2 edits live only in Yjs', async () => {
+        const { lab, studyId } = await createTestProposalDraft({ enclaveSlug: 'step2-collab-doc-enclave' })
+        // A DRAFT may carry a null title, which the dashboard renders as blank; normalize the way the
+        // table does so the row can go through the same projection the Edit link uses.
+        const stateFor = async () => {
+            const rows = actionResult(await fetchStudiesForOrgAction({ orgSlug: lab.slug }))
+            const row = rows.find((s) => s.id === studyId)!
+            return { row, state: projectStudyState(dashboardRawStateFromRow({ ...row, title: row.title ?? '' })) }
+        }
+
+        const before = await stateFor()
+        expect(before.row.status).toBe('DRAFT')
+        expect(before.row.hasStep2CollabDoc).toBe(false)
+        expect(before.state.hasStep2Progress).toBe(false)
+
+        await db
+            .insertInto('yjsDocument')
+            .values({ name: proposalFieldsDocName(studyId), studyId, data: Buffer.from([0]) })
+            .execute()
+
+        const after = await stateFor()
+        expect(after.row.hasStep2CollabDoc).toBe(true)
+        expect(after.state.hasStep2Progress).toBe(true)
     })
 
     it('DRAFT studies have lastUpdatedAt defaulting to creation time', async () => {

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -22,6 +22,7 @@ import {
     type LatestJobForStudy,
 } from '@/server/db/queries'
 import { nextVersionForStudyComment } from '@/server/db/mutations'
+import { hasStep2CollabDocSql } from '@/server/db/step2-collab-doc'
 import { purgeCodeReviewFeedbackYjsDoc, purgeReviewFeedbackYjsDocBeforeAt } from '@/server/db/yjs-cleanup'
 import {
     deferred,
@@ -115,6 +116,7 @@ function fetchStudyQuery(db: DBExecutor) {
             'reviewer.fullName as reviewerName',
             'latestStudyJob.jobId as latestStudyJobId',
         ])
+        .select(hasStep2CollabDocSql.as('hasStep2CollabDoc'))
         .orderBy('study.lastUpdatedAt', 'desc')
 }
 

--- a/src/server/db/step2-collab-doc.ts
+++ b/src/server/db/step2-collab-doc.ts
@@ -1,0 +1,26 @@
+import { sql } from 'kysely'
+import { PROPOSAL_FIELDS_SUFFIX, PROPOSAL_PREFIX, PROPOSAL_TEXT_SLUGS } from '@/lib/collaboration-documents'
+
+// Step 2 of the proposal wizard persists into Yjs, not into the study columns: every edit goes to the
+// `proposal-<studyId>-fields` document or to one per lexical field, and the columns are written only by
+// Previous / View as reviewer / Submit. A draft edited on Step 2 and left by any other exit (nav link,
+// closed tab, back button) therefore has empty Step 2 columns, which used to send the researcher back to
+// the Step 1 picker on reopen (OTTER-572).
+//
+// Every document name Step 2 can write for a study. The fields document alone would very nearly do, since
+// it is created the first time Step 2 mounts (use-yjs-form-map seeds title/datasets/piName/piUserId into a
+// document that does not exist yet), but listing the lexical documents too keeps the signal correct if that
+// seeding ever changes.
+const STEP2_DOC_SUFFIXES = [PROPOSAL_FIELDS_SUFFIX, ...PROPOSAL_TEXT_SLUGS.map((slug) => `-${slug}`)]
+
+const docNameForStudyRow = (suffix: string) => sql`${PROPOSAL_PREFIX} || "study"."id"::text || ${suffix}`
+
+// Exact name equality, never `name like 'proposal-' || id || '-%'`: a pattern built per outer row is not a
+// planner-time constant, so it could not drive a prefix range scan (and a non-C collation would need
+// text_pattern_ops anyway), whereas equality against the outer row resolves through yjs_document's
+// name primary key.
+export const hasStep2CollabDocSql = sql<boolean>`exists (
+    select 1
+      from "yjs_document"
+     where "yjs_document"."name" = any(array[${sql.join(STEP2_DOC_SUFFIXES.map(docNameForStudyRow))}])
+)`

--- a/src/server/db/study-state-query.test.ts
+++ b/src/server/db/study-state-query.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { db } from '@/database'
-import { insertTestStudyJobData } from '@/tests/unit.helpers'
+import { insertTestStudyJobData, insertTestStudyOnly, setTestStudyStatus } from '@/tests/unit.helpers'
+import { proposalFieldsDocName, proposalTextFieldDocName } from '@/lib/collaboration-documents'
 import { rawStudyStateForStudy } from './study-state-query'
 
 describe('rawStudyStateForStudy', () => {
@@ -20,5 +21,60 @@ describe('rawStudyStateForStudy', () => {
 
     it('returns null for an unknown study id', async () => {
         expect(await rawStudyStateForStudy('01900000-0000-7000-8000-0000000000ff')).toBeNull()
+    })
+
+    // OTTER-572: the collaborative documents are the only trace of Step 2 edits that were never flushed
+    // to the study columns, so the query has to report them.
+    describe('hasStep2CollabDoc', () => {
+        const insertDraft = async () => {
+            const { study } = await insertTestStudyOnly()
+            await setTestStudyStatus(study.id, 'DRAFT')
+            return study
+        }
+
+        const insertYjsDoc = (studyId: string, name: string) =>
+            db
+                .insertInto('yjsDocument')
+                .values({ name, studyId, data: Buffer.from([0]) })
+                .execute()
+
+        it('is false for a draft with no collaborative document', async () => {
+            const study = await insertDraft()
+            const raw = await rawStudyStateForStudy(study.id)
+            expect(raw!.hasStep2CollabDoc).toBe(false)
+        })
+
+        it('is true once the proposal fields document exists', async () => {
+            const study = await insertDraft()
+            await insertYjsDoc(study.id, proposalFieldsDocName(study.id))
+
+            const raw = await rawStudyStateForStudy(study.id)
+            expect(raw!.hasStep2CollabDoc).toBe(true)
+        })
+
+        it('is true from a lexical field document alone', async () => {
+            const study = await insertDraft()
+            await insertYjsDoc(study.id, proposalTextFieldDocName(study.id, 'researchQuestions'))
+
+            const raw = await rawStudyStateForStudy(study.id)
+            expect(raw!.hasStep2CollabDoc).toBe(true)
+        })
+
+        it("does not read another study's documents", async () => {
+            const study = await insertDraft()
+            const other = await insertDraft()
+            await insertYjsDoc(other.id, proposalFieldsDocName(other.id))
+
+            const raw = await rawStudyStateForStudy(study.id)
+            expect(raw!.hasStep2CollabDoc).toBe(false)
+        })
+
+        it('ignores documents that are not Step 2 proposal documents', async () => {
+            const study = await insertDraft()
+            await insertYjsDoc(study.id, `review-feedback-${study.id}-v1`)
+
+            const raw = await rawStudyStateForStudy(study.id)
+            expect(raw!.hasStep2CollabDoc).toBe(false)
+        })
     })
 })

--- a/src/server/db/study-state-query.test.ts
+++ b/src/server/db/study-state-query.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { db } from '@/database'
 import { insertTestStudyJobData, insertTestStudyOnly, setTestStudyStatus } from '@/tests/unit.helpers'
-import { proposalFieldsDocName, proposalTextFieldDocName } from '@/lib/collaboration-documents'
+import {
+    proposalFieldsDocName,
+    proposalResubmissionNoteDocNameForVersion,
+    proposalTextFieldDocName,
+} from '@/lib/collaboration-documents'
 import { rawStudyStateForStudy } from './study-state-query'
 
 describe('rawStudyStateForStudy', () => {
@@ -72,6 +76,16 @@ describe('rawStudyStateForStudy', () => {
         it('ignores documents that are not Step 2 proposal documents', async () => {
             const study = await insertDraft()
             await insertYjsDoc(study.id, `review-feedback-${study.id}-v1`)
+
+            const raw = await rawStudyStateForStudy(study.id)
+            expect(raw!.hasStep2CollabDoc).toBe(false)
+        })
+
+        // The resubmission note shares the `proposal-<studyId>-` prefix but is written on the
+        // change-requested resubmit screen, not on Step 2, so a prefix match would misreport it.
+        it('ignores a resubmission-note document despite its proposal prefix', async () => {
+            const study = await insertDraft()
+            await insertYjsDoc(study.id, proposalResubmissionNoteDocNameForVersion(study.id, 1))
 
             const raw = await rawStudyStateForStudy(study.id)
             expect(raw!.hasStep2CollabDoc).toBe(false)

--- a/src/server/db/study-state-query.ts
+++ b/src/server/db/study-state-query.ts
@@ -1,5 +1,6 @@
 import { db as defaultDb, jsonArrayFrom, type DBExecutor } from '@/database'
 import type { RawStudyState } from '@/lib/study-screen'
+import { hasStep2CollabDocSql } from '@/server/db/step2-collab-doc'
 
 // Accepts an optional executor (mirrors codeSubmissionVersion) so a mutation action can run this gate
 // on its own handler transaction rather than the module singleton. Pages call it with the default.
@@ -26,6 +27,7 @@ export async function rawStudyStateForStudy(
             'study.impact',
             'study.additionalNotes',
         ])
+        .select(hasStep2CollabDocSql.as('hasStep2CollabDoc'))
         .select((eb) => [
             jsonArrayFrom(
                 eb

--- a/tests/unit.helpers.tsx
+++ b/tests/unit.helpers.tsx
@@ -1104,6 +1104,7 @@ export const mockStudyRow = (overrides: Partial<StudyRow> = {}): StudyRow => ({
     projectSummary: null,
     impact: null,
     additionalNotes: null,
+    hasStep2CollabDoc: false,
     ...overrides,
 })
 


### PR DESCRIPTION
see [OTTER-572](https://openstax.atlassian.net/browse/OTTER-572)

A proposal draft left on Step 2 still reopened on the Step 1 data-partner picker, so the card regressed again after the June fix.

## Why the previous fix stopped holding

The dashboard resume rule is right, but the fact it reads was sourced from the wrong storage layer.

`hasStep2Progress` was derived only from the Step 2 study columns (`piUserId`, `datasets`, `researchQuestions`, `projectSummary`, `impact`, `additionalNotes`). In collaborative mode those columns are not what Step 2 writes: every edit goes into the `proposal-<studyId>-fields` Yjs document or a per-field lexical document, and the columns are flushed only by `Previous`, `View as reviewer`, and `Submit`. There is no interval autosave and no unload flush, and the editor service mirrors exactly one value back into the study row (the title, in `title-mirror.ts`).

So the reported flow: Step 1, Proceed, fill Step 2, see "All changes saved", then leave through the nav or close the tab. The columns are still null, `hasStep2Progress` is false, and the dashboard sends the researcher to Step 1. The work is not lost, it reloads from Yjs on the way back, but the landing step is wrong.

This only shows up in collaborative environments, which is why CI stayed green: the existing e2e leaves Step 2 through `Previous` (which flushes), and CI runs with `SINGLE_USER_EDITING=t`, where the columns and Yjs cannot diverge.

A second, smaller case had the same root cause: after reopening Step 2 the form is seeded from Yjs and reset to pristine, so `Previous` skips its flush and the columns stay empty even on the one path meant to write them.

## The fix

Read the resume signal from Step 2's actual persistence layer, and keep the rule and the state machine as they are.

- New `hasStep2CollabDoc` fact on `RawStudyState`, projected into `hasStep2Progress` alongside the existing column check.
- `server/db/step2-collab-doc.ts` holds the shared `EXISTS` fragment over `yjs_document`, used by both producers of `RawStudyState` (the dashboard listing query and `rawStudyStateForStudy`).
- The fragment matches the five document names Step 2 can write for a study (the fields map plus one per lexical field) by **exact name equality**, so each probe resolves through `yjs_document`'s `name` primary key. A `name LIKE 'proposal-' || id || '-%'` variant would be built per outer row rather than being a planner-time constant, so it could not drive a prefix range scan, and a non-C collation would additionally need `text_pattern_ops`.

No migration, no new write path, no extra mirroring: the change is read-side only.

The signal means "reached Step 2", so a researcher who opened Step 2, walked back with `Previous`, and then left from Step 1 now resumes on Step 2. That was equally true of the column-based version once any Step 2 field had been written, and `Previous` remains one click away.

## Alternatives considered

- **Extend the editor-service mirror** to write `datasets` / `piUserId` / `piName` back like the title. Follows existing precedent, but it does not cover a researcher who only types into the lexical fields, so the bug stays reproducible. Mirroring those would mean headless lexical serialization on every debounced store flush.
- **Link every DRAFT to Step 2** and delete the fact. Smallest diff, but it depends on "a draft row implies Step 2 was reached", which the in-flight draft-architecture work breaks by lazy-creating a draft on the first Step 1 edit.
- **A stored `last_draft_step` marker.** The only way to track the last step literally, but it needs a migration and writes on both steps. Worth raising with PM only if per-step fidelity is wanted over "reached Step 2".

## Tests

Full unit suite passes (266 files, 2612 tests), along with `pnpm run checks`.

- `state.test.ts`: Step 2 progress comes from the collaborative document with every column empty.
- `dashboard-raw-state.test.ts`: the row field reaches the projection.
- `study-action-link.test.tsx`: a DRAFT with only a collaborative document links to `/proposal`.
- `study-state-query.test.ts`: real rows for the fields document, a lexical document alone, another study's document, and a non-Step-2 document.
- `study.actions.test.ts`: the dashboard listing query reports the fact and the row projects to Step 2 progress.

E2E coverage note: the existing `Researcher resumes a Step 2 draft on Step 2` spec covers the flush path and still passes. The "leave through the nav" path cannot be asserted in CI, because in single-user mode nothing is persisted on that exit at all, so there is nothing to resume. The collaborative path is covered by the server-side tests above plus manual QA.

## Manual verification

Needs a collaborative environment (local docker qualifies, `editor-service` runs and `SINGLE_USER_EDITING` is unset).

1. Researcher, Propose New Study, pick Data Partner and language, Proceed to Step 2.
2. Fill only the research question and wait for "All changes saved".
3. Leave through the top nav or close the tab, not `Previous`.
4. Dashboard, the draft row, `Edit`: lands on `/study/{id}/proposal` on STEP 2 with the typed content.
5. Repeat with only datasets, then only the PI, to cover the fields document.
6. A draft abandoned before Step 2 ever opened still lands on Step 1.

[OTTER-572]: https://openstax.atlassian.net/browse/OTTER-572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ