### PR TITLE
Don't report a note autosave that fails after navigating away

### DIFF
--- a/src/contexts/edit-code-resubmit/context.test.tsx
+++ b/src/contexts/edit-code-resubmit/context.test.tsx
@@ -9,6 +9,13 @@ vi.mock('@/server/actions/study-request', () => ({
     saveCodeResubmissionNoteDraftAction: vi.fn(),
 }))
 
+// The provider passes reportMutationError's returned handler to useMutation's onError, so asserting
+// on the returned handler is what tells us whether a failure was surfaced to the researcher.
+const mutationErrorHandler = vi.fn()
+vi.mock('@/components/errors', () => ({
+    reportMutationError: vi.fn(() => mutationErrorHandler),
+}))
+
 const STUDY_ID = '11111111-1111-4111-8111-111111111111'
 
 function Harness({ onSaveResult }: { onSaveResult: (result: boolean) => void }) {
@@ -29,6 +36,44 @@ function Harness({ onSaveResult }: { onSaveResult: (result: boolean) => void }) 
 }
 
 describe('EditCodeResubmitProvider', () => {
+    // A Server Action posts to whatever route is current when the request goes out, so an autosave
+    // already in flight when the researcher navigates away resolves against the NEW route, which
+    // has no matching action. Next returns a non-RSC 200 and the client throws "An unexpected
+    // response was received from the server." — an "Unable to save resubmission note draft" toast
+    // on a page the researcher already left.
+    it('does not report an autosave that rejects after the provider unmounts', async () => {
+        ;(useParams as Mock).mockReturnValue({ orgSlug: 'lab-1' })
+        mutationErrorHandler.mockClear()
+
+        const saveDraftAction = vi.mocked(saveCodeResubmissionNoteDraftAction)
+        // Stays pending until we reject it, so the save is genuinely in flight across the unmount.
+        let rejectSave: (error: Error) => void = () => {}
+        saveDraftAction.mockImplementation(
+            () =>
+                new Promise((_resolve, reject) => {
+                    rejectSave = reject
+                }) as ReturnType<typeof saveCodeResubmissionNoteDraftAction>,
+        )
+
+        const onSaveResult = vi.fn()
+
+        const { unmount } = renderWithProviders(
+            <EditCodeResubmitProvider studyId={STUDY_ID} initialNote="">
+                <Harness onSaveResult={onSaveResult} />
+            </EditCodeResubmitProvider>,
+        )
+
+        const note = 'typed right before navigating away'
+        fireEvent.change(screen.getByLabelText('Resubmission note'), { target: { value: note } })
+        await waitFor(() => expect(saveDraftAction).toHaveBeenCalled())
+
+        unmount()
+        rejectSave(new Error('An unexpected response was received from the server.'))
+        await new Promise((resolve) => setTimeout(resolve, 50))
+
+        expect(mutationErrorHandler).not.toHaveBeenCalled()
+    })
+
     it('retries the same note after a save failure instead of marking it saved', async () => {
         ;(useParams as Mock).mockReturnValue({ orgSlug: 'lab-1' })
         const saveDraftAction = vi.mocked(saveCodeResubmissionNoteDraftAction)

--- a/src/contexts/edit-code-resubmit/context.tsx
+++ b/src/contexts/edit-code-resubmit/context.tsx
@@ -56,9 +56,26 @@ export function EditCodeResubmitProvider({ children, studyId, initialNote }: Edi
     const savingValueRef = useRef<string | null>(null)
     const inFlightSaveRef = useRef<Promise<boolean> | null>(null)
 
+    // A Server Action posts to whatever route is current when the request goes out, so an autosave
+    // still in flight when the researcher navigates away resolves against the new route. That route
+    // has no matching action, so Next returns a non-RSC 200 and the client throws "An unexpected
+    // response was received from the server." Reporting it would show an "unable to save" toast on
+    // a page the researcher already left, about a save they did not ask for and cannot retry.
+    const isMountedRef = useRef(true)
+    useEffect(() => {
+        isMountedRef.current = true
+        return () => {
+            isMountedRef.current = false
+        }
+    }, [])
+
+    const reportSaveError = reportMutationError('Unable to save resubmission note draft')
     const saveMutation = useMutation({
         mutationFn: (note: string) => saveCodeResubmissionNoteDraftAction({ studyId, note }),
-        onError: reportMutationError('Unable to save resubmission note draft'),
+        onError: (error: unknown) => {
+            if (!isMountedRef.current) return
+            reportSaveError(error)
+        },
     })
 
     const flushSave = useCallback(

--- a/src/contexts/edit-resubmit/context.test.tsx
+++ b/src/contexts/edit-resubmit/context.test.tsx
@@ -10,6 +10,20 @@ vi.mock('@/server/actions/study-request', () => ({
     saveProposalResubmissionNoteDraftAction: vi.fn(),
 }))
 
+// The provider passes reportMutationError's returned handler to useMutation's onError, so asserting
+// on the returned handler is what tells us whether a failure was surfaced to the researcher.
+const mutationErrorHandler = vi.fn()
+vi.mock('@/components/errors', () => ({
+    reportMutationError: vi.fn(() => mutationErrorHandler),
+}))
+
+// The debounced autosave only runs in single-user mode; collaborative editing persists through Yjs
+// instead. Force it on so the debounce path under test actually fires.
+vi.mock('@/lib/realtime/yjs-websocket-context', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@/lib/realtime/yjs-websocket-context')>()),
+    useSingleUserEditing: () => true,
+}))
+
 const STUDY_ID = '11111111-1111-4111-8111-111111111111'
 
 function Harness({ onSaveResult }: { onSaveResult: (result: boolean) => void }) {
@@ -67,6 +81,48 @@ describe('EditResubmitProvider — proposal resubmission note autosave', () => {
         const noteCalls = saveNoteAction.mock.calls.filter((args) => args[0]?.note === note)
         expect(noteCalls.length).toBeGreaterThanOrEqual(2)
         expect(saveNoteAction).toHaveBeenCalledWith({ studyId: STUDY_ID, note })
+    })
+
+    // A Server Action posts to whatever route is current when the request goes out. An autosave
+    // already in flight when the researcher navigates away resolves against the NEW route, which
+    // has no matching action, so Next returns a non-RSC 200 and the client throws "An unexpected
+    // response was received from the server." — surfacing as an "Unable to save resubmission note
+    // draft" toast on a page the researcher already left. The queued-but-not-yet-fired case is
+    // already covered by the effect's clearTimeout; this is the in-flight one that is not.
+    it('does not report an autosave that rejects after the provider unmounts', async () => {
+        ;(useParams as Mock).mockReturnValue({ orgSlug: 'lab-1' })
+
+        const saveNoteAction = vi.mocked(saveProposalResubmissionNoteDraftAction)
+        // Stays pending until we resolve it, so the save is genuinely in flight across the unmount.
+        let rejectSave: (error: Error) => void = () => {}
+        saveNoteAction.mockImplementation(
+            () =>
+                new Promise((_resolve, reject) => {
+                    rejectSave = reject
+                }) as ReturnType<typeof saveProposalResubmissionNoteDraftAction>,
+        )
+
+        const onSaveResult = vi.fn()
+
+        const { unmount } = renderWithProviders(
+            <EditResubmitProvider studyId={STUDY_ID} initialNote="">
+                <Harness onSaveResult={onSaveResult} />
+            </EditResubmitProvider>,
+        )
+
+        const note = 'typed right before navigating away'
+        fireEvent.change(screen.getByLabelText('Resubmission note'), { target: { value: note } })
+        await waitFor(() => expect(screen.getByLabelText('Resubmission note')).toHaveValue(note))
+
+        // Let the debounce fire so the request is in flight, then navigate away.
+        await waitFor(() => expect(saveNoteAction).toHaveBeenCalled())
+        unmount()
+
+        // The request lands on the new route and Next throws.
+        rejectSave(new Error('An unexpected response was received from the server.'))
+        await new Promise((resolve) => setTimeout(resolve, 50))
+
+        expect(mutationErrorHandler).not.toHaveBeenCalled()
     })
 
     it('does not call the save action when the note has not been edited', async () => {

--- a/src/contexts/edit-resubmit/context.tsx
+++ b/src/contexts/edit-resubmit/context.tsx
@@ -88,9 +88,26 @@ export function EditResubmitProvider({ children, studyId, draftData, initialNote
     const savingNoteRef = useRef<string | null>(null)
     const inFlightNoteSaveRef = useRef<Promise<boolean> | null>(null)
 
+    // A Server Action posts to whatever route is current when the request goes out, so an autosave
+    // still in flight when the researcher navigates away resolves against the new route. That route
+    // has no matching action, so Next returns a non-RSC 200 and the client throws "An unexpected
+    // response was received from the server." Reporting it would show an "unable to save" toast on
+    // a page the researcher already left, about a save they did not ask for and cannot retry.
+    const isMountedRef = useRef(true)
+    useEffect(() => {
+        isMountedRef.current = true
+        return () => {
+            isMountedRef.current = false
+        }
+    }, [])
+
+    const reportNoteSaveError = reportMutationError('Unable to save resubmission note draft')
     const noteSaveMutation = useMutation({
         mutationFn: (note: string) => saveProposalResubmissionNoteDraftAction({ studyId, note }),
-        onError: reportMutationError('Unable to save resubmission note draft'),
+        onError: (error: unknown) => {
+            if (!isMountedRef.current) return
+            reportNoteSaveError(error)
+        },
     })
 
     const flushNoteSave = useCallback(


### PR DESCRIPTION
## Problem

Researchers saw `Unable to save resubmission note draft` toasts on QA with an
opaque reference, and the app kept working.

A Server Action posts to whatever route is current when the request goes out.
The debounced resubmission-note autosave can still be in flight when the
researcher navigates away, and it then resolves against the **new** route,
which has no matching action. Next returns a non-RSC 200, and the client throws:

```
An unexpected response was received from the server.
```

The Sentry event (MANAGEMENT-APP-3K1) shows the sequence plainly:

1. POST `/resubmit` → 200 (autosave, fine)
2. POST `/resubmit` → 200 (autosave, fine)
3. **navigation** `/resubmit` → `/view`
4. GET `/view?_rsc=…` → 200
5. POST **`/view`** → 200, `response_body_size: 2` ← throws

Every breadcrumb is **status 200**, which is what distinguishes this from a
rejected Server Action (those are 4xx/500). Next's throw needs both a non-RSC
content-type *and* no redirect header:

```js
if (!isRscResponse && !redirectLocation) throw new Error('An unexpected response was received from the server.')
```

## Change

Skip reporting when the provider has unmounted, in both the proposal and code
resubmit contexts (they had identical copies of the bug).

The queued-but-not-yet-fired case was already handled by the autosave effect's
`clearTimeout`; this covers the **in-flight** one, which wasn't.

Server Actions can't accept an `AbortSignal` (not serializable), so the request
itself can't be cancelled — only its now-meaningless failure suppressed. The
toast was reporting a save the researcher never asked for, on a page they'd
already left, that they have no way to retry.

## Tests

A regression test per context. Both fail without the fix, with the same error
text seen in Sentry:

```
expected "vi.fn()" to not be called at all, but actually been called 1 times
  [Error: An unexpected response was received from the server.]
```

## Verification

Typecheck and lint clean; the changed suites pass.

Note: `context.integration.test.tsx`, `use-resubmit-proposal.test.ts`, and
`use-submit-proposal.test.ts` fail locally with `missing ARN DB_SECRET_ARN` —
they need a database. They fail identically on a clean checkout of `main`, so
they're unaffected by this change, but I could not run them.

## Not the same bug as the encryption-key PRs

This is **not** a stale Server Action ID. Those return 4xx/500 and log
`Invalid Server Actions request.` server-side; this one is 200 throughout.
management-app #967 and iac #218 fix that separate cutover issue, which
produces a similar-looking toast.