### PR TITLE
Require a pinned Server Actions encryption key in deployed builds

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -19,6 +19,26 @@ const fakeClerk = Boolean(process.env.E2E_FAKE_CLERK)
 // ever suspected stale, bust the cache by bumping the tpc token in the workflow cache key.
 const turbopackFsCache = Boolean(process.env.TURBOPACK_FS_CACHE)
 
+// Server Action IDs, and the encrypted arguments bound into them, are derived from Next's Server
+// Actions encryption key. Left unset, Next mints a fresh key per build, so a browser still holding
+// the previous build's JS posts an action ID the new build cannot resolve; Next rejects it with
+// "Invalid Server Actions request." before any of our code — and so before Sentry — runs, which is
+// why those 500s never reached Sentry. A blue/green slot cutover swaps builds under live tabs,
+// which is exactly that case.
+//
+// Next 16 reads the key ONLY from this environment variable — the old
+// experimental.serverActions.encryptionKey config option no longer exists — and it has to be set
+// identically for `next build` (the IDs are baked in there) and for the running server. Deployed
+// builds get it from Secrets Manager; local dev and CI let Next generate a throwaway one, since
+// nothing there outlives a rebuild. A deployed build silently falling back to a generated key is
+// the bug being fixed here, so fail loudly rather than ship one.
+if (!process.env.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY && !isDev) {
+    throw new Error(
+        'NEXT_SERVER_ACTIONS_ENCRYPTION_KEY must be set for a production build. ' +
+            'It comes from the MgmntAppBuildVars secret; see cicd/management-app in the iac repo.',
+    )
+}
+
 const securityHeaders = [
     // Clickjacking protection (SIINFOSEC-470, ZAP-10020).
     // We never want this app embedded in a frame; DENY is stricter than SAMEORIGIN


### PR DESCRIPTION
## Problem

QA users hit `Unable to save ...` toasts showing only an opaque reference
(e.g. `f2d3af6801734abe835db6710ddba1ed`), with nothing in Sentry, while the
app kept working.

CloudWatch (`/aws/MgmntApp-dev-v20260812`) shows the cause:

```
⨯ Error: Invalid Server Actions request.
Error: The Server Reference ID did not match the expected format. Received "x".
```

Next derives Server Action IDs — and encrypts the arguments bound into them —
from its Server Actions encryption key. Unset, it mints a fresh key per build,
so a browser holding the previous build's JS posts an action ID the new build
cannot resolve. Next rejects that inside its own request handling, **before any
app code runs**, which is why Sentry never saw it and why only an error digest
(generated by Next, never logged server-side) reached the user.

A blue/green slot cutover swaps builds under live tabs, which is exactly this
case. Occurrences cluster in bursts across several Lambda instances rather than
spreading evenly — a cutover signature, not one user clicking Save.

## Change

Fail the build when `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` is missing from a
deployed build, instead of letting Next quietly generate a per-build key.

Next 16 reads the key **only** from that environment variable — the old
`experimental.serverActions.encryptionKey` config option no longer exists in
this version, so there is nothing to set in `next.config.ts` beyond the guard.
Dev and CI still let Next generate one, since nothing there outlives a rebuild.

The value is supplied from Secrets Manager by the companion iac PR, which sets
it for both the build and the Lambda runtime — they must match.

## Verification

Against a real production build:

- Two builds sharing a key → **identical** action IDs for all 112 actions.
- Two builds with different keys → **zero** overlap.
- The guard throws for a production build with no key, and stays quiet for dev/CI.

## Merge order

Merge the iac PR first (it populates the secret); otherwise this guard fails
the deploy build.