### PR TITLE
OTTER-695: route the feedback-only outputs decision to its own resear…

### DIFF
--- a/docs/study-screens-logic.md
+++ b/docs/study-screens-logic.md
@@ -131,16 +131,21 @@ raw jobs.
 
 | #   | When                                                                             | Screen              |
 | --- | -------------------------------------------------------------------------------- | ------------------- |
-| 1   | `hasResults && !awaitingFilesDecisionOnError`                                    | `study-results`     |
-| 2   | `codeDecision === 'CODE-APPROVED' && isExecuting`                                | `outputs-pending`   |
-| 3   | `codeDecision === 'CODE-APPROVED'`                                               | `code-approved`     |
-| 4   | `codeDecision === 'CODE-CHANGES-REQUESTED'` or `'CODE-REJECTED'`                 | `code-feedback`     |
-| 5   | `codeAwaitingDecision`                                                           | `code-under-review` |
-| 6   | `status === 'APPROVED' && !hasSubmittedCode`                                     | `proposal-feedback` |
-| 7   | `status === 'PENDING-REVIEW'`                                                    | `study-overview`    |
-| 8   | `status` ∈ `CHANGE-REQUESTED`/`REJECTED`/`APPROVED` (decided; APPROVED has code) | `proposal-feedback` |
-| 9   | `isDraft`                                                                        | `study-overview`    |
-| 10  | fallback                                                                         | `study-overview`    |
+| 1   | `resultsRejected && !resultsErrored`                                             | `outputs-feedback`  |
+| 2   | `hasResults && !awaitingFilesDecisionOnError`                                    | `study-results`     |
+| 3   | `codeDecision === 'CODE-APPROVED' && isExecuting`                                | `outputs-pending`   |
+| 4   | `codeDecision === 'CODE-APPROVED'`                                               | `code-approved`     |
+| 5   | `codeDecision === 'CODE-CHANGES-REQUESTED'` or `'CODE-REJECTED'`                 | `code-feedback`     |
+| 6   | `codeAwaitingDecision`                                                           | `code-under-review` |
+| 7   | `status === 'APPROVED' && !hasSubmittedCode`                                     | `proposal-feedback` |
+| 8   | `status === 'PENDING-REVIEW'`                                                    | `study-overview`    |
+| 9   | `status` ∈ `CHANGE-REQUESTED`/`REJECTED`/`APPROVED` (decided; APPROVED has code) | `proposal-feedback` |
+| 10  | `isDraft`                                                                        | `study-overview`    |
+| 11  | fallback                                                                         | `study-overview`    |
+
+Researcher precedence note (OTTER-695): rule #1 claims a clean run decided with **Share feedback
+only** before `study-results` can; an errored run's `FILES-REJECTED` and `resultsApproved` both
+still fall through to `study-results` (#2).
 
 **Reviewer table (`reviewer-screen-rules.ts`)** — transcribes the legacy `review/page.tsx`
 cascade with the `?from=` cases removed (those became routing, not screen-selection):

--- a/src/app/[orgSlug]/study/[studyId]/_screens/outputs-feedback-screen.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/outputs-feedback-screen.test.tsx
@@ -1,0 +1,259 @@
+import {
+    actionResult,
+    describe,
+    expect,
+    insertTestStudyJobData,
+    it,
+    type Mock,
+    mockSessionWithTestData,
+    renderWithProviders,
+    requireRawState,
+    screen,
+} from '@/tests/unit.helpers'
+import { useParams } from 'next/navigation'
+import dayjs from 'dayjs'
+import { db } from '@/database'
+import { lexicalJson } from '@/lib/lexical'
+import { displayOrgName } from '@/lib/string'
+import type { RawStudyState } from '@/lib/study-screen'
+import { getStudyAction } from '@/server/actions/study.actions'
+import { setupStudyAction } from '@/tests/db-action.helpers'
+import { OutputsFeedbackScreen } from './outputs-feedback-screen'
+import type { ScreenComponentProps } from './types'
+
+const APPROVED_AT = new Date('2026-06-20T12:00:00Z')
+const SUBMITTED_AT = new Date('2026-07-01T12:00:00Z')
+const DECIDED_AT = new Date('2026-08-05T12:00:00Z')
+
+const BANNER_BODY = (dataPartner: string) =>
+    `${dataPartner} has shared feedback on the latest code run. The outputs are not available for this study. When you are ready, edit your code and resubmit.`
+
+const renderScreen = async (
+    study: ScreenComponentProps['study'],
+    raw: RawStudyState,
+    orgSlug: string,
+    returnTo?: 'org',
+) => renderWithProviders(await OutputsFeedbackScreen({ study, raw, orgSlug, returnTo }))
+
+// Clean run + "Share feedback only": FILES-REJECTED plus a RESULTS decision comment (OTTER-695).
+const setupFeedbackOnly = async ({ withNote = false }: { withNote?: boolean } = {}) => {
+    const { org, user } = await mockSessionWithTestData({ orgSlug: 'test-lab', orgType: 'lab' })
+    const { study: dbStudy, job } = await insertTestStudyJobData({
+        org,
+        researcherId: user.id,
+        jobStatus: 'CODE-SUBMITTED',
+    })
+
+    // Pin timestamps: rows written in one test transaction tie on now(), which would make the
+    // banner date and entry order non-deterministic.
+    await db
+        .updateTable('jobStatusChange')
+        .set({ createdAt: SUBMITTED_AT })
+        .where('studyJobId', '=', job.id)
+        .where('status', '=', 'CODE-SUBMITTED')
+        .execute()
+    await db
+        .insertInto('jobStatusChange')
+        .values({ studyJobId: job.id, status: 'CODE-APPROVED', userId: user.id, createdAt: APPROVED_AT })
+        .execute()
+    await db.insertInto('jobStatusChange').values({ studyJobId: job.id, status: 'RUN-COMPLETE' }).execute()
+    await db
+        .insertInto('jobStatusChange')
+        .values({ studyJobId: job.id, status: 'FILES-REJECTED', userId: user.id, createdAt: DECIDED_AT })
+        .execute()
+    await db
+        .insertInto('studyReviewComment')
+        .values({
+            studyId: dbStudy.id,
+            studyJobId: job.id,
+            authorId: user.id,
+            reviewKind: 'RESULTS',
+            entryType: 'DECISION',
+            decision: 'NEEDS-CLARIFICATION',
+            body: JSON.parse(lexicalJson('Remove the row-level output before resharing.')),
+            round: 1,
+            createdAt: DECIDED_AT,
+        })
+        .execute()
+    if (withNote) {
+        await db
+            .updateTable('studyJob')
+            .set({ resubmissionNote: JSON.parse(lexicalJson('Adjusted the aggregation query.')), resubmissionRound: 1 })
+            .where('id', '=', job.id)
+            .execute()
+    }
+
+    const study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+    const raw = await requireRawState(dbStudy.id)
+    ;(useParams as Mock).mockReturnValue({ orgSlug: org.slug, studyId: study.id })
+    return { org, user, study, raw, job }
+}
+
+describe('OutputsFeedbackScreen', () => {
+    it('renders the reused page header and STEP 4 "Verify outputs" section header with the study title', async () => {
+        const { org, study, raw } = await setupFeedbackOnly()
+        await renderScreen(study, raw, org.slug)
+
+        expect(screen.getByRole('heading', { level: 1, name: 'Secondary analysis study' })).toBeInTheDocument()
+        const header = screen.getByTestId('proposal-section-header')
+        expect(header).toHaveTextContent('STEP 4')
+        expect(header).toHaveTextContent('Verify outputs')
+        expect(header).toHaveTextContent(study.title!)
+    })
+
+    it('renders the reused action alert with the exact copy, data partner name, and decision date', async () => {
+        const { org, study, raw } = await setupFeedbackOnly()
+        await renderScreen(study, raw, org.slug)
+
+        const alert = screen.getByTestId('status-alert')
+        expect(alert).toHaveAttribute('data-variant', 'action')
+        expect(alert).toHaveTextContent(`Feedback on outputs available • ${dayjs(DECIDED_AT).format('MMM DD, YYYY')}`)
+        expect(alert).toHaveTextContent(BANNER_BODY(displayOrgName(org.name)))
+    })
+
+    it('dates the banner from the FILES-REJECTED decision, not code approval or today', async () => {
+        const { org, study, raw } = await setupFeedbackOnly()
+        await renderScreen(study, raw, org.slug)
+
+        const alert = screen.getByTestId('status-alert')
+        expect(alert).toHaveTextContent(dayjs(DECIDED_AT).format('MMM DD, YYYY'))
+        expect(alert).not.toHaveTextContent(dayjs(APPROVED_AT).format('MMM DD, YYYY'))
+        expect(alert).not.toHaveTextContent(dayjs(new Date()).format('MMM DD, YYYY'))
+    })
+
+    it('degrades to an undated banner when the payload job carries no FILES-REJECTED row', async () => {
+        const { org, study, raw, job } = await setupFeedbackOnly()
+        // raw was captured before this delete, so routing still lands here; the payload lacks the date.
+        await db
+            .deleteFrom('jobStatusChange')
+            .where('studyJobId', '=', job.id)
+            .where('status', '=', 'FILES-REJECTED')
+            .execute()
+        await renderScreen(study, raw, org.slug)
+
+        const alert = screen.getByTestId('status-alert')
+        expect(alert).toHaveTextContent('Feedback on outputs available')
+        expect(alert).not.toHaveTextContent('•')
+    })
+
+    it("renders the reused feedback-and-notes section with this study's outputs feedback", async () => {
+        const { org, user, study, raw } = await setupFeedbackOnly({ withNote: true })
+        await renderScreen(study, raw, org.slug)
+
+        const section = screen.getByTestId('feedback-and-notes-section')
+        expect(section).toHaveTextContent('Reviewer feedback (v1.0)')
+        expect(section).toHaveTextContent('Remove the row-level output before resharing.')
+        expect(section).toHaveTextContent('Resubmission note (v1.0)')
+        expect(section).toHaveTextContent('Adjusted the aggregation query.')
+        expect(section).toHaveTextContent(user.fullName)
+        expect(screen.getAllByTestId('entry-divider')).toHaveLength(1)
+    })
+
+    it("shows only this study's feedback, not another study's", async () => {
+        const { org, user, study, raw } = await setupFeedbackOnly()
+        const { study: otherStudy, job: otherJob } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            jobStatus: 'CODE-SUBMITTED',
+        })
+        await db
+            .insertInto('studyReviewComment')
+            .values({
+                studyId: otherStudy.id,
+                studyJobId: otherJob.id,
+                authorId: user.id,
+                reviewKind: 'RESULTS',
+                entryType: 'DECISION',
+                decision: 'NEEDS-CLARIFICATION',
+                body: JSON.parse(lexicalJson('Feedback that belongs to the other study.')),
+                round: 1,
+            })
+            .execute()
+
+        await renderScreen(study, raw, org.slug)
+
+        expect(screen.getByText('Remove the row-level output before resharing.')).toBeInTheDocument()
+        expect(screen.queryByText('Feedback that belongs to the other study.')).not.toBeInTheDocument()
+    })
+
+    it('does not surface code-review feedback in the outputs thread', async () => {
+        const { org, user, study, raw, job } = await setupFeedbackOnly()
+        await db
+            .insertInto('studyReviewComment')
+            .values({
+                studyId: study.id,
+                studyJobId: job.id,
+                authorId: user.id,
+                reviewKind: 'CODE',
+                entryType: 'DECISION',
+                decision: 'APPROVE',
+                body: JSON.parse(lexicalJson('Code-step approval feedback.')),
+                round: 1,
+            })
+            .execute()
+
+        await renderScreen(study, raw, org.slug)
+
+        expect(screen.queryByText('Code-step approval feedback.')).not.toBeInTheDocument()
+    })
+
+    it('wires Previous step (subtle) to the code step page and Edit code (outline, enabled) to the resubmit page', async () => {
+        const { org, study, raw } = await setupFeedbackOnly()
+        await renderScreen(study, raw, org.slug)
+
+        const previous = screen.getByRole('link', { name: /previous step/i })
+        expect(previous).toHaveAttribute('href', `/${org.slug}/study/${study.id}/view/code`)
+        expect(previous).toHaveAttribute('data-variant', 'subtle')
+
+        const edit = screen.getByRole('link', { name: /edit code/i })
+        expect(edit).toHaveAttribute('href', `/${org.slug}/study/${study.id}/resubmit`)
+        expect(edit).toHaveAttribute('data-variant', 'outline')
+        expect(edit).not.toHaveAttribute('data-disabled')
+    })
+
+    it('passes returnTo through to the Previous step link', async () => {
+        const { org, study, raw } = await setupFeedbackOnly()
+        await renderScreen(study, raw, org.slug, 'org')
+
+        expect(screen.getByRole('link', { name: /previous step/i })).toHaveAttribute(
+            'href',
+            `/${org.slug}/study/${study.id}/view/code?returnTo=org`,
+        )
+    })
+
+    it('shows a not-found alert when the study has no submitted job', async () => {
+        const { org, study } = await setupStudyAction({ orgSlug: 'test-lab', orgType: 'lab', createJob: false })
+        ;(useParams as Mock).mockReturnValue({ orgSlug: org.slug, studyId: study.id })
+        const raw = await requireRawState(study.id)
+        await renderScreen(study, raw, org.slug)
+        expect(screen.getByText('No submission found')).toBeInTheDocument()
+    })
+
+    it('guards against rendering without a feedback-only decision (undecided clean run)', async () => {
+        const { org, user } = await mockSessionWithTestData({ orgSlug: 'test-lab', orgType: 'lab' })
+        const { study: dbStudy, job } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            jobStatus: 'CODE-SUBMITTED',
+        })
+        await db.insertInto('jobStatusChange').values({ studyJobId: job.id, status: 'RUN-COMPLETE' }).execute()
+        const study = actionResult(await getStudyAction({ studyId: dbStudy.id }))
+        const raw = await requireRawState(dbStudy.id)
+        ;(useParams as Mock).mockReturnValue({ orgSlug: org.slug, studyId: study.id })
+
+        await renderScreen(study, raw, org.slug)
+
+        expect(screen.getByText('Feedback not found')).toBeInTheDocument()
+        expect(screen.queryByTestId('status-alert')).not.toBeInTheDocument()
+    })
+
+    it('guards against rendering for an errored run, whose FILES-REJECTED belongs to the errored flow', async () => {
+        const { org, study, job } = await setupFeedbackOnly()
+        await db.insertInto('jobStatusChange').values({ studyJobId: job.id, status: 'JOB-ERRORED' }).execute()
+        const erroredRaw = await requireRawState(study.id)
+
+        await renderScreen(study, erroredRaw, org.slug)
+
+        expect(screen.getByText('Feedback not found')).toBeInTheDocument()
+    })
+})

--- a/src/app/[orgSlug]/study/[studyId]/_screens/outputs-feedback-screen.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/outputs-feedback-screen.tsx
@@ -1,0 +1,98 @@
+import type { Route } from 'next'
+import { Box, Group, Stack } from '@mantine/core'
+import { CaretLeftIcon } from '@phosphor-icons/react/dist/ssr'
+import dayjs from 'dayjs'
+import { AlertNotFound } from '@/components/errors'
+import { ButtonLink } from '@/components/links'
+import { FeedbackAndNotesSection } from '@/components/study/feedback-and-notes'
+import { ProposalStepHeader } from '@/components/study/proposal-step-header'
+import { StatusAlert, STATUS_ALERT_SEPARATOR, STATUS_ALERT_VARIANT } from '@/components/study/status-alert'
+import { StudyPageHeader } from '@/components/study/study-page-header'
+import { Routes } from '@/lib/routes'
+import { displayOrgName } from '@/lib/string'
+import { latestStatusAt } from '@/lib/study-job-status'
+import { projectStudyState } from '@/lib/study-screen'
+import type { OutputsFeedbackEntry } from '@/server/actions/study.actions'
+import { getOrgNameFromId, latestSubmittedJobForStudy } from '@/server/db/queries'
+import { loadOutputsFeedback } from '../view/load-outputs-feedback'
+import type { ScreenComponentProps } from './types'
+
+const FeedbackOnlyBanner = ({ decidedAt, dataPartner }: { decidedAt: Date | string | null; dataPartner: string }) => {
+    // Display-only date: degrade to an undated banner rather than block a page routing already chose.
+    const decidedOn = decidedAt ? ` ${STATUS_ALERT_SEPARATOR} ${dayjs(decidedAt).format('MMM DD, YYYY')}` : ''
+    return (
+        <StatusAlert variant={STATUS_ALERT_VARIANT.action} title={`Feedback on outputs available${decidedOn}`}>
+            {dataPartner} has shared feedback on the latest code run. The outputs are not available for this study. When
+            you are ready, edit your code and resubmit.
+        </StatusAlert>
+    )
+}
+
+// Mirrors the code surface: a failed fetch swaps in the shared notice instead of hiding the section.
+const FeedbackSection = ({
+    feedbackLoadError,
+    entries,
+}: {
+    feedbackLoadError: boolean
+    entries: OutputsFeedbackEntry[]
+}) => {
+    if (feedbackLoadError) {
+        return <AlertNotFound title="Feedback could not be loaded" message="Please refresh and try again" />
+    }
+    return <FeedbackAndNotesSection entries={entries} alwaysExpandLatest />
+}
+
+// OTTER-695: clean run whose outputs the reviewer withheld with "Share feedback only"
+// (FILES-REJECTED without JOB-ERRORED); the researcher reads the feedback and resubmits.
+export async function OutputsFeedbackScreen({
+    study,
+    raw,
+    orgSlug,
+    returnTo,
+}: Pick<ScreenComponentProps, 'study' | 'raw' | 'orgSlug' | 'returnTo'>) {
+    const job = await latestSubmittedJobForStudy(study.id)
+    if (!job) {
+        return <AlertNotFound title="No submission found" message="This study has no submitted code yet." />
+    }
+
+    // Guards the same facts the researcher rule routes on, so routing and rendering cannot
+    // disagree; the query above supplies only the banner's date payload.
+    const state = projectStudyState(raw)
+    if (!state.resultsRejected || state.resultsErrored) {
+        return (
+            <AlertNotFound
+                title="Feedback not found"
+                message="This study does not have outputs feedback to display yet."
+            />
+        )
+    }
+
+    const { entries, feedbackLoadError } = await loadOutputsFeedback(study.id)
+    const dataPartner = displayOrgName(await getOrgNameFromId(study.orgId))
+    const decidedAt = latestStatusAt(job.statusChanges, 'FILES-REJECTED')
+    const previousHref = Routes.studyViewCode({ orgSlug, studyId: study.id, returnTo }) as Route
+    const editCodeHref = Routes.studyResubmit({ orgSlug, studyId: study.id }) as Route
+
+    return (
+        <Box bg="grey.10">
+            <Stack px="xl" gap="xxl" py="xl">
+                <StudyPageHeader>Secondary analysis study</StudyPageHeader>
+                <ProposalStepHeader
+                    stepLabel="STEP 4"
+                    heading="Verify outputs"
+                    studyTitle={study.title!}
+                    banner={<FeedbackOnlyBanner decidedAt={decidedAt} dataPartner={dataPartner} />}
+                />
+                <FeedbackSection feedbackLoadError={feedbackLoadError} entries={entries} />
+                <Group justify="space-between">
+                    <ButtonLink href={previousHref} variant="subtle" leftSection={<CaretLeftIcon />}>
+                        Previous step
+                    </ButtonLink>
+                    <ButtonLink href={editCodeHref} variant="outline" size="md">
+                        Edit code
+                    </ButtonLink>
+                </Group>
+            </Stack>
+        </Box>
+    )
+}

--- a/src/app/[orgSlug]/study/[studyId]/_screens/registry.ts
+++ b/src/app/[orgSlug]/study/[studyId]/_screens/registry.ts
@@ -12,6 +12,7 @@ import { ReviewerAgreementsScreen } from './reviewer-agreements-screen'
 import { ReviewerCodeReviewScreen } from './reviewer-code-review-screen'
 import { ReviewerCodeFeedbackScreen } from './reviewer-code-feedback-screen'
 import { OutputsPendingScreen } from './outputs-pending-screen'
+import { OutputsFeedbackScreen } from './outputs-feedback-screen'
 import { ReviewerOutputsPendingScreen } from './reviewer-outputs-pending-screen'
 import { ReviewerOutputsErroredScreen } from './reviewer-outputs-errored-screen'
 import { ReviewerOutputsAvailableScreen } from './reviewer-outputs-available-screen'
@@ -31,6 +32,7 @@ export const SCREEN_COMPONENTS: Record<ScreenId, ScreenComponent> = {
     'proposal-feedback': ProposalFeedbackScreen,
     'study-results': StudyResultsScreen,
     'outputs-pending': OutputsPendingScreen,
+    'outputs-feedback': OutputsFeedbackScreen,
     'study-overview': StudyOverviewScreen,
     'reviewer-proposal-review': ReviewerProposalReviewScreen,
     'reviewer-proposal-feedback': ReviewerProposalFeedbackScreen,

--- a/src/app/[orgSlug]/study/[studyId]/view/load-outputs-feedback.ts
+++ b/src/app/[orgSlug]/study/[studyId]/view/load-outputs-feedback.ts
@@ -1,0 +1,9 @@
+import { getOutputsFeedbackAction } from '@/server/actions/study.actions'
+import { isActionError } from '@/lib/errors'
+
+export async function loadOutputsFeedback(studyId: string) {
+    const entriesResult = await getOutputsFeedbackAction({ studyId })
+    const feedbackLoadError = isActionError(entriesResult)
+    const entries = feedbackLoadError ? [] : entriesResult
+    return { entries, feedbackLoadError }
+}

--- a/src/app/[orgSlug]/study/[studyId]/view/page.test.tsx
+++ b/src/app/[orgSlug]/study/[studyId]/view/page.test.tsx
@@ -580,8 +580,9 @@ describe('StudyViewPage', () => {
     describe('study-details redesign (OTTER-538)', () => {
         // JOB-ERRORED is intentionally excluded here: a bare error stays hidden from the researcher
         // until a reviewer records a FILES-* decision, so it holds on the code-approved page instead
-        // (see the execution-window describe block / OTTER-598 comment 43898).
-        it.each(['RUN-COMPLETE', 'FILES-APPROVED', 'FILES-REJECTED'] as const)(
+        // (see the execution-window describe block / OTTER-598 comment 43898). A clean-run
+        // FILES-REJECTED left this list for the outputs-feedback screen (OTTER-695, below).
+        it.each(['RUN-COMPLETE', 'FILES-APPROVED'] as const)(
             'renders StudyDetailsResearcher when latest job status is %s',
             async (jobStatus) => {
                 const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
@@ -609,6 +610,35 @@ describe('StudyViewPage', () => {
                 )
             },
         )
+
+        it('renders the outputs-feedback screen when the reviewer shared feedback only (FILES-REJECTED)', async () => {
+            const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })
+            const { study } = await insertTestStudyJobData({
+                org,
+                researcherId: user.id,
+                studyStatus: 'APPROVED',
+                jobStatus: 'CODE-SUBMITTED',
+            })
+            await addJobStatus(study.id, 'RUN-COMPLETE')
+            await addJobStatus(study.id, 'FILES-REJECTED')
+
+            const page = await StudyReviewPage({
+                params: Promise.resolve({ orgSlug: org.slug, studyId: study.id }),
+                searchParams: defaultSearchParams,
+            })
+
+            renderWithProviders(page!)
+            expect(screen.getByText(/Feedback on outputs available/)).toBeInTheDocument()
+            expect(screen.getByText('Verify outputs')).toBeInTheDocument()
+            expect(screen.getByRole('link', { name: /previous step/i })).toHaveAttribute(
+                'href',
+                `/${org.slug}/study/${study.id}/view/code`,
+            )
+            expect(screen.getByRole('link', { name: /edit code/i })).toHaveAttribute(
+                'href',
+                `/${org.slug}/study/${study.id}/resubmit`,
+            )
+        })
 
         it('threads returnTo=org to the results screen via dashboardHref', async () => {
             const { org, user } = await mockSessionWithTestData({ orgType: 'lab' })

--- a/src/lib/study-screen/consistency.test.ts
+++ b/src/lib/study-screen/consistency.test.ts
@@ -19,6 +19,8 @@ describe('Tier-1 ↔ Tier-2 consistency', () => {
         full({ status: 'REJECTED', isDraft: false }),
         full({ status: 'CHANGE-REQUESTED', isDraft: false }),
         full({ status: 'APPROVED', isDraft: false, hasResults: true, resultsApproved: true }),
+        // Feedback-only outputs decision → outputs-feedback screen (OTTER-695).
+        full({ status: 'APPROVED', isDraft: false, hasResults: true, resultsRejected: true }),
         // Errored job, no reviewer files decision: the pill reads "Code approved", so the 'View' link
         // must resolve to a real screen (outputs-pending), never the study-overview fallback (OTTER-598).
         full({

--- a/src/lib/study-screen/researcher-screen-rules.ts
+++ b/src/lib/study-screen/researcher-screen-rules.ts
@@ -6,6 +6,11 @@ import { awaitingFilesDecisionOnError } from './state'
 // The live contract is the researcher table in docs/study-screens-logic.md — extend from there.
 
 export const RESEARCHER_SCREEN_RULES = [
+    // Share-feedback-only decision on a clean run (FILES-REJECTED without JOB-ERRORED): the
+    // researcher reads the feedback and resubmits (OTTER-695). Out-ranks study-results, which would
+    // otherwise claim any FILES-* decision; an errored run's FILES-REJECTED stays below.
+    ['outputs-feedback', { when: (s) => s.resultsRejected && !s.resultsErrored }],
+
     // Results have landed: results-only Study Details. A bare JOB-ERRORED is excluded until a reviewer
     // records a FILES-* decision (awaitingFilesDecisionOnError) — until then the researcher sits on
     // outputs-pending below (the job's JOB-* statuses keep isExecuting true), or on code-under-review

--- a/src/lib/study-screen/resolve.test.ts
+++ b/src/lib/study-screen/resolve.test.ts
@@ -29,6 +29,34 @@ describe('resolveScreen (researcher)', () => {
             ).screen,
         ).toBe('study-results')
     })
+    it('OTTER-695: feedback-only decision on a clean run → outputs-feedback (out-ranks study-results)', () => {
+        expect(
+            resolveScreen(
+                'researcher',
+                state({ hasResults: true, resultsRejected: true, codeDecision: 'CODE-APPROVED' }),
+            ).screen,
+        ).toBe('outputs-feedback')
+    })
+    it('OTTER-695: share-outputs decision (resultsApproved) still → study-results', () => {
+        expect(
+            resolveScreen(
+                'researcher',
+                state({ hasResults: true, resultsApproved: true, codeDecision: 'CODE-APPROVED' }),
+            ).screen,
+        ).toBe('study-results')
+    })
+    it('OTTER-695: clean run with no files decision yet (RUN-COMPLETE) still → study-results, not outputs-feedback', () => {
+        expect(
+            resolveScreen(
+                'researcher',
+                state({
+                    hasResults: true,
+                    resultsDisplayStatus: 'RUN-COMPLETE',
+                    codeDecision: 'CODE-APPROVED',
+                }),
+            ).screen,
+        ).toBe('study-results')
+    })
     it('errored job with a stale code decision (resubmission) → code-under-review, NOT study-results (OTTER-598)', () => {
         // Edge case raised in PR #837: resultsErrored excludes from study-results, the prior
         // CODE-APPROVED was dropped by dropStale (so codeDecision is null and codeAwaitingDecision
@@ -106,6 +134,18 @@ describe('resolveResearcherCodeScreen (read-only /view/code)', () => {
             resultsApproved: true,
         })
         expect(resolveResearcherCodeScreen(resultsStudy)).toEqual({ screen: 'code-approved' })
+    })
+
+    it('OTTER-695: feedback-only results study → approved-code screen (Previous step target)', () => {
+        const s = state({
+            status: 'APPROVED',
+            isDraft: false,
+            hasSubmittedCode: true,
+            codeDecision: 'CODE-APPROVED',
+            hasResults: true,
+            resultsRejected: true,
+        })
+        expect(resolveResearcherCodeScreen(s)).toEqual({ screen: 'code-approved' })
     })
 
     it('picks the code screen by state: changes-requested → code-feedback', () => {

--- a/src/lib/study-screen/screens.ts
+++ b/src/lib/study-screen/screens.ts
@@ -7,6 +7,7 @@ export type ScreenId =
     | 'code-approved'
     | 'code-feedback'
     | 'outputs-pending'
+    | 'outputs-feedback'
     | 'study-results'
     | 'study-overview'
     // reviewer

--- a/src/server/actions/study.actions.test.ts
+++ b/src/server/actions/study.actions.test.ts
@@ -25,6 +25,7 @@ import {
     fetchStudiesForCurrentResearcherUserAction,
     fetchStudiesForOrgAction,
     getCodeReviewFeedbackAction,
+    getOutputsFeedbackAction,
     getStudyAction,
     rejectStudyProposalAction,
     softDeleteStudyAction,
@@ -2266,6 +2267,96 @@ describe('submitCodeReviewDecisionAction', () => {
             .where('name', '=', `code-review-feedback-${job.id}`)
             .execute()
         expect(remaining).toHaveLength(0)
+    })
+})
+
+describe('getOutputsFeedbackAction', () => {
+    it('returns RESULTS decision rows with resubmission notes, newest first, and excludes CODE rows', async () => {
+        const { user, org } = await mockSessionWithTestData({ orgType: 'lab' })
+        const { study, job } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            jobStatus: 'CODE-SUBMITTED',
+        })
+
+        // Pin the submission timestamp so the note (dated by the latest CODE-SUBMITTED) sorts
+        // deterministically below the outputs decision instead of tying on the transaction's now().
+        await db
+            .updateTable('jobStatusChange')
+            .set({ createdAt: new Date('2026-07-01T00:00:00Z') })
+            .where('studyJobId', '=', job.id)
+            .where('status', '=', 'CODE-SUBMITTED')
+            .execute()
+        await db
+            .updateTable('studyJob')
+            .set({ resubmissionNote: JSON.parse(lexicalJson('my resubmission note')), resubmissionRound: 1 })
+            .where('id', '=', job.id)
+            .execute()
+
+        await db
+            .insertInto('studyReviewComment')
+            .values({
+                studyId: study.id,
+                studyJobId: job.id,
+                authorId: user.id,
+                reviewKind: 'CODE',
+                entryType: 'DECISION',
+                decision: 'APPROVE',
+                body: JSON.parse(lexicalJson('code approval note')),
+                round: 1,
+                createdAt: new Date('2026-07-02T00:00:00Z'),
+            })
+            .execute()
+        const outputs = await db
+            .insertInto('studyReviewComment')
+            .values({
+                studyId: study.id,
+                studyJobId: job.id,
+                authorId: user.id,
+                reviewKind: 'RESULTS',
+                entryType: 'DECISION',
+                decision: 'NEEDS-CLARIFICATION',
+                body: JSON.parse(lexicalJson('outputs withheld, fix aggregation')),
+                round: 1,
+                createdAt: new Date('2026-08-05T00:00:00Z'),
+            })
+            .returning('id')
+            .executeTakeFirstOrThrow()
+
+        const rows = actionResult(await getOutputsFeedbackAction({ studyId: study.id }))
+
+        expect(rows).toHaveLength(2)
+        expect(rows[0].id).toBe(outputs.id)
+        expect(rows[0].entryType).toBe('REVIEWER-FEEDBACK')
+        expect(rows[0].version).toBe(1)
+        expect(rows[1].entryType).toBe('RESUBMISSION-NOTE')
+        expect(rows[1].version).toBe(1)
+    })
+
+    it('kind isolation is symmetric: the CODE action does not return RESULTS rows', async () => {
+        const { user, org } = await mockSessionWithTestData({ orgType: 'lab' })
+        const { study, job } = await insertTestStudyJobData({
+            org,
+            researcherId: user.id,
+            jobStatus: 'CODE-SUBMITTED',
+        })
+
+        await db
+            .insertInto('studyReviewComment')
+            .values({
+                studyId: study.id,
+                studyJobId: job.id,
+                authorId: user.id,
+                reviewKind: 'RESULTS',
+                entryType: 'DECISION',
+                decision: 'NEEDS-CLARIFICATION',
+                body: JSON.parse(lexicalJson('outputs feedback only')),
+                round: 1,
+            })
+            .execute()
+
+        const codeRows = actionResult(await getCodeReviewFeedbackAction({ studyId: study.id }))
+        expect(codeRows.filter((r) => r.entryType === 'REVIEWER-FEEDBACK')).toHaveLength(0)
     })
 })
 

--- a/src/server/actions/study.actions.ts
+++ b/src/server/actions/study.actions.ts
@@ -4,7 +4,7 @@ import { db as database, type DBExecutor, jsonArrayFrom } from '@/database'
 import { sql } from 'kysely'
 import { ActionFailure, isPgUniqueViolation, throwNotFound } from '@/lib/errors'
 import { ActionSuccessType, sharedFileSchema, type SharedFile } from '@/lib/types'
-import type { StudyStatus } from '@/database/types'
+import type { StudyReviewCommentKind, StudyStatus } from '@/database/types'
 import { normalizeFeedbackToLexical } from '@/lib/lexical'
 import { CODE_REVIEW_FEEDBACK_MAX_WORDS, FEEDBACK_MAX_WORDS, FEEDBACK_MIN_WORDS } from '@/lib/proposal-review'
 import { toReviewDecision, type Decision } from '@/lib/review-decision'
@@ -855,6 +855,122 @@ export const submitCodeReviewDecisionAction = new Action('submitCodeReviewDecisi
         return { submitterFullName: submitter.fullName }
     })
 
+// Reviewer DECISION rows of one reviewKind merged with resubmission notes, newest first. Shared by
+// the code and outputs feedback actions so entry shape, version labels, and ordering can't drift.
+async function loadReviewFeedbackThread(
+    db: DBExecutor,
+    studyId: string,
+    reviewKind: Extract<StudyReviewCommentKind, 'CODE' | 'RESULTS'>,
+) {
+    // Both reviewer decisions and resubmission notes are versioned by the study-wide submission
+    // round (see codeSubmissionVersion): the decision stores it in studyReviewComment.round, the
+    // note in studyJob.resubmissionRound. This keeps a round's note and decision on the same
+    // label even when a same-job resubmit revises in place (OTTER-316/638) and the job ordinal
+    // would not advance. jobVersion (job creation order) is only a fallback for legacy rows whose
+    // resubmissionRound was not backfilled. studyJob has no userId column; the author of the
+    // resubmission note is the user recorded on the job's latest CODE-SUBMITTED (left-joined so
+    // the timestamp and author are independent: a null/deleted user does not lose the submission
+    // row). A same-job resubmit appends more than one CODE-SUBMITTED, so joining the rows directly
+    // would multiply the job into duplicate codeJobs rows (and duplicate note entries); a lateral
+    // join to the single latest submission keeps each job to one row.
+    const codeJobs = await db
+        .selectFrom('studyJob')
+        .leftJoinLateral(
+            (eb) =>
+                eb
+                    .selectFrom('jobStatusChange as cs')
+                    .leftJoin('user as submitter', 'submitter.id', 'cs.userId')
+                    .select([
+                        'cs.userId as authorId',
+                        'submitter.fullName as authorName',
+                        'cs.createdAt as submittedAt',
+                    ])
+                    .whereRef('cs.studyJobId', '=', 'studyJob.id')
+                    .where('cs.status', '=', 'CODE-SUBMITTED')
+                    .orderBy('cs.createdAt', 'desc')
+                    .orderBy('cs.id', 'desc')
+                    .limit(1)
+                    .as('latestSubmission'),
+            (join) => join.onTrue(),
+        )
+        .select([
+            'studyJob.id as studyJobId',
+            'studyJob.resubmissionNote',
+            'studyJob.resubmissionRound',
+            'studyJob.createdAt',
+            'latestSubmission.authorId',
+            'latestSubmission.authorName',
+            'latestSubmission.submittedAt',
+        ])
+        .where('studyJob.studyId', '=', studyId)
+        .orderBy('studyJob.createdAt', 'asc')
+        .execute()
+
+    const jobVersion = new Map(codeJobs.map((j, i) => [j.studyJobId, i + 1]))
+
+    const reviewerRows = await db
+        .selectFrom('studyReviewComment')
+        .innerJoin('user as author', 'author.id', 'studyReviewComment.authorId')
+        .select([
+            'studyReviewComment.id',
+            'studyReviewComment.authorId',
+            'studyReviewComment.entryType',
+            'studyReviewComment.decision',
+            'studyReviewComment.body',
+            'studyReviewComment.criteria',
+            'studyReviewComment.createdAt',
+            'studyReviewComment.round',
+            'author.fullName as authorName',
+        ])
+        .where('studyReviewComment.studyId', '=', studyId)
+        .where('studyReviewComment.reviewKind', '=', reviewKind)
+        .where('studyReviewComment.entryType', '=', 'DECISION')
+        .execute()
+
+    const reviewerEntries = reviewerRows.map((row) => ({
+        id: row.id,
+        authorId: row.authorId,
+        entryType: 'REVIEWER-FEEDBACK' as const,
+        decision: row.decision,
+        body: row.body,
+        criteria: row.criteria,
+        createdAt: row.createdAt,
+        authorName: row.authorName,
+        version: row.round ?? null,
+    }))
+
+    const noteEntries = codeJobs
+        .filter((j) => j.resubmissionNote != null)
+        .map((j) => ({
+            id: `job-note-${j.studyJobId}`,
+            authorId: j.authorId ?? '',
+            entryType: 'RESUBMISSION-NOTE' as const,
+            decision: null,
+            body: j.resubmissionNote as NonNullable<typeof j.resubmissionNote>,
+            criteria: null,
+            // The note is written at resubmit time, not job creation: a same-job resubmit revises
+            // an old job in place, so use the latest CODE-SUBMITTED timestamp to position the note
+            // in the round it opened (newest-first sort below). Falls back to job creation only for
+            // a job with no submission (which never carries a note).
+            createdAt: j.submittedAt ?? j.createdAt,
+            authorName: j.authorName ?? '',
+            version: j.resubmissionRound ?? jobVersion.get(j.studyJobId) ?? null,
+        }))
+
+    return [...reviewerEntries, ...noteEntries].sort((a, b) => {
+        const createdAtDiff = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        if (createdAtDiff !== 0) return createdAtDiff
+
+        const versionDiff = (b.version ?? 0) - (a.version ?? 0)
+        if (versionDiff !== 0) return versionDiff
+
+        const entryTypeDiff = a.entryType.localeCompare(b.entryType)
+        if (entryTypeDiff !== 0) return entryTypeDiff
+
+        return a.id.localeCompare(b.id)
+    })
+}
+
 export const getCodeReviewFeedbackAction = new Action('getCodeReviewFeedbackAction')
     .params(z.object({ studyId: z.string().uuid() }))
     .middleware(async ({ params: { studyId }, db }) => {
@@ -866,117 +982,26 @@ export const getCodeReviewFeedbackAction = new Action('getCodeReviewFeedbackActi
         return { orgId: study.orgId, submittedByOrgId: study.submittedByOrgId, status: study.status }
     })
     .requireAbilityTo('view', 'Study')
-    .handler(async ({ params: { studyId }, db }) => {
-        // Both reviewer decisions and resubmission notes are versioned by the study-wide submission
-        // round (see codeSubmissionVersion): the decision stores it in studyReviewComment.round, the
-        // note in studyJob.resubmissionRound. This keeps a round's note and decision on the same
-        // label even when a same-job resubmit revises in place (OTTER-316/638) and the job ordinal
-        // would not advance. jobVersion (job creation order) is only a fallback for legacy rows whose
-        // resubmissionRound was not backfilled. studyJob has no userId column; the author of the
-        // resubmission note is the user recorded on the job's latest CODE-SUBMITTED (left-joined so
-        // the timestamp and author are independent: a null/deleted user does not lose the submission
-        // row). A same-job resubmit appends more than one CODE-SUBMITTED, so joining the rows directly
-        // would multiply the job into duplicate codeJobs rows (and duplicate note entries); a lateral
-        // join to the single latest submission keeps each job to one row.
-        const codeJobs = await db
-            .selectFrom('studyJob')
-            .leftJoinLateral(
-                (eb) =>
-                    eb
-                        .selectFrom('jobStatusChange as cs')
-                        .leftJoin('user as submitter', 'submitter.id', 'cs.userId')
-                        .select([
-                            'cs.userId as authorId',
-                            'submitter.fullName as authorName',
-                            'cs.createdAt as submittedAt',
-                        ])
-                        .whereRef('cs.studyJobId', '=', 'studyJob.id')
-                        .where('cs.status', '=', 'CODE-SUBMITTED')
-                        .orderBy('cs.createdAt', 'desc')
-                        .orderBy('cs.id', 'desc')
-                        .limit(1)
-                        .as('latestSubmission'),
-                (join) => join.onTrue(),
-            )
-            .select([
-                'studyJob.id as studyJobId',
-                'studyJob.resubmissionNote',
-                'studyJob.resubmissionRound',
-                'studyJob.createdAt',
-                'latestSubmission.authorId',
-                'latestSubmission.authorName',
-                'latestSubmission.submittedAt',
-            ])
-            .where('studyJob.studyId', '=', studyId)
-            .orderBy('studyJob.createdAt', 'asc')
-            .execute()
-
-        const jobVersion = new Map(codeJobs.map((j, i) => [j.studyJobId, i + 1]))
-
-        const reviewerRows = await db
-            .selectFrom('studyReviewComment')
-            .innerJoin('user as author', 'author.id', 'studyReviewComment.authorId')
-            .select([
-                'studyReviewComment.id',
-                'studyReviewComment.authorId',
-                'studyReviewComment.entryType',
-                'studyReviewComment.decision',
-                'studyReviewComment.body',
-                'studyReviewComment.criteria',
-                'studyReviewComment.createdAt',
-                'studyReviewComment.round',
-                'author.fullName as authorName',
-            ])
-            .where('studyReviewComment.studyId', '=', studyId)
-            .where('studyReviewComment.reviewKind', '=', 'CODE')
-            .where('studyReviewComment.entryType', '=', 'DECISION')
-            .execute()
-
-        const reviewerEntries = reviewerRows.map((row) => ({
-            id: row.id,
-            authorId: row.authorId,
-            entryType: 'REVIEWER-FEEDBACK' as const,
-            decision: row.decision,
-            body: row.body,
-            criteria: row.criteria,
-            createdAt: row.createdAt,
-            authorName: row.authorName,
-            version: row.round ?? null,
-        }))
-
-        const noteEntries = codeJobs
-            .filter((j) => j.resubmissionNote != null)
-            .map((j) => ({
-                id: `job-note-${j.studyJobId}`,
-                authorId: j.authorId ?? '',
-                entryType: 'RESUBMISSION-NOTE' as const,
-                decision: null,
-                body: j.resubmissionNote as NonNullable<typeof j.resubmissionNote>,
-                criteria: null,
-                // The note is written at resubmit time, not job creation: a same-job resubmit revises
-                // an old job in place, so use the latest CODE-SUBMITTED timestamp to position the note
-                // in the round it opened (newest-first sort below). Falls back to job creation only for
-                // a job with no submission (which never carries a note).
-                createdAt: j.submittedAt ?? j.createdAt,
-                authorName: j.authorName ?? '',
-                version: j.resubmissionRound ?? jobVersion.get(j.studyJobId) ?? null,
-            }))
-
-        return [...reviewerEntries, ...noteEntries].sort((a, b) => {
-            const createdAtDiff = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-            if (createdAtDiff !== 0) return createdAtDiff
-
-            const versionDiff = (b.version ?? 0) - (a.version ?? 0)
-            if (versionDiff !== 0) return versionDiff
-
-            const entryTypeDiff = a.entryType.localeCompare(b.entryType)
-            if (entryTypeDiff !== 0) return entryTypeDiff
-
-            return a.id.localeCompare(b.id)
-        })
-    })
+    .handler(async ({ params: { studyId }, db }) => loadReviewFeedbackThread(db, studyId, 'CODE'))
 
 export type CodeReviewFeedbackEntry = ActionSuccessType<typeof getCodeReviewFeedbackAction>[number]
+
+// OTTER-695: outputs counterpart of getCodeReviewFeedbackAction ('RESULTS' rows are written by
+// submitOutputsDecisionAction).
+export const getOutputsFeedbackAction = new Action('getOutputsFeedbackAction')
+    .params(z.object({ studyId: z.string().uuid() }))
+    .middleware(async ({ params: { studyId }, db }) => {
+        const study = await db
+            .selectFrom('study')
+            .select(['orgId', 'submittedByOrgId', 'status'])
+            .where('id', '=', studyId)
+            .executeTakeFirstOrThrow(throwNotFound('study'))
+        return { orgId: study.orgId, submittedByOrgId: study.submittedByOrgId, status: study.status }
+    })
+    .requireAbilityTo('view', 'Study')
+    .handler(async ({ params: { studyId }, db }) => loadReviewFeedbackThread(db, studyId, 'RESULTS'))
+
+export type OutputsFeedbackEntry = ActionSuccessType<typeof getOutputsFeedbackAction>[number]
 
 export const doesTestImageExistForStudyAction = new Action('doesTestImageExistForStudyAction')
     .params(z.object({ studyId: z.string() }))


### PR DESCRIPTION
## What this does

A clean run (`RUN-COMPLETE`, never `JOB-ERRORED`) that the Data Partner decided with **Share feedback only** used to fall through to the results-only Study Details screen. The researcher table now claims that state first and routes `/view` to a new `outputs-feedback` screen:

- **Rule** (`researcher-screen-rules.ts`): `['outputs-feedback', { when: (s) => s.resultsRejected && !s.resultsErrored }]`, inserted above `study-results`. Per `submitOutputsDecisionAction` (OTTER-675/676), "Share feedback only" is persisted as `FILES-REJECTED`, so this is the ticket's "results-approved + Share feedback only" condition expressed in projected state. An errored run's `FILES-REJECTED` still lands on `study-results` (the errored variant is its own card), as does a share-outputs decision (`resultsApproved`).
- **Screen** (`_screens/outputs-feedback-screen.tsx`): reuses `StudyPageHeader`, `ProposalStepHeader` (STEP 4 / Verify outputs, which owns the lg-spaced divider), the **action**-variant `StatusAlert` titled `Feedback on outputs available • {date}` (date = the `FILES-REJECTED` status change, undated degrade when missing), `FeedbackAndNotesSection`, and the `xxl` stack spacing used by the sibling outputs screens. Nav: **Previous step** (subtle) → `/view/code` (resolves to the code-approved screen for these studies), **Edit code** (outline, enabled) → `/resubmit` — already resubmit-eligible via `canResearcherResubmitCode` (`resultsRejected`), no route changes.
- **Data** (`getOutputsFeedbackAction`): the `RESULTS` counterpart of `getCodeReviewFeedbackAction`. Both now delegate to a shared `loadReviewFeedbackThread(db, studyId, reviewKind)` so entry shape, version labels, and newest-first ordering can't drift between the code and outputs surfaces. The CODE action's behavior is unchanged (its existing tests all pass untouched).
- **Docs**: researcher table + precedence note updated in `docs/study-screens-logic.md` per the screen-rules doc rule.
- `hasNextStepFromCode` delegation means the code-approved page's forward link starts working for this state with no change there (by design, see `next-step.ts`).


## Tests

- `resolve.test.ts`: redirection matrix — feedback-only → `outputs-feedback`; share-outputs, undecided `RUN-COMPLETE`, and errored+rejected all stay on `study-results`; walk-back (`/view/code`) resolves to `code-approved` for this state.
- `consistency.test.ts`: dashboard `View` link for the state resolves to a real screen.
- `outputs-feedback-screen.test.tsx` (12 tests): reused header/section-header/alert/feedback-section via their shared test ids, exact banner copy + DP-name interpolation, decision date (not approval date, not today), undated degrade, null-thread and wrong-state guards, study-scoped feedback isolation, CODE-entry exclusion, nav hrefs + `subtle`/`outline` variants + enabled-by-default.
- `page.test.tsx`: full `/view` dispatch lands on the new screen for `FILES-REJECTED` (moved out of the Study Details `it.each`, which documented the pre-refactor behavior).
- `study.actions.test.ts`: `getOutputsFeedbackAction` returns RESULTS + notes newest-first with round labels; kind isolation is symmetric with the CODE action.